### PR TITLE
Avoiding a warning on build. Fixes #177

### DIFF
--- a/microsoft-azure-api/pom.xml
+++ b/microsoft-azure-api/pom.xml
@@ -104,6 +104,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>


### PR DESCRIPTION
warnings on build (future Maven versions might no longer support building
such malformed projects)
