### PR TITLE
Issue 228

### DIFF
--- a/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/blob/implementation/ISO8601DateConverter.java
+++ b/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/blob/implementation/ISO8601DateConverter.java
@@ -33,6 +33,10 @@ public class ISO8601DateConverter {
         return getFormat().format(date);
     }
 
+    public String shortFormat(Date date) {
+        return getShortFormat().format(date);
+    }
+
     public Date parse(String date) throws ParseException {
         if (date == null)
             return null;

--- a/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/implementation/AtomReaderWriter.java
+++ b/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/implementation/AtomReaderWriter.java
@@ -179,7 +179,7 @@ public class AtomReaderWriter {
             writer.writeEndElement(); // title
 
             writer.writeStartElement("updated");
-            writer.writeCharacters(iso8601DateConverter.format(dateFactory.getDate()));
+            writer.writeCharacters(iso8601DateConverter.shortFormat(dateFactory.getDate()));
             writer.writeEndElement(); // updated
 
             writer.writeStartElement("author");

--- a/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/implementation/DefaultEdmValueConterter.java
+++ b/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/implementation/DefaultEdmValueConterter.java
@@ -25,7 +25,7 @@ public class DefaultEdmValueConterter implements EdmValueConverter {
 
         String serializedValue;
         if (value instanceof Date) {
-            serializedValue = iso8601DateConverter.format((Date) value);
+            serializedValue = iso8601DateConverter.shortFormat((Date) value);
         }
         else {
             serializedValue = value.toString();

--- a/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/blob/implementation/ISO8601DateConverterTests.java
+++ b/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/blob/implementation/ISO8601DateConverterTests.java
@@ -20,8 +20,6 @@ import java.util.Date;
 
 import org.junit.Test;
 
-import com.microsoft.windowsazure.services.blob.implementation.ISO8601DateConverter;
-
 public class ISO8601DateConverterTests {
     @Test
     public void shortFormatWorks() throws Exception {
@@ -47,5 +45,20 @@ public class ISO8601DateConverterTests {
 
         // Assert
         assertNotNull(result);
+    }
+
+    @Test
+    public void shortFormatRoundTrips() throws Exception {
+        // Arrange
+        ISO8601DateConverter converter = new ISO8601DateConverter();
+        String value = "2012-01-12T00:35:58Z";
+
+        // Act
+        Date result = converter.parse(value);
+        String value2 = converter.shortFormat(result);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(value, value2);
     }
 }


### PR DESCRIPTION
Date time for table should have precision only down to seconds. Fixes #228

DateTime parser doesn't appear to round-trip accurately lower than that.
