### PR TITLE
CloudTableClient should use Iterator instead of Iterable.

### DIFF
--- a/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/client/CloudTableClient.java
+++ b/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/client/CloudTableClient.java
@@ -25,6 +25,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -657,7 +658,7 @@ public final class CloudTableClient extends ServiceClient {
      *         <code>R</code> of the results of executing the query.
      */
     @DoesServiceRequest
-    public <R> Iterable<R> execute(final TableQuery<?> query, final EntityResolver<R> resolver) {
+    public <R> Iterator<R> execute(final TableQuery<?> query, final EntityResolver<R> resolver) {
         return this.execute(query, resolver, null, null);
     }
 
@@ -692,11 +693,11 @@ public final class CloudTableClient extends ServiceClient {
      */
     @DoesServiceRequest
     @SuppressWarnings("unchecked")
-    public <R> Iterable<R> execute(final TableQuery<?> query, final EntityResolver<R> resolver,
+    public <R> Iterator<R> execute(final TableQuery<?> query, final EntityResolver<R> resolver,
             final TableRequestOptions options, final OperationContext opContext) {
         Utility.assertNotNull("query", query);
         Utility.assertNotNull("Query requires a valid class type or resolver.", resolver);
-        return (Iterable<R>) this.generateIteratorForQuery(query, resolver, options, opContext);
+        return (Iterator<R>) this.generateIteratorForQuery(query, resolver, options, opContext);
     }
 
     /**
@@ -716,7 +717,7 @@ public final class CloudTableClient extends ServiceClient {
      *         executing the query.
      */
     @DoesServiceRequest
-    public <T extends TableEntity> Iterable<T> execute(final TableQuery<T> query) {
+    public <T extends TableEntity> Iterator<T> execute(final TableQuery<T> query) {
         return this.execute(query, null, null);
     }
 
@@ -748,10 +749,10 @@ public final class CloudTableClient extends ServiceClient {
      */
     @SuppressWarnings("unchecked")
     @DoesServiceRequest
-    public <T extends TableEntity> Iterable<T> execute(final TableQuery<T> query, final TableRequestOptions options,
+    public <T extends TableEntity> Iterator<T> execute(final TableQuery<T> query, final TableRequestOptions options,
             final OperationContext opContext) {
         Utility.assertNotNull("query", query);
-        return (Iterable<T>) this.generateIteratorForQuery(query, null, options, opContext);
+        return (Iterator<T>) this.generateIteratorForQuery(query, null, options, opContext);
     }
 
     /**
@@ -942,7 +943,7 @@ public final class CloudTableClient extends ServiceClient {
      *         An <code>Iterable</code> collection of the table names in the storage account.
      */
     @DoesServiceRequest
-    public Iterable<String> listTables() {
+    public Iterator<String> listTables() {
         return this.listTables(null);
     }
 
@@ -961,7 +962,7 @@ public final class CloudTableClient extends ServiceClient {
      *         prefix.
      */
     @DoesServiceRequest
-    public Iterable<String> listTables(final String prefix) {
+    public Iterator<String> listTables(final String prefix) {
         return this.listTables(prefix, null, null);
     }
 
@@ -991,7 +992,7 @@ public final class CloudTableClient extends ServiceClient {
      *         prefix.
      */
     @DoesServiceRequest
-    public Iterable<String> listTables(final String prefix, final TableRequestOptions options,
+    public Iterator<String> listTables(final String prefix, final TableRequestOptions options,
             final OperationContext opContext) {
         return this.execute(this.generateListTablesQuery(prefix), this.tableNameResolver, options, opContext);
     }

--- a/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/table/client/TableClientTests.java
+++ b/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/table/client/TableClientTests.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import junit.framework.Assert;
 
@@ -142,8 +143,8 @@ public class TableClientTests extends TableTestBase {
         try {
             // With prefix
             int currTable = 0;
-            for (String s : tClient.listTables(tableBaseName, null, null)) {
-                Assert.assertEquals(s,
+            for (Iterator<String> iterator = tClient.listTables(tableBaseName, null, null); iterator.hasNext();) {
+                Assert.assertEquals(iterator.next(),
                         String.format("%s%s", tableBaseName, new DecimalFormat("#0000").format(currTable)));
                 currTable++;
             }
@@ -152,8 +153,8 @@ public class TableClientTests extends TableTestBase {
 
             // Without prefix
             currTable = 0;
-            for (String s : tClient.listTables()) {
-                if (s.startsWith(tableBaseName)) {
+            for (Iterator<String> iterator = tClient.listTables(tableBaseName, null, null); iterator.hasNext();) {
+                if (iterator.next().startsWith(tableBaseName)) {
                     currTable++;
                 }
             }

--- a/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/table/client/TableEscapingTests.java
+++ b/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/table/client/TableEscapingTests.java
@@ -14,6 +14,7 @@
  */
 package com.microsoft.windowsazure.services.table.client;
 
+import java.util.Iterator;
 import java.util.UUID;
 
 import junit.framework.Assert;
@@ -217,7 +218,8 @@ public class TableEscapingTests extends TableTestBase {
 
         int count = 0;
 
-        for (class1 ent : tClient.execute(query)) {
+        for (Iterator<class1> iterator = tClient.execute(query); iterator.hasNext();) {
+            class1 ent = iterator.next();
             count++;
             Assert.assertEquals(ent.getA(), ref.getA());
             Assert.assertEquals(ent.getB(), ref.getB());

--- a/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/table/client/TableQueryTests.java
+++ b/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/table/client/TableQueryTests.java
@@ -20,10 +20,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.UUID;
+import java.util.*;
 
 import junit.framework.Assert;
 
@@ -64,11 +61,12 @@ public class TableQueryTests extends TableTestBase {
         // Create entity to check against
         class1 randEnt = TableTestBase.generateRandomEnitity(null);
 
-        final Iterable<DynamicTableEntity> result = tClient.execute(TableQuery.from(testSuiteTableName,
+        final Iterator<DynamicTableEntity> result = tClient.execute(TableQuery.from(testSuiteTableName,
                 DynamicTableEntity.class));
 
         // Validate results
-        for (DynamicTableEntity ent : result) {
+        while (result.hasNext()) {
+            DynamicTableEntity ent = result.next();
             Assert.assertEquals(ent.getProperties().size(), 4);
             Assert.assertEquals(ent.getProperties().get("A").getValueAsString(), randEnt.getA());
             Assert.assertEquals(ent.getProperties().get("B").getValueAsString(), randEnt.getB());
@@ -81,11 +79,12 @@ public class TableQueryTests extends TableTestBase {
     public void tableQueryWithProjection() {
         // Create entity to check against
         class1 randEnt = TableTestBase.generateRandomEnitity(null);
-        final Iterable<class1> result = tClient.execute(TableQuery.from(testSuiteTableName, class1.class).select(
+        final Iterator<class1> result = tClient.execute(TableQuery.from(testSuiteTableName, class1.class).select(
                 new String[] { "A", "C" }));
 
         // Validate results
-        for (class1 ent : result) {
+        while (result.hasNext()) {
+            class1 ent = result.next();
             // Validate core properties were sent.
             Assert.assertNotNull(ent.getPartitionKey());
             Assert.assertNotNull(ent.getRowKey());
@@ -116,12 +115,13 @@ public class TableQueryTests extends TableTestBase {
             }
         });
 
-        final Iterable<class1> result = tClient.execute(
+        final Iterator<class1> result = tClient.execute(
                 TableQuery.from(testSuiteTableName, class1.class).select(
                         new String[] { "PartitionKey", "RowKey", "Timestamp" }), null, opContext);
 
         // Validate results
-        for (class1 ent : result) {
+        while (result.hasNext()) {
+            class1 ent = result.next();
             Assert.assertEquals(ent.getA(), null);
             Assert.assertEquals(ent.getB(), null);
             Assert.assertEquals(ent.getC(), null);
@@ -134,10 +134,11 @@ public class TableQueryTests extends TableTestBase {
         // Create entity to check against
         class1 randEnt = TableTestBase.generateRandomEnitity(null);
 
-        final Iterable<class1> result = tClient.execute(TableQuery.from(testSuiteTableName, class1.class));
+        final Iterator<class1> result = tClient.execute(TableQuery.from(testSuiteTableName, class1.class));
 
         // Validate results
-        for (class1 ent : result) {
+        while (result.hasNext()) {
+            class1 ent = result.next();
             Assert.assertEquals(ent.getA(), randEnt.getA());
             Assert.assertEquals(ent.getB(), randEnt.getB());
             Assert.assertEquals(ent.getC(), randEnt.getC());
@@ -150,7 +151,7 @@ public class TableQueryTests extends TableTestBase {
         // Create entity to check against
         class1 randEnt = TableTestBase.generateRandomEnitity(null);
 
-        final Iterable<class1> result = tClient.execute(TableQuery.from(testSuiteTableName, TableServiceEntity.class),
+        final Iterator<class1> result = tClient.execute(TableQuery.from(testSuiteTableName, TableServiceEntity.class),
                 new EntityResolver<class1>() {
                     @Override
                     public class1 resolve(String partitionKey, String rowKey, Date timeStamp,
@@ -166,7 +167,8 @@ public class TableQueryTests extends TableTestBase {
                 });
 
         // Validate results
-        for (class1 ent : result) {
+        while (result.hasNext()) {
+            class1 ent = result.next();
             Assert.assertEquals(ent.getA(), randEnt.getA());
             Assert.assertEquals(ent.getB(), randEnt.getB());
             Assert.assertEquals(ent.getC(), randEnt.getC());
@@ -202,7 +204,8 @@ public class TableQueryTests extends TableTestBase {
 
         int count = 0;
 
-        for (class1 ent : tClient.execute(query)) {
+        for (Iterator<class1> iterator = tClient.execute(query); iterator.hasNext();) {
+            class1 ent = iterator.next();
             Assert.assertEquals(ent.getA(), randEnt.getA());
             Assert.assertEquals(ent.getB(), randEnt.getB());
             Assert.assertEquals(ent.getC(), randEnt.getC());
@@ -225,7 +228,8 @@ public class TableQueryTests extends TableTestBase {
 
         int count = 0;
         int pk = 1;
-        for (class1 ent : tClient.execute(query)) {
+        for (Iterator<class1> iterator = tClient.execute(query); iterator.hasNext();) {
+            class1 ent = iterator.next();
             Assert.assertEquals(ent.getA(), randEnt.getA());
             Assert.assertEquals(ent.getB(), randEnt.getB());
             Assert.assertEquals(ent.getC(), randEnt.getC());
@@ -406,8 +410,8 @@ public class TableQueryTests extends TableTestBase {
             TableQuery<ComplexEntity> query = TableQuery.from(testSuiteTableName, ComplexEntity.class).where(
                     String.format("PartitionKey eq '%s'", pk));
 
-            for (ComplexEntity e : tClient.execute(query)) {
-                delBatch.delete(e);
+            for (Iterator<ComplexEntity> iterator = tClient.execute(query); iterator.hasNext();) {
+                delBatch.delete(iterator.next());
             }
 
             tClient.execute(testSuiteTableName, delBatch);
@@ -417,8 +421,7 @@ public class TableQueryTests extends TableTestBase {
     private void executeQueryAndAssertResults(String filter, int expectedResults) {
         int count = 0;
         TableQuery<ComplexEntity> query = TableQuery.from(testSuiteTableName, ComplexEntity.class).where(filter);
-        for (@SuppressWarnings("unused")
-        ComplexEntity e : tClient.execute(query)) {
+        for (Iterator<ComplexEntity> iterator = tClient.execute(query); iterator.hasNext();) {
             count++;
         }
 


### PR DESCRIPTION
# The Problem

`CloudTableClient#execute(TableQuery<?>, ..)` overloads return `Iterable`, which implies a collection that can be iterated over multiple times. However, the return value is implemented as an `Iterator` that implements `Iterable` by returning `this`, which is generally regarded as a Bad Thing. [More on this.](http://stackoverflow.com/a/5836220/9700)

The temptation to do this is common given the seductive lure of being able to use your iterator in a foreach loop:

``` java
foreach (Result r : tableClient.execute(query, resolver)) {
 // handle results
}
```

But, because `execute` returns an `Iterator` under the hood, this breaks down if you try to do it twice:

``` java
Iterable<Result> result = tableClient.execute(query, resolver);

foreach (Result r : result) {
 // handle results
}

foreach (Result r : result) {
 // never reached
}
```

`Iterable` expects this to work, as does mountains of client code that consume `Iterable` instances. The fact that `Iterator` can't normally be used in this way is a warning and reminder to users that iterators are single pass only.

_In general, methods that return a result that can only be iterated once should return `Iterator`, not `Iterable`._ This pull request implements that policy for `CloudTableClient`, at the cost of breaking client code.
# Alternative solutions

If breaking client code is not an option, the following alternatives can be explored:
## Deprecate the old code, and add new methods

This option keeps the broken old behavior but deprecates it, so that end user expectations aren't changed. New methods that return `Iterator` could be added to indicate the single-pass semantics.
## Keep the old interface, but make it support the correct semantics.

`Iterable` should return a new iterator for each call to `iterator`. There are some options for how to achieve this, such as (a) caching the results, or (b) issuing a new query to the service. Each choice has trade-offs, which is why dropping or deprecating the API should be preferred. But a correctly functioning API that has trade-offs is better than an incorrect one. 
