### PR TITLE
Issue#62: AtomPubParser now accepts empty strings in PartitionKey and RowKey values

### DIFF
--- a/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/client/AtomPubParser.java
+++ b/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/client/AtomPubParser.java
@@ -416,8 +416,8 @@ class AtomPubParser {
         }
 
         if (!isTableEntry) {
-            Utility.assertNotNullOrEmpty(TableConstants.PARTITION_KEY, entity.getPartitionKey());
-            Utility.assertNotNullOrEmpty(TableConstants.ROW_KEY, entity.getRowKey());
+            Utility.assertNotNull(TableConstants.PARTITION_KEY, entity.getPartitionKey());
+            Utility.assertNotNull(TableConstants.ROW_KEY, entity.getRowKey());
             Utility.assertNotNull(TableConstants.TIMESTAMP, entity.getTimestamp());
         }
 

--- a/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/table/client/AtomPubParserTests.java
+++ b/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/table/client/AtomPubParserTests.java
@@ -1,0 +1,61 @@
+package com.microsoft.windowsazure.services.table.client;
+
+import com.microsoft.windowsazure.services.core.storage.OperationContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.xml.stream.XMLStreamWriter;
+import java.util.Date;
+
+import static com.microsoft.windowsazure.services.table.client.AtomPubParser.writeEntityToStream;
+import static org.mockito.Mockito.*;
+
+public class AtomPubParserTests {
+
+    public static final String WHITESPACE = " ";
+    public static final String EMPTYSTRING = "";
+    private TableEntity entity;
+    private XMLStreamWriter writer;
+    private OperationContext context;
+
+    @Before
+    public void setUp() {
+        entity = mock(TableEntity.class);
+        writer = mock(XMLStreamWriter.class);
+        context = new OperationContext();
+    }
+
+    @Test
+    public void writeEntityShouldAcceptWhiteSpaces() throws Exception {
+        when(entity.getPartitionKey()).thenReturn(WHITESPACE);
+        when(entity.getRowKey()).thenReturn(WHITESPACE);
+        when(entity.getTimestamp()).thenReturn(new Date());
+
+        writeEntityToStream(entity, false, writer, context);
+
+        verify(entity, atLeastOnce()).getPartitionKey();
+        verify(entity, atLeastOnce()).getRowKey();
+    }
+
+    @Test
+    public void writeEntityShouldAcceptEmpytString() throws Exception {
+        when(entity.getPartitionKey()).thenReturn(EMPTYSTRING);
+        when(entity.getRowKey()).thenReturn(EMPTYSTRING);
+        when(entity.getTimestamp()).thenReturn(new Date());
+
+        writeEntityToStream(entity, false, writer, context);
+
+        verify(entity, atLeastOnce()).getPartitionKey();
+        verify(entity, atLeastOnce()).getRowKey();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void writeEntityShouldNotAcceptEmptyStrings() throws Exception {
+        when(entity.getPartitionKey()).thenReturn(EMPTYSTRING);
+        when(entity.getRowKey()).thenReturn(EMPTYSTRING);
+        when(entity.getTimestamp()).thenReturn(new Date());
+
+        writeEntityToStream(entity, false, writer, context);
+    }
+
+}


### PR DESCRIPTION
I changed the assertion in AtomPubParser#writeEntityToStream for accept empty strings at TableEntity#PartitionKey and TableEntity#RowKey.

Added some test cases that validate the change.
