### PR TITLE
Fixed test for surrogate pair, removed encoding

### DIFF
--- a/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/implementation/AtomReaderWriter.java
+++ b/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/implementation/AtomReaderWriter.java
@@ -340,7 +340,6 @@ public class AtomReaderWriter {
     }
 
     private boolean isIllegalChar(char c) {
-        return !(c == 9 || c == 0xA || c == 0xD || (c >= 0x20 && c < 0xD800) ||
-                (c >= 0xE000 && c < 0xFFFE) || (c >= 0x10000 && c < 0x110000));
+        return !(c == 9 || c == 0xA || c == 0xD || (c >= 0x20 && c < 0xFFFE));
     }
 }

--- a/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/table/TableServiceIntegrationTest.java
+++ b/microsoft-azure-api/src/test/java/com/microsoft/windowsazure/services/table/TableServiceIntegrationTest.java
@@ -409,7 +409,7 @@ public class TableServiceIntegrationTest extends IntegrationTestBase {
                 .setProperty("test5", EdmType.STRING, "\ub2e2")
                 .setProperty("test6", EdmType.STRING, " \ub2e2")
                 .setProperty("test7", EdmType.STRING, "ok \ub2e2")
-                .setProperty("test8", EdmType.STRING, "\uD840");
+                .setProperty("test8", EdmType.STRING, "\uD840\uDC00")
                 ;
 
         service.insertEntity(TEST_TABLE_2, insertedEntity);
@@ -448,7 +448,7 @@ public class TableServiceIntegrationTest extends IntegrationTestBase {
         assertEquals("ok \ub2e2", actualTest7);
 
         String actualTest8 = (String)entity.getPropertyValue("test8");
-        assertEquals("&#xd840;", actualTest8);
+        assertEquals("\uD840\uDC00", actualTest8);
     }
 
 


### PR DESCRIPTION
Properly handing surrogate pairs without encoding them. Issue #111
