### PR TITLE
Code for Issues #301 & #112

### DIFF
--- a/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/serviceBus/implementation/ServiceBusRestProxy.java
+++ b/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/serviceBus/implementation/ServiceBusRestProxy.java
@@ -183,6 +183,11 @@ public class ServiceBusRestProxy implements ServiceBusContract {
             throw new RuntimeException("Unknown ReceiveMode");
         }
 
+        //Empty Queue scenario
+        if (clientResult.getStatus() == 204) {
+            return null;
+        }
+
         BrokerProperties brokerProperties;
         if (clientResult.getHeaders().containsKey("BrokerProperties")) {
             brokerProperties = mapper.fromString(clientResult.getHeaders().getFirst("BrokerProperties"));


### PR DESCRIPTION
API returns HTTP Status Code 204 when Queue is empty. In this case
calling getValue() on the ReceiveQueueMessageResult will return null.

Changed ServiceBusRestProxy:receiveMessage() now returns a null BrokeredMessage from the getValue() call in cases where the REST call returns a 204 Status Code, which indicates the Queue is empty and remained empty until recieveMessage() call times out.

Tests added in ServiceBusIntegrationTest to test empty Queues in both Receive/Delete and Peek/Lock scenarios. Updated peekLockedMessageCanBeDeleted() to function with null BrokeredMessage returned in empty Queue scenario.
