### PR TITLE
Long value filtering has error when value more than MAX_INT 

### DIFF
--- a/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/client/TableQuery.java
+++ b/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/table/client/TableQuery.java
@@ -380,9 +380,11 @@ public class TableQuery<T extends TableEntity> {
     public static String generateFilterCondition(String propertyName, String operation, String value, EdmType edmType) {
         String valueOperand = null;
 
-        if (edmType == EdmType.BOOLEAN || edmType == EdmType.DOUBLE || edmType == EdmType.INT32
-                || edmType == EdmType.INT64) {
+        if (edmType == EdmType.BOOLEAN || edmType == EdmType.DOUBLE || edmType == EdmType.INT32) {
             valueOperand = value;
+        }
+        else if (edmType == EdmType.INT64) {
+            valueOperand = String.format("%sL", value);
         }
         else if (edmType == EdmType.DATE_TIME) {
             valueOperand = String.format("datetime'%s'", value);


### PR DESCRIPTION
In this PR, and fixes the following problems.
In the current code, When you specify a filter to the property of Edm:Int64, value of MAX_INT or more, it is an error.
Because  post fix 'L' is missing.
