### PR TITLE
Updated next() method to satisfy the iterator contract and not throw a null pointer exception

### DIFF
--- a/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/core/storage/utils/implementation/LazySegmentedIterator.java
+++ b/microsoft-azure-api/src/main/java/com/microsoft/windowsazure/services/core/storage/utils/implementation/LazySegmentedIterator.java
@@ -130,7 +130,11 @@ public final class LazySegmentedIterator<CLIENT_TYPE, PARENT_TYPE, ENTITY_TYPE> 
      */
     @Override
     public ENTITY_TYPE next() {
-        return this.currentSegmentIterator.next();
+        if(hasNext()) {
+          return this.currentSegmentIterator.next();
+        } else {
+            throw new NoSuchElementException();
+        }
     }
 
     /**


### PR DESCRIPTION
Updated next() method to satisfy the iterator contract and not throw a null pointer exception, if it was called without hasNext() being called.

The previous implementation did not initialize the _currentSegmentIterator_, unless _hasNext()_ has been called, which lead to unexpected _NullPointerException_.
I've changed the impl to call _hasNext()_ prior to the next call.
