### PR TITLE
Update Swagger Transform to Use Correct Return Type

### DIFF
--- a/sdk/storage/azure-storage-file/src/main/java/com/azure/storage/file/implementation/DirectorysImpl.java
+++ b/sdk/storage/azure-storage-file/src/main/java/com/azure/storage/file/implementation/DirectorysImpl.java
@@ -28,9 +28,8 @@ import com.azure.storage.file.models.DirectorysListHandlesResponse;
 import com.azure.storage.file.models.DirectorysSetMetadataResponse;
 import com.azure.storage.file.models.DirectorysSetPropertiesResponse;
 import com.azure.storage.file.models.StorageErrorException;
-import reactor.core.publisher.Mono;
-
 import java.util.Map;
+import reactor.core.publisher.Mono;
 
 /**
  * An instance of this class provides access to all the operations defined in

--- a/sdk/storage/azure-storage-file/src/main/java/com/azure/storage/file/models/FileDownloadHeaders.java
+++ b/sdk/storage/azure-storage-file/src/main/java/com/azure/storage/file/models/FileDownloadHeaders.java
@@ -197,19 +197,19 @@ public final class FileDownloadHeaders {
      * Creation time for the file.
      */
     @JsonProperty(value = "x-ms-file-creation-time")
-    private DateTimeRfc1123 fileCreationTime;
+    private OffsetDateTime fileCreationTime;
 
     /*
      * Last write time for the file.
      */
     @JsonProperty(value = "x-ms-file-last-write-time")
-    private DateTimeRfc1123 fileLastWriteTime;
+    private OffsetDateTime fileLastWriteTime;
 
     /*
      * Change time for the file.
      */
     @JsonProperty(value = "x-ms-file-change-time")
-    private DateTimeRfc1123 fileChangeTime;
+    private OffsetDateTime fileChangeTime;
 
     /*
      * Key of the permission set for the file.
@@ -830,10 +830,7 @@ public final class FileDownloadHeaders {
      * @return the fileCreationTime value.
      */
     public OffsetDateTime fileCreationTime() {
-        if (this.fileCreationTime == null) {
-            return null;
-        }
-        return this.fileCreationTime.dateTime();
+        return this.fileCreationTime;
     }
 
     /**
@@ -843,11 +840,7 @@ public final class FileDownloadHeaders {
      * @return the FileDownloadHeaders object itself.
      */
     public FileDownloadHeaders fileCreationTime(OffsetDateTime fileCreationTime) {
-        if (fileCreationTime == null) {
-            this.fileCreationTime = null;
-        } else {
-            this.fileCreationTime = new DateTimeRfc1123(fileCreationTime);
-        }
+        this.fileCreationTime = fileCreationTime;
         return this;
     }
 
@@ -857,10 +850,7 @@ public final class FileDownloadHeaders {
      * @return the fileLastWriteTime value.
      */
     public OffsetDateTime fileLastWriteTime() {
-        if (this.fileLastWriteTime == null) {
-            return null;
-        }
-        return this.fileLastWriteTime.dateTime();
+        return this.fileLastWriteTime;
     }
 
     /**
@@ -870,11 +860,7 @@ public final class FileDownloadHeaders {
      * @return the FileDownloadHeaders object itself.
      */
     public FileDownloadHeaders fileLastWriteTime(OffsetDateTime fileLastWriteTime) {
-        if (fileLastWriteTime == null) {
-            this.fileLastWriteTime = null;
-        } else {
-            this.fileLastWriteTime = new DateTimeRfc1123(fileLastWriteTime);
-        }
+        this.fileLastWriteTime = fileLastWriteTime;
         return this;
     }
 
@@ -884,10 +870,7 @@ public final class FileDownloadHeaders {
      * @return the fileChangeTime value.
      */
     public OffsetDateTime fileChangeTime() {
-        if (this.fileChangeTime == null) {
-            return null;
-        }
-        return this.fileChangeTime.dateTime();
+        return this.fileChangeTime;
     }
 
     /**
@@ -897,11 +880,7 @@ public final class FileDownloadHeaders {
      * @return the FileDownloadHeaders object itself.
      */
     public FileDownloadHeaders fileChangeTime(OffsetDateTime fileChangeTime) {
-        if (fileChangeTime == null) {
-            this.fileChangeTime = null;
-        } else {
-            this.fileChangeTime = new DateTimeRfc1123(fileChangeTime);
-        }
+        this.fileChangeTime = fileChangeTime;
         return this;
     }
 

--- a/sdk/storage/azure-storage-file/swagger/README.md
+++ b/sdk/storage/azure-storage-file/swagger/README.md
@@ -334,6 +334,9 @@ directive:
         op.get.responses["200"].headers["x-ms-file-creation-time"].format = "date-time";
         op.get.responses["200"].headers["x-ms-file-last-write-time"].format = "date-time";
         op.get.responses["200"].headers["x-ms-file-change-time"].format = "date-time";
+        op.get.responses["206"].headers["x-ms-file-creation-time"].format = "date-time";
+        op.get.responses["206"].headers["x-ms-file-last-write-time"].format = "date-time";
+        op.get.responses["206"].headers["x-ms-file-change-time"].format = "date-time";
         op.head.responses["200"].headers["x-ms-file-creation-time"].format = "date-time";
         op.head.responses["200"].headers["x-ms-file-last-write-time"].format = "date-time";
         op.head.responses["200"].headers["x-ms-file-change-time"].format = "date-time";


### PR DESCRIPTION
Swagger transformation to use ISO8601 instead of RFC1123 to match the return type from the service.