### PR TITLE
add more eng entries to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,8 +29,8 @@
 ###########
 /eng/   @weshaggard @mitchdenny @danieljurek
 /eng/code-quality-reports/ @mssfang @JonathanGiles
-/eng/jacoco-test-coverage/ @mssfang @JonathanGiles
-/eng/spotbugs-aggregate-report/ @mssfang @JonathanGiles
+/eng/jacoco-test-coverage/ @srnagar @JonathanGiles
+/eng/spotbugs-aggregate-report/ @srnagar @JonathanGiles
 
 /**/tests.yml   @danieljurek
 /**/ci.yml      @mitchdenny


### PR DESCRIPTION
Also including @JonathanGiles as he's in the other entries

@Azure/azure-sdk-eng 