### PR TITLE
Removes codesnippet from EventData.properties()

### DIFF
--- a/eng/code-quality-reports/src/main/resources/checkstyle/checkstyle-suppressions.xml
+++ b/eng/code-quality-reports/src/main/resources/checkstyle/checkstyle-suppressions.xml
@@ -138,7 +138,6 @@
 
   <!-- CodeSnippet Suppression for now, which need code owner's attention -->
   <suppress checks="com.azure.tools.checkstyle.checks.JavadocCodeSnippetCheck" files="com.azure.data.appconfiguration.ConfigurationAsyncClient.java"/>
-  <suppress checks="com.azure.tools.checkstyle.checks.JavadocCodeSnippetCheck" files="com.azure.messaging.eventhubs.EventData.java"/>
 
   <!-- ClientLogger class suppression -->
   <suppress checks="com.azure.tools.checkstyle.checks.GoodLoggingCheck" files="ClientLogger.java"/>

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/main/java/com/azure/messaging/eventhubs/EventData.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/main/java/com/azure/messaging/eventhubs/EventData.java
@@ -178,14 +178,8 @@ public class EventData implements Comparable<EventData> {
      *
      * <p>
      * A common use case for {@code properties()} is to associate serialization hints for the {@link #body()} as an aid
-     * to consumers who wish to deserialize the binary data.
+     * to consumers who wish to deserialize the binary data. See {@link #addProperty(String, Object)} for a sample.
      * </p>
-     *
-     * <p>
-     * <strong>Adding serialization hint using {@link #addProperty(String, Object)}</strong>
-     * </p>
-     *
-     * {@codesnippet com.azure.messaging.eventhubs.eventdata.addProperty#string-object}
      *
      * @return Application properties associated with this {@link EventData}.
      */


### PR DESCRIPTION
Removes codesnippet from EventData.properties() to fix checkstyle issue,

Fixes #5141 