### PR TITLE
Use README Links with Correct Version

### DIFF
--- a/sdk/appconfiguration/azure-data-appconfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/azure-data-appconfiguration/CHANGELOG.md
@@ -7,9 +7,9 @@ For details on the Azure SDK for Java (September 2019 Preview) release refer to 
 - Added logging when throwing `RutimeException`s.
 
 This package's 
-[documentation](https://github.com/Azure/azure-sdk-for-java/blob/azure-data-appconfiguration_1.0.0-preview.3/sdk/appconfiguration/azure-data-appconfiguration/README.md) 
+[documentation](https://github.com/Azure/azure-sdk-for-java/blob/4375acbb70d4b85db238d6b5147b697d9355f45e/sdk/appconfiguration/azure-data-appconfiguration/README.md) 
 and 
-[samples](https://github.com/Azure/azure-sdk-for-java/tree/azure-data-appconfiguration_1.0.0-preview.3/sdk/appconfiguration/azure-data-appconfiguration/src/samples/java/com/azure/data/appconfiguration) 
+[samples](https://github.com/Azure/azure-sdk-for-java/tree/4375acbb70d4b85db238d6b5147b697d9355f45e/sdk/appconfiguration/azure-data-appconfiguration/src/samples/java/com/azure/data/appconfiguration) 
 demonstrate the new API.
 
 ## Version 1.0.0-preview.2 (2019-08-06)

--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -19,9 +19,9 @@ For details on the Azure SDK for Java (September 2019 Preview) release, you can 
 - Simplified API to return model types directly on non-maximal overloads. Maximal overloads return `Response<T>` and suffixed with WithResponse.
 
 This package's
-[documentation](https://github.com/Azure/azure-sdk-for-java/blob/azure-storage-blob_12.0.0-preview.3/sdk/storage/azure-storage-blob/README.md)
+[documentation](https://github.com/Azure/azure-sdk-for-java/blob/085c8570b411defff26860ef56ea189af07d3d6a/sdk/storage/azure-storage-blob/README.md)
 and
-[samples](https://github.com/Azure/azure-sdk-for-java/blob/azure-storage-blob_12.0.0-preview.3/sdk/storage/azure-storage-blob/src/samples/java/com/azure/storage/blob)
+[samples](https://github.com/Azure/azure-sdk-for-java/blob/085c8570b411defff26860ef56ea189af07d3d6a/sdk/storage/azure-storage-blob/src/samples/java/com/azure/storage/blob)
 demonstrate the new API.
 
 ## Version 12.0.0-preview.2 (2019-08-08)

--- a/sdk/storage/azure-storage-file/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file/CHANGELOG.md
@@ -4,9 +4,9 @@
 For details on the Azure SDK for Java (September 2019 Preview) release, you can refer to the [release announcement](https://aka.ms/azure-sdk-preview3-java).
 
 This package's
-[documentation](https://github.com/Azure/azure-sdk-for-java/blob/azure-storage-file_12.0.0-preview.3/sdk/storage/azure-storage-file/README.md)
+[documentation](https://github.com/Azure/azure-sdk-for-java/blob/085c8570b411defff26860ef56ea189af07d3d6a/sdk/storage/azure-storage-file/README.md)
 and
-[samples](https://github.com/Azure/azure-sdk-for-java/tree/azure-storage-file_12.0.0-preview.3/sdk/storage/azure-storage-file/src/samples/java/com/azure/storage/file)
+[samples](https://github.com/Azure/azure-sdk-for-java/tree/085c8570b411defff26860ef56ea189af07d3d6a/sdk/storage/azure-storage-file/src/samples/java/com/azure/storage/file)
 demonstrate the new API.
 
 - Added tracing telemetry on maximum overload API.

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -3,9 +3,9 @@
 For details on the Azure SDK for Java (September 2019 Preview) release, you can refer to the [release announcement](https://aka.ms/azure-sdk-preview2-java).
 
 This package's
-[documentation](https://github.com/Azure/azure-sdk-for-java/blob/azure-storage-queue_12.0.0-preview.3/sdk/storage/azure-storage-queue/README.md)
+[documentation](https://github.com/Azure/azure-sdk-for-java/blob/085c8570b411defff26860ef56ea189af07d3d6a/sdk/storage/azure-storage-queue/README.md)
 and
-[samples](https://github.com/Azure/azure-sdk-for-java/tree/azure-storage-queue_12.0.0-preview.3/sdk/storage/azure-storage-queue/src/samples/java/com/azure/storage/queue)
+[samples](https://github.com/Azure/azure-sdk-for-java/tree/085c8570b411defff26860ef56ea189af07d3d6a/sdk/storage/azure-storage-queue/src/samples/java/com/azure/storage/queue)
 
 - Added tracing telemetry on maximum overload API.
 - Added generate SAS token APIs.


### PR DESCRIPTION
Uses commit hash links instead of the tagged commit for README and samples.