### PR TITLE
Switch over to new artifact staging script.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-pom-only.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-pom-only.yml
@@ -68,12 +68,23 @@ jobs:
           inputs:
             mavenPomFile: sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/pom.xml
             goals: 'deploy'
-            options: '-pl ${{artifact.groupId}}:${{artifact.name}} -DaltDeploymentRepository=id::default::file://$(Build.ArtifactStagingDirectory) -Ddependency-checker -Dgpg.skip'
+            options: '-pl ${{artifact.groupId}}:${{artifact.name}} -DaltDeploymentRepository=id::default::file://$(System.DefaultWorkingDirectory)/build -Ddependency-checker -Dgpg.skip'
             mavenOptions: '$(MemoryOptions) $(LoggingOptions)'
             javaHomeOption: 'JDKVersion'
             jdkVersionOption: $(JavaBuildVersion)
             jdkArchitectureOption: 'x64'
             publishJUnitResults: false
+
+      - task: PowerShell@2
+        displayName: 'Copy artifacts to staging'
+        inputs:
+          pwsh: true
+          workingDirectory: $(Agent.BuildDirectory)
+          filePath: eng/scripts/Stage-MavenPackageArtifacts.ps1
+          arguments: >
+            -SourceDirectory $(System.DefaultWorkingDirectory)/build
+            -TargetDirectory $(Build.ArtifactStagingDirectory)
+            -InformationAction Continue
 
       - publish: $(Build.ArtifactStagingDirectory)
         displayName: 'Publish Artifacts $(ArtifactName)'


### PR DESCRIPTION
The POM/BOM pipelines are not staging artifacts correctly. This change switches over to the staging logic that we are now using for the other pipelines which should be a bit more robust.