### PR TITLE
Fix Issue when Dependency Tag is Using Multiple Underscores

### DIFF
--- a/eng/versioning/pom_file_version_scanner.ps1
+++ b/eng/versioning/pom_file_version_scanner.ps1
@@ -527,7 +527,7 @@ Get-ChildItem -Path $Path -Filter pom*.xml -Recurse -File | ForEach-Object {
         {
             # unfortunately because there are POM exceptions we need to wildcard the group which may be
             # something like <area>_groupId
-            if ($versionNode.NextSibling.Value.Trim() -notmatch "{x-version-update;(\w+)?$($groupId):$($artifactId);\w+}")
+            if ($versionNode.NextSibling.Value.Trim() -notmatch "{x-version-update;(.+)?$($groupId):$($artifactId);\w+}")
             {
                 $script:FoundError = $true
                 Write-Error-With-Color "Error: dependency version update tag for groupId=$($groupId), artifactId=$($artifactId) should be <!-- {x-version-update;$($groupId):$($artifactId);current|dependency|external_dependency<select one>} -->"
@@ -587,7 +587,7 @@ Get-ChildItem -Path $Path -Filter pom*.xml -Recurse -File | ForEach-Object {
         {
             # unfortunately because there are POM exceptions we need to wildcard the group which may be
             # something like <area>_groupId
-            if ($versionNode.NextSibling.Value.Trim() -notmatch "{x-version-update;(\w+)?$($groupId):$($artifactId);\w+}")
+            if ($versionNode.NextSibling.Value.Trim() -notmatch "{x-version-update;(.+)?$($groupId):$($artifactId);\w+}")
             {
                 $script:FoundError = $true
                 Write-Error-With-Color "Error: plugin version update tag for groupId=$($groupId), artifactId=$($artifactId) should be <!-- {x-version-update;$($groupId):$($artifactId);current|dependency|external_dependency<select one>} -->"
@@ -630,7 +630,7 @@ Get-ChildItem -Path $Path -Filter pom*.xml -Recurse -File | ForEach-Object {
                     $script:FoundError = $true
                     Write-Error-With-Color "Error: <include> is missing the update tag which should be <!-- {x-include-update;$($groupId):$($artifactId);current|dependency|external_dependency<select one>} -->"
                 }
-                elseif ($includeNode.NextSibling.Value.Trim() -notmatch "{x-include-update;(\w+)?$($groupId):$($artifactId);(current|dependency|external_dependency)}")
+                elseif ($includeNode.NextSibling.Value.Trim() -notmatch "{x-include-update;(.+)?$($groupId):$($artifactId);(current|dependency|external_dependency)}")
                 {
                     $script:FoundError = $true
                     Write-Error-With-Color "Error: <include> version update tag for $($includeNode.InnerText) should be <!-- {x-include-update;$($groupId):$($artifactId);current|dependency|external_dependency<select one>} -->"

--- a/eng/versioning/utils.py
+++ b/eng/versioning/utils.py
@@ -40,6 +40,9 @@ prerelease_version_regex_with_name = r'^beta\.(?P<revision>0|[1-9]\d*)$'
 # This is special for track 1, data track, which can be <major>.<minor>.<version>-beta with no ".X"
 prerelease_data_version_regex = r'^beta$'
 
+# Allow list prefix remover
+allowlist_exception_identifier_remover_regex = re.compile(r'^(?:.+_)(?=.+:)(.*)$')
+
 class UpdateType(Enum):
     external_dependency = 'external_dependency'
     library = 'library'
@@ -118,8 +121,9 @@ class CodeModule:
             # '_' in them if they're an external dependency exception. Since the allowlist
             # name needs to be the actual dependency, take everything after the _ which is
             # the actual name
-            if '_' in temp:
-                temp = temp.split('_')[1]
+            match = allowlist_exception_identifier_remover_regex.match(temp)
+            if match:
+                temp = match.group(1)
             return temp + ':[' + self.external_dependency + ']'
         else:
             raise ValueError('string_for_allowlist_include called on non-external_dependency: ' + self.name)


### PR DESCRIPTION
This PR resolves an issue when a dependency tag is using multiple underscores (`_`) in the version tag. Examples of this are `appconfig_spring_com.fasterxml.jackson.core:jackson-annotations;2.11.4` or `cosmos_org.apache.spark:spark-sql_2.12;3.1.1`.