### PR TITLE
Regenerate IoT Hub control plane to match latest swagger

### DIFF
--- a/sdk/iothub/azure-resourcemanager-iothub/src/main/java/com/azure/resourcemanager/iothub/IotHubManager.java
+++ b/sdk/iothub/azure-resourcemanager-iothub/src/main/java/com/azure/resourcemanager/iothub/IotHubManager.java
@@ -194,7 +194,7 @@ public final class IotHubManager {
                 .append("-")
                 .append("com.azure.resourcemanager.iothub")
                 .append("/")
-                .append("1.1.0");
+                .append("1.0.0");
             if (!Configuration.getGlobalConfiguration().get("AZURE_TELEMETRY_DISABLED", false)) {
                 userAgentBuilder
                     .append(" (")


### PR DESCRIPTION
Most of these changes appear to be from how autorest formats the code now vs the last time it generated, but the important part is that the isVerified flag in CertificateProperties.java is no longer write-only

This is the swagger change that is being captured by this pr:
https://github.com/Azure/azure-rest-api-specs/pull/15722