### PR TITLE
Added user-configurable retryWith options

### DIFF
--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosClientBuilder.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosClientBuilder.java
@@ -108,6 +108,7 @@ public class CosmosClientBuilder {
     private boolean multipleWriteRegionsEnabled = true;
     private boolean readRequestsFallbackEnabled = true;
     private boolean clientTelemetryEnabled = false;
+    private RetryWithOptions retryWithOptions;
 
     /**
      * Instantiates a new Cosmos client builder.
@@ -118,6 +119,7 @@ public class CosmosClientBuilder {
         //  Some default values
         this.userAgentSuffix = "";
         this.throttlingRetryOptions = new ThrottlingRetryOptions();
+        this.retryWithOptions = new RetryWithOptions();
     }
 
     CosmosClientBuilder metadataCaches(CosmosClientMetadataCachesSnapshot metadataCachesSnapshot) {
@@ -632,6 +634,24 @@ public class CosmosClientBuilder {
     }
 
     /**
+     * Sets the configuration for the retry-with policy that gets applied when
+     * a request hits a RetryWithException with custom values rather than default ones.
+     *<p>
+     * DEFAULT values for these options are as follows:
+     * initialRetryIntervalMilliseconds = 10
+     * maximumRetryIntervalMilliseconds = 1000
+     * randomSaltMaxValueMilliseconds = 5
+     * totalWaitTimeMilliseconds = 30000
+     *
+     * @param retryWithOptions options for retry-with policy.
+     * @return current CosmosClientBuilder
+     */
+    public CosmosClientBuilder retryWithOptions(RetryWithOptions retryWithOptions) {
+        this.retryWithOptions = retryWithOptions;
+        return this;
+    }
+
+    /**
      * Gets the GATEWAY connection configuration to be used.
      *
      * @return gateway connection config
@@ -776,6 +796,7 @@ public class CosmosClientBuilder {
         this.connectionPolicy.setMultipleWriteRegionsEnabled(this.multipleWriteRegionsEnabled);
         this.connectionPolicy.setReadRequestsFallbackEnabled(this.readRequestsFallbackEnabled);
         this.connectionPolicy.setClientTelemetryEnabled(this.clientTelemetryEnabled);
+        this.connectionPolicy.setRetryWithOptions(this.retryWithOptions);
     }
 
     private void validateConfig() {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/RetryWithOptions.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/RetryWithOptions.java
@@ -1,0 +1,146 @@
+package com.azure.cosmos;
+
+/**
+ * Encapsulates options for RetryWithException failures in the Azure Cosmos DB database service.
+ */
+public class RetryWithOptions {
+    private Integer initialBackoffIntervalMilliseconds;
+    private Integer maximumBackoffIntervalMilliseconds;
+    private Integer randomSaltMaxValueMilliseconds;
+    private Integer totalWaitTimeMilliseconds;
+
+    public RetryWithOptions() {
+        this.initialBackoffIntervalMilliseconds = 10;
+        this.maximumBackoffIntervalMilliseconds = 1000;
+        this.randomSaltMaxValueMilliseconds = null;
+        this.totalWaitTimeMilliseconds = 30000;
+    }
+
+    /**
+     * Gets the initial backoff retry duration.
+     *
+     * @return the initial backoff retry duration.
+     */
+    public Integer getInitialBackoffForRetryWith() {
+        return this.initialBackoffIntervalMilliseconds;
+    }
+
+    /**
+     * Sets the initial delay retry time in milliseconds.
+     * <p>
+     * When a request hits a RetryWithException, the client delays and retries the request.
+     * The initialRetryIntervalMilliseconds flag allows the application to set an initial delay
+     * retry time for all retry attempts on this operation. This covers errors that occur due to
+     * concurrency errors in the store.
+     * <p>
+     * The default value is 10 milliseconds.
+     *
+     * @param initialRetryIntervalMilliseconds the initial delay duration for requests to be retried.
+     * @throws IllegalArgumentException thrown if an error occurs
+     */
+    public RetryWithOptions setInitialBackoffForRetryWith(Integer initialRetryIntervalMilliseconds) {
+        if (initialRetryIntervalMilliseconds < 0 || initialRetryIntervalMilliseconds > Integer.MAX_VALUE / 1000) {
+            throw new IllegalArgumentException(
+                "value must be a positive integer between the range of 0 to " + Integer.MAX_VALUE / 1000);
+        }
+        this.initialBackoffIntervalMilliseconds = initialRetryIntervalMilliseconds;
+        return this;
+    }
+
+    /**
+     * Gets the maximum delay retry duration.
+     *
+     * @return the maximum delay retry duration.
+     */
+    public Integer getMaximumBackoffForRetryWith() {
+        return this.maximumBackoffIntervalMilliseconds;
+    }
+
+    /**
+     * Sets the maximum delay retry time in milliseconds to use during retry with operations.
+     * <p>
+     * When a request hits a RetryWithException, the client delays and retries the request.
+     * The maximumRetryIntervalMilliseconds flag allows the application to set a maximum delay
+     * retry time for all retry attempts on this operation. This covers errors that occur due to
+     * concurrency errors in the store.
+     * <p>
+     * The default value is 1000 milliseconds.
+     *
+     * @param maximumRetryIntervalMilliseconds the maximum delay duration for requests to be retried.
+     * @throws IllegalArgumentException thrown if an error occurs
+     */
+    public RetryWithOptions setMaximumBackoffForRetryWith(Integer maximumRetryIntervalMilliseconds) {
+        if (maximumRetryIntervalMilliseconds < 0 || maximumRetryIntervalMilliseconds > Integer.MAX_VALUE / 1000) {
+            throw new IllegalArgumentException(
+                "value must be a positive integer between the range of 0 to " + Integer.MAX_VALUE / 1000);
+        }
+        this.maximumBackoffIntervalMilliseconds = maximumRetryIntervalMilliseconds;
+        return this;
+    }
+
+    /**
+     * Gets the maximum random salt value to use during retry with operations.
+     *
+     * @return the maximum random salt retry value.
+     */
+    public Integer getRandomSaltForRetryWith() {
+        return this.randomSaltMaxValueMilliseconds;
+    }
+
+    /**
+     * Sets the maximum random salt retry value in milliseconds.
+     * <p>
+     * When a request hits a RetryWithException, the client delays and retries the request.
+     * The randomSaltMaxValue flag allows the application to set a random salt value
+     * time for all retry attempts on this operation. This will spread the retry values from 1...n
+     * from the exponential backoff subscribed. This covers errors that occur due to
+     * concurrency errors in the store.
+     * <p>
+     * The default value is not to salt.
+     *
+     * @param randomSaltMaxValueMilliseconds the maximum random salt value for requests to be retried.
+     * @throws IllegalArgumentException thrown if an error occurs
+     */
+    public RetryWithOptions setRandomSaltForRetryWith(Integer randomSaltMaxValueMilliseconds) {
+        if (randomSaltMaxValueMilliseconds != null && (randomSaltMaxValueMilliseconds < 0 || randomSaltMaxValueMilliseconds > Integer.MAX_VALUE / 1000)) {
+            throw new IllegalArgumentException(
+                "value must be a positive integer between the range of 0 to " + Integer.MAX_VALUE / 1000);
+        }
+        this.randomSaltMaxValueMilliseconds = randomSaltMaxValueMilliseconds;
+        return this;
+    }
+
+
+
+    /**
+     * Gets the total wait time retry duration.
+     *
+     * @return the total wait time retry duration.
+     */
+    public Integer getTotalWaitTimeForRetryWith() {
+        return this.totalWaitTimeMilliseconds;
+    }
+
+    /**
+     * Sets the total wait time retry duration in milliseconds.
+     * <p>
+     * When a request hits a RetryWithException, the client delays and retries the request.
+     * The totalWaitTime flag allows the application to set a total delay retry time duration
+     * for all retry attempts on this operation, after which the request will be failed.
+     * This covers errors that occur due to concurrency errors in the store.
+     * <p>
+     * The default value is 30 seconds.
+     *
+     * @param totalWaitTimeMilliseconds the maximum random salt value for a request to be retried.
+     * @throws IllegalArgumentException thrown if an error occurs
+     */
+    public RetryWithOptions setTotalWaitTimeForRetryWith(Integer totalWaitTimeMilliseconds) {
+        if (totalWaitTimeMilliseconds < 0 || totalWaitTimeMilliseconds > Integer.MAX_VALUE / 1000) {
+            throw new IllegalArgumentException(
+                "value must be a positive integer between the range of 0 to " + Integer.MAX_VALUE / 1000);
+        }
+        this.totalWaitTimeMilliseconds = totalWaitTimeMilliseconds;
+        return this;
+    }
+
+}

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ConnectionPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ConnectionPolicy.java
@@ -9,6 +9,7 @@ import com.azure.cosmos.ConnectionMode;
 import com.azure.cosmos.DirectConnectionConfig;
 import com.azure.cosmos.GatewayConnectionConfig;
 import com.azure.cosmos.ThrottlingRetryOptions;
+import com.azure.cosmos.RetryWithOptions;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -29,6 +30,7 @@ public final class ConnectionPolicy {
     private boolean readRequestsFallbackEnabled;
     private ThrottlingRetryOptions throttlingRetryOptions;
     private String userAgentSuffix;
+    private RetryWithOptions retryWithOptions;
 
     //  Gateway connection config properties
     private int maxConnectionPoolSize;
@@ -69,6 +71,7 @@ public final class ConnectionPolicy {
         this.maxRequestsPerConnection = directConnectionConfig.getMaxRequestsPerConnection();
         this.requestTimeout = BridgeInternal.getRequestTimeoutFromDirectConnectionConfig(directConnectionConfig);
         this.tcpConnectionEndpointRediscoveryEnabled = directConnectionConfig.isConnectionEndpointRediscoveryEnabled();
+        this.setRetryWithOptions(new RetryWithOptions());
     }
 
     private ConnectionPolicy(ConnectionMode connectionMode) {
@@ -79,6 +82,7 @@ public final class ConnectionPolicy {
         this.multipleWriteRegionsEnabled = true;
         this.readRequestsFallbackEnabled = true;
         this.throttlingRetryOptions = new ThrottlingRetryOptions();
+        this.retryWithOptions = new RetryWithOptions();
         this.userAgentSuffix = "";
     }
 
@@ -273,6 +277,36 @@ public final class ConnectionPolicy {
         }
 
         this.throttlingRetryOptions = throttlingRetryOptions;
+        return this;
+    }
+
+    /**
+     * Gets the retry policy options associated with the DocumentClient instance.
+     *
+     * @return the RetryOptions instance.
+     */
+    public RetryWithOptions getRetryWithOptions() {
+        return this.retryWithOptions;
+    }
+
+    /**
+     * Sets the retry policy options associated with the DocumentClient instance.
+     * <p>
+     * Properties in the RetryOptions class allow application to customize the built-in
+     * retry policies. This property is optional. When it's not set, the SDK uses the
+     * default values for configuring the retry policies.  See RetryOptions class for
+     * more details.
+     *
+     * @param retryWithOptions the RetryOptions instance.
+     * @return the ConnectionPolicy.
+     * @throws IllegalArgumentException thrown if an error occurs
+     */
+    public ConnectionPolicy setRetryWithOptions(RetryWithOptions retryWithOptions) {
+        if (retryWithOptions == null) {
+            throw new IllegalArgumentException("retryWithOptions value must not be null.");
+        }
+
+        this.retryWithOptions = retryWithOptions;
         return this;
     }
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RetryWithException.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RetryWithException.java
@@ -31,6 +31,10 @@ public class RetryWithException extends CosmosException {
         BridgeInternal.setPartitionKeyRangeId(this, partitionKeyRangeId);
     }
 
+    public RetryWithException() {
+        this(RMResources.RetryWith, null);
+    }
+
     RetryWithException(String message, URI requestUri) {
         this(message, null, null, requestUri);
     }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
@@ -483,7 +483,8 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
             this.connectionPolicy,
             // this.maxConcurrentConnectionOpenRequests,
             this.userAgentContainer,
-            this.connectionSharingAcrossClientsEnabled
+            this.connectionSharingAcrossClientsEnabled,
+            this.connectionPolicy.getRetryWithOptions()
         );
 
         this.createStoreModel(true);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/StoreClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/StoreClient.java
@@ -6,6 +6,7 @@ package com.azure.cosmos.implementation.directconnectivity;
 import com.azure.cosmos.BridgeInternal;
 import com.azure.cosmos.ConsistencyLevel;
 import com.azure.cosmos.CosmosException;
+import com.azure.cosmos.RetryWithOptions;
 import com.azure.cosmos.implementation.DiagnosticsClientContext;
 import com.azure.cosmos.implementation.InternalServerErrorException;
 import com.azure.cosmos.implementation.BackoffRetryUtility;
@@ -50,6 +51,7 @@ public class StoreClient implements IStoreClient {
     private final ReplicatedResourceClient replicatedResourceClient;
     private final TransportClient transportClient;
     private final String ZERO_PARTITION_KEY_RANGE = "0";
+    private final RetryWithOptions retryWithOptions = new RetryWithOptions();
 
     public StoreClient(
             DiagnosticsClientContext diagnosticsClientContext,
@@ -58,7 +60,8 @@ public class StoreClient implements IStoreClient {
             SessionContainer sessionContainer,
             GatewayServiceConfigurationReader serviceConfigurationReader, IAuthorizationTokenProvider userTokenProvider,
             TransportClient transportClient,
-            boolean useMultipleWriteLocations) {
+            boolean useMultipleWriteLocations,
+            RetryWithOptions retryWithOptions) {
         this.diagnosticsClientContext = diagnosticsClientContext;
         this.transportClient = transportClient;
         this.sessionContainer = sessionContainer;
@@ -72,7 +75,8 @@ public class StoreClient implements IStoreClient {
             serviceConfigurationReader,
             userTokenProvider,
             false,
-            useMultipleWriteLocations);
+            useMultipleWriteLocations,
+            retryWithOptions);
     }
 
     public void enableThroughputControl(ThroughputControlStore throughputControlStore) {
@@ -85,7 +89,7 @@ public class StoreClient implements IStoreClient {
             throw new NullPointerException("request");
         }
 
-        Callable<Mono<StoreResponse>> storeResponseDelegate = () -> this.replicatedResourceClient.invokeAsync(request, prepareRequestAsyncDelegate);
+        Callable<Mono<StoreResponse>> storeResponseDelegate = () -> this.replicatedResourceClient.invokeAsync(request, prepareRequestAsyncDelegate, retryWithOptions);
 
         Mono<StoreResponse> storeResponse;
         try {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/StoreClientFactory.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/StoreClientFactory.java
@@ -3,6 +3,7 @@
 
 package com.azure.cosmos.implementation.directconnectivity;
 
+import com.azure.cosmos.RetryWithOptions;
 import com.azure.cosmos.implementation.Configs;
 import com.azure.cosmos.implementation.ConnectionPolicy;
 import com.azure.cosmos.implementation.DiagnosticsClientContext;
@@ -21,6 +22,7 @@ public class StoreClientFactory implements AutoCloseable {
     private final Configs configs;
     private final TransportClient transportClient;
     private volatile boolean isClosed;
+    private final RetryWithOptions retryWithOptions;
 
     public StoreClientFactory(
         IAddressResolver addressResolver,
@@ -28,7 +30,8 @@ public class StoreClientFactory implements AutoCloseable {
         Configs configs,
         ConnectionPolicy connectionPolicy,
         UserAgentContainer userAgent,
-        boolean enableTransportClientSharing) {
+        boolean enableTransportClientSharing,
+        RetryWithOptions retryWithOptions) {
 
         this.configs = configs;
         Protocol protocol = configs.getProtocol();
@@ -54,6 +57,7 @@ public class StoreClientFactory implements AutoCloseable {
                 throw new IllegalArgumentException(String.format("protocol: %s", protocol));
             }
         }
+        this.retryWithOptions = retryWithOptions;
     }
 
     public void close() throws Exception {
@@ -80,7 +84,8 @@ public class StoreClientFactory implements AutoCloseable {
             serviceConfigurationReader,
             authorizationTokenProvider,
             this.transportClient,
-            useMultipleWriteLocations);
+            useMultipleWriteLocations,
+            this.retryWithOptions);
     }
 
     private void throwIfClosed() {

--- a/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/GoneAndRetryWithRetryPolicyTest.java
+++ b/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/GoneAndRetryWithRetryPolicyTest.java
@@ -16,6 +16,8 @@ import com.azure.cosmos.implementation.RequestTimeoutException;
 import com.azure.cosmos.implementation.ResourceType;
 import com.azure.cosmos.implementation.RxDocumentServiceRequest;
 import com.azure.cosmos.implementation.ShouldRetryResult;
+import com.azure.cosmos.implementation.RetryWithException;
+import com.azure.cosmos.RetryWithOptions;
 import com.azure.cosmos.implementation.guava25.base.Supplier;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Mono;
@@ -40,7 +42,7 @@ public class GoneAndRetryWithRetryPolicyTest {
             mockDiagnosticsClientContext(),
             OperationType.Read,
             ResourceType.Document);
-        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30);
+        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30, new RetryWithOptions());
         Mono<ShouldRetryResult> singleShouldRetry = goneAndRetryWithRetryPolicy
                 .shouldRetry(new GoneException());
         ShouldRetryResult shouldRetryResult = singleShouldRetry.block();
@@ -82,7 +84,7 @@ public class GoneAndRetryWithRetryPolicyTest {
             mockDiagnosticsClientContext(),
             OperationType.Create,
             ResourceType.Document);
-        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30);
+        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30, new RetryWithOptions());
 
         Supplier<GoneException> goneExceptionForNotYetFlushedRequestSupplier = () -> {
             GoneException goneExceptionForNotYetFlushedRequest = new GoneException();
@@ -140,7 +142,7 @@ public class GoneAndRetryWithRetryPolicyTest {
             return goneExceptionForFlushedRequest;
         };
 
-        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30);
+        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30, new RetryWithOptions());
         Mono<ShouldRetryResult> singleShouldRetry = goneAndRetryWithRetryPolicy
             .shouldRetry(goneExceptionForFlushedRequestSupplier.get());
         ShouldRetryResult shouldRetryResult = singleShouldRetry.block();
@@ -164,7 +166,7 @@ public class GoneAndRetryWithRetryPolicyTest {
             OperationType.Create,
             ResourceType.Document);
         GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy =
-            new GoneAndRetryWithRetryPolicy(request, 30);
+            new GoneAndRetryWithRetryPolicy(request, 30, new RetryWithOptions());
 
         Supplier<GoneException> goneExceptionForFlushedRequestSupplier = () -> {
             GoneException goneExceptionForFlushedRequest = new GoneException();
@@ -214,7 +216,7 @@ public class GoneAndRetryWithRetryPolicyTest {
             OperationType.Read,
             ResourceType.Document);
 
-        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30);
+        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30, new RetryWithOptions());
         Mono<ShouldRetryResult> singleShouldRetry = goneAndRetryWithRetryPolicy
             .shouldRetry(new RequestTimeoutException());
         ShouldRetryResult shouldRetryResult = singleShouldRetry.block();
@@ -228,7 +230,7 @@ public class GoneAndRetryWithRetryPolicyTest {
             OperationType.Create,
             ResourceType.Document);
 
-        goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30);
+        goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30, new RetryWithOptions());
         singleShouldRetry = goneAndRetryWithRetryPolicy
             .shouldRetry(new RequestTimeoutException());
         shouldRetryResult = singleShouldRetry.block();
@@ -247,7 +249,7 @@ public class GoneAndRetryWithRetryPolicyTest {
             mockDiagnosticsClientContext(),
             OperationType.Read,
             ResourceType.Document);
-        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30);
+        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30, new RetryWithOptions());
         Mono<ShouldRetryResult> singleShouldRetry = goneAndRetryWithRetryPolicy
                 .shouldRetry(new PartitionIsMigratingException());
         ShouldRetryResult shouldRetryResult = singleShouldRetry.block();
@@ -265,7 +267,7 @@ public class GoneAndRetryWithRetryPolicyTest {
             mockDiagnosticsClientContext(),
             OperationType.Read,
             ResourceType.Document);
-        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30);
+        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30, new RetryWithOptions());
         Mono<ShouldRetryResult> singleShouldRetry = goneAndRetryWithRetryPolicy
                 .shouldRetry(new InvalidPartitionException());
         ShouldRetryResult shouldRetryResult = singleShouldRetry.block();
@@ -293,7 +295,7 @@ public class GoneAndRetryWithRetryPolicyTest {
             mockDiagnosticsClientContext(),
             OperationType.Read,
             ResourceType.Document);
-        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30);
+        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30, new RetryWithOptions());
         Mono<ShouldRetryResult> singleShouldRetry = goneAndRetryWithRetryPolicy
                 .shouldRetry(new PartitionKeyRangeIsSplittingException());
         ShouldRetryResult shouldRetryResult = singleShouldRetry.block();
@@ -314,11 +316,98 @@ public class GoneAndRetryWithRetryPolicyTest {
             mockDiagnosticsClientContext(),
             OperationType.Read,
             ResourceType.Document);
-        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30);
+        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30, new RetryWithOptions());
         Mono<ShouldRetryResult> singleShouldRetry = goneAndRetryWithRetryPolicy
                 .shouldRetry(new BadRequestException());
         ShouldRetryResult shouldRetryResult = singleShouldRetry.block();
         assertThat(shouldRetryResult.shouldRetry).isFalse();
+    }
+
+    /**
+     * Test for default retryWith values
+     */
+    @Test(groups = { "unit" }, timeOut = TIMEOUT)
+    public void retryWithDefaultTimeouts() {
+        int expectedDelayInMs = 10;
+        RxDocumentServiceRequest request = RxDocumentServiceRequest.create(
+            mockDiagnosticsClientContext(),
+            OperationType.Create,
+            ResourceType.Document);
+        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30, new RetryWithOptions());
+
+        RetryWithException retryWithException = new RetryWithException();
+
+        Mono<ShouldRetryResult> singleShouldRetry = goneAndRetryWithRetryPolicy.shouldRetry(retryWithException);
+        ShouldRetryResult shouldRetryResult = singleShouldRetry.block();
+        assertThat(shouldRetryResult.policyArg.getValue3()).isEqualTo(1);
+        validateRetryWithTimeRange(expectedDelayInMs, shouldRetryResult, null);
+
+        singleShouldRetry = goneAndRetryWithRetryPolicy.shouldRetry(retryWithException);
+        shouldRetryResult = singleShouldRetry.block();
+        assertThat(shouldRetryResult.policyArg.getValue3()).isEqualTo(2);
+        expectedDelayInMs = expectedDelayInMs * 2; //backoff multiplier
+        validateRetryWithTimeRange(expectedDelayInMs, shouldRetryResult, null);
+
+        singleShouldRetry = goneAndRetryWithRetryPolicy.shouldRetry(retryWithException);
+        shouldRetryResult = singleShouldRetry.block();
+        assertThat(shouldRetryResult.policyArg.getValue3()).isEqualTo(3);
+        expectedDelayInMs = expectedDelayInMs * 2; //backoff multiplier
+        validateRetryWithTimeRange(expectedDelayInMs, shouldRetryResult, null);
+    }
+
+    /**
+     * Test for custom retryWith values
+     */
+    @Test(groups = { "unit" }, timeOut = TIMEOUT)
+    public void retryWithCustomTimeouts() {
+        int customInitialDelayInMs = 11;
+        int customMaximumDelayInMs = 900;
+        int customSalt = 3;
+        int customTotalTime = 20000;
+        RxDocumentServiceRequest request = RxDocumentServiceRequest.create(
+            mockDiagnosticsClientContext(),
+            OperationType.Create,
+            ResourceType.Document);
+        RetryWithOptions retryWithOptions = new RetryWithOptions()
+            .setInitialBackoffForRetryWith(customInitialDelayInMs)
+            .setMaximumBackoffForRetryWith(customMaximumDelayInMs)
+            .setRandomSaltForRetryWith(customSalt)
+            .setTotalWaitTimeForRetryWith(customTotalTime);
+        GoneAndRetryWithRetryPolicy goneAndRetryWithRetryPolicy = new GoneAndRetryWithRetryPolicy(request, 30, retryWithOptions);
+
+        RetryWithException retryWithException = new RetryWithException();
+
+        Mono<ShouldRetryResult> singleShouldRetry = goneAndRetryWithRetryPolicy.shouldRetry(retryWithException);
+        ShouldRetryResult shouldRetryResult = singleShouldRetry.block();
+        assertThat(shouldRetryResult.policyArg.getValue3()).isEqualTo(1);
+        validateRetryWithTimeRange(customInitialDelayInMs, shouldRetryResult, customSalt);
+
+        singleShouldRetry = goneAndRetryWithRetryPolicy.shouldRetry(retryWithException);
+        shouldRetryResult = singleShouldRetry.block();
+        assertThat(shouldRetryResult.policyArg.getValue3()).isEqualTo(2);
+        customInitialDelayInMs = customInitialDelayInMs * 2; //backoff multiplier
+        validateRetryWithTimeRange(customInitialDelayInMs, shouldRetryResult, customSalt);
+
+        singleShouldRetry = goneAndRetryWithRetryPolicy.shouldRetry(retryWithException);
+        shouldRetryResult = singleShouldRetry.block();
+        assertThat(shouldRetryResult.policyArg.getValue3()).isEqualTo(3);
+        customInitialDelayInMs = customInitialDelayInMs * 2; //backoff multiplier
+        validateRetryWithTimeRange(customInitialDelayInMs, shouldRetryResult, customSalt);
+    }
+
+    private static void validateRetryWithTimeRange(
+        int expectedDelayInMs,
+        ShouldRetryResult retryResult,
+        Integer saltValueInMs) {
+        int saltValue = saltValueInMs == null ? 0 : saltValueInMs;
+        assertThat(retryResult.shouldRetry).isTrue();
+        assertThat(retryResult.backOffTime.toMillis() >= 0).isTrue();
+        if (saltValue == 0) {
+            assertThat(retryResult.backOffTime.toMillis() == expectedDelayInMs).isTrue();
+        } else {
+            assertThat(retryResult.backOffTime.toMillis() > expectedDelayInMs - saltValue).isTrue();
+            assertThat(retryResult.backOffTime.toMillis() < expectedDelayInMs + saltValue).isTrue();
+        }
     }
 
 }

--- a/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/ReplicatedResourceClientGoneForWriteTest.java
+++ b/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/ReplicatedResourceClientGoneForWriteTest.java
@@ -6,6 +6,7 @@ package com.azure.cosmos.implementation.directconnectivity;
 import com.azure.cosmos.BridgeInternal;
 import com.azure.cosmos.ConsistencyLevel;
 import com.azure.cosmos.CosmosException;
+import com.azure.cosmos.RetryWithOptions;
 import com.azure.cosmos.implementation.Configs;
 import com.azure.cosmos.implementation.DocumentServiceRequestContext;
 import com.azure.cosmos.implementation.FailureValidator;
@@ -96,7 +97,8 @@ public class ReplicatedResourceClientGoneForWriteTest {
             gatewayServiceConfigurationReaderWrapper.gatewayServiceConfigurationReader,
             authorizationTokenProvider,
             false,
-            false);
+            false,
+            new RetryWithOptions());
 
         RxDocumentServiceRequest request = RxDocumentServiceRequest.createFromName(
             mockDiagnosticsClientContext(),
@@ -107,7 +109,7 @@ public class ReplicatedResourceClientGoneForWriteTest {
         request.getHeaders().put(HttpConstants.HttpHeaders.CONSISTENCY_LEVEL, consistencyLevel.toString());
 
         Function<RxDocumentServiceRequest, Mono<RxDocumentServiceRequest>> prepareRequestAsyncDelegate = null;
-        Mono<StoreResponse> storeResponseObs = resourceClient.invokeAsync(request, prepareRequestAsyncDelegate);
+        Mono<StoreResponse> storeResponseObs = resourceClient.invokeAsync(request, prepareRequestAsyncDelegate, new RetryWithOptions());
 
         // Address refresh is happening in the background - allowing some time to finish the refresh
         // Because this is all using mocking (no emulator) the delay of a couple hundred ms should be sufficient

--- a/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/ReplicatedResourceClientPartitionSplitTest.java
+++ b/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/ReplicatedResourceClientPartitionSplitTest.java
@@ -5,6 +5,7 @@ package com.azure.cosmos.implementation.directconnectivity;
 
 import com.azure.cosmos.ConsistencyLevel;
 import com.azure.cosmos.CosmosException;
+import com.azure.cosmos.RetryWithOptions;
 import com.azure.cosmos.implementation.Configs;
 import com.azure.cosmos.implementation.DocumentServiceRequestContext;
 import com.azure.cosmos.implementation.FailureValidator;
@@ -122,7 +123,8 @@ public class ReplicatedResourceClientPartitionSplitTest {
                                                                                gatewayServiceConfigurationReaderWrapper.gatewayServiceConfigurationReader,
                                                                                authorizationTokenProvider,
                                                                                false,
-                                                                               false);
+                                                                               false,
+                                                                                new RetryWithOptions());
 
         RxDocumentServiceRequest request = RxDocumentServiceRequest.createFromName(mockDiagnosticsClientContext(),
                 OperationType.Read, "/dbs/db/colls/col/docs/docId", ResourceType.Document);
@@ -131,7 +133,7 @@ public class ReplicatedResourceClientPartitionSplitTest {
         request.getHeaders().put(HttpConstants.HttpHeaders.CONSISTENCY_LEVEL, consistencyLevel.toString());
 
         Function<RxDocumentServiceRequest, Mono<RxDocumentServiceRequest>> prepareRequestAsyncDelegate = null;
-        Mono<StoreResponse> storeResponseObs = resourceClient.invokeAsync(request, prepareRequestAsyncDelegate);
+        Mono<StoreResponse> storeResponseObs = resourceClient.invokeAsync(request, prepareRequestAsyncDelegate, new RetryWithOptions());
 
         if (partitionIsSplitting < Integer.MAX_VALUE) {
 

--- a/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/ReplicatedResourceClientRetryWithTest.java
+++ b/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/ReplicatedResourceClientRetryWithTest.java
@@ -4,6 +4,7 @@
 package com.azure.cosmos.implementation.directconnectivity;
 
 import com.azure.cosmos.ConsistencyLevel;
+import com.azure.cosmos.RetryWithOptions;
 import com.azure.cosmos.implementation.Configs;
 import com.azure.cosmos.implementation.DocumentServiceRequestContext;
 import com.azure.cosmos.implementation.HttpConstants;
@@ -74,19 +75,19 @@ public class ReplicatedResourceClientRetryWithTest {
                 primaryAddress,
                 OperationType.Create,
                 ResourceType.Document,
-                new RetryWithException("Simultated 449 conflict", new HttpHeaders(), new URI("http://localhost")),
+                new RetryWithException("Simulated 449 conflict", new HttpHeaders(), new URI("http://localhost")),
                 false)
             .exceptionOn(
                 primaryAddress,
                 OperationType.Create,
                 ResourceType.Document,
-                new RetryWithException("Simultated 449 conflict", new HttpHeaders(), new URI("http://localhost")),
+                new RetryWithException("Simulated 449 conflict", new HttpHeaders(), new URI("http://localhost")),
                 false)
             .exceptionOn(
                 primaryAddress,
                 OperationType.Create,
                 ResourceType.Document,
-                new RetryWithException("Simultated 449 conflict", new HttpHeaders(), new URI("http://localhost")),
+                new RetryWithException("Simulated 449 conflict", new HttpHeaders(), new URI("http://localhost")),
                 false)
             .storeResponseOn(
                 primaryAddress,
@@ -115,7 +116,8 @@ public class ReplicatedResourceClientRetryWithTest {
             gatewayServiceConfigurationReaderWrapper.gatewayServiceConfigurationReader,
             authorizationTokenProvider,
             false,
-            false);
+            false,
+            new RetryWithOptions());
 
         RxDocumentServiceRequest request = RxDocumentServiceRequest.createFromName(mockDiagnosticsClientContext(),
             OperationType.Create, "/dbs/db/colls/col/docs", ResourceType.Document);
@@ -126,7 +128,7 @@ public class ReplicatedResourceClientRetryWithTest {
         Function<RxDocumentServiceRequest, Mono<RxDocumentServiceRequest>> prepareRequestAsyncDelegate = null;
 
         Instant start = Instant.now();
-        Mono<StoreResponse> storeResponseObs = resourceClient.invokeAsync(request, prepareRequestAsyncDelegate);
+        Mono<StoreResponse> storeResponseObs = resourceClient.invokeAsync(request, prepareRequestAsyncDelegate, new RetryWithOptions());
 
         StoreResponseValidator validator = StoreResponseValidator.create()
                                                                  .withBELSN(lsn)

--- a/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/StoreReaderDotNetTest.java
+++ b/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/StoreReaderDotNetTest.java
@@ -5,6 +5,7 @@ package com.azure.cosmos.implementation.directconnectivity;
 
 import com.azure.cosmos.BridgeInternal;
 import com.azure.cosmos.ConsistencyLevel;
+import com.azure.cosmos.RetryWithOptions;
 import com.azure.cosmos.implementation.AuthorizationTokenType;
 import com.azure.cosmos.implementation.Configs;
 import com.azure.cosmos.implementation.DocumentServiceRequestContext;
@@ -626,7 +627,7 @@ public class StoreReaderDotNetTest {
         Mockito.when(mockServiceConfigReader.getUserReplicationPolicy()).thenReturn(replicationPolicy);
 
         try {
-            StoreClient storeClient = new StoreClient(mockDiagnosticsClientContext(), new Configs(),mockAddressCache, sessionContainer, mockServiceConfigReader, mockAuthorizationTokenProvider, mockTransportClient, false);
+            StoreClient storeClient = new StoreClient(mockDiagnosticsClientContext(), new Configs(),mockAddressCache, sessionContainer, mockServiceConfigReader, mockAuthorizationTokenProvider, mockTransportClient, false, new RetryWithOptions());
 
             ServerStoreModel storeModel = new ServerStoreModel(storeClient);
             Mono<RxDocumentServiceResponse> result = storeModel.processMessage(entity).single();


### PR DESCRIPTION
This change was previously made in the .NET SDK and is now here for Java.

With this change, users will be able to add their own configurable timeout and backoff values (in milliseconds) for the retryWith policy that gets executed for requests that run into error code 449 after a failed request due to concurrency errors.

The configurable integer options are as follows:
_initialBackoffIntervalMilliseconds_: the initial delay for the retry requests, default is 10ms
_maximumBackoffIntervalMilliseconds_: the maximum delay for the retry requests, default is 1000ms (1s)
_randomSaltMaxValueMilliseconds_: a random value in this range (exclusive) will be added to the current backoff to help avoid conflicts on retries, default is set to not salt
_totalWaitTimeMilliseconds_: the total wait time cap after which a request will be failed if reached, default is 30000ms (30s)