### PR TITLE
Adding force refresh header for partition address gateway call during partition split

### DIFF
--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/GoneAndRetryWithRetryPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/GoneAndRetryWithRetryPolicy.java
@@ -265,7 +265,7 @@ public class GoneAndRetryWithRetryPolicy implements IRetryPolicy {
             this.request.requestContext.quorumSelectedStoreResponse = null;
             logger.debug("Received partition key range splitting exception, will retry, {}", exception.toString());
             this.request.forcePartitionKeyRangeRefresh = true;
-            return Pair.of(null, false);
+            return Pair.of(null, true);
         }
 
         private Pair<Mono<ShouldRetryResult>, Boolean> handleInvalidPartitionException(InvalidPartitionException exception) {

--- a/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/GoneAndRetryWithRetryPolicyTest.java
+++ b/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/implementation/directconnectivity/GoneAndRetryWithRetryPolicyTest.java
@@ -301,7 +301,7 @@ public class GoneAndRetryWithRetryPolicyTest {
         assertThat(request.forcePartitionKeyRangeRefresh).isTrue();
         assertThat(request.requestContext.resolvedPartitionKeyRange).isNull();
         assertThat(request.requestContext.quorumSelectedLSN).isEqualTo(-1);
-        assertThat(shouldRetryResult.policyArg.getValue0()).isFalse();
+        assertThat(shouldRetryResult.policyArg.getValue0()).isTrue();
 
     }
 


### PR DESCRIPTION
We are currently sending force refresh flag during transient gone exception from the sdk to gateway so gateway can refresh their cache and send updated address.
With this PR we will be sending force refresh flag on 410/1007 as well
