### PR TITLE
Update version to prepare for GA release

### DIFF
--- a/eng/jacoco-test-coverage/pom.xml
+++ b/eng/jacoco-test-coverage/pom.xml
@@ -244,7 +244,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-monitor-query</artifactId>
-      <version>1.0.0-beta.5</version> <!-- {x-version-update;com.azure:azure-monitor-query;current} -->
+      <version>1.0.0</version> <!-- {x-version-update;com.azure:azure-monitor-query;current} -->
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -103,7 +103,7 @@ com.azure:azure-messaging-webpubsub;1.0.0-beta.3;1.0.0-beta.4
 com.azure:azure-mixedreality-authentication;1.1.2;1.2.0-beta.1
 com.azure:azure-mixedreality-remoterendering;1.1.0;1.2.0-beta.1
 com.azure:azure-monitor-opentelemetry-exporter;1.0.0-beta.4;1.0.0-beta.5
-com.azure:azure-monitor-query;1.0.0-beta.4;1.0.0-beta.5
+com.azure:azure-monitor-query;1.0.0-beta.4;1.0.0
 com.azure:azure-monitor-query-perf;1.0.0-beta.1;1.0.0-beta.1
 com.azure:azure-quantum-jobs;1.0.0-beta.1;1.0.0-beta.2
 com.azure:azure-search-documents;11.4.3;11.5.0-beta.4

--- a/sdk/monitor/azure-monitor-query-perf/pom.xml
+++ b/sdk/monitor/azure-monitor-query-perf/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-monitor-query</artifactId>
-      <version>1.0.0-beta.5</version> <!-- {x-version-update;com.azure:azure-monitor-query;current} -->
+      <version>1.0.0</version> <!-- {x-version-update;com.azure:azure-monitor-query;current} -->
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/sdk/monitor/azure-monitor-query/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-query/CHANGELOG.md
@@ -1,14 +1,24 @@
 # Release History
 
-## 1.0.0-beta.5 (Unreleased)
+## 1.0.0 (2021-10-07)
 
 ### Features Added
+- Added `getMetricByName` API on `MetricsQueryResult` to get the metric result for a specific metric name.
+- Added `LogsQueryStatus` enum to specify if the query was successful, partially successful or failed.
 
 ### Breaking Changes
-
-### Bugs Fixed
+- Changed `query` API name in `LogsQuery*Client` to `queryWorkspace`
+- Changed `query` API name in `MetricsQuery*Client` to `queryResource`
+- Changed `addQuery` API name in `LogsQueryBatch` to `addWorkspaceQuery`
+- Removed `status` from `LogsBatchQueryResult`
+- Throws exception if a logs query is partially successful with an option in `LogsQueryOptions` to disable this 
+  behavior.
 
 ### Other Changes
+
+#### Dependency Updates
+- Upgraded `azure-core` to `1.21.0`.
+- Upgraded `azure-core-http-netty` to `1.11.1`.
 
 ## 1.0.0-beta.4 (2021-09-10)
 
@@ -23,8 +33,8 @@
 ### Other Changes 
 
 #### Dependency Updates
-- Upgraded `azure-core` from `1.18.0` to `1.19.0`.
-- Upgraded `azure-core-http-netty` from `1.10.1` to `1.10.2`.
+- Upgraded `azure-core` from `1.19.0` to `1.20.0`.
+- Upgraded `azure-core-http-netty` from `1.10.2` to `1.11.0`.
 
 
 ## 1.0.0-beta.3 (2021-08-11)

--- a/sdk/monitor/azure-monitor-query/README.md
+++ b/sdk/monitor/azure-monitor-query/README.md
@@ -32,7 +32,7 @@ Install the Azure Monitor Query client library for Java by adding the following 
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-monitor-query</artifactId>
-    <version>1.0.0-beta.4</version>
+    <version>1.0.0</version>
 </dependency>
 ```
 

--- a/sdk/monitor/azure-monitor-query/pom.xml
+++ b/sdk/monitor/azure-monitor-query/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.azure</groupId>
   <artifactId>azure-monitor-query</artifactId>
-  <version>1.0.0-beta.5</version> <!-- {x-version-update;com.azure:azure-monitor-query;current} -->
+  <version>1.0.0</version> <!-- {x-version-update;com.azure:azure-monitor-query;current} -->
 
   <name>Microsoft Azure SDK for Azure Monitor Logs and Metrics Query</name>
   <description>This package contains the Microsoft Azure SDK for querying Azure Monitor's Logs and Metrics data sources.</description>

--- a/sdk/monitor/pom.xml
+++ b/sdk/monitor/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
           <groupId>com.azure</groupId>
           <artifactId>azure-monitor-query</artifactId>
-          <version>1.0.0-beta.5</version> <!-- {x-version-update;com.azure:azure-monitor-query;current} -->
+          <version>1.0.0</version> <!-- {x-version-update;com.azure:azure-monitor-query;current} -->
         </dependency>
       </dependencies>
 


### PR DESCRIPTION
This PR prepares azure-monitor-query library for a GA release - version 1.0.0.