### PR TITLE
smallFixForGoneAndRetryPolicy

### DIFF
--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/GoneAndRetryWithRetryPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/GoneAndRetryWithRetryPolicy.java
@@ -54,11 +54,11 @@ public class GoneAndRetryWithRetryPolicy implements IRetryPolicy {
 
         return this.retryWithRetryPolicy.shouldRetry(exception)
                                         .flatMap((retryWithResult) -> {
-
-            if (retryWithResult.shouldRetry) {
+            if (!retryWithResult.nonRelatedException) {
                 return Mono.just(retryWithResult);
             }
 
+            // only pass request to gone retry policy if retryWithRetryPolicy can not handle the exception.
             return this.goneRetryPolicy.shouldRetry(exception)
                 .flatMap((goneRetryResult) -> {
                     if (!goneRetryResult.shouldRetry) {
@@ -109,7 +109,6 @@ public class GoneAndRetryWithRetryPolicy implements IRetryPolicy {
 
         private boolean isNonRetryableException(Exception exception) {
             if (exception instanceof GoneException ||
-                exception instanceof RetryWithException ||
                 exception instanceof PartitionIsMigratingException ||
                 exception instanceof PartitionKeyRangeIsSplittingException) {
 


### PR DESCRIPTION
Issue: 
when SDK constantly getting 449 back from server, there is a chance SDK will throw the following exception: 
![image](https://user-images.githubusercontent.com/64233642/136472990-91fcd677-023b-4da9-8395-b5ff4c5ea655.png)
