### PR TITLE
Changed Issue Tag Reference for Good First Issues Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 Many people all over the world have helped make this project better.  You'll want to check out:
 
-- [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-java/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
+- [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-java/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
 - [How to build and test your change](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
 - [How you can make a change happen!](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#pull-requests)
 - Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for Java wiki](https://github.com/azure/azure-sdk-for-java/wiki).


### PR DESCRIPTION
Fixes #24691

Changed the issue tag being referenced in the contributing section from `up for grabs` to `help wanted` to reflect the changes made in issue tagging in the repository.