### PR TITLE
Removed the need for Maven parser for parsing BOM file

### DIFF
--- a/eng/bomgenerator/generateAzureSDKBOM.ps1
+++ b/eng/bomgenerator/generateAzureSDKBOM.ps1
@@ -6,7 +6,7 @@ $pomFileName = "pom.xml"
 $defaultVersionClientFilePath = Join-Path $inputDir $versionClientFileName
 $defaultPomFilePath = Join-Path $inputDir $pomFileName
 $versionClientFilePath = Join-Path $repoRoot "eng" "versioning" $versionClientFileName
-$bomPomFilePath = Join-Path $repoRoot "sdk" "containerregistry" "azure-containers-containerregistry" $pomFileName
+$bomPomFilePath = Join-Path $repoRoot "sdk" "boms" "azure-sdk-bom" $pomFileName
 
 if(! (Test-Path $inputDir)) { 
   New-Item -Path $PSScriptRoot -Name "inputDir" -ItemType "directory"
@@ -19,10 +19,6 @@ if(! (Test-Path $defaultVersionClientFilePath)) {
 if(! (Test-Path $defaultPomFilePath)) {
  Copy-Item $bomPomFilePath -Destination $inputDir
 }
-  
 
-"mvn exec:java -Dexec.args='-inputDir=$inputDir -outputDir=$outputDir -mode=analyze'"
-if($LASTEXITCODE -ne 0) {
-  LogError "Failed to generate the BOM."
-  exit 1
-}
+$mvnResults = mvn install
+$mvnResults = "mvn exec:java -Dexec.args=`"-inputDir=$inputDir -outputDir=$outputDir -mode=analyze`""

--- a/eng/bomgenerator/pom.xml
+++ b/eng/bomgenerator/pom.xml
@@ -76,6 +76,7 @@
           <arguments>
             <argument>-inputdir=${project.basedir}/inputdir</argument>
             <argument>-outputdir=${project.basedir}/outputdir</argument>
+            <argument>-mode=analyze</argument>
           </arguments>
           <cleanupDaemonThreads>false</cleanupDaemonThreads>
         </configuration>

--- a/eng/bomgenerator/src/main/java/com/azure/tools/bomgenerator/Utils.java
+++ b/eng/bomgenerator/src/main/java/com/azure/tools/bomgenerator/Utils.java
@@ -184,12 +184,19 @@ public class Utils {
 
     static List<BomDependency> parsePomFileContent(Reader responseStream) {
         List<BomDependency> bomDependencies = new ArrayList<>();
+        List<Dependency> dependencies;
 
         ObjectMapper mapper = new XmlMapper();
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         try {
             Model value = mapper.readValue(responseStream, Model.class);
-            List<Dependency> dependencies = value.getDependencies();
+            if(value.getPackaging().equalsIgnoreCase("pom")) {
+               // This is a bom file.
+                dependencies = value.getDependencyManagement().getDependencies();
+            }
+            else {
+                dependencies = value.getDependencies();
+            }
 
             if(dependencies == null) {
                 return bomDependencies;
@@ -213,46 +220,5 @@ public class Utils {
         }
 
         return bomDependencies.stream().distinct().collect(Collectors.toList());
-    }
-
-    static List<BomDependency> parseBomFileContent(Reader responseStream) {
-        MavenXpp3Reader reader = new MavenXpp3Reader();
-        try {
-            Model model = reader.read(responseStream);
-            DependencyManagement management = model.getDependencyManagement();
-
-            return management.getDependencies().stream().map(dep -> {
-                String version = getPropertyName(dep.getVersion());
-
-                while(model.getProperties().getProperty(version) != null) {
-                    version = getPropertyName(model.getProperties().getProperty(version));
-
-                    if(version.equals(PROJECT_VERSION)) {
-                        version = model.getVersion();
-                    }
-                }
-
-                if(version == null) {
-                    version = dep.getVersion();
-                }
-
-                BomDependency bomDependency = new BomDependency(dep.getGroupId(), dep.getArtifactId(), version);
-                return bomDependency;
-            }).collect(Collectors.toList());
-        } catch (IOException exception) {
-            exception.printStackTrace();
-        } catch (XmlPullParserException e) {
-            e.printStackTrace();
-        }
-
-        return null;
-    }
-
-    private static String getPropertyName(String propertyValue) {
-        if(propertyValue.startsWith("${")) {
-            return propertyValue.substring(2, propertyValue.length() - 1);
-        }
-
-        return propertyValue;
     }
 }


### PR DESCRIPTION
In order to support validation of single POM file we enabled support for parsing POM file which is not a BOM. Extending that support to now also include BOM file parsing and removing the special parsing of the BOM file via Maven plugin. 