### PR TITLE
Bump digital twin dataplane SDK version for 10/12/2021 release

### DIFF
--- a/eng/jacoco-test-coverage/pom.xml
+++ b/eng/jacoco-test-coverage/pom.xml
@@ -575,7 +575,7 @@
 	  <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-digitaltwins-core</artifactId>
-      <version>1.2.0-beta.1</version> <!-- {x-version-update;com.azure:azure-digitaltwins-core;current} -->
+      <version>1.1.3</version> <!-- {x-version-update;com.azure:azure-digitaltwins-core;current} -->
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -85,7 +85,7 @@ com.azure:azure-data-schemaregistry;1.0.0-beta.6;1.0.0-beta.7
 com.azure:azure-data-schemaregistry-apacheavro;1.0.0-beta.6;1.0.0-beta.7
 com.azure:azure-data-tables;12.1.3;12.2.0-beta.1
 com.azure:azure-data-tables-perf;1.0.0-beta.1;1.0.0-beta.1
-com.azure:azure-digitaltwins-core;1.1.2;1.2.0-beta.1
+com.azure:azure-digitaltwins-core;1.1.2;1.1.3
 com.azure:azure-e2e;1.0.0-beta.1;1.0.0-beta.1
 com.azure:azure-identity;1.3.7;1.4.0-beta.2
 com.azure:azure-identity-perf;1.0.0-beta.1;1.0.0-beta.1

--- a/sdk/digitaltwins/azure-digitaltwins-core/CHANGELOG.md
+++ b/sdk/digitaltwins/azure-digitaltwins-core/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.1.3 (2021-10-12)
 
 ### Other Changes
+#### Dependency updates
+- Upgraded `azure-core` dependency from `1.20.0` to `1.21.0`.
+  - [azure-core changelog](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core/CHANGELOG.md#1210-2021-10-01)
+- Upgraded `azure-core-http-netty` dependency from `1.11.0` to `1.11.1`.
+  - [azure-core-http-netty changelog](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core-http-netty/CHANGELOG.md#1111-2021-10-01)
+- Upgraded `azure-core-serializer-json-jackson` dependency from `1.2.7` to `1.2.8`.
+  - [azure-core-serializer-json-jackson changelog](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core-serializer-json-jackson/CHANGELOG.md#128-2021-10-01)
+- Upgraded `jackson-annotations` dependency from `2.12.4` to `2.12.5`.
 
 ## 1.1.2 (2021-09-10)
 

--- a/sdk/digitaltwins/azure-digitaltwins-core/README.md
+++ b/sdk/digitaltwins/azure-digitaltwins-core/README.md
@@ -51,7 +51,7 @@ add the direct dependency to your project as follows.
 <dependency>
   <groupId>com.azure</groupId>
   <artifactId>azure-digitaltwins-core</artifactId>
-  <version>1.1.2</version>
+  <version>1.1.3</version>
 </dependency>
 ```
 

--- a/sdk/digitaltwins/azure-digitaltwins-core/pom.xml
+++ b/sdk/digitaltwins/azure-digitaltwins-core/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.azure</groupId>
   <artifactId>azure-digitaltwins-core</artifactId>
-  <version>1.2.0-beta.1</version> <!-- {x-version-update;com.azure:azure-digitaltwins-core;current} -->
+  <version>1.1.3</version> <!-- {x-version-update;com.azure:azure-digitaltwins-core;current} -->
 
   <name>Microsoft Azure client library for Digital Twins</name>
   <description>This package contains the Microsoft Azure DigitalTwins client library.</description>

--- a/sdk/digitaltwins/pom.xml
+++ b/sdk/digitaltwins/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
           <groupId>com.azure</groupId>
           <artifactId>azure-digitaltwins-core</artifactId>
-          <version>1.2.0-beta.1</version> <!-- {x-version-update;com.azure:azure-digitaltwins-core;current} -->
+          <version>1.1.3</version> <!-- {x-version-update;com.azure:azure-digitaltwins-core;current} -->
         </dependency>
       </dependencies>
 


### PR DESCRIPTION
Just a patch release to capture the latest azure-core releases