### PR TITLE
Minor Performance Improvements in Storage

### DIFF
--- a/sdk/storage/azure-storage-blob-nio/src/main/java/com/azure/storage/blob/nio/AzureFileSystemProvider.java
+++ b/sdk/storage/azure-storage-blob-nio/src/main/java/com/azure/storage/blob/nio/AzureFileSystemProvider.java
@@ -1143,9 +1143,9 @@ public final class AzureFileSystemProvider extends FileSystemProvider {
 
         String endpoint = Flux.fromArray(uri.getQuery().split("&"))
                 .filter(s -> s.startsWith(ENDPOINT_QUERY_KEY + "="))
-                .switchIfEmpty(Mono.error(LoggingUtility.logError(this.logger, new IllegalArgumentException(
-                        "URI does not contain an \"" + ENDPOINT_QUERY_KEY + "=\" parameter. FileSystems require a URI "
-                            + "of the format \"azb://?endpoint=<endpoint>\""))))
+                .switchIfEmpty(Mono.defer(() -> Mono.error(LoggingUtility.logError(this.logger,
+                    new IllegalArgumentException("URI does not contain an \"" + ENDPOINT_QUERY_KEY + "=\" parameter. "
+                        + "FileSystems require a URI of the format \"azb://?endpoint=<endpoint>\"")))))
                 .map(s -> s.substring(ENDPOINT_QUERY_KEY.length() + 1)) // Trim the query key and =
                 .blockLast();
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/specialized/BlobAsyncClientBase.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/specialized/BlobAsyncClientBase.java
@@ -1122,7 +1122,7 @@ public class BlobAsyncClientBase {
                     },
                     finalOptions.getMaxRetryRequests(),
                     finalRange.getOffset()
-                ).switchIfEmpty(Flux.just(ByteBuffer.wrap(new byte[0])));
+                ).switchIfEmpty(Flux.defer(() -> Flux.just(ByteBuffer.wrap(new byte[0]))));
 
                 return new BlobDownloadAsyncResponse(response.getRequest(), response.getStatusCode(),
                     response.getHeaders(), bufferFlux, blobDownloadHeaders);

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/specialized/ReliableDownload.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/specialized/ReliableDownload.java
@@ -93,7 +93,7 @@ final class ReliableDownload {
             ? rawResponse.getValue().timeout(TIMEOUT_VALUE)
             : applyReliableDownload(rawResponse.getValue(), -1, options);
 
-        return value.switchIfEmpty(Flux.just(ByteBuffer.wrap(new byte[0])));
+        return value.switchIfEmpty(Flux.defer(() -> Flux.just(ByteBuffer.wrap(new byte[0]))));
     }
 
     private Flux<ByteBuffer> tryContinueFlux(Throwable t, int retryCount, DownloadRetryOptions options) {

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/Utility.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/Utility.java
@@ -21,6 +21,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Utility methods for storage client libraries.
@@ -51,6 +52,11 @@ public final class Utility {
      */
     private static final int MAX_PRECISION_DATESTRING_LENGTH = MAX_PRECISION_PATTERN.replaceAll("'", "")
             .length();
+    /**
+     * A compiled Pattern that finds 'Z'. This is used as Java 8's String.replace method uses Pattern.compile
+     * internally without simple case opt-outs.
+     */
+    private static final Pattern Z_PATTERN = Pattern.compile("Z");
 
 
     /**
@@ -193,11 +199,11 @@ public final class Utility {
                 break;
             case 23: // "yyyy-MM-dd'T'HH:mm:ss.SS'Z'"-> [2012-01-04T23:21:59.12Z] length = 23
                 // SS is assumed to be milliseconds, so a trailing 0 is necessary
-                dateString = dateString.replace("Z", "0");
+                dateString = Z_PATTERN.matcher(dateString).replaceAll("0");
                 break;
             case 22: // "yyyy-MM-dd'T'HH:mm:ss.S'Z'"-> [2012-01-04T23:21:59.1Z] length = 22
                 // S is assumed to be milliseconds, so trailing 0's are necessary
-                dateString = dateString.replace("Z", "00");
+                dateString = Z_PATTERN.matcher(dateString).replaceAll("00");
                 break;
             case 20: // "yyyy-MM-dd'T'HH:mm:ss'Z'"-> [2012-01-04T23:21:59Z] length = 20
                 pattern = Utility.ISO8601_PATTERN;

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/ScrubEtagPolicy.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/ScrubEtagPolicy.java
@@ -10,18 +10,19 @@ import com.azure.core.http.HttpPipelineNextPolicy;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.http.policy.HttpPipelinePolicy;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
+import java.util.regex.Pattern;
 
 /**
  * Wraps any potential error responses from the service and applies post processing of the response's eTag header to
  * standardize the value.
  */
 public class ScrubEtagPolicy implements HttpPipelinePolicy {
+    private static final Pattern QUOTE_PATTERN = Pattern.compile("\"");
     private static final String ETAG = "eTag";
 
     /**
@@ -49,9 +50,9 @@ public class ScrubEtagPolicy implements HttpPipelinePolicy {
         }
         String eTag = eTagHeader.getValue();
 
-        eTag = eTag.replace("\"", "");
+        eTag = QUOTE_PATTERN.matcher(eTag).replaceAll("");
         HttpHeaders headers = unprocessedResponse.getHeaders();
-        headers.put(eTagHeader.getName(), eTag);
+        headers.set(eTagHeader.getName(), eTag);
         return new InnerHttpResponse(unprocessedResponse, headers, unprocessedResponse.getRequest());
     }
 

--- a/sdk/storage/azure-storage-file-share/src/main/java/com/azure/storage/file/share/ShareFileAsyncClient.java
+++ b/sdk/storage/azure-storage-file-share/src/main/java/com/azure/storage/file/share/ShareFileAsyncClient.java
@@ -728,8 +728,8 @@ public class ShareFileAsyncClient {
     private Mono<Response<ShareFileProperties>> downloadResponseInChunk(Response<ShareFileProperties> response,
         AsynchronousFileChannel channel, ShareFileRange range, ShareRequestConditions requestConditions,
         Context context) {
-        return Mono.justOrEmpty(range).switchIfEmpty(Mono.just(new ShareFileRange(0, response.getValue()
-            .getContentLength())))
+        return Mono.justOrEmpty(range).switchIfEmpty(Mono.defer(() -> Mono.just(new ShareFileRange(0, response.getValue()
+            .getContentLength()))))
             .map(currentRange -> {
                 List<ShareFileRange> chunks = new ArrayList<>();
                 for (long pos = currentRange.getStart(); pos < currentRange.getEnd(); pos += FILE_DEFAULT_BLOCK_SIZE) {
@@ -925,7 +925,7 @@ public class ShareFileAsyncClient {
                     },
                     retryOptions.getMaxRetryRequests(),
                     range.getStart()
-                ).switchIfEmpty(Flux.just(ByteBuffer.wrap(new byte[0])));
+                ).switchIfEmpty(Flux.defer(() -> Flux.just(ByteBuffer.wrap(new byte[0]))));
 
                 return new ShareFileDownloadAsyncResponse(response.getRequest(), response.getStatusCode(),
                     response.getHeaders(), bufferFlux, headers);


### PR DESCRIPTION
Minor performance improvements in azure-storage-* based on learnings from other libraries.

- Always defer `switchIfEmpty` and `defaultIfEmpty` when constructing objects.
- Use `Pattern` instead of String.replace, String.replaceFirst, and String.replaceAll.