### PR TITLE
Remove Usage of AccessController in azure-search-documents

### DIFF
--- a/sdk/search/azure-search-documents/src/test/java/com/azure/search/documents/LookupSyncTests.java
+++ b/sdk/search/azure-search-documents/src/test/java/com/azure/search/documents/LookupSyncTests.java
@@ -476,7 +476,7 @@ public class LookupSyncTests extends SearchTestBase {
     }
 
     String setupIndexWithDataTypes() {
-        SearchIndex index = new SearchIndex("data-types-tests-index")
+        SearchIndex index = new SearchIndex(testResourceNamer.randomName("data-types-tests-index", 64))
             .setFields(Arrays.asList(
                  new SearchField("Key", SearchFieldDataType.STRING)
                     .setKey(true)

--- a/sdk/search/azure-search-documents/src/test/java/com/azure/search/documents/SearchSyncTests.java
+++ b/sdk/search/azure-search-documents/src/test/java/com/azure/search/documents/SearchSyncTests.java
@@ -972,7 +972,7 @@ public class SearchSyncTests extends SearchTestBase {
     }
 
     String createIndexWithNonNullableTypes() {
-        SearchIndex index = new SearchIndex("non-nullable-index")
+        SearchIndex index = new SearchIndex(testResourceNamer.randomName("non-nullable-index", 64))
             .setFields(Arrays.asList(
                 new SearchField("Key", SearchFieldDataType.STRING)
                     .setHidden(false)
@@ -1008,7 +1008,7 @@ public class SearchSyncTests extends SearchTestBase {
     }
 
     String createIndexWithValueTypes() {
-        SearchIndex index = new SearchIndex("testindex")
+        SearchIndex index = new SearchIndex(testResourceNamer.randomName("testindex", 64))
             .setFields(Arrays.asList(
                 new SearchField("Key", SearchFieldDataType.STRING)
                     .setKey(true)

--- a/sdk/search/azure-search-documents/src/test/java/com/azure/search/documents/SearchTestBase.java
+++ b/sdk/search/azure-search-documents/src/test/java/com/azure/search/documents/SearchTestBase.java
@@ -36,21 +36,20 @@ import com.azure.search.documents.indexes.models.SoftDeleteColumnDeletionDetecti
 import com.azure.search.documents.indexes.models.TagScoringFunction;
 import com.azure.search.documents.indexes.models.TagScoringParameters;
 import com.azure.search.documents.indexes.models.TextWeights;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import reactor.core.Exceptions;
 
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
 import static com.azure.search.documents.TestHelpers.BLOB_DATASOURCE_NAME;
 import static com.azure.search.documents.TestHelpers.HOTEL_INDEX_NAME;
+import static com.azure.search.documents.TestHelpers.MAPPER;
 import static com.azure.search.documents.TestHelpers.SQL_DATASOURCE_NAME;
 import static com.azure.search.documents.indexes.DataSourceSyncTests.FAKE_AZURE_SQL_CONNECTION_STRING;
 
@@ -89,24 +88,16 @@ public abstract class SearchTestBase extends TestBase {
     }
 
     protected String setupIndexFromJsonFile(String jsonFile) {
-        Reader indexData = new InputStreamReader(Objects.requireNonNull(getClass().getClassLoader()
-            .getResourceAsStream(jsonFile)));
         try {
-            return setupIndex(TestHelpers.MAPPER.readValue(indexData, SearchIndex.class));
+            ObjectNode jsonData = (ObjectNode) MAPPER.readTree(TestHelpers.loadResource(jsonFile));
+            jsonData.set("name", new TextNode(testResourceNamer.randomName(jsonData.get("name").asText(), 64)));
+            return setupIndex(MAPPER.treeToValue(jsonData, SearchIndex.class));
         } catch (Exception e) {
             throw Exceptions.propagate(e);
         }
     }
 
     protected String setupIndex(SearchIndex index) {
-        try {
-            Field searchIndexName = index.getClass().getDeclaredField("name");
-            searchIndexName.setAccessible(true);
-
-            searchIndexName.set(index, testResourceNamer.randomName(index.getName(), 64));
-        } catch (Exception e) {
-            throw Exceptions.propagate(e);
-        }
         getSearchIndexClientBuilder().buildClient().createOrUpdateIndex(index);
 
         return index.getName();


### PR DESCRIPTION
Fixes #24517

This PR remove the usage of `AccessController` in `azure-search-documents` tests. Instead of reflectively changing the deserialized object the JSON string is mutated to replace the index name JSON property before deserialization, resulting in the same outcome.