### PR TITLE
wps, use only GA api-version

### DIFF
--- a/sdk/webpubsub/azure-messaging-webpubsub/src/main/java/com/azure/messaging/webpubsub/WebPubSubServiceVersion.java
+++ b/sdk/webpubsub/azure-messaging-webpubsub/src/main/java/com/azure/messaging/webpubsub/WebPubSubServiceVersion.java
@@ -8,12 +8,6 @@ import com.azure.core.util.ServiceVersion;
 
 /** Service version of WebPubSubService. */
 public enum WebPubSubServiceVersion implements ServiceVersion {
-    /** Enum value 2021-05-01-preview. */
-    V2021_05_01_PREVIEW("2021-05-01-preview"),
-
-    /** Enum value 2021-08-01-preview. */
-    V2021_08_01_PREVIEW("2021-08-01-preview"),
-
     /** Enum value 2021-10-01. */
     V2021_10_01("2021-10-01");
 

--- a/sdk/webpubsub/azure-messaging-webpubsub/swagger/llc_readme.md
+++ b/sdk/webpubsub/azure-messaging-webpubsub/swagger/llc_readme.md
@@ -19,7 +19,5 @@ low-level-client: true
 generate-sync-async-clients: true
 service-name: WebPubSubService
 service-versions:
-  - 2021-05-01-preview
-  - 2021-08-01-preview
   - '2021-10-01'
 ```


### PR DESCRIPTION
As API surface is not exact same between 2021-10-01 and earlier preview, use only the GA api-version in SDK.