### PR TITLE
Skip version checks that will never work

### DIFF
--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/jackson/JacksonVersion.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/jackson/JacksonVersion.java
@@ -79,6 +79,7 @@ final class JacksonVersion {
     private void checkVersion(SemanticVersion version, String packageName) {
         if (!version.isValid()) {
             logger.warning("Could not find version of '{}'.", packageName);
+            return;
         }
 
         if (version.compareTo(MIN_SUPPORTED_VERSION) < 0) {


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-java/pull/23441/files#r730457564

Lots of log spam after updating my SDK version:
```
WARNING: Could not find version of 'jackson-annotations'.
Oct 17, 2021 7:23:00 PM com.azure.core.util.logging.ClientLogger performLogging
SEVERE: Version 'unknown' of package 'jackson-annotations' is not supported (older than earliest supported version - `2.10.0`), please upgrade.
Oct 17, 2021 7:23:00 PM com.azure.core.util.logging.ClientLogger performLogging
WARNING: Could not find version of 'jackson-core'.
Oct 17, 2021 7:23:00 PM com.azure.core.util.logging.ClientLogger performLogging
SEVERE: Version 'unknown' of package 'jackson-core' is not supported (older than earliest supported version - `2.10.0`), please upgrade.
Oct 17, 2021 7:23:00 PM com.azure.core.util.logging.ClientLogger performLogging
WARNING: Could not find version of 'jackson-databind'.
Oct 17, 2021 7:23:00 PM com.azure.core.util.logging.ClientLogger performLogging
SEVERE: Version 'unknown' of package 'jackson-databind' is not supported (older than earliest supported version - `2.10.0`), please upgrade.
Oct 17, 2021 7:23:00 PM com.azure.core.util.logging.ClientLogger performLogging
WARNING: Could not find version of 'jackson-dataformat-xml'.
Oct 17, 2021 7:23:00 PM com.azure.core.util.logging.ClientLogger performLogging
SEVERE: Version 'unknown' of package 'jackson-dataformat-xml' is not supported (older than earliest supported version - `2.10.0`), please upgrade.
Oct 17, 2021 7:23:00 PM com.azure.core.util.logging.ClientLogger performLogging
WARNING: Could not find version of 'jackson-datatype-jsr310'.
Oct 17, 2021 7:23:00 PM com.azure.core.util.logging.ClientLogger performLogging
SEVERE: Version 'unknown' of package 'jackson-datatype-jsr310' is not supported (older than earliest supported version - `2.10.0`), please upgrade.
Oct 17, 2021 7:23:00 PM com.azure.core.util.logging.ClientLogger info
INFO: Package versions: jackson-annotations=unknown, jackson-core=unknown, jackson-databind=unknown, jackson-dataformat-xml=unknown, jackson-datatype-jsr310=unknown, azure-core=1.21.0
```