### PR TITLE
Add POM parent element fallback for GroupId and Version

### DIFF
--- a/eng/scripts/MavenPackaging.ps1
+++ b/eng/scripts/MavenPackaging.ps1
@@ -111,12 +111,17 @@ function Get-MavenPackageDetails([string]$ArtifactDirectory) {
     [xml]$pomDocument = Get-Content $pomFile
 
     $packageDetail.GroupID = $pomDocument.project.groupId
+    if (!$packageDetail.GroupID) { $packageDetail.GroupID = $pomDocument.project.parent.groupId }
+    if (!$packageDetail.GroupID) { throw "No GroupID found for $pomFile" }
     Write-Information "Group ID is: $($packageDetail.GroupID)"
 
     $packageDetail.ArtifactID = $pomDocument.project.artifactId
+    if (!$packageDetail.ArtifactID) { throw "No ArtifactID found for $pomFile" }
     Write-Information "Artifact ID is: $($packageDetail.ArtifactID)"
 
     $packageDetail.Version = $pomDocument.project.version
+    if (!$packageDetail.Version) { $packageDetail.Version = $pomDocument.project.parent.version }
+    if (!$packageDetail.Version) { throw "No Version found for $pomFile" }
     Write-Information "Version is: $($packageDetail.Version)"
 
     $packageDetail.IsSnapshot = $packageDetail.Version.EndsWith("-SNAPSHOT")


### PR DESCRIPTION
Partner releases were failing when they didn't have explicit `groupId` or  `version` elements.  This changes allows GroupID and Version to fall back to the value in the POM's `parent` element.

Also, null checks are added for GroupID, Version, and ArtifactID