### PR TITLE
Add related content to make sure KeyVaultJcaProvider position

### DIFF
--- a/sdk/spring/azure-spring-boot-starter-keyvault-certificates/src/main/java/com/azure/spring/security/keyvault/certificates/starter/KeyVaultCertificatesEnvironmentPostProcessor.java
+++ b/sdk/spring/azure-spring-boot-starter-keyvault-certificates/src/main/java/com/azure/spring/security/keyvault/certificates/starter/KeyVaultCertificatesEnvironmentPostProcessor.java
@@ -56,6 +56,7 @@ public class KeyVaultCertificatesEnvironmentPostProcessor implements Environment
             propertySources.addFirst(new PropertiesPropertySource("TrustStorePropertySource", properties));
         }
 
+        Security.removeProvider("AzureKeyVault");
         Security.insertProviderAt(new KeyVaultJcaProvider(), 1);
         if (overrideTrustManagerFactory(environment)) {
             Security.insertProviderAt(new KeyVaultTrustManagerFactoryProvider(), 1);

--- a/sdk/spring/azure-spring-boot-starter-keyvault-certificates/src/test/java/com/azure/spring/security/keyvault/certificates/starter/KeyVaultCertificatesEnvironmentPostProcessorTest.java
+++ b/sdk/spring/azure-spring-boot-starter-keyvault-certificates/src/test/java/com/azure/spring/security/keyvault/certificates/starter/KeyVaultCertificatesEnvironmentPostProcessorTest.java
@@ -2,10 +2,15 @@
 // Licensed under the MIT License.
 package com.azure.spring.security.keyvault.certificates.starter;
 
+import com.azure.security.keyvault.jca.KeyVaultJcaProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.Security;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,4 +52,28 @@ public class KeyVaultCertificatesEnvironmentPostProcessorTest {
                           .applyTo(environment);
         assertTrue(KeyVaultCertificatesEnvironmentPostProcessor.overrideTrustManagerFactory(environment));
     }
+
+    @Test
+    public void insertProviderTest() throws KeyStoreException {
+        // Simulated users added KeyVaultJcaProvider to java.security
+        Security.removeProvider("AzureKeyVault");
+        Security.insertProviderAt(new KeyVaultJcaProvider(), 11);
+        ConfigurableEnvironment environment = new StandardEnvironment();
+        KeyVaultCertificatesEnvironmentPostProcessor postProcessor = new KeyVaultCertificatesEnvironmentPostProcessor();
+        postProcessor.postProcessEnvironment(environment, null);
+        KeyStore keyStore = KeyStore.getInstance("DKS");
+        assertTrue(keyStore.getProvider() instanceof KeyVaultJcaProvider);
+    }
+
+    @Test
+    public void insertProviderDefaultFileTest() throws KeyStoreException {
+        // Simulated default java.security
+        Security.removeProvider("AzureKeyVault");
+        ConfigurableEnvironment environment = new StandardEnvironment();
+        KeyVaultCertificatesEnvironmentPostProcessor postProcessor = new KeyVaultCertificatesEnvironmentPostProcessor();
+        postProcessor.postProcessEnvironment(environment, null);
+        KeyStore keyStore = KeyStore.getInstance("DKS");
+        assertTrue(keyStore.getProvider() instanceof KeyVaultJcaProvider);
+    }
+
 }


### PR DESCRIPTION
When use our starter, if user added the 
`security.provider.n=com.azure.security.keyvault.jca.KeyVaultJcaProvider` in java.security in back position,
`Security.insertProviderAt(new KeyVaultJcaProvider(), 1);` will fail because this provider is already included.

In test, `System.setProperty("java.security.properties", filePath);` should be better, but which won't work beacuse `Security` will be initialized before our code run. we can only run test by `-Djava.security.properties=d:\java.security` to make which work.
So we use `Security.insertProviderAt(new KeyVaultJcaProvider(), 11);` to simulate the used edited the `java.security` and set the `KeyVaultJcaProvider` with back position.