### PR TITLE
fix SerializableContent.getLength

### DIFF
--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/SerializableContent.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/SerializableContent.java
@@ -37,7 +37,7 @@ public final class SerializableContent extends BinaryDataContent {
 
     @Override
     public Long getLength() {
-        return null;
+        return this.content == null ? null : (long) toBytes().length;
     }
 
     @Override

--- a/sdk/core/azure-core/src/test/java/com/azure/core/util/BinaryDataTest.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/util/BinaryDataTest.java
@@ -134,7 +134,9 @@ public class BinaryDataTest {
 
     @Test
     public void createFromNullObject() {
-        assertThrows(NullPointerException.class, () -> BinaryData.fromObject(null, null));
+        BinaryData binaryData = BinaryData.fromObject(null, BinaryData.SERIALIZER);
+        Assertions.assertNull(binaryData.toBytes());
+        Assertions.assertNull(binaryData.getLength());
     }
 
     @Test


### PR DESCRIPTION
I see Srikanta's PR was merged. Here is the fix on `SerializableContent.getLength`.

A pending question is whether it should throw in ctor when `content` is `null`.