### PR TITLE
Update App Configuration CI to have Feature Branch for Spring

### DIFF
--- a/sdk/appconfiguration/ci.yml
+++ b/sdk/appconfiguration/ci.yml
@@ -6,6 +6,7 @@ trigger:
       - main
       - hotfix/*
       - release/*
+      - azconfigFeature/*
   paths:
     include:
       - sdk/appconfiguration/ci.yml
@@ -47,6 +48,7 @@ pr:
       - feature/*
       - hotfix/*
       - release/*
+      - azconfigFeature/*
   paths:
     include:
       - sdk/appconfiguration/ci.yml


### PR DESCRIPTION
Updating so the App Configuration Spring Library can use Feature Branches as part of move to 4.0.0.

Because the App Configuration Library has features added to it that take multiple PRs we will need feature branches to we can control when they go in, but still have the run against CI.