### PR TITLE
Cosmos DB: Databricks integration CI concurrency fix

### DIFF
--- a/sdk/cosmos/azure-cosmos-spark_3_2-12/test-databricks/databricks-jar-install.sh
+++ b/sdk/cosmos/azure-cosmos-spark_3_2-12/test-databricks/databricks-jar-install.sh
@@ -25,9 +25,6 @@ done
 
 bash sdk/cosmos/azure-cosmos-spark_3_2-12/test-databricks/databricks-cluster-restart.sh $CLUSTER_ID
 
-echo "Deleting files in dbfs:/tmp/libraries"
-dbfs rm --recursive dbfs:/tmp/libraries
-
 for file in $JARPATH/*.jar
 do
 	filename=${file##*/}
@@ -42,6 +39,10 @@ then
 	echo "Cannot find Jar files at $JARPATH"
 	exit 1
 fi
+
+echo "Deleting files in dbfs:/tmp/libraries/$JARFILE"
+dbfs rm dbfs:/tmp/libraries/$JARFILE
+dbfs ls dbfs:/tmp/libraries/
 
 echo "Copying files to DBFS $JARPATH/$JARFILE"
 dbfs cp $JARPATH/$JARFILE dbfs:/tmp/libraries/$JARFILE --overwrite

--- a/sdk/cosmos/spark.yml
+++ b/sdk/cosmos/spark.yml
@@ -6,7 +6,7 @@ variables:
   - name: AdditionalArgs
     value: ''
 
-steps:
+stages:
   - template: /sdk/cosmos/spark.databricks.yml
     parameters:
       CosmosEndpoint: $(spark-databricks-cosmos-endpoint)


### PR DESCRIPTION
The current Databricks scripts, before installing the new library on the cluster, would delete all content of the Workspace folder. 

In a concurrent scenario, where 2 jobs need to copy 2 different files to the folder and then install them on each particular cluster, it was possible that 1 job would copy the file and before the install happened, the other job would run the folder delete, making the first job fail on library installation.

To fix it we are replacing the folder delete with a targeted file delete.