### PR TITLE
Updated versions for release of java SDK 4.29.1

### DIFF
--- a/eng/jacoco-test-coverage/pom.xml
+++ b/eng/jacoco-test-coverage/pom.xml
@@ -178,7 +178,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-cosmos</artifactId>
-      <version>4.30.0-beta.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
+      <version>4.29.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -81,7 +81,7 @@ com.azure:azure-core-serializer-json-gson;1.1.14;1.2.0-beta.1
 com.azure:azure-core-serializer-json-jackson;1.2.15;1.3.0-beta.1
 com.azure:azure-core-test;1.7.10;1.8.0-beta.1
 com.azure:azure-core-tracing-opentelemetry;1.0.0-beta.22;1.0.0-beta.23
-com.azure:azure-cosmos;4.29.0;4.30.0-beta.1
+com.azure:azure-cosmos;4.29.0;4.29.1
 com.azure:azure-cosmos-benchmark;4.0.1-beta.1;4.0.1-beta.1
 com.azure:azure-cosmos-dotnet-benchmark;4.0.1-beta.1;4.0.1-beta.1
 com.azure.cosmos.spark:azure-cosmos-spark_3_2-12;1.0.0-beta.1;1.0.0-beta.1

--- a/sdk/cosmos/azure-cosmos-benchmark/pom.xml
+++ b/sdk/cosmos/azure-cosmos-benchmark/pom.xml
@@ -51,7 +51,7 @@ Licensed under the MIT License.
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-cosmos</artifactId>
-      <version>4.30.0-beta.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
+      <version>4.29.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
     </dependency>
 
     <dependency>

--- a/sdk/cosmos/azure-cosmos-dotnet-benchmark/pom.xml
+++ b/sdk/cosmos/azure-cosmos-dotnet-benchmark/pom.xml
@@ -50,7 +50,7 @@ Licensed under the MIT License.
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-cosmos</artifactId>
-      <version>4.30.0-beta.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
+      <version>4.29.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
     </dependency>
 
     <dependency>

--- a/sdk/cosmos/azure-cosmos-encryption/pom.xml
+++ b/sdk/cosmos/azure-cosmos-encryption/pom.xml
@@ -56,7 +56,7 @@ Licensed under the MIT License.
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-cosmos</artifactId>
-      <version>4.30.0-beta.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
+      <version>4.29.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
     </dependency>
 
     <dependency>

--- a/sdk/cosmos/azure-cosmos-spark_3-1_2-12/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3-1_2-12/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-cosmos</artifactId>
-      <version>4.30.0-beta.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
+      <version>4.29.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/sdk/cosmos/azure-cosmos-spark_3-2_2-12/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3-2_2-12/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-cosmos</artifactId>
-      <version>4.30.0-beta.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
+      <version>4.29.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/sdk/cosmos/azure-cosmos-spark_3_2-12/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3_2-12/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-cosmos</artifactId>
-      <version>4.30.0-beta.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
+      <version>4.29.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
     </dependency>
     <dependency>
       <groupId>org.scala-lang.modules</groupId>

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -1,14 +1,8 @@
 ## Release History
 
-### 4.30.0-beta.1 (Unreleased)
-
-#### Features Added
-
-#### Breaking Changes
-
+### 4.29.1 (2022-04-27)
 #### Bugs Fixed
-
-#### Other Changes
+* Fixed AAD authentication for `CosmosPatchOperations` - See [PR 28537](https://github.com/Azure/azure-sdk-for-java/pull/28537)
 
 ### 4.29.0 (2022-04-22)
 #### Features Added

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -45,7 +45,7 @@ add the direct dependency to your project as follows.
 <dependency>
   <groupId>com.azure</groupId>
   <artifactId>azure-cosmos</artifactId>
-  <version>4.29.0</version>
+  <version>4.29.1</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/cosmos/azure-cosmos/pom.xml
+++ b/sdk/cosmos/azure-cosmos/pom.xml
@@ -13,7 +13,7 @@ Licensed under the MIT License.
 
   <groupId>com.azure</groupId>
   <artifactId>azure-cosmos</artifactId>
-  <version>4.30.0-beta.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
+  <version>4.29.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
   <name>Microsoft Azure SDK for SQL API of Azure Cosmos DB Service</name>
   <description>This Package contains Microsoft Azure Cosmos SDK (with Reactive Extension Reactor support) for Azure Cosmos DB SQL API</description>
   <packaging>jar</packaging>

--- a/sdk/cosmos/azure-spring-data-cosmos/pom.xml
+++ b/sdk/cosmos/azure-spring-data-cosmos/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-cosmos</artifactId>
-      <version>4.30.0-beta.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
+      <version>4.29.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>

--- a/sdk/cosmos/pom.xml
+++ b/sdk/cosmos/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
           <groupId>com.azure</groupId>
           <artifactId>azure-cosmos</artifactId>
-          <version>4.30.0-beta.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
+          <version>4.29.1</version> <!-- {x-version-update;com.azure:azure-cosmos;current} -->
         </dependency>
       </dependencies>
 


### PR DESCRIPTION
## azure-cosmos

### 4.29.1 (2022-04-27)
#### Bugs Fixed
* Fixed AAD authentication for `CosmosPatchOperations` - See [PR 28537](https://github.com/Azure/azure-sdk-for-java/pull/28537)