### PR TITLE
Storage: Mitigate memory test failure

### DIFF
--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -352,6 +352,7 @@ com.azure.tools:azure-sdk-build-tool;1.0.0-beta.1;1.0.0-beta.2
 # <!-- {x-version-update;unreleased_com.azure:azure-core;dependency} -->
 unreleased_com.azure:azure-aot-graalvm-perf;1.0.0-beta.1
 unreleased_com.azure:azure-core;1.28.0-beta.1
+unreleased_com.azure:azure-core-http-netty;1.12.0-beta.1
 unreleased_com.azure:azure-messaging-eventhubs;5.12.0-beta.1
 unreleased_com.azure.spring:spring-cloud-azure-autoconfigure;4.1.0-beta.1
 unreleased_com.azure.spring:spring-cloud-azure-resourcemanager;4.1.0-beta.1

--- a/sdk/storage/azure-storage-blob/pom.xml
+++ b/sdk/storage/azure-storage-blob/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-netty</artifactId>
-      <version>1.11.9</version> <!-- {x-version-update;com.azure:azure-core-http-netty;dependency} -->
+      <version>1.12.0-beta.1</version> <!-- {x-version-update;unreleased_com.azure:azure-core-http-netty;dependency} -->
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>


### PR DESCRIPTION
In this PR:
- Use unreleased netty module in addition to unreleased core.

Related change https://github.com/Azure/azure-sdk-for-java/commit/f18f77bbf1c2f2ae07d89d2682c34b0304483079 .
If mixing unreleased core and old netty this results in switching to JDK ssl provider that's more memory demanding.