### PR TITLE
Adding option to specify client telemetry proxy with credentials

### DIFF
--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ClientTelemetryConfig.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ClientTelemetryConfig.java
@@ -77,13 +77,28 @@ public class ClientTelemetryConfig {
 
                 if (logger.isDebugEnabled()) {
                     logger.debug(
-                            "Enable proxy with type {}, host {}, port {}",
+                            "Enable proxy with type {}, host {}, port {}, userName {}, password length {}",
                             type,
                             proxyOptionsConfig.host,
-                            proxyOptionsConfig.port);
+                            proxyOptionsConfig.port,
+                            proxyOptionsConfig.username,
+                            proxyOptionsConfig.password != null ? proxyOptionsConfig.password.length() : -1
+                        );
                 }
 
-                return new ProxyOptions(type, new InetSocketAddress(proxyOptionsConfig.host, proxyOptionsConfig.port));
+                ProxyOptions proxyOptions = new ProxyOptions(
+                    type,
+                    new InetSocketAddress(proxyOptionsConfig.host, proxyOptionsConfig.port));
+
+                if (!Strings.isNullOrEmpty(proxyOptionsConfig.username) ||
+                    !Strings.isNullOrEmpty(proxyOptionsConfig.password)) {
+
+                    proxyOptions.setCredentials(
+                        proxyOptionsConfig.username != null ? proxyOptionsConfig.username : "",
+                        proxyOptionsConfig.password != null ? proxyOptionsConfig.password : "");
+                }
+
+                return proxyOptions;
             } catch (JsonProcessingException e) {
                 logger.error("Failed to parse client telemetry proxy option config", e);
             }
@@ -99,12 +114,18 @@ public class ClientTelemetryConfig {
         private int port;
         @JsonProperty
         private String type;
+        @JsonProperty
+        private String username;
+        @JsonProperty
+        private String password;
 
         private JsonProxyOptionsConfig() {}
-        private JsonProxyOptionsConfig(String host, int port, String type) {
+        private JsonProxyOptionsConfig(String host, int port, String type, String username, String password) {
             this.host = host;
             this.port = port;
             this.type = type;
+            this.username = username;
+            this.password = password;
         }
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/ConnectionConfigTest.java
+++ b/sdk/cosmos/azure-cosmos/src/test/java/com/azure/cosmos/ConnectionConfigTest.java
@@ -16,6 +16,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -212,9 +213,18 @@ public class ConnectionConfigTest extends TestSuiteBase {
         String proxyHost = "127.0.0.0";
         int proxyPort = 8080;
         ProxyOptions proxyOptions = new ProxyOptions(ProxyOptions.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+        String username = UUID.randomUUID().toString();
+        String password = UUID.randomUUID().toString();
+        proxyOptions.setCredentials(username, password);
         System.setProperty(
                 "COSMOS.CLIENT_TELEMETRY_PROXY_OPTIONS_CONFIG",
-                String.format("{\"type\":\"%s\", \"host\": \"%s\", \"port\": %d}", proxyOptions.getType().toString(), proxyHost, proxyPort));
+                String.format(
+                    "{\"type\":\"%s\", \"host\": \"%s\", \"port\": %d, \"username\": \"%s\", \"password\":\"%s\"}",
+                    proxyOptions.getType().toString(),
+                    proxyHost,
+                    proxyPort,
+                    username,
+                    password));
 
         CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder()
                 .endpoint(TestConfigurations.HOST)
@@ -232,6 +242,8 @@ public class ConnectionConfigTest extends TestSuiteBase {
         assertThat(clientTelemetryConfig.isClientTelemetryEnabled()).isTrue();
         assertThat(clientTelemetryConfig.getProxy().getType()).isEqualTo(proxyOptions.getType());
         assertThat(clientTelemetryConfig.getProxy().getAddress()).isEqualTo(proxyOptions.getAddress());
+        assertThat(clientTelemetryConfig.getProxy().getUsername()).isEqualTo(proxyOptions.getUsername());
+        assertThat(clientTelemetryConfig.getProxy().getPassword()).isEqualTo(proxyOptions.getPassword());
     }
 
     private void validateDirectAndGatewayConnectionConfig(ConnectionPolicy connectionPolicy, CosmosClientBuilder cosmosClientBuilder,


### PR DESCRIPTION
# Description
Fix issue: https://github.com/Azure/azure-sdk-for-java/issues/29023. Customer would like to ONLY enable proxy for their clientTelemetry requests. But currently, clientTelemetryRequests and gatewayRequests are sharing the same HttpClient which makes it impossible. IN PR https://github.com/Azure/azure-sdk-for-java/pull/29022 we separated the httpclients and allowed customer to config the proxy through System property.
This PR adds the option to also specify proxy credentials.

Example code:
```
 System.setProperty(
                        "COSMOS.CLIENT_TELEMETRY_PROXY_OPTIONS_CONFIG",
                       "{\"type\":\"HTTP\", \"host\": \"localhost\", \"port\": 8080, \"username\": \"SomeUser\", \"password\": \"SomeSecret\"}");

```

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
