### PR TITLE
Fix the unit test failure of kafka configuring user agent

### DIFF
--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/kafka/AbstractKafkaPropertiesBeanPostProcessor.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/kafka/AbstractKafkaPropertiesBeanPostProcessor.java
@@ -217,7 +217,7 @@ abstract class AbstractKafkaPropertiesBeanPostProcessor<T> implements BeanPostPr
     /**
      * Configure Spring Cloud Azure user-agent for Kafka client. This method is idempotent to avoid configuring UA repeatedly.
      */
-    synchronized void configureKafkaUserAgent() {
+    static synchronized void configureKafkaUserAgent() {
         Method dataMethod = ReflectionUtils.findMethod(ApiVersionsRequest.class, "data");
         if (dataMethod != null) {
             ApiVersionsRequest apiVersionsRequest = new ApiVersionsRequest.Builder().build();

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/kafka/AbstractKafkaPropertiesBeanPostProcessorTest.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/kafka/AbstractKafkaPropertiesBeanPostProcessorTest.java
@@ -113,7 +113,7 @@ abstract class AbstractKafkaPropertiesBeanPostProcessorTest<P extends AbstractKa
     @Test
     void testConfigureKafkaUserAgent() {
         getApiVersionsRequestData().ifPresent(method -> {
-            processor.configureKafkaUserAgent();
+            AbstractKafkaPropertiesBeanPostProcessor.configureKafkaUserAgent();
             ApiVersionsRequest apiVersionsRequest = new ApiVersionsRequest.Builder().build();
             ApiVersionsRequestData apiVersionsRequestData = (ApiVersionsRequestData) ReflectionUtils.invokeMethod(method, apiVersionsRequest);
             assertTrue(apiVersionsRequestData.clientSoftwareName()
@@ -126,8 +126,8 @@ abstract class AbstractKafkaPropertiesBeanPostProcessorTest<P extends AbstractKa
     @Test
     void testConfigureKafkaUserAgentMultipleTimes() {
         getApiVersionsRequestData().ifPresent(method -> {
-            processor.configureKafkaUserAgent();
-            processor.configureKafkaUserAgent();
+            AbstractKafkaPropertiesBeanPostProcessor.configureKafkaUserAgent();
+            AbstractKafkaPropertiesBeanPostProcessor.configureKafkaUserAgent();
             ApiVersionsRequest apiVersionsRequest = new ApiVersionsRequest.Builder().build();
             ApiVersionsRequestData apiVersionsRequestData = (ApiVersionsRequestData) ReflectionUtils.invokeMethod(method, apiVersionsRequest);
             assertTrue(apiVersionsRequestData.clientSoftwareName()


### PR DESCRIPTION
This pr is to fix the unit test failure of [kafka configuring user agent](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2034284&view=logs&j=bf44eda5-cc3d-5f9c-af41-cedf8d421052&t=d6cdb422-b9be-5b81-6371-7ff7c9aaef73).
During the refactoring process of Kafka password-less connection support in https://github.com/Azure/azure-sdk-for-java/issues/31182, we moved some methods from a util class to a superclass, and also modified them from class methods to instance methods since they are only used within that class. 
However, the synchronized method `configureKafkaUserAgent` should be a class method to make it idempotent and thread-safe across calling from all subclass instances, which should not be modified as non-static.