### PR TITLE
[OpenAI] Replace Object by BinaryData in FunctionDefinition's parameter

### DIFF
--- a/sdk/openai/azure-ai-openai/src/main/java/com/azure/ai/openai/models/FunctionDefinition.java
+++ b/sdk/openai/azure-ai-openai/src/main/java/com/azure/ai/openai/models/FunctionDefinition.java
@@ -5,6 +5,7 @@ package com.azure.ai.openai.models;
 
 import com.azure.core.annotation.Fluent;
 import com.azure.core.annotation.Generated;
+import com.azure.core.util.BinaryData;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -32,9 +33,8 @@ public final class FunctionDefinition {
     /*
      * The parameters the function accepts, described as a JSON Schema object.
      */
-    @Generated
     @JsonProperty(value = "parameters")
-    private Object parameters;
+    private BinaryData parameters;
 
     /**
      * Creates an instance of FunctionDefinition class.
@@ -88,8 +88,7 @@ public final class FunctionDefinition {
      *
      * @return the parameters value.
      */
-    @Generated
-    public Object getParameters() {
+    public BinaryData getParameters() {
         return this.parameters;
     }
 
@@ -99,8 +98,7 @@ public final class FunctionDefinition {
      * @param parameters the parameters value to set.
      * @return the FunctionDefinition object itself.
      */
-    @Generated
-    public FunctionDefinition setParameters(Object parameters) {
+    public FunctionDefinition setParameters(BinaryData parameters) {
         this.parameters = parameters;
         return this;
     }

--- a/sdk/openai/azure-ai-openai/src/samples/java/com/azure/ai/openai/FunctionCallSample.java
+++ b/sdk/openai/azure-ai-openai/src/samples/java/com/azure/ai/openai/FunctionCallSample.java
@@ -48,7 +48,7 @@ public class FunctionCallSample {
         List<FunctionDefinition> functions = Arrays.asList(
             new FunctionDefinition("getCurrentWeather")
                 .setDescription("Get the current weather")
-                .setParameters(getFunctionDefinition())
+                .setParameters(BinaryData.fromObject(getFunctionDefinition()))
         );
 
         List<ChatRequestMessage> chatMessages = new ArrayList<>();

--- a/sdk/openai/azure-ai-openai/src/samples/java/com/azure/ai/openai/StreamingToolCall.java
+++ b/sdk/openai/azure-ai-openai/src/samples/java/com/azure/ai/openai/StreamingToolCall.java
@@ -164,7 +164,7 @@ public class StreamingToolCall {
         FunctionDefinition functionDefinition = new FunctionDefinition("FutureTemperature");
         functionDefinition.setDescription("Get the future temperature for a given location and date.");
         FutureTemperatureParameters parameters = new FutureTemperatureParameters();
-        functionDefinition.setParameters(parameters);
+        functionDefinition.setParameters(BinaryData.fromObject(parameters));
         return functionDefinition;
     }
 

--- a/sdk/openai/azure-ai-openai/src/samples/java/com/azure/ai/openai/usage/GetChatCompletionsToolCallAsyncSample.java
+++ b/sdk/openai/azure-ai-openai/src/samples/java/com/azure/ai/openai/usage/GetChatCompletionsToolCallAsyncSample.java
@@ -122,7 +122,7 @@ public class GetChatCompletionsToolCallAsyncSample {
         FunctionDefinition functionDefinition = new FunctionDefinition("FutureTemperature");
         functionDefinition.setDescription("Get the future temperature for a given location and date.");
         FutureTemperatureParameters parameters = new FutureTemperatureParameters();
-        functionDefinition.setParameters(parameters);
+        functionDefinition.setParameters(BinaryData.fromObject(parameters));
         return functionDefinition;
     }
 

--- a/sdk/openai/azure-ai-openai/src/samples/java/com/azure/ai/openai/usage/GetChatCompletionsToolCallSample.java
+++ b/sdk/openai/azure-ai-openai/src/samples/java/com/azure/ai/openai/usage/GetChatCompletionsToolCallSample.java
@@ -113,7 +113,7 @@ public class GetChatCompletionsToolCallSample {
         FunctionDefinition functionDefinition = new FunctionDefinition("FutureTemperature");
         functionDefinition.setDescription("Get the future temperature for a given location and date.");
         FutureTemperatureParameters parameters = new FutureTemperatureParameters();
-        functionDefinition.setParameters(parameters);
+        functionDefinition.setParameters(BinaryData.fromObject(parameters));
         return functionDefinition;
     }
 

--- a/sdk/openai/azure-ai-openai/src/test/java/com/azure/ai/openai/OpenAIClientTestBase.java
+++ b/sdk/openai/azure-ai-openai/src/test/java/com/azure/ai/openai/OpenAIClientTestBase.java
@@ -362,14 +362,14 @@ public abstract class OpenAIClientTestBase extends TestProxyTestBase {
     private FunctionDefinition getFunctionDefinition() {
         FunctionDefinition functionDefinition = new FunctionDefinition("MyFunction");
         Parameters parameters = new Parameters();
-        functionDefinition.setParameters(parameters);
+        functionDefinition.setParameters(BinaryData.fromObject(parameters));
         return functionDefinition;
     }
 
     private FunctionDefinition getFutureTemperatureFunctionDefinition() {
         FunctionDefinition functionDefinition = new FunctionDefinition("FutureTemperature");
         FutureTemperatureParameters parameters = new FutureTemperatureParameters();
-        functionDefinition.setParameters(parameters);
+        functionDefinition.setParameters(BinaryData.fromObject(parameters));
         return functionDefinition;
     }
 


### PR DESCRIPTION
For type-safe purpose, we replace the type `Object` by `BinaryData`.