### PR TITLE
Fix proxy config for Key Vault proxy clients

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-certificates/src/main/resources/META-INF/native-image/com.azure/azure-security-keyvault-certificates/proxy-config.json
+++ b/sdk/keyvault/azure-security-keyvault-certificates/src/main/resources/META-INF/native-image/com.azure/azure-security-keyvault-certificates/proxy-config.json
@@ -1,6 +1,6 @@
 [
   [
-    "com.azure.security.keyvault.certificates.implementation.CertificateClientImpl$CertificateService"
+    "com.azure.security.keyvault.certificates.implementation.CertificateClientImpl$CertificateClientService"
   ],
   [
     "com.microsoft.aad.msal4jextensions.persistence.mac.ISecurityLibrary"

--- a/sdk/keyvault/azure-security-keyvault-keys/src/main/resources/META-INF/native-image/com.azure/azure-security-keyvault-keys/proxy-config.json
+++ b/sdk/keyvault/azure-security-keyvault-keys/src/main/resources/META-INF/native-image/com.azure/azure-security-keyvault-keys/proxy-config.json
@@ -1,5 +1,8 @@
 [
   [
-    "com.azure.security.keyvault.keys.implementation.KeyClientImpl$KeyService"
+    "com.azure.security.keyvault.keys.implementation.KeyClientImpl$KeyClientService"
+  ],
+  [
+    "com.azure.security.keyvault.keys.implementation.SecretMinClientImpl$SecretMinClientService"
   ]
 ]

--- a/sdk/keyvault/azure-security-keyvault-secrets/src/main/resources/META-INF/native-image/com.azure/azure-security-keyvault-secrets/proxy-config.json
+++ b/sdk/keyvault/azure-security-keyvault-secrets/src/main/resources/META-INF/native-image/com.azure/azure-security-keyvault-secrets/proxy-config.json
@@ -1,3 +1,3 @@
 [
-  ["com.azure.security.keyvault.secrets.implementation.SecretClientImpl$SecretService"]
+  ["com.azure.security.keyvault.secrets.implementation.SecretClientImpl$SecretClientService"]
 ]


### PR DESCRIPTION
The proxy service interface type name was changed but the name was not updated in proxy-config.json. This PR fixes the config to use the updated interface name.