### PR TITLE
Added support for TokenCredentials configuration

### DIFF
--- a/sdk/storage/azure-storage-blob-nio/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob-nio/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.0.0-beta.29 (Unreleased)
 
 ### Features Added
+- Added support for TokenCredentials configurations for Authentication against Microsoft EntraID 
 
 ### Breaking Changes
 

--- a/sdk/storage/azure-storage-blob-nio/pom.xml
+++ b/sdk/storage/azure-storage-blob-nio/pom.xml
@@ -105,5 +105,10 @@
       <version>1.15.5</version> <!-- {x-version-update;testdep_net.bytebuddy:byte-buddy-agent;external_dependency} -->
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-identity</artifactId>
+      <version>1.14.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/sdk/storage/azure-storage-blob-nio/src/main/java/com/azure/storage/blob/nio/AzureFileSystem.java
+++ b/sdk/storage/azure-storage-blob-nio/src/main/java/com/azure/storage/blob/nio/AzureFileSystem.java
@@ -4,6 +4,7 @@
 package com.azure.storage.blob.nio;
 
 import com.azure.core.credential.AzureSasCredential;
+import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.HttpClient;
 import com.azure.core.http.policy.HttpLogDetailLevel;
 import com.azure.core.http.policy.HttpPipelinePolicy;
@@ -66,6 +67,11 @@ public final class AzureFileSystem extends FileSystem {
      * Expected type: String
      */
     public static final String AZURE_STORAGE_SAS_TOKEN_CREDENTIAL = "AzureStorageSasTokenCredential";
+
+    /**
+     * Expected type: String
+     */
+    public static final String AZURE_STORAGE_TOKEN_CREDENTIAL = "AzureStorageTokenCredential";
 
     /**
      * Expected type: com.azure.core.http.policy.HttpLogLevelDetail
@@ -399,12 +405,15 @@ public final class AzureFileSystem extends FileSystem {
             builder.credential((StorageSharedKeyCredential) config.get(AZURE_STORAGE_SHARED_KEY_CREDENTIAL));
         } else if (config.containsKey(AZURE_STORAGE_SAS_TOKEN_CREDENTIAL)) {
             builder.credential((AzureSasCredential) config.get(AZURE_STORAGE_SAS_TOKEN_CREDENTIAL));
+        } else if (config.containsKey(AZURE_STORAGE_TOKEN_CREDENTIAL)) {
+            builder.credential((TokenCredential) config.get(AZURE_STORAGE_TOKEN_CREDENTIAL));
         } else {
             throw LoggingUtility
                 .logError(LOGGER,
                     new IllegalArgumentException(String.format("No credentials were "
                         + "provided. Please specify one of the following when constructing an AzureFileSystem: %s, %s.",
-                        AZURE_STORAGE_SHARED_KEY_CREDENTIAL, AZURE_STORAGE_SAS_TOKEN_CREDENTIAL)));
+                        AZURE_STORAGE_SHARED_KEY_CREDENTIAL, AZURE_STORAGE_SAS_TOKEN_CREDENTIAL,
+                        AZURE_STORAGE_TOKEN_CREDENTIAL)));
         }
 
         // Configure options and client.

--- a/sdk/storage/azure-storage-blob-nio/src/test/java/com/azure/storage/blob/nio/AzureFileSystemTests.java
+++ b/sdk/storage/azure-storage-blob-nio/src/test/java/com/azure/storage/blob/nio/AzureFileSystemTests.java
@@ -4,6 +4,7 @@
 package com.azure.storage.blob.nio;
 
 import com.azure.core.credential.AzureSasCredential;
+import com.azure.core.test.utils.MockTokenCredential;
 import com.azure.core.util.CoreUtils;
 import com.azure.storage.common.sas.AccountSasPermission;
 import com.azure.storage.common.sas.AccountSasResourceType;
@@ -89,6 +90,21 @@ public class AzureFileSystemTests extends BlobNioTestBase {
 
         assertThrows(IllegalArgumentException.class,
             () -> new AzureFileSystem(new AzureFileSystemProvider(), ENV.getPrimaryAccount().getName(), config));
+    }
+
+    @Test
+    public void createWithTokenCredential() throws IOException {
+        String containerName = generateContainerName();
+        config.put(AzureFileSystem.AZURE_STORAGE_FILE_STORES, containerName);
+        config.put(AzureFileSystem.AZURE_STORAGE_TOKEN_CREDENTIAL, new MockTokenCredential());
+        AzureFileSystem azureFileSystem
+            = new AzureFileSystem(new AzureFileSystemProvider(), ENV.getPrimaryAccount().getBlobEndpoint(), config);
+
+        List<String> actualContainerNames = new ArrayList<>();
+        azureFileSystem.getFileStores().forEach(fs -> actualContainerNames.add(fs.name()));
+
+        assertEquals(1, actualContainerNames.size());
+        assertTrue(actualContainerNames.contains(containerName));
     }
 
     @Test


### PR DESCRIPTION
Added support for TokenCredentials configuration for Authentication against Microsoft EntraID 

fixes #43341

Basically I have fixed the issue I requested in #43341. I added a simple test but I have manually tested in against our Azure account with:

            ClientSecretCredentialBuilder()
                        .tenantId("valid tenant")
                        .clientId("valid client")
                        .clientSecret("valid secret")
                        .build();

where I created a Role Assignment (Storage Blob Data Reader), for a OIDC service principle that I used. I worked very nicely.

Also, for the test to work, I created an asset:

.assets/O1O5S5vXwx/java/sdk/storage/azure-storage-blob-nio/src/test/resources/session-records/AzureFileSystemTests.createWithTokenCredential.json

that was a copy of:

.assets/O1O5S5vXwx/java/sdk/storage/azure-storage-blob-nio/src/test/resources/session-records/AzureFileSystemTests.create[4].json

but since .assets/ directory is in .gitignore, I did not include it in the pull request