### PR TITLE
App Config Spring - Remove Feature Flags as Config

### DIFF
--- a/sdk/spring/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/appconfiguration/config/implementation/AppConfigurationApplicationSettingPropertySource.java
+++ b/sdk/spring/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/appconfiguration/config/implementation/AppConfigurationApplicationSettingPropertySource.java
@@ -127,7 +127,8 @@ class AppConfigurationApplicationSettingPropertySource extends AppConfigurationP
 
     void handleFeatureFlag(String key, FeatureFlagConfigurationSetting setting, List<String> trimStrings)
         throws InvalidConfigurationPropertyValueException {
-        handleJson(setting, trimStrings);
+        // Feature Flags aren't loaded as configuration, but are loaded as feature flags when loading a snapshot.
+        return;
     }
 
     private void handleJson(ConfigurationSetting setting, List<String> keyPrefixTrimValues)

--- a/sdk/spring/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/appconfiguration/config/implementation/AppConfigurationApplicationSettingPropertySourceSnapshotTest.java
+++ b/sdk/spring/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/appconfiguration/config/implementation/AppConfigurationApplicationSettingPropertySourceSnapshotTest.java
@@ -72,7 +72,7 @@ public class AppConfigurationApplicationSettingPropertySourceSnapshotTest {
         createItem("/bar/", "test_key_4", "test_value_4", "test_label_4", EMPTY_CONTENT_TYPE);
 
     private static final FeatureFlagConfigurationSetting FEATURE_ITEM = createItemFeatureFlag(".appconfig.featureflag/",
-        "Alpha", FEATURE_VALUE, FEATURE_LABEL, FEATURE_FLAG_CONTENT_TYPE);
+        "Alpha", FEATURE_VALUE, FEATURE_LABEL, FEATURE_FLAG_CONTENT_TYPE, "fake-etag");
 
     private static final ConfigurationSetting ITEM_NULL =
         createItem(KEY_FILTER, TEST_KEY_3, TEST_VALUE_3, TEST_LABEL_3, null);

--- a/sdk/spring/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/appconfiguration/config/implementation/AppConfigurationApplicationSettingPropertySourceTest.java
+++ b/sdk/spring/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/appconfiguration/config/implementation/AppConfigurationApplicationSettingPropertySourceTest.java
@@ -16,6 +16,7 @@ import static com.azure.spring.cloud.appconfiguration.config.implementation.Test
 import static com.azure.spring.cloud.appconfiguration.config.implementation.TestConstants.TEST_VALUE_2;
 import static com.azure.spring.cloud.appconfiguration.config.implementation.TestConstants.TEST_VALUE_3;
 import static com.azure.spring.cloud.appconfiguration.config.implementation.TestUtils.createItem;
+import static com.azure.spring.cloud.appconfiguration.config.implementation.TestUtils.createItemFeatureFlag;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
@@ -38,6 +39,7 @@ import org.springframework.boot.context.properties.source.InvalidConfigurationPr
 
 import com.azure.core.util.Context;
 import com.azure.data.appconfiguration.models.ConfigurationSetting;
+import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting;
 import com.azure.spring.cloud.appconfiguration.config.implementation.properties.AppConfigurationProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -67,6 +69,8 @@ public class AppConfigurationApplicationSettingPropertySourceTest {
     private static final ConfigurationSetting ITEM_INVALID_JSON = createItem(KEY_FILTER, TEST_KEY_3, TEST_VALUE_3,
         TEST_LABEL_3,
         JSON_CONTENT_TYPE);
+    
+    private static final FeatureFlagConfigurationSetting FEATURE_FLAG = createItemFeatureFlag("Beta",  "/0");
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -104,6 +108,7 @@ public class AppConfigurationApplicationSettingPropertySourceTest {
         testItems.add(ITEM_1);
         testItems.add(ITEM_2);
         testItems.add(ITEM_3);
+        testItems.add(FEATURE_FLAG);
 
         String[] labelFilter = { "\0" };
 
@@ -126,7 +131,7 @@ public class AppConfigurationApplicationSettingPropertySourceTest {
         propertySource.initProperties(null, contextMock);
 
         String[] keyNames = propertySource.getPropertyNames();
-        String[] expectedKeyNames = testItems.stream()
+        String[] expectedKeyNames = testItems.stream().filter(config -> !(config instanceof FeatureFlagConfigurationSetting))
             .map(t -> t.getKey().substring(KEY_FILTER.length())).toArray(String[]::new);
 
         assertThat(keyNames).containsExactlyInAnyOrder(expectedKeyNames);

--- a/sdk/spring/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/appconfiguration/config/implementation/TestUtils.java
+++ b/sdk/spring/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/appconfiguration/config/implementation/TestUtils.java
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 package com.azure.spring.cloud.appconfiguration.config.implementation;
 
+import static com.azure.spring.cloud.appconfiguration.config.implementation.AppConfigurationConstants.FEATURE_FLAG_CONTENT_TYPE;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -47,42 +49,47 @@ public final class TestUtils {
         return item;
     }
 
-    static FeatureFlagConfigurationSetting createItemFeatureFlag(String prefix, String key, String value, String label,
-         String contentType) {
-        return createItemFeatureFlag(prefix, key, value, label, contentType, null);
+    static FeatureFlagConfigurationSetting createItemFeatureFlag(String key, String label) {
+        return createItemFeatureFlag(".appconfig.featureflag/", key, null, label, FEATURE_FLAG_CONTENT_TYPE, null);
     }
 
     static FeatureFlagConfigurationSetting createItemFeatureFlag(String prefix, String key, String value, String label,
         String contentType, String eTag) {
         FeatureFlagConfigurationSetting item = new FeatureFlagConfigurationSetting(key, true);
-        item.setValue(value);
+        if (value != null) {
+            item.setValue(value);
+        }
         item.setClientFilters(new ArrayList<>());
-        item.setKey(prefix + key);
+        if (prefix != null) {
+            item.setKey(prefix + key);
+        }
         item.setLabel(label);
         item.setContentType(contentType);
         item.setETag(eTag);
 
         try {
-            JsonNode node = MAPPER.readTree(value).get("conditions").get("client_filters");
+            if (value != null) {
+                JsonNode node = MAPPER.readTree(value).get("conditions").get("client_filters");
 
-            for (int i = 0; i < node.size(); i++) {
-                JsonNode nodeFilter = node.get(i);
-                FeatureFlagFilter filter = new FeatureFlagFilter(nodeFilter.get("Name").asText());
+                for (int i = 0; i < node.size(); i++) {
+                    JsonNode nodeFilter = node.get(i);
+                    FeatureFlagFilter filter = new FeatureFlagFilter(nodeFilter.get("Name").asText());
 
-                JsonNode nodeParams = nodeFilter.get("Parameters");
-                if (nodeParams != null) {
-                    for (int j = 0; j < nodeParams.size(); j++) {
-                        // JsonNode param = nodeParams.
-                        Map<String, Object> result = MAPPER.convertValue(nodeParams,
-                            new TypeReference<Map<String, Object>>() {
-                            });
-                        Set<String> parameters = result.keySet();
-                        for (String paramKey : parameters) {
-                            filter.addParameter(paramKey, result.get(paramKey));
+                    JsonNode nodeParams = nodeFilter.get("Parameters");
+                    if (nodeParams != null) {
+                        for (int j = 0; j < nodeParams.size(); j++) {
+                            // JsonNode param = nodeParams.
+                            Map<String, Object> result = MAPPER.convertValue(nodeParams,
+                                new TypeReference<Map<String, Object>>() {
+                                });
+                            Set<String> parameters = result.keySet();
+                            for (String paramKey : parameters) {
+                                filter.addParameter(paramKey, result.get(paramKey));
+                            }
                         }
                     }
+                    item.addClientFilter(filter);
                 }
-                item.addClientFilter(filter);
             }
         } catch (JsonProcessingException e) {
             LOGGER.log(LogLevel.VERBOSE, () -> "Failed to create FeatureFlagConfigurationSetting.", e);


### PR DESCRIPTION
# Description

Feature Flags shouldn't be loaded as configuration. If they are loaded via snapshot they are loaded as actual feature flags.
