### PR TITLE
Make ChangeFeedProcessor AutoCloseable

### DIFF
--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/ChangeFeedProcessor.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/ChangeFeedProcessor.java
@@ -60,7 +60,7 @@ import java.util.Map;
  * </pre>
  * <!-- end com.azure.cosmos.allVersionsAndDeletesChangeFeedProcessor.builder -->
  */
-public interface ChangeFeedProcessor {
+public interface ChangeFeedProcessor extends AutoCloseable {
 
     /**
      * Start listening for changes asynchronously.

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/epkversion/ChangeFeedProcessorImplBase.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/epkversion/ChangeFeedProcessorImplBase.java
@@ -53,7 +53,7 @@ import java.util.function.Consumer;
 import static com.azure.cosmos.CosmosBridgeInternal.getContextClient;
 import static com.azure.cosmos.implementation.guava25.base.Preconditions.checkNotNull;
 
-public abstract class ChangeFeedProcessorImplBase<T> implements ChangeFeedProcessor, AutoCloseable{
+public abstract class ChangeFeedProcessorImplBase<T> implements ChangeFeedProcessor {
     private final Logger logger = LoggerFactory.getLogger(ChangeFeedProcessorImplBase.class);
     private final Duration sleepTime = Duration.ofSeconds(15);
     private final Duration lockTime = Duration.ofSeconds(30);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/pkversion/IncrementalChangeFeedProcessorImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/pkversion/IncrementalChangeFeedProcessorImpl.java
@@ -70,7 +70,7 @@ import static com.azure.cosmos.implementation.guava25.base.Preconditions.checkNo
  * }
  * </pre>
  */
-public class IncrementalChangeFeedProcessorImpl implements ChangeFeedProcessor, AutoCloseable {
+public class IncrementalChangeFeedProcessorImpl implements ChangeFeedProcessor {
     private static final String PK_RANGE_ID_SEPARATOR = ":";
     private static final String SEGMENT_SEPARATOR = "#";
     private static final String PROPERTY_NAME_LSN = "_lsn";


### PR DESCRIPTION
# Description

Making ChangeFeedProcessor extend the AutoCloseable interface. All the current implementations already implement it and this will ensure future implementations do as well.

This helps with associating the ChangeFeedProcessor with the application lifecycle as well for certain frameworks (Like dropwizard)

```java
ChangeFeedProcessor changeFeedProcessor = new ChangeFeedProcessorBuilder()
    .options(options)
    .hostName(String.format("%s-%s", config.processorName(), UUID.randomUUID()))
    .feedContainer("feed-container")
    .leaseContainer("lease-container")
    .handleChanges(changeFeedHandler)
    .buildChangeFeedProcessor();

// Example from dropwizard. Currently this won't work as changeFeedProcessor is not AutoCloseable.
// Even though all it's implementations are
environment.lifecycle().manage(new AutoCloseableManager(changeFeedProcessor));
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
