### PR TITLE
Marking problematic CI test as @LiveOnly until test-proxy issue is resolved

### DIFF
--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/BlobAsyncApiTests.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/BlobAsyncApiTests.java
@@ -2665,7 +2665,7 @@ public class BlobAsyncApiTests extends BlobTestBase {
     }
 
     @Test
-    @LiveOnly //TODO isbr: remove @LiveOnly when a different HTTP stack is chosen for test-proxy
+    @LiveOnly //TODO (isbr): remove @LiveOnly when a different HTTP stack is chosen for test-proxy
     public void getAccountInfoBaseFail() {
         BlobServiceAsyncClient serviceClient
             = instrument(new BlobServiceClientBuilder().endpoint(ENVIRONMENT.getPrimaryAccount().getBlobEndpoint())


### PR DESCRIPTION
Due to issues with the Netty HTTP client and test-proxy, `PrematureCloseException`s trigger unintended retries, leading to test-proxy throwing an error over the unexpected request. 