### PR TITLE
core, PoC to add exceptionBodyClass in UnexpectedResponseExceptionType

### DIFF
--- a/sdk/core/azure-core/src/main/java/com/azure/core/annotation/UnexpectedResponseExceptionType.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/annotation/UnexpectedResponseExceptionType.java
@@ -68,4 +68,13 @@ public @interface UnexpectedResponseExceptionType {
      * @return The HTTP status codes that trigger the exception to be thrown or returned.
      */
     int[] code() default { };
+
+    /**
+     * The class to decode the body of the HTTP response that accompanies an {@link HttpResponseException} to be thrown
+     * or returned.
+     *
+     * @return The class to decode the body of the HTTP response that accompanies an {@link HttpResponseException} to be
+     * thrown or returned.
+     */
+    Class<?> exceptionBodyClass() default Object.class;
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/UnexpectedExceptionInformation.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/UnexpectedExceptionInformation.java
@@ -21,13 +21,26 @@ public class UnexpectedExceptionInformation {
      * @param exceptionType Exception type to be thrown.
      */
     public UnexpectedExceptionInformation(Class<? extends HttpResponseException> exceptionType) {
+        this(exceptionType, Object.class);
+    }
+
+    /**
+     * Creates an UnexpectedExceptionInformation object with the given exception type and expected response body.
+     * @param exceptionType Exception type to be thrown.
+     * @param exceptionBodyType The type of body of the exception.
+     */
+    public UnexpectedExceptionInformation(Class<? extends HttpResponseException> exceptionType,
+        Class<?> exceptionBodyType) {
         this.exceptionType = exceptionType;
 
         // Should always have a value() method. Register Object as a fallback plan.
-        Class<?> exceptionBodyType = Object.class;
         try {
             final Method exceptionBodyMethod = exceptionType.getDeclaredMethod(EXCEPTION_BODY_METHOD);
-            exceptionBodyType = exceptionBodyMethod.getReturnType();
+            Class<?> exceptionBodyReturnType = exceptionBodyMethod.getReturnType();
+            if (!exceptionBodyReturnType.isAssignableFrom(exceptionBodyType)) {
+                // the exceptionBodyType is not valid
+                exceptionBodyType = exceptionBodyReturnType;
+            }
         } catch (NoSuchMethodException ignored) {
             // no-op
         }

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/rest/SwaggerMethodParser.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/rest/SwaggerMethodParser.java
@@ -669,7 +669,8 @@ public class SwaggerMethodParser implements HttpResponseDecodeData {
         HashMap<Integer, UnexpectedExceptionInformation> exceptionHashMap = new HashMap<>();
 
         for (UnexpectedResponseExceptionType exceptionAnnotation : unexpectedResponseExceptionTypes) {
-            UnexpectedExceptionInformation exception = new UnexpectedExceptionInformation(exceptionAnnotation.value());
+            UnexpectedExceptionInformation exception = new UnexpectedExceptionInformation(exceptionAnnotation.value(),
+                exceptionAnnotation.exceptionBodyClass());
             if (exceptionAnnotation.code().length == 0) {
                 defaultException = exception;
             } else {

--- a/sdk/core/azure-core/src/samples/java/com/azure/core/http/rest/RestProxyExceptionTests.java
+++ b/sdk/core/azure-core/src/samples/java/com/azure/core/http/rest/RestProxyExceptionTests.java
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.http.rest;
+
+import com.azure.core.annotation.ExpectedResponses;
+import com.azure.core.annotation.Get;
+import com.azure.core.annotation.Host;
+import com.azure.core.annotation.ServiceInterface;
+import com.azure.core.annotation.UnexpectedResponseExceptionType;
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.MockHttpResponse;
+import com.azure.core.models.ResponseError;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+
+public final class RestProxyExceptionTests {
+
+    @Host("https://azure.com")
+    @ServiceInterface(name = "myService")
+    interface TestInterface {
+        @Get("my/url/path")
+        @ExpectedResponses({200})
+        @UnexpectedResponseExceptionType(value = HttpResponseException.class, exceptionBodyClass = ResponseError.class)
+        Mono<Response<Void>> testMethod();
+    }
+
+    @Test
+    public void exceptionBodyClassTests() {
+        String responseStr = "{\"error\":{\"code\":\"RESOURCE_NOT_FOUND\",\"message\":\"resource not found\"}}";
+
+        HttpClient client = request -> Mono.just(
+                new MockHttpResponse(request, 404, new HttpHeaders(), responseStr.getBytes(StandardCharsets.UTF_8)));
+        HttpPipeline pipeline = new HttpPipelineBuilder().httpClient(client).build();
+        TestInterface testInterface = RestProxy.create(TestInterface.class, pipeline);
+
+        HttpResponseException exception = Assertions.assertThrows(HttpResponseException.class, () -> {
+            testInterface.testMethod().block();
+        });
+        Assertions.assertInstanceOf(ResponseError.class, exception.getValue());
+    }
+}


### PR DESCRIPTION
similar to https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/clientcore/core/src/main/java/io/clientcore/core/http/annotations/UnexpectedResponseExceptionDetail.java#L72

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
