### PR TITLE
Don't trigger openrewrite-sample-compiler-ci on every PR

### DIFF
--- a/sdk/tools/openrewrite-sample-compiler-ci.yml
+++ b/sdk/tools/openrewrite-sample-compiler-ci.yml
@@ -4,6 +4,7 @@ trigger:
       - main
   paths:
     include:
+      - /sdk/tools/openrewrite-sample-compiler-ci.yml
       - /sdk/tools/azure-openrewrite/
       - /sdk/tools/azure-openrewrite-compiler-maven-plugin/
 
@@ -16,6 +17,7 @@ pr:
       - release/*
   paths:
     include:
+      - /sdk/tools/openrewrite-sample-compiler-ci.yml
       - /sdk/tools/azure-openrewrite/
       - /sdk/tools/azure-openrewrite-compiler-maven-plugin/
 


### PR DESCRIPTION
# Description

`openrewrite-sample-compiler-ci.yml` didn't have a PR triggers defined which resulted in it running for every PR. This fixes that to only run when it should.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
