### PR TITLE
Make it possible to configure how the JmsConnectionFactory should be created.

### DIFF
--- a/sdk/spring/spring-cloud-azure-autoconfigure/CHANGELOG.md
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 5.23.0-beta.1 (Unreleased)
 
 ### Features Added
-
+- Create a new interface 'AzureServiceBusJmsConnectionFactoryFactory' that allows a user to specify how the JmsConnectionFactory should be created.
+- 
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/jms/ServiceBusJmsConnectionFactoryConfiguration.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/jms/ServiceBusJmsConnectionFactoryConfiguration.java
@@ -6,6 +6,7 @@ package com.azure.spring.cloud.autoconfigure.implementation.jms;
 import com.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
 import com.azure.spring.cloud.autoconfigure.implementation.jms.properties.AzureServiceBusJmsProperties;
 import com.azure.spring.cloud.autoconfigure.jms.AzureServiceBusJmsConnectionFactoryCustomizer;
+import com.azure.spring.cloud.autoconfigure.jms.AzureServiceBusJmsConnectionFactoryFactory;
 import jakarta.jms.ConnectionFactory;
 import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
 import org.springframework.beans.BeansException;
@@ -117,10 +118,11 @@ class ServiceBusJmsConnectionFactoryConfiguration {
 
         private ServiceBusJmsConnectionFactory createServiceBusJmsConnectionFactory() {
             AzureServiceBusJmsProperties serviceBusJmsProperties = beanFactory.getBean(AzureServiceBusJmsProperties.class);
+            AzureServiceBusJmsConnectionFactoryFactory instanceFactory = beanFactory.getBean(AzureServiceBusJmsConnectionFactoryFactory.class);
             ObjectProvider<AzureServiceBusJmsConnectionFactoryCustomizer> factoryCustomizers = beanFactory.getBeanProvider(AzureServiceBusJmsConnectionFactoryCustomizer.class);
             return new ServiceBusJmsConnectionFactoryFactory(serviceBusJmsProperties,
                 factoryCustomizers.orderedStream().collect(Collectors.toList()))
-                .createConnectionFactory(ServiceBusJmsConnectionFactory.class);
+                .createConnectionFactory(instanceFactory);
         }
     }
 }

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/jms/AzureServiceBusJmsConnectionFactoryFactory.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/jms/AzureServiceBusJmsConnectionFactoryFactory.java
@@ -1,0 +1,16 @@
+package com.azure.spring.cloud.autoconfigure.jms;
+
+import com.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
+
+/**
+ * The interface used to define how the {@link ServiceBusJmsConnectionFactory} instance is created.
+ */
+public interface AzureServiceBusJmsConnectionFactoryFactory {
+
+    /**
+     * Creates an instance of {@link ServiceBusJmsConnectionFactory} or a subclass thereof.
+     *
+     * @return an instance of {@link ServiceBusJmsConnectionFactory}
+     */
+    ServiceBusJmsConnectionFactory createServiceBusJmsConnectionFactory();
+}

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/jms/AzureServiceBusJmsConnectionFactoryFactory.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/jms/AzureServiceBusJmsConnectionFactoryFactory.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package com.azure.spring.cloud.autoconfigure.jms;
 
 import com.azure.servicebus.jms.ServiceBusJmsConnectionFactory;

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/jms/ServiceBusJmsConnectionFactoryConfigurationTests.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/jms/ServiceBusJmsConnectionFactoryConfigurationTests.java
@@ -3,23 +3,37 @@
 
 package com.azure.spring.cloud.autoconfigure.implementation.jms;
 
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.extensions.implementation.credential.TokenCredentialProviderOptions;
+import com.azure.identity.extensions.implementation.credential.provider.TokenCredentialProvider;
+import com.azure.servicebus.jms.ConnectionStringBuilder;
 import com.azure.servicebus.jms.ServiceBusJmsConnectionFactory;
+import com.azure.servicebus.jms.ServiceBusJmsConnectionFactorySettings;
 import com.azure.spring.cloud.autoconfigure.implementation.context.properties.AzureGlobalProperties;
+import com.azure.spring.cloud.autoconfigure.implementation.jms.properties.AzureServiceBusJmsProperties;
+import com.azure.spring.cloud.autoconfigure.jms.AzureServiceBusJmsConnectionFactoryFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jms.JmsAutoConfiguration;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.jms.connection.CachingConnectionFactory;
 
+import static com.azure.spring.cloud.autoconfigure.implementation.util.SpringPasswordlessPropertiesUtils.enhancePasswordlessProperties;
 import static com.azure.spring.cloud.autoconfigure.implementation.util.TestServiceBusUtils.CONNECTION_STRING_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class ServiceBusJmsConnectionFactoryConfigurationTests {
+import java.util.Properties;
+
+public class ServiceBusJmsConnectionFactoryConfigurationTests {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withBean(AzureGlobalProperties.class, AzureGlobalProperties::new)
@@ -140,9 +154,91 @@ class ServiceBusJmsConnectionFactoryConfigurationTests {
             });
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"standard", "premium"})
+    void useAlternativeConnectionFactoryForPoolConnection(String pricingTier) {
+        this.contextRunner
+            .withConfiguration(AutoConfigurations.of(AlternativeConnectionFactoryConfiguration.class))
+            .withPropertyValues(
+                "spring.jms.servicebus.pricing-tier=" + pricingTier,
+                "spring.jms.servicebus.pool.enabled=true"
+            )
+            .run(context -> {
+                assertThat(context).hasSingleBean(JmsPoolConnectionFactory.class);
+                JmsPoolConnectionFactory wrapper = context.getBean(JmsPoolConnectionFactory.class);
+                assertEquals(AlternativeConnectionFactory.class, wrapper.getConnectionFactory().getClass());
+            });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"standard", "premium"})
+    void useAlternativeConnectionFactoryForCacheConnection(String pricingTier) {
+        this.contextRunner
+            .withConfiguration(AutoConfigurations.of(AlternativeConnectionFactoryConfiguration.class))
+            .withPropertyValues(
+                "spring.jms.servicebus.pricing-tier=" + pricingTier,
+                "spring.jms.servicebus.pool.enabled=false"
+            )
+            .run(context -> {
+                assertThat(context).hasSingleBean(CachingConnectionFactory.class);
+                CachingConnectionFactory wrapper = context.getBean(CachingConnectionFactory.class);
+                assertEquals(AlternativeConnectionFactory.class, wrapper.getTargetConnectionFactory().getClass());
+            });
+    }
+
     @Configuration
     @PropertySource("classpath:servicebus/additional.properties")
     static class AdditionalPropertySourceConfiguration {
 
     }
+
+    @Configuration
+    static class AlternativeConnectionFactoryConfiguration {
+
+        @Autowired
+        AzureServiceBusJmsProperties properties;
+
+        @Bean
+        @Primary
+        AzureServiceBusJmsConnectionFactoryFactory connectionInstanceFactory() {
+            return () -> {
+                if (properties.isPasswordlessEnabled()) {
+                    String hostName =
+                        properties.getNamespace() + "." + properties.getProfile().getEnvironment().getServiceBusDomainName();
+                    Properties passwordlessProperties = properties.toPasswordlessProperties();
+                    enhancePasswordlessProperties(AzureServiceBusJmsProperties.PREFIX, properties, passwordlessProperties);
+                    TokenCredentialProvider tokenCredentialProvider = TokenCredentialProvider.createDefault(new TokenCredentialProviderOptions(passwordlessProperties));
+                    TokenCredential tokenCredential = tokenCredentialProvider.get();
+                    return new AlternativeConnectionFactory(tokenCredential, hostName, new ServiceBusJmsConnectionFactorySettings());
+                } else {
+                    return new AlternativeConnectionFactory(properties.getConnectionString(), new ServiceBusJmsConnectionFactorySettings());
+                }
+            };
+        }
+    }
+
+    // declare the "access chain" public or face a from checkstyle violation or a
+    // java.lang.NoSuchMethodException when running the tests from the command line
+    public static class AlternativeConnectionFactory extends ServiceBusJmsConnectionFactory {
+
+        public AlternativeConnectionFactory() {
+        }
+
+        public AlternativeConnectionFactory(String connectionString, ServiceBusJmsConnectionFactorySettings settings) {
+            super(connectionString, settings);
+        }
+
+        public AlternativeConnectionFactory(ConnectionStringBuilder connectionStringBuilder, ServiceBusJmsConnectionFactorySettings settings) {
+            super(connectionStringBuilder, settings);
+        }
+
+        public AlternativeConnectionFactory(String sasKeyName, String sasKey, String host, ServiceBusJmsConnectionFactorySettings settings) {
+            super(sasKey, sasKey, host, settings);
+        }
+
+        public AlternativeConnectionFactory(TokenCredential credential, String host, ServiceBusJmsConnectionFactorySettings settings) {
+            super(credential, host, settings);
+        }
+    }
 }
+


### PR DESCRIPTION
# Description
Creates a new interface 'AzureServiceBusJmsConnectionFactoryFactory' that allows a user to specify how the JmsConnectionFactory should be created.
There is a default implementation should the user decide to go with the standard Azure component.
This implementation greatly simplifies the creation by removing the usage of reflection and instead making the implementation compile time safe.
It could be discussed if ServiceBusJmsConnectionFactoryFactory should be removed completely by moving the remaining functionality to ServiceBusJmsConnectionFactoryConfiguration.

Fixes #45942

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
