### PR TITLE
Prepare OTel AutoConfigure release v1.3.0

### DIFF
--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -161,7 +161,7 @@ com.azure:azure-messaging-webpubsub-client;1.1.2;1.2.0-beta.1
 com.azure:azure-mixedreality-authentication;1.2.33;1.3.0-beta.1
 com.azure:azure-mixedreality-remoterendering;1.1.38;1.2.0-beta.1
 com.azure:azure-monitor-opentelemetry-exporter;1.0.0-beta.32;1.0.0-beta.33
-com.azure:azure-monitor-opentelemetry-autoconfigure;1.2.0;1.3.0-beta.1
+com.azure:azure-monitor-opentelemetry-autoconfigure;1.2.0;1.3.0
 com.azure:azure-monitor-ingestion;1.2.11;1.3.0-beta.1
 com.azure:azure-monitor-ingestion-perf;1.0.0-beta.1;1.0.0-beta.1
 com.azure:azure-monitor-query;1.5.7;1.6.0-beta.1

--- a/sdk/monitor/azure-monitor-opentelemetry-autoconfigure/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-autoconfigure/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.3.0 (2025-08-01)
 
 ### Bugs Fixed
-
-### Other Changes
+- Don't call .toString() or .length() on null strings/urls ([#44933](https://github.com/Azure/azure-sdk-for-java/pull/44933))
+- Fix null exception message error ([#46001](https://github.com/Azure/azure-sdk-for-java/pull/46001))
+- Fix live metrics race condition ([#45944](https://github.com/Azure/azure-sdk-for-java/pull/45944))
 
 ## 1.2.0 (2025-04-11)
 

--- a/sdk/monitor/azure-monitor-opentelemetry-autoconfigure/pom.xml
+++ b/sdk/monitor/azure-monitor-opentelemetry-autoconfigure/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>com.azure</groupId>
   <artifactId>azure-monitor-opentelemetry-autoconfigure</artifactId>
-  <version>1.3.0-beta.1</version> <!-- {x-version-update;com.azure:azure-monitor-opentelemetry-autoconfigure;current} -->
+  <version>1.3.0</version> <!-- {x-version-update;com.azure:azure-monitor-opentelemetry-autoconfigure;current} -->
 
   <name>Azure Monitor OpenTelemetry SDK Autoconfigure Distro</name>
   <description>This package contains Azure Monitor OpenTelemetry SDK Autoconfigure Distro.</description>


### PR DESCRIPTION
Used the Prepare-Release.ps1 script to prepare this library for v1.3.0 release.

```
.\eng\common\scripts\Prepare-Release.ps1 azure-monitor-opentelemetry-autoconfigure monitor
```