### PR TITLE
mgmt search, fix link

### DIFF
--- a/sdk/search/README.md
+++ b/sdk/search/README.md
@@ -17,7 +17,7 @@ Functionality is exposed through several client libraries:
   [azure-core](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core/README.md) and the
   [Azure SDK Design Guidelines for Java](https://azure.github.io/azure-sdk/java_introduction.html).
 
-- [azure-resourcemanager-search](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/resourcemanager/azure-resourcemanager-search/)
+- [azure-resourcemanager-search](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/search/azure-resourcemanager-search/)
   supports managing Azure AI Search services and API keys.
 
 ## Contributing


### PR DESCRIPTION
# Description

- Fix link to point to the new azure-resourcemanager-search location.
- resourcemanager release CI passed: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5203459&view=results

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
