### PR TITLE
spring mgmt, fix azure-resourcemanager-search dependency in from-source test

### DIFF
--- a/sdk/spring/pipeline/ClientFromSourcePom.xml
+++ b/sdk/spring/pipeline/ClientFromSourcePom.xml
@@ -52,7 +52,7 @@
     <module>../../resourcemanager/azure-resourcemanager-privatedns/pom.xml</module>
     <module>../../resourcemanager/azure-resourcemanager-redis/pom.xml</module>
     <module>../../resourcemanager/azure-resourcemanager-resources/pom.xml</module>
-    <module>../../resourcemanager/azure-resourcemanager-search/pom.xml</module>
+    <module>../../search/azure-resourcemanager-search/pom.xml</module>
     <module>../../resourcemanager/azure-resourcemanager-servicebus/pom.xml</module>
     <module>../../resourcemanager/azure-resourcemanager-sql/pom.xml</module>
     <module>../../resourcemanager/azure-resourcemanager-storage/pom.xml</module>

--- a/sdk/spring/pipeline/compatibility-tests-job.yml
+++ b/sdk/spring/pipeline/compatibility-tests-job.yml
@@ -43,6 +43,7 @@ jobs:
             - 'sdk/parents/azure-perf-test-parent'
             - 'sdk/parents/azure-sdk-parent'
             - 'sdk/resourcemanager'
+            - 'sdk/search/azure-resourcemanager-search'
             - 'sdk/serialization'
             - 'sdk/servicebus'
             - 'sdk/storage'


### PR DESCRIPTION
# Description

## Context

Azure MGMT SDK is progressively separating resourcemanager libraries into individual service directories:
- https://github.com/Azure/azure-sdk-for-java/issues/45920

We've now splitted azure-resourcemanager-search:
- https://github.com/Azure/azure-sdk-for-java/pull/46322

This affects Spring's compatibility check. 
https://dev.azure.com/azure-sdk/public/_build/results?buildId=5204341&view=results

## This PR

This PR updates the azure-resourcemanager-search module dependency to point to the new location.

There could be more PRs in the future once we migrated other packages.


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
