### PR TITLE
Update replaced multipart boundary `placeholder`  

### DIFF
--- a/sdk/openai/azure-ai-openai-assistants/src/test/java/com/azure/ai/openai/assistants/AssistantsClientTestBase.java
+++ b/sdk/openai/azure-ai-openai-assistants/src/test/java/com/azure/ai/openai/assistants/AssistantsClientTestBase.java
@@ -150,7 +150,7 @@ public abstract class AssistantsClientTestBase extends TestProxyTestBase {
                 new TestProxySanitizer("$..endpoint", null, "https://REDACTED", TestProxySanitizerType.BODY_KEY),
                 new TestProxySanitizer("Content-Type",
                     "(^multipart\\/form-data; boundary=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{2})",
-                    "multipart\\/form-data; boundary=BOUNDARY", TestProxySanitizerType.HEADER)));
+                    "multipart\\/form-data; boundary=REDACTED", TestProxySanitizerType.HEADER)));
     }
 
     private void addCustomMatchers() {

--- a/sdk/openai/azure-ai-openai/src/test/java/com/azure/ai/openai/OpenAIClientTestBase.java
+++ b/sdk/openai/azure-ai-openai/src/test/java/com/azure/ai/openai/OpenAIClientTestBase.java
@@ -189,7 +189,7 @@ public abstract class OpenAIClientTestBase extends TestProxyTestBase {
                 new TestProxySanitizer("$..endpoint", null, "https://REDACTED", TestProxySanitizerType.BODY_KEY),
                 new TestProxySanitizer("Content-Type",
                     "(^multipart\\/form-data; boundary=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{2})",
-                    "multipart\\/form-data; boundary=BOUNDARY", TestProxySanitizerType.HEADER)));
+                    "multipart\\/form-data; boundary=REDACTED", TestProxySanitizerType.HEADER)));
     }
 
     private void addCustomMatchers() {

--- a/sdk/openai/azure-ai-openai/src/test/java/com/azure/ai/openai/responses/AzureResponsesTestBase.java
+++ b/sdk/openai/azure-ai-openai/src/test/java/com/azure/ai/openai/responses/AzureResponsesTestBase.java
@@ -74,7 +74,7 @@ public class AzureResponsesTestBase extends TestProxyTestBase {
                 new TestProxySanitizer("$..endpoint", null, "https://REDACTED", TestProxySanitizerType.BODY_KEY),
                 new TestProxySanitizer("Content-Type",
                     "(^multipart\\/form-data; boundary=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{2})",
-                    "multipart\\/form-data; boundary=BOUNDARY", TestProxySanitizerType.HEADER)));
+                    "multipart\\/form-data; boundary=REDACTED", TestProxySanitizerType.HEADER)));
     }
 
     private void addCustomMatchers() {


### PR DESCRIPTION
1. Proxy release last monday broke a lot of tests
2. On investigation, this is occuring during `matching` of the incoming request. This is occuring because the proxy now treats all `multipart/*` the same as `multipart/mixed`, which implies actual parsing of the request for sanitization.
3. The proxy is failing to parse the body because of sanitizerId = 73, which corresponds to a `HeaderRegexSanitizer` `(^multipart/form-data; boundary=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{2})`
4. We're replacing the boundary with `boundary=BOUNDARY`, and we're using that as the initial boundary when parsing the multipart body.
5. The proxy is able to "figure out" what to do with redacted boundaries. It looks at the first few bytes of the body to find it there, if the existing value is one the proxy judges to be `placeholder`. It _didn't_ recognize `BOUNDARY` as a placeholder value,. We were 500ing during matching due to running past the end of the body without finding that boundary in the content.

I think long term, the proper solution is to remove these sanitizer entirely. They are no longer necessary as `multipart` matching now ignores the value of the boundary in the `Content-Type` header.

Let's test all my assumptions with this PR. We should have stuff going green for the most part.

FYI @alzimmermsft 