### PR TITLE
mgmt, increment version after resourcemanager release

### DIFF
--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -266,7 +266,7 @@ com.azure.spring:spring-cloud-azure-stream-binder-servicebus-core;6.0.0;6.1.0-be
 com.azure.spring:spring-cloud-azure-stream-binder-servicebus;6.0.0;6.1.0-beta.1
 com.azure.spring:spring-cloud-azure-testcontainers;6.0.0;6.1.0-beta.1
 com.azure:azure-spring-data-cosmos;6.0.0;6.1.0-beta.1
-com.azure.resourcemanager:azure-resourcemanager;2.54.0;2.55.0
+com.azure.resourcemanager:azure-resourcemanager;2.54.0;2.55.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-appplatform;2.51.0;2.52.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-appservice;2.53.4;2.54.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-authorization;2.53.3;2.54.0-beta.1

--- a/sdk/resourcemanager/azure-resourcemanager-perf/pom.xml
+++ b/sdk/resourcemanager/azure-resourcemanager-perf/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>
       <artifactId>azure-resourcemanager</artifactId>
-      <version>2.55.0</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
+      <version>2.55.0-beta.1</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
     </dependency>
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>

--- a/sdk/resourcemanager/azure-resourcemanager-samples/pom.xml
+++ b/sdk/resourcemanager/azure-resourcemanager-samples/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>
       <artifactId>azure-resourcemanager</artifactId>
-      <version>2.55.0</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
+      <version>2.55.0-beta.1</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
     </dependency>
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>

--- a/sdk/resourcemanager/azure-resourcemanager/CHANGELOG.md
+++ b/sdk/resourcemanager/azure-resourcemanager/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.55.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.55.0 (2025-09-30)
 
 ### azure-resourcemanager-network

--- a/sdk/resourcemanager/azure-resourcemanager/pom.xml
+++ b/sdk/resourcemanager/azure-resourcemanager/pom.xml
@@ -15,7 +15,7 @@
 
   <groupId>com.azure.resourcemanager</groupId>
   <artifactId>azure-resourcemanager</artifactId>
-  <version>2.55.0</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
+  <version>2.55.0-beta.1</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
   <packaging>jar</packaging>
 
   <name>Microsoft Azure SDK for Management</name>


### PR DESCRIPTION
# Description

It seems Maven now rejects GET requests without User-Agent header. 
https://repo1.maven.org/maven2/com/azure/resourcemanager/azure-resourcemanager/maven-metadata.xml
Had to do manual increment again.
Will raise an issue.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
