### PR TITLE
Added packageInfo to Find-java-Artifacts-For-Apireview function

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -79,7 +79,7 @@ jobs:
       Codeql.BuildIdentifier: ${{ parameters.ServiceDirectory }}
       Codeql.SkipTaskAutoInjection: false
       SDKType: ${{ parameters.SDKType }}
-    
+
     # Only run CG and codeql on internal build job
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       templateContext:
@@ -260,7 +260,9 @@ jobs:
 
       - template: /eng/common/pipelines/templates/steps/create-apireview.yml
         parameters:
-          Artifacts: ${{parameters.ReleaseArtifacts}}
+          PackageInfoFiles:
+            - ${{ each artifact in parameters.ReleaseArtifacts }}:
+              - $(Build.ArtifactStagingDirectory)/PackageInfo/${{artifact.name}}.json
 
       - template: /eng/common/pipelines/templates/steps/detect-api-changes.yml
 

--- a/eng/pipelines/templates/stages/archetype-java-release-batch.yml
+++ b/eng/pipelines/templates/stages/archetype-java-release-batch.yml
@@ -277,8 +277,10 @@ stages:
 
             - template: /eng/common/pipelines/templates/steps/create-apireview.yml
               parameters:
+                PackageInfoFiles:
+                  - ${{ each artifact in parameters.Artifacts }}:
+                    - $(Pipeline.Workspace)/packages-signed/PackageInfo/${{artifact.name}}.json
                 ArtifactPath: $(Pipeline.Workspace)/packages-signed
-                Artifacts: ${{parameters.Artifacts}}
                 ConfigFileDir: $(Pipeline.Workspace)/packages-signed/PackageInfo
                 MarkPackageAsShipped: true
                 ArtifactName: packages-signed

--- a/eng/pipelines/templates/stages/archetype-java-release-patch.yml
+++ b/eng/pipelines/templates/stages/archetype-java-release-patch.yml
@@ -175,8 +175,10 @@ stages:
                 ArtifactPath: $(Pipeline.Workspace)/packages-signed
             - template: /eng/common/pipelines/templates/steps/create-apireview.yml
               parameters:
+                PackageInfoFiles:
+                  - ${{ each artifact in parameters.Artifacts }}:
+                    - $(Pipeline.Workspace)/packages-signed/PackageInfo/${{artifact.name}}.json
                 ArtifactPath: $(Pipeline.Workspace)/packages-signed
-                Artifacts: ${{parameters.Artifacts}}
                 ConfigFileDir: $(Pipeline.Workspace)/packages-signed/PackageInfo
                 MarkPackageAsShipped: true
                 ArtifactName: packages-signed

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -485,8 +485,16 @@ function Get-java-GithubIoDocIndex()
 
 # function is used to filter packages to submit to API view tool
 # Function pointer name: FindArtifactForApiReviewFn
-function Find-java-Artifacts-For-Apireview($artifactDir, $pkgName, $packageInfo = $null)
+function Find-java-Artifacts-For-Apireview($artifactDir, $packageInfo)
 {
+  # Check if packageInfo is null first
+  if (!$packageInfo) {
+    Write-Host "Package info is null, skipping API review artifact search"
+    return $null
+  }
+
+  $pkgName = $packageInfo.ArtifactName ?? $packageInfo.Name
+
   # skip spark packages
   if ($pkgName.Contains("-spark")) {
     return $null
@@ -497,7 +505,7 @@ function Find-java-Artifacts-For-Apireview($artifactDir, $pkgName, $packageInfo 
   }
 
   if ($packageInfo) {
-    $artifactPath = Join-Path $artifactDir $packageInfo.Group $packageInfo.ArtifactName
+    $artifactPath = Join-Path $artifactDir $packageInfo.Group $pkgName
     $files = @(Get-ChildItem "${artifactPath}" | Where-Object -FilterScript {$_.Name.EndsWith("sources.jar")})
   } else {
     # Find all source jar files in given artifact directory


### PR DESCRIPTION
Enable the artifact discovery based on the `groupId` and `artifactName` from the `packageInfo`.

Parent issue is at https://github.com/Azure/azure-sdk-tools/issues/10219