### PR TITLE
cosmos: Enable endToEndTimeout for queryDocumentChangeFeed operation

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/EndToEndTimeOutValidationTests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/EndToEndTimeOutValidationTests.java
@@ -6,10 +6,12 @@ import com.azure.cosmos.implementation.Configs;
 import com.azure.cosmos.implementation.HttpConstants;
 import com.azure.cosmos.implementation.OperationCancelledException;
 import com.azure.cosmos.implementation.TestConfigurations;
+import com.azure.cosmos.models.CosmosChangeFeedRequestOptions;
 import com.azure.cosmos.models.CosmosContainerProperties;
 import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
+import com.azure.cosmos.models.FeedRange;
 import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.rx.TestSuiteBase;
@@ -251,6 +253,41 @@ public class EndToEndTimeOutValidationTests extends TestSuiteBase {
                         .verify();
         } finally {
             if (faultInjectionRule !=  null) {
+                faultInjectionRule.disable();
+            }
+
+            safeClose(cosmosClient);
+        }
+    }
+
+    @Test(groups = {"fast"}, timeOut = 10000L, retryAnalyzer = FlakyTestRetryAnalyzer.class)
+    public void queryChangeFeedWithEndToEndTimeoutPolicyInOptionsShouldTimeout() {
+        if (getClientBuilder().buildConnectionPolicy().getConnectionMode() != ConnectionMode.DIRECT) {
+            throw new SkipException("Failure injection only supported for DIRECT mode");
+        }
+
+        CosmosAsyncClient cosmosClient = initializeClient(endToEndOperationLatencyPolicyConfig);
+        FaultInjectionRule faultInjectionRule = null;
+        try {
+            CosmosEndToEndOperationLatencyPolicyConfig endToEndOperationLatencyPolicyConfig =
+                new CosmosEndToEndOperationLatencyPolicyConfigBuilder(Duration.ofSeconds(1))
+                    .build();
+
+            CosmosChangeFeedRequestOptions options =
+                CosmosChangeFeedRequestOptions.createForProcessingFromBeginning(FeedRange.forFullRange());
+            options.setCosmosEndToEndOperationLatencyPolicyConfig(endToEndOperationLatencyPolicyConfig);
+
+            faultInjectionRule = injectFailure(createdContainer, FaultInjectionOperationType.READ_FEED_ITEM, null);
+            CosmosPagedFlux<TestObject> changeFeedPagedFlux =
+                createdContainer.queryChangeFeed(options, TestObject.class);
+
+            StepVerifier.create(changeFeedPagedFlux)
+                        .expectErrorMatches(throwable -> throwable instanceof OperationCancelledException
+                            && ((OperationCancelledException) throwable).getSubStatusCode()
+                            == HttpConstants.SubStatusCodes.CLIENT_OPERATION_TIMEOUT)
+                        .verify();
+        } finally {
+            if (faultInjectionRule != null) {
                 faultInjectionRule.disable();
             }
 

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/EndToEndTimeOutValidationTests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/EndToEndTimeOutValidationTests.java
@@ -296,6 +296,44 @@ public class EndToEndTimeOutValidationTests extends TestSuiteBase {
     }
 
     @Test(groups = {"fast"}, timeOut = 10000L, retryAnalyzer = FlakyTestRetryAnalyzer.class)
+    public void queryChangeFeedWithEndToEndTimeoutPolicyAndAvailabilityStrategyShouldTimeout() {
+        if (getClientBuilder().buildConnectionPolicy().getConnectionMode() != ConnectionMode.DIRECT) {
+            throw new SkipException("Failure injection only supported for DIRECT mode");
+        }
+
+        CosmosAsyncClient cosmosClient = initializeClient(endToEndOperationLatencyPolicyConfig);
+        FaultInjectionRule faultInjectionRule = null;
+        try {
+            CosmosEndToEndOperationLatencyPolicyConfig endToEndOperationLatencyPolicyConfig =
+                new CosmosEndToEndOperationLatencyPolicyConfigBuilder(Duration.ofSeconds(1))
+                    .availabilityStrategy(
+                        new ThresholdBasedAvailabilityStrategy(
+                            Duration.ofMillis(100), Duration.ofMillis(200)))
+                    .build();
+
+            CosmosChangeFeedRequestOptions options =
+                CosmosChangeFeedRequestOptions.createForProcessingFromBeginning(FeedRange.forFullRange());
+            options.setCosmosEndToEndOperationLatencyPolicyConfig(endToEndOperationLatencyPolicyConfig);
+
+            faultInjectionRule = injectFailure(createdContainer, FaultInjectionOperationType.READ_FEED_ITEM, null);
+            CosmosPagedFlux<TestObject> changeFeedPagedFlux =
+                createdContainer.queryChangeFeed(options, TestObject.class);
+
+            StepVerifier.create(changeFeedPagedFlux)
+                        .expectErrorMatches(throwable -> throwable instanceof OperationCancelledException
+                            && ((OperationCancelledException) throwable).getSubStatusCode()
+                            == HttpConstants.SubStatusCodes.CLIENT_OPERATION_TIMEOUT)
+                        .verify();
+        } finally {
+            if (faultInjectionRule != null) {
+                faultInjectionRule.disable();
+            }
+
+            safeClose(cosmosClient);
+        }
+    }
+
+    @Test(groups = {"fast"}, timeOut = 10000L, retryAnalyzer = FlakyTestRetryAnalyzer.class)
     public void queryItemWithEndToEndTimeoutPolicyInOptionsShouldTimeoutWithClientConfig() {
         if (getClientBuilder().buildConnectionPolicy().getConnectionMode() != ConnectionMode.DIRECT) {
             throw new SkipException("Failure injection only supported for DIRECT mode");

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Features Added
 * Added support for N-Region synchronous commit feature - See [PR 47757](https://github.com/Azure/azure-sdk-for-java/pull/47757)
+* Added support for `CosmosEndToEndOperationLatencyPolicyConfig` on `queryChangeFeed` operations so that an end-to-end operation timeout (and associated availability strategy) configured at the client level, request level, or via `CosmosOperationPolicy` is now honored for change feed queries. - See [PR 48144](https://github.com/Azure/azure-sdk-for-java/pull/48144)
 
 #### Breaking Changes
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/CosmosChangeFeedRequestOptionsImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/CosmosChangeFeedRequestOptionsImpl.java
@@ -53,6 +53,7 @@ public final class CosmosChangeFeedRequestOptionsImpl implements OverridableRequ
     private boolean completeAfterAllCurrentChangesRetrieved;
     private Long endLSN;
     private ReadConsistencyStrategy readConsistencyStrategy;
+    private CosmosEndToEndOperationLatencyPolicyConfig endToEndOperationLatencyPolicyConfig;
 
     public CosmosChangeFeedRequestOptionsImpl(CosmosChangeFeedRequestOptionsImpl toBeCloned) {
         if (toBeCloned.continuationState != null) {
@@ -80,6 +81,7 @@ public final class CosmosChangeFeedRequestOptionsImpl implements OverridableRequ
         this.keywordIdentifiers = toBeCloned.keywordIdentifiers;
         this.completeAfterAllCurrentChangesRetrieved = toBeCloned.completeAfterAllCurrentChangesRetrieved;
         this.endLSN = toBeCloned.endLSN;
+        this.endToEndOperationLatencyPolicyConfig = toBeCloned.endToEndOperationLatencyPolicyConfig;
     }
 
     public CosmosChangeFeedRequestOptionsImpl(
@@ -296,8 +298,11 @@ public final class CosmosChangeFeedRequestOptionsImpl implements OverridableRequ
 
     @Override
     public CosmosEndToEndOperationLatencyPolicyConfig getCosmosEndToEndLatencyPolicyConfig() {
-        // @TODO: Implement this and some of the others below
-        return null;
+        return this.endToEndOperationLatencyPolicyConfig;
+    }
+
+    public void setCosmosEndToEndLatencyPolicyConfig(CosmosEndToEndOperationLatencyPolicyConfig endToEndOperationLatencyPolicyConfig) {
+        this.endToEndOperationLatencyPolicyConfig = endToEndOperationLatencyPolicyConfig;
     }
 
     @Override

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/CosmosChangeFeedRequestOptionsImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/CosmosChangeFeedRequestOptionsImpl.java
@@ -421,6 +421,9 @@ public final class CosmosChangeFeedRequestOptionsImpl implements OverridableRequ
         this.throughputControlGroupName = overrideOption(cosmosRequestOptions.getThroughputControlGroupName(), this.throughputControlGroupName);
         this.thresholds = overrideOption(cosmosRequestOptions.getDiagnosticsThresholds(), this.thresholds);
         this.keywordIdentifiers = overrideOption(cosmosRequestOptions.getKeywordIdentifiers(), this.keywordIdentifiers);
+        this.endToEndOperationLatencyPolicyConfig = overrideOption(
+            cosmosRequestOptions.getCosmosEndToEndLatencyPolicyConfig(),
+            this.endToEndOperationLatencyPolicyConfig);
     }
 
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
@@ -1520,6 +1520,50 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
             });
     }
 
+    private static <T> Flux<FeedResponse<T>> getChangeFeedResponseFluxWithTimeout(
+        Flux<FeedResponse<T>> feedResponseFlux,
+        CosmosEndToEndOperationLatencyPolicyConfig endToEndPolicyConfig,
+        DiagnosticsClientContext diagnosticsClientContext) {
+
+        Duration endToEndTimeout = endToEndPolicyConfig.getEndToEndOperationTimeout();
+
+        if (endToEndTimeout.isNegative()) {
+            return feedResponseFlux
+                .timeout(endToEndTimeout)
+                .onErrorMap(throwable -> {
+                    if (throwable instanceof TimeoutException) {
+                        CosmosException cancellationException = getNegativeTimeoutException(null, endToEndTimeout);
+                        cancellationException.setStackTrace(throwable.getStackTrace());
+
+                        CosmosDiagnostics mostRecentDiagnostics = diagnosticsClientContext.getMostRecentlyCreatedDiagnostics();
+                        if (mostRecentDiagnostics != null) {
+                            BridgeInternal.setCosmosDiagnostics(cancellationException, mostRecentDiagnostics);
+                        }
+
+                        return cancellationException;
+                    }
+                    return throwable;
+                });
+        }
+
+        return feedResponseFlux
+            .timeout(endToEndTimeout)
+            .onErrorMap(throwable -> {
+                if (throwable instanceof TimeoutException) {
+                    CosmosException exception = new OperationCancelledException();
+                    exception.setStackTrace(throwable.getStackTrace());
+
+                    CosmosDiagnostics mostRecentDiagnostics = diagnosticsClientContext.getMostRecentlyCreatedDiagnostics();
+                    if (mostRecentDiagnostics != null) {
+                        BridgeInternal.setCosmosDiagnostics(exception, mostRecentDiagnostics);
+                    }
+
+                    return exception;
+                }
+                return throwable;
+            });
+    }
+
     private void addUserAgentSuffix(UserAgentContainer userAgentContainer, Set<UserAgentFeatureFlags> userAgentFeatureFlags) {
 
         if (!this.globalPartitionEndpointManagerForPerPartitionAutomaticFailover.isPerPartitionAutomaticFailoverEnabled()) {
@@ -4775,7 +4819,25 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
             diagnosticsClientContext,
             crossRegionAvailabilityContextForRequest);
 
-        return changeFeedQueryImpl.executeAsync();
+        CosmosChangeFeedRequestOptionsImpl implOptions =
+            ImplementationBridgeHelpers
+                .CosmosChangeFeedRequestOptionsHelper
+                .getCosmosChangeFeedRequestOptionsAccessor()
+                .getImpl(requestOptions);
+
+        CosmosEndToEndOperationLatencyPolicyConfig endToEndPolicyConfig =
+            this.getEffectiveEndToEndOperationLatencyPolicyConfig(
+                implOptions.getCosmosEndToEndLatencyPolicyConfig(),
+                ResourceType.Document,
+                OperationType.ReadFeed);
+
+        Flux<FeedResponse<T>> feedResponseFlux = changeFeedQueryImpl.executeAsync();
+
+        if (endToEndPolicyConfig != null && endToEndPolicyConfig.isEnabled()) {
+            return getChangeFeedResponseFluxWithTimeout(feedResponseFlux, endToEndPolicyConfig, diagnosticsClientContext);
+        }
+
+        return feedResponseFlux;
     }
 
     @Override

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
@@ -1439,6 +1439,9 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
                 exception,
                 mostRecentlyCreatedDiagnostics);
         } else {
+            if (requestOptions == null) {
+                return;
+            }
             List<CosmosDiagnostics> cancelledRequestDiagnostics =
                 qryOptAccessor
                     .getCancelledRequestDiagnosticsTracker(requestOptions);
@@ -1492,7 +1495,9 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
                         CosmosException cancellationException = getNegativeTimeoutException(null, endToEndTimeout);
                         cancellationException.setStackTrace(throwable.getStackTrace());
 
-                        isQueryCancelledOnTimeout.set(true);
+                        if (isQueryCancelledOnTimeout != null) {
+                            isQueryCancelledOnTimeout.set(true);
+                        }
 
                         applyExceptionToMergedDiagnosticsForQuery(
                             requestOptions, cancellationException, diagnosticsClientContext);
@@ -1510,53 +1515,11 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
                     CosmosException exception = new OperationCancelledException();
                     exception.setStackTrace(throwable.getStackTrace());
 
-                    isQueryCancelledOnTimeout.set(true);
+                    if (isQueryCancelledOnTimeout != null) {
+                        isQueryCancelledOnTimeout.set(true);
+                    }
 
                     applyExceptionToMergedDiagnosticsForQuery(requestOptions, exception, diagnosticsClientContext);
-
-                    return exception;
-                }
-                return throwable;
-            });
-    }
-
-    private static <T> Flux<FeedResponse<T>> getChangeFeedResponseFluxWithTimeout(
-        Flux<FeedResponse<T>> feedResponseFlux,
-        CosmosEndToEndOperationLatencyPolicyConfig endToEndPolicyConfig,
-        DiagnosticsClientContext diagnosticsClientContext) {
-
-        Duration endToEndTimeout = endToEndPolicyConfig.getEndToEndOperationTimeout();
-
-        if (endToEndTimeout.isNegative()) {
-            return feedResponseFlux
-                .timeout(endToEndTimeout)
-                .onErrorMap(throwable -> {
-                    if (throwable instanceof TimeoutException) {
-                        CosmosException cancellationException = getNegativeTimeoutException(null, endToEndTimeout);
-                        cancellationException.setStackTrace(throwable.getStackTrace());
-
-                        CosmosDiagnostics mostRecentDiagnostics = diagnosticsClientContext.getMostRecentlyCreatedDiagnostics();
-                        if (mostRecentDiagnostics != null) {
-                            BridgeInternal.setCosmosDiagnostics(cancellationException, mostRecentDiagnostics);
-                        }
-
-                        return cancellationException;
-                    }
-                    return throwable;
-                });
-        }
-
-        return feedResponseFlux
-            .timeout(endToEndTimeout)
-            .onErrorMap(throwable -> {
-                if (throwable instanceof TimeoutException) {
-                    CosmosException exception = new OperationCancelledException();
-                    exception.setStackTrace(throwable.getStackTrace());
-
-                    CosmosDiagnostics mostRecentDiagnostics = diagnosticsClientContext.getMostRecentlyCreatedDiagnostics();
-                    if (mostRecentDiagnostics != null) {
-                        BridgeInternal.setCosmosDiagnostics(exception, mostRecentDiagnostics);
-                    }
 
                     return exception;
                 }
@@ -4834,7 +4797,12 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
         Flux<FeedResponse<T>> feedResponseFlux = changeFeedQueryImpl.executeAsync();
 
         if (endToEndPolicyConfig != null && endToEndPolicyConfig.isEnabled()) {
-            return getChangeFeedResponseFluxWithTimeout(feedResponseFlux, endToEndPolicyConfig, diagnosticsClientContext);
+            return getFeedResponseFluxWithTimeout(
+                feedResponseFlux,
+                endToEndPolicyConfig,
+                null,
+                null,
+                diagnosticsClientContext);
         }
 
         return feedResponseFlux;

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosChangeFeedRequestOptions.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosChangeFeedRequestOptions.java
@@ -5,6 +5,7 @@ package com.azure.cosmos.models;
 
 import com.azure.cosmos.ConsistencyLevel;
 import com.azure.cosmos.CosmosDiagnosticsThresholds;
+import com.azure.cosmos.CosmosEndToEndOperationLatencyPolicyConfig;
 import com.azure.cosmos.CosmosItemSerializer;
 import com.azure.cosmos.ReadConsistencyStrategy;
 import com.azure.cosmos.implementation.CosmosChangeFeedRequestOptionsImpl;
@@ -113,6 +114,20 @@ public final class CosmosChangeFeedRequestOptions {
     @Beta(value = Beta.SinceVersion.V4_69_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public CosmosChangeFeedRequestOptions setReadConsistencyStrategy(ReadConsistencyStrategy readConsistencyStrategy) {
         this.actualRequestOptions.setReadConsistencyStrategy(readConsistencyStrategy);
+        return this;
+    }
+
+    /**
+     * Sets the {@link CosmosEndToEndOperationLatencyPolicyConfig} to be used for the request. If the config is already
+     * set on the client, then this will override the client level config for this request.
+     *
+     * @param cosmosEndToEndOperationLatencyPolicyConfig the {@link CosmosEndToEndOperationLatencyPolicyConfig}
+     * @return the CosmosChangeFeedRequestOptions
+     */
+    public CosmosChangeFeedRequestOptions setCosmosEndToEndOperationLatencyPolicyConfig(
+        CosmosEndToEndOperationLatencyPolicyConfig cosmosEndToEndOperationLatencyPolicyConfig) {
+
+        this.actualRequestOptions.setCosmosEndToEndLatencyPolicyConfig(cosmosEndToEndOperationLatencyPolicyConfig);
         return this;
     }
 


### PR DESCRIPTION
## Description

Fixes #40507

`endToEndTimeout` is supported for read and query operations via `CosmosEndToEndOperationLatencyPolicyConfig`, but the `queryDocumentChangeFeed` operation previously ignored this configuration entirely.

This PR enables endToEndTimeout on queryChangeFeed

## Changes

- **`CosmosChangeFeedRequestOptionsImpl`**: Added `endToEndOperationLatencyPolicyConfig` field and implemented the previously stubbed `getCosmosEndToEndLatencyPolicyConfig()` getter. Added corresponding setter.
- **`CosmosChangeFeedRequestOptions`** (public API): Added `setCosmosEndToEndOperationLatencyPolicyConfig()` method, mirroring the same API on `CosmosQueryRequestOptions`.
- **`RxDocumentClientImpl`**: Added `getChangeFeedResponseFluxWithTimeout()` helper and wired it into `queryDocumentChangeFeed()` - extracting the e2e policy config from request options and wrapping the change feed flux with timeout when enabled.
- **`EndToEndTimeOutValidationTests`**: Added `queryChangeFeedWithEndToEndTimeoutPolicyInOptionsShouldTimeout()` test using `READ_FEED_ITEM` fault injection, verifying `OperationCancelledException` with `CLIENT_OPERATION_TIMEOUT` substatus is thrown.