### PR TITLE
Add CosmosEndToEndOperationLatencyPolicyConfig support to azure-cosmos-benchmark

### DIFF
--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
@@ -10,6 +10,8 @@ import com.azure.cosmos.CosmosAsyncContainer;
 import com.azure.cosmos.CosmosAsyncDatabase;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosDiagnosticsThresholds;
+import com.azure.cosmos.CosmosEndToEndOperationLatencyPolicyConfig;
+import com.azure.cosmos.CosmosEndToEndOperationLatencyPolicyConfigBuilder;
 import com.azure.cosmos.CosmosContainerProactiveInitConfigBuilder;
 import com.azure.cosmos.CosmosException;
 import com.azure.cosmos.DirectConnectionConfig;
@@ -60,11 +62,24 @@ abstract class AsyncBenchmark<T> implements Benchmark {
     final String partitionKey;
     final TenantWorkloadConfig workloadConfig;
     final List<PojoizedJson> docsToRead;
+    final CosmosEndToEndOperationLatencyPolicyConfig e2ePolicyConfig;
 
     AsyncBenchmark(TenantWorkloadConfig cfg, Scheduler scheduler) {
 
         workloadConfig = cfg;
         this.benchmarkScheduler = scheduler;
+
+        // Build E2E timeout policy if configured (applied per-request, NOT at client level)
+        if (cfg.getEndToEndTimeoutMs() != null) {
+            logger.info("E2E timeout policy: {}ms (will be set on request options, not client builder)",
+                cfg.getEndToEndTimeoutMs());
+            this.e2ePolicyConfig = new CosmosEndToEndOperationLatencyPolicyConfigBuilder(
+                Duration.ofMillis(cfg.getEndToEndTimeoutMs()))
+                .enable(true)
+                .build();
+        } else {
+            this.e2ePolicyConfig = null;
+        }
 
         final TokenCredential credential = cfg.isManagedIdentityRequired()
             ? cfg.buildTokenCredential()

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncQueryBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncQueryBenchmark.java
@@ -41,6 +41,9 @@ class AsyncQueryBenchmark extends AsyncBenchmark<FeedResponse<PojoizedJson>> {
         Flux<FeedResponse<PojoizedJson>> obs;
         Random r = new Random();
         CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
+        if (e2ePolicyConfig != null) {
+            options.setCosmosEndToEndOperationLatencyPolicyConfig(e2ePolicyConfig);
+        }
 
         if (workloadConfig.getOperationType() == Operation.QueryCross) {
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncReadBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncReadBenchmark.java
@@ -3,6 +3,7 @@
 
 package com.azure.cosmos.benchmark;
 
+import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.PartitionKey;
 
@@ -11,8 +12,14 @@ import reactor.core.scheduler.Scheduler;
 
 class AsyncReadBenchmark extends AsyncBenchmark<PojoizedJson> {
 
+    private final CosmosItemRequestOptions readOptions;
+
     AsyncReadBenchmark(TenantWorkloadConfig cfg, Scheduler scheduler) {
         super(cfg, scheduler);
+        this.readOptions = new CosmosItemRequestOptions();
+        if (e2ePolicyConfig != null) {
+            readOptions.setCosmosEndToEndOperationLatencyPolicyConfig(e2ePolicyConfig);
+        }
     }
 
     @Override
@@ -20,7 +27,7 @@ class AsyncReadBenchmark extends AsyncBenchmark<PojoizedJson> {
         int index = (int) (i % docsToRead.size());
         PojoizedJson doc = docsToRead.get(index);
         return cosmosAsyncContainer.readItem(doc.getId(),
-            new PartitionKey(doc.getId()), PojoizedJson.class)
+            new PartitionKey(doc.getId()), readOptions, PojoizedJson.class)
             .map(CosmosItemResponse::getItem);
     }
 }

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncWriteBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncWriteBenchmark.java
@@ -3,6 +3,7 @@
 
 package com.azure.cosmos.benchmark;
 
+import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.PartitionKey;
 
@@ -16,12 +17,17 @@ class AsyncWriteBenchmark extends AsyncBenchmark<CosmosItemResponse> {
 
     private final String uuid;
     private final String dataFieldValue;
+    private final CosmosItemRequestOptions writeOptions;
 
     AsyncWriteBenchmark(TenantWorkloadConfig cfg, Scheduler scheduler) {
         super(cfg, scheduler);
 
         uuid = UUID.randomUUID().toString();
         dataFieldValue = RandomStringUtils.randomAlphabetic(workloadConfig.getDocumentDataFieldSize());
+        this.writeOptions = new CosmosItemRequestOptions();
+        if (e2ePolicyConfig != null) {
+            writeOptions.setCosmosEndToEndOperationLatencyPolicyConfig(e2ePolicyConfig);
+        }
     }
 
     @Override
@@ -40,7 +46,7 @@ class AsyncWriteBenchmark extends AsyncBenchmark<CosmosItemResponse> {
                 partitionKey,
                 workloadConfig.getDocumentDataFieldCount()),
                 new PartitionKey(id),
-                null);
+                writeOptions);
         }
         // Raw type cast is required because CosmosItemResponse uses wildcard generics
         // that cannot be expressed in the class type parameter without propagating

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/CosmosMetricsReporter.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/CosmosMetricsReporter.java
@@ -214,16 +214,17 @@ public class CosmosMetricsReporter {
 
         ObjectNode doc = createBaseDoc(timestamp, summary, "distribution", cpuPercent);
         doc.put("Count", summary.count());
-        doc.put("Mean", round(summary.mean()));
-        doc.put("Max", round(summary.max()));
+        doc.put("MeanMs", round(summary.mean()));
+        doc.put("MaxMs", round(summary.max()));
+        doc.put("Value", round(summary.totalAmount()));
 
         HistogramSnapshot snapshot = summary.takeSnapshot();
         for (ValueAtPercentile vp : snapshot.percentileValues()) {
             double p = vp.percentile();
-            if (p == 0.5) doc.put("P50", round(vp.value()));
-            else if (p == 0.9) doc.put("P90", round(vp.value()));
-            else if (p == 0.95) doc.put("P95", round(vp.value()));
-            else if (p == 0.99) doc.put("P99", round(vp.value()));
+            if (p == 0.5) doc.put("P50Ms", round(vp.value()));
+            else if (p == 0.9) doc.put("P90Ms", round(vp.value()));
+            else if (p == 0.95) doc.put("P95Ms", round(vp.value()));
+            else if (p == 0.99) doc.put("P99Ms", round(vp.value()));
         }
 
         uploadDoc(doc);

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/TenantWorkloadConfig.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/TenantWorkloadConfig.java
@@ -188,6 +188,12 @@ public class TenantWorkloadConfig {
     @JsonProperty("aggressiveWarmupDuration")
     private String aggressiveWarmupDuration;
 
+    @JsonProperty("endToEndTimeoutMs")
+    private Integer endToEndTimeoutMs;
+
+    @JsonProperty("availabilityStrategyEnabled")
+    private Boolean availabilityStrategyEnabled;
+
     // ======== Connection params ========
 
     @JsonProperty("connectionMode")
@@ -313,6 +319,9 @@ public class TenantWorkloadConfig {
         if (aggressiveWarmupDuration == null) return Duration.ZERO;
         return Duration.parse(aggressiveWarmupDuration);
     }
+
+    public Integer getEndToEndTimeoutMs() { return endToEndTimeoutMs; }
+    public boolean isAvailabilityStrategyEnabled() { return availabilityStrategyEnabled != null && availabilityStrategyEnabled; }
 
     public int getNumberOfCollectionForCtl() { return numberOfCollectionForCtl != null ? numberOfCollectionForCtl : 4; }
     public String getReadWriteQueryReadManyPct() { return readWriteQueryReadManyPct != null ? readWriteQueryReadManyPct : "90,8,1,1"; }
@@ -496,6 +505,10 @@ public class TenantWorkloadConfig {
                     if (overwrite || proactiveConnectionRegionsCount == null) proactiveConnectionRegionsCount = Integer.parseInt(value); break;
                 case "aggressiveWarmupDuration":
                     if (overwrite || aggressiveWarmupDuration == null) aggressiveWarmupDuration = value; break;
+                case "endToEndTimeoutMs":
+                    if (overwrite || endToEndTimeoutMs == null) endToEndTimeoutMs = Integer.parseInt(value); break;
+                case "availabilityStrategyEnabled":
+                    if (overwrite || availabilityStrategyEnabled == null) availabilityStrategyEnabled = Boolean.parseBoolean(value); break;
                 case "connectionMode":
                     if (overwrite || connectionMode == null) connectionMode = value; break;
                 case "consistencyLevel":


### PR DESCRIPTION
## Add CosmosEndToEndOperationLatencyPolicyConfig support to azure-cosmos-benchmark

### Motivation

Walmart reported that `CosmosEndToEndOperationLatencyPolicyConfig` was not being adhered to during Gateway V2 benchmarking under constrained compute (1-core/2GB, 60K-80K OPM). Our theory is that CPU/memory pressure on small VMs causes the Reactor timeout operator to not fire within the configured E2E budget.

To validate this theory, we need the benchmark module to support configuring E2E timeout policy + availability strategy on a per-request basis, so we can run soak tests (8 hours) and observe timeout behavior under sustained load.

### What Changed

**Per-request E2E timeout policy** — applied on `Cosmos(Item|Query)RequestOptions`, **not** at the client builder level. This is intentional: client-level E2E policy would apply to metadata calls (database/container reads at startup), which could cause failures during benchmark initialization.

| File | Change |
|------|--------|
| `TenantWorkloadConfig.java` | Added `endToEndTimeoutMs` (Integer) and `availabilityStrategyEnabled` (Boolean) JSON config fields, getters, and `applyField` support |
| `AsyncBenchmark.java` | Base class builds `CosmosEndToEndOperationLatencyPolicyConfig` once in constructor, exposes as `e2ePolicyConfig` for subclasses |
| `AsyncReadBenchmark.java` | Creates `CosmosItemRequestOptions` with E2E policy, passes 4-arg `readItem(id, pk, options, type)` (was using 3-arg overload) |
| `AsyncWriteBenchmark.java` | Creates `CosmosItemRequestOptions` with E2E policy, replaces `null` options in `createItem()` |
| `AsyncQueryBenchmark.java` | Sets E2E policy on `CosmosQueryRequestOptions` after construction — applies to all query operation types |

### Usage

In the workload config JSON (`tenantDefaults` or per-tenant):

```json
{
  "endToEndTimeoutMs": 3000,
  "availabilityStrategyEnabled": true
}
```

When `endToEndTimeoutMs` is not set (or null), no E2E policy is applied — existing behavior is unchanged.

### Part of

Gateway V2 Performance Benchmarking Infrastructure — this is the first of several benchmark module enhancements to support proactive perf validation matching Walmart's production configuration (3s E2E timeout, Session consistency, availability strategy enabled).