### PR TITLE
[KeyVault] Add samples for new certificate SANs (IP/URI) and secret outContentType/previousVersion features

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-certificates/src/samples/java/com/azure/security/keyvault/certificates/HelloWorld.java
+++ b/sdk/keyvault/azure-security-keyvault-certificates/src/samples/java/com/azure/security/keyvault/certificates/HelloWorld.java
@@ -47,8 +47,12 @@ public class HelloWorld {
 
         // Let's create a self-signed certificate valid for 1 year. If the certificate already exists in the key vault,
         // then a new version of the certificate is created.
+        // Subject Alternative Names (SANs) can include emails, DNS names, IP addresses, and URIs.
         CertificatePolicy policy = new CertificatePolicy("Self", "CN=SelfSignedJavaPkcs12")
-            .setSubjectAlternativeNames(new SubjectAlternativeNames().setEmails(Arrays.asList("wow@gmail.com")))
+            .setSubjectAlternativeNames(new SubjectAlternativeNames()
+                .setEmails(Arrays.asList("wow@gmail.com"))
+                .setIpAddresses(Arrays.asList("10.0.0.1", "2001:db8::1"))
+                .setUniformResourceIdentifiers(Arrays.asList("https://mydomain.com")))
             .setKeyReusable(true)
             .setKeyType(CertificateKeyType.EC)
             .setKeyCurveName(CertificateKeyCurveName.P_256)

--- a/sdk/keyvault/azure-security-keyvault-secrets/src/samples/java/com/azure/security/keyvault/secrets/HelloWorld.java
+++ b/sdk/keyvault/azure-security-keyvault-secrets/src/samples/java/com/azure/security/keyvault/secrets/HelloWorld.java
@@ -67,8 +67,9 @@ public class HelloWorld {
             .setProperties(new SecretProperties()
                 .setExpiresOn(OffsetDateTime.now().plusYears(1))));
 
-        // For secrets created after June 1, 2025, we can retrieve the previous version identifier.
-        // This is useful for certificate-backed secrets to track version history.
+        // For secrets created after June 1, 2025, the service may populate the previous version identifier
+        // when applicable. This is primarily useful for certificate-backed secrets to track version history,
+        // and it may be null for other secrets.
         KeyVaultSecret latestSecret = secretClient.getSecret("BankAccountPassword");
         String previousVersion = latestSecret.getProperties().getPreviousVersion();
 

--- a/sdk/keyvault/azure-security-keyvault-secrets/src/samples/java/com/azure/security/keyvault/secrets/HelloWorld.java
+++ b/sdk/keyvault/azure-security-keyvault-secrets/src/samples/java/com/azure/security/keyvault/secrets/HelloWorld.java
@@ -47,6 +47,10 @@ public class HelloWorld {
 
         System.out.printf("Secret is returned with name %s and value %s \n", bankSecret.getName(), bankSecret.getValue());
 
+        // For certificate-backed secrets, we can retrieve the secret value in a different format using outContentType.
+        // For example, to get the value in PEM format instead of the default PKCS#12 format:
+        // KeyVaultSecret pemSecret = secretClient.getSecret("MyCertSecret", null, "application/x-pem-file");
+
         // After one year, the bank account is still active, we need to update the expiry time of the secret.
         // The update method can be used to update the expiry attribute of the secret. It cannot be used to update the
         // value of the secret.
@@ -62,6 +66,15 @@ public class HelloWorld {
         secretClient.setSecret(new KeyVaultSecret("BankAccountPassword", "bhjd4DDgsa")
             .setProperties(new SecretProperties()
                 .setExpiresOn(OffsetDateTime.now().plusYears(1))));
+
+        // For secrets created after June 1, 2025, we can retrieve the previous version identifier.
+        // This is useful for certificate-backed secrets to track version history.
+        KeyVaultSecret latestSecret = secretClient.getSecret("BankAccountPassword");
+        String previousVersion = latestSecret.getProperties().getPreviousVersion();
+
+        if (previousVersion != null) {
+            System.out.printf("Secret's previous version is %s \n", previousVersion);
+        }
 
         // The bank account was closed, need to delete its credentials from the key vault.
         SyncPoller<DeletedSecret, Void> deletedBankSecretPoller =


### PR DESCRIPTION
## Description
This PR adds sample code demonstrating new KeyVault features:

### Certificates
- IP addresses in Subject Alternative Names (SANs)
- URIs in Subject Alternative Names (SANs)

### Secrets
- `outContentType` parameter for format conversion (PFX/PEM)
- `previousVersion` property on SecretProperties

## Files Changed
- `sdk/keyvault/azure-security-keyvault-certificates/src/samples/java/com/azure/security/keyvault/certificates/HelloWorld.java`  
- `sdk/keyvault/azure-security-keyvault-secrets/src/samples/java/com/azure/security/keyvault/secrets/HelloWorld.java`