### PR TITLE
eng, remove api-version required check, and infer sdk release type from api-version if not provided

### DIFF
--- a/eng/automation/generate.py
+++ b/eng/automation/generate.py
@@ -307,6 +307,34 @@ def infer_sdk_release_type(sdk_root: str, sdk_folder: str, module: str) -> str:
         return "beta"
 
 
+def ensure_revapi_skip(pom_path: str):
+    """Ensure <revapi.skip>true</revapi.skip> is present in pom.xml properties.
+
+    If <revapi.skip>false</revapi.skip> exists, change it to true.
+    If no revapi.skip property exists, add it before </properties>.
+    """
+    try:
+        with open(pom_path, "r") as f:
+            content = f.read()
+        if "<revapi.skip>true</revapi.skip>" in content:
+            return
+        if "<revapi.skip>false</revapi.skip>" in content:
+            new_content = content.replace("<revapi.skip>false</revapi.skip>", "<revapi.skip>true</revapi.skip>")
+            logging.info(f"[SelfServe] Changed revapi.skip to true in {pom_path}")
+        else:
+            new_content = re.sub(
+                r'([ \t]*)</properties>',
+                r'\1  <revapi.skip>true</revapi.skip>\n\1</properties>',
+                content,
+                count=1,
+            )
+            logging.info(f"[SelfServe] Added revapi.skip=true to {pom_path}")
+        with open(pom_path, "w") as f:
+            f.write(new_content)
+    except Exception as e:
+        logging.warning(f"[SelfServe] Failed to ensure revapi.skip in {pom_path}: {e}")
+
+
 def sdk_automation_typespec_project(tsp_project: str, config: dict) -> dict:
 
     base_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
@@ -350,6 +378,10 @@ def sdk_automation_typespec_project(tsp_project: str, config: dict) -> dict:
         stable_version, current_version = set_or_increase_version(sdk_root, GROUP_ID, module, preview=release_beta_sdk)
         output_folder = sdk_folder
         update_version(sdk_root, output_folder)
+
+        # Ensure revapi.skip=true for beta releases
+        if release_beta_sdk:
+            ensure_revapi_skip(os.path.join(sdk_root, output_folder, "pom.xml"))
 
         # compile
         succeeded = compile_arm_package(sdk_root, module)

--- a/eng/automation/generate.py
+++ b/eng/automation/generate.py
@@ -307,32 +307,38 @@ def infer_sdk_release_type(sdk_root: str, sdk_folder: str, module: str) -> str:
         return "beta"
 
 
-def ensure_revapi_skip(pom_path: str):
-    """Ensure <revapi.skip>true</revapi.skip> is present in pom.xml properties.
+def update_revapi_skip(pom_path: str, beta: bool):
+    """Update revapi.skip property in pom.xml based on release type.
 
-    If <revapi.skip>false</revapi.skip> exists, change it to true.
-    If no revapi.skip property exists, add it before </properties>.
+    beta=True:  ensure <revapi.skip>true</revapi.skip> (add if missing, flip if false)
+    beta=False: flip <revapi.skip>true</revapi.skip> to false if present (skip if absent, as false is default)
     """
     try:
         with open(pom_path, "r") as f:
             content = f.read()
-        if "<revapi.skip>true</revapi.skip>" in content:
-            return
-        if "<revapi.skip>false</revapi.skip>" in content:
-            new_content = content.replace("<revapi.skip>false</revapi.skip>", "<revapi.skip>true</revapi.skip>")
-            logging.info(f"[SelfServe] Changed revapi.skip to true in {pom_path}")
+        if beta:
+            if "<revapi.skip>true</revapi.skip>" in content:
+                return
+            if "<revapi.skip>false</revapi.skip>" in content:
+                new_content = content.replace("<revapi.skip>false</revapi.skip>", "<revapi.skip>true</revapi.skip>")
+                logging.info(f"[SelfServe] Changed revapi.skip to true in {pom_path}")
+            else:
+                new_content = re.sub(
+                    r'([ \t]*)</properties>',
+                    r'\1  <revapi.skip>true</revapi.skip>\n\1</properties>',
+                    content,
+                    count=1,
+                )
+                logging.info(f"[SelfServe] Added revapi.skip=true to {pom_path}")
         else:
-            new_content = re.sub(
-                r'([ \t]*)</properties>',
-                r'\1  <revapi.skip>true</revapi.skip>\n\1</properties>',
-                content,
-                count=1,
-            )
-            logging.info(f"[SelfServe] Added revapi.skip=true to {pom_path}")
+            if "<revapi.skip>true</revapi.skip>" not in content:
+                return
+            new_content = content.replace("<revapi.skip>true</revapi.skip>", "<revapi.skip>false</revapi.skip>")
+            logging.info(f"[SelfServe] Changed revapi.skip to false in {pom_path}")
         with open(pom_path, "w") as f:
             f.write(new_content)
     except Exception as e:
-        logging.warning(f"[SelfServe] Failed to ensure revapi.skip in {pom_path}: {e}")
+        logging.warning(f"[SelfServe] Failed to update revapi.skip in {pom_path}: {e}")
 
 
 def sdk_automation_typespec_project(tsp_project: str, config: dict) -> dict:
@@ -378,9 +384,8 @@ def sdk_automation_typespec_project(tsp_project: str, config: dict) -> dict:
         output_folder = sdk_folder
         update_version(sdk_root, output_folder)
 
-        # Ensure revapi.skip=true for beta releases
-        if release_beta_sdk:
-            ensure_revapi_skip(os.path.join(sdk_root, output_folder, "pom.xml"))
+        # Update revapi.skip based on release type
+        update_revapi_skip(os.path.join(sdk_root, output_folder, "pom.xml"), beta=release_beta_sdk)
 
         # compile
         succeeded = compile_arm_package(sdk_root, module)

--- a/eng/automation/generate.py
+++ b/eng/automation/generate.py
@@ -359,7 +359,6 @@ def sdk_automation_typespec_project(tsp_project: str, config: dict) -> dict:
         remove_before_regen=True,
         group_id=GROUP_ID,
         api_version=api_version,
-        generate_beta_sdk=release_beta_sdk,
     )
 
     if succeeded:

--- a/eng/automation/generate.py
+++ b/eng/automation/generate.py
@@ -277,17 +277,34 @@ def sdk_automation_typespec(config: dict) -> List[dict]:
     return packages
 
 
-def verify_self_serve_parameters(api_version, sdk_release_type):
-    if sdk_release_type and sdk_release_type not in ["stable", "beta"]:
-        raise ValueError(f"Invalid SDK release type [{sdk_release_type}], only support 'stable' or 'beta'.")
-    if api_version and sdk_release_type:
-        if api_version.endswith("-preview") and sdk_release_type == "stable":
-            raise ValueError(f"SDK release type is [stable], but API version [{api_version}] is preview.")
-        logging.info(f"[SelfServe] Generate with apiVersion: {api_version} and sdkReleaseType: {sdk_release_type}")
-    elif api_version or sdk_release_type:
-        raise ValueError(
-            "Both [API version] and [SDK release type] parameters are required for self-serve SDK generation."
-        )
+def infer_sdk_release_type(sdk_root: str, sdk_folder: str, module: str) -> str:
+    """Infer SDK release type from the generated metadata JSON.
+
+    Reads {sdk_root}/{sdk_folder}/src/main/resources/META-INF/{module}_metadata.json
+    and inspects the apiVersions values:
+    - All GA (no 'preview' substring) -> 'stable'
+    - Any preview or mixed -> 'beta'
+    - Fallback on error -> 'beta' (safe default)
+    """
+    metadata_path = os.path.join(sdk_root, sdk_folder, "src", "main", "resources", "META-INF", f"{module}_metadata.json")
+    try:
+        with open(metadata_path, "r") as f:
+            metadata = json.load(f)
+        api_versions = metadata.get("apiVersions", {})
+        if not api_versions:
+            logging.warning(f"[SelfServe] No apiVersions found in {metadata_path}, defaulting to beta.")
+            return "beta"
+
+        has_preview = any("preview" in v.lower() for v in api_versions.values())
+        inferred = "beta" if has_preview else "stable"
+        logging.info(f"[SelfServe] Inferred sdkReleaseType={inferred} from apiVersions: {api_versions}")
+        return inferred
+    except FileNotFoundError:
+        logging.warning(f"[SelfServe] Metadata file not found: {metadata_path}, defaulting to beta.")
+        return "beta"
+    except Exception as e:
+        logging.warning(f"[SelfServe] Failed to read metadata file {metadata_path}: {e}, defaulting to beta.")
+        return "beta"
 
 
 def sdk_automation_typespec_project(tsp_project: str, config: dict) -> dict:
@@ -299,14 +316,11 @@ def sdk_automation_typespec_project(tsp_project: str, config: dict) -> dict:
     repo_url: str = config["repoHttpsUrl"]
     sdk_release_type: str = config["sdkReleaseType"] if "sdkReleaseType" in config else None
     api_version = config["apiVersion"] if "apiVersion" in config else None
+    # Generate with beta by default; will be corrected after inference if needed
     release_beta_sdk: bool = not sdk_release_type or sdk_release_type == "beta"
     breaking: bool = False
     changelog = ""
     breaking_change_items = []
-    run_mode: str = config["runMode"] if "runMode" in config else None
-
-    if run_mode == "release" or run_mode == "local":
-        verify_self_serve_parameters(api_version, sdk_release_type)
 
     succeeded, require_sdk_integration, sdk_folder, service, module = generate_typespec_project(
         tsp_project,
@@ -321,6 +335,11 @@ def sdk_automation_typespec_project(tsp_project: str, config: dict) -> dict:
     )
 
     if succeeded:
+        # Infer sdk release type from generated metadata when not explicitly provided
+        if not sdk_release_type and sdk_folder and module:
+            inferred_type = infer_sdk_release_type(sdk_root, sdk_folder, module)
+            release_beta_sdk = inferred_type == "beta"
+
         # TODO (weidxu): move to typespec-java
         if require_sdk_integration:
             update_service_files_for_new_lib(sdk_root, service, GROUP_ID, module)

--- a/eng/automation/generate_utils.py
+++ b/eng/automation/generate_utils.py
@@ -532,7 +532,6 @@ def generate_typespec_project(
     remove_before_regen: bool = False,
     group_id: str = None,
     api_version: str = None,
-    generate_beta_sdk: bool = True,
     version: str = None,  # SDK version
     disable_customization: bool = False,
     **kwargs,
@@ -610,10 +609,6 @@ def generate_typespec_project(
 
                 if remove_before_regen and group_id:
                     remove_generated_source_code(os.path.join(sdk_root, sdk_folder), f"{group_id}.{service}")
-                    _, current_version = set_or_increase_version(
-                        sdk_root, group_id, module, version=version, preview=generate_beta_sdk
-                    )
-                    emitter_options.append(f"package-version={current_version}")
                     if api_version:
                         emitter_options.append(f"api-version={api_version}")
 

--- a/eng/automation/test_generate.py
+++ b/eng/automation/test_generate.py
@@ -1,0 +1,84 @@
+import os
+import tempfile
+import unittest
+
+from generate import update_revapi_skip
+
+POM_WITH_REVAPI_TRUE = """\
+<project>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jacoco.min.linecoverage>0</jacoco.min.linecoverage>
+    <revapi.skip>true</revapi.skip>
+  </properties>
+</project>
+"""
+
+POM_WITH_REVAPI_FALSE = """\
+<project>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jacoco.min.linecoverage>0</jacoco.min.linecoverage>
+    <revapi.skip>false</revapi.skip>
+  </properties>
+</project>
+"""
+
+POM_WITHOUT_REVAPI = """\
+<project>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jacoco.min.linecoverage>0</jacoco.min.linecoverage>
+  </properties>
+</project>
+"""
+
+
+class TestUpdateRevapiSkip(unittest.TestCase):
+
+    def _write_and_update(self, content: str, beta: bool) -> str:
+        fd, path = tempfile.mkstemp(suffix=".xml")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(content)
+            update_revapi_skip(path, beta)
+            with open(path, "r") as f:
+                return f.read()
+        finally:
+            os.unlink(path)
+
+    # --- beta=True cases ---
+
+    def test_beta_already_true_no_change(self):
+        result = self._write_and_update(POM_WITH_REVAPI_TRUE, beta=True)
+        self.assertEqual(result, POM_WITH_REVAPI_TRUE)
+
+    def test_beta_false_flipped_to_true(self):
+        result = self._write_and_update(POM_WITH_REVAPI_FALSE, beta=True)
+        self.assertIn("<revapi.skip>true</revapi.skip>", result)
+        self.assertNotIn("<revapi.skip>false</revapi.skip>", result)
+
+    def test_beta_missing_added_true(self):
+        result = self._write_and_update(POM_WITHOUT_REVAPI, beta=True)
+        self.assertIn("<revapi.skip>true</revapi.skip>", result)
+        self.assertIn("</properties>", result)
+
+    # --- beta=False (stable) cases ---
+
+    def test_stable_true_flipped_to_false(self):
+        result = self._write_and_update(POM_WITH_REVAPI_TRUE, beta=False)
+        self.assertIn("<revapi.skip>false</revapi.skip>", result)
+        self.assertNotIn("<revapi.skip>true</revapi.skip>", result)
+
+    def test_stable_already_false_no_change(self):
+        result = self._write_and_update(POM_WITH_REVAPI_FALSE, beta=False)
+        self.assertEqual(result, POM_WITH_REVAPI_FALSE)
+
+    def test_stable_missing_not_added(self):
+        result = self._write_and_update(POM_WITHOUT_REVAPI, beta=False)
+        self.assertNotIn("revapi.skip", result)
+        self.assertEqual(result, POM_WITHOUT_REVAPI)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

- fix https://github.com/Azure/azure-sdk-tools/issues/14851
Tested locally

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
