### PR TITLE
Added npm and nuget installation from internal feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- Do not add any additional feeds. If new packages are needed they need to
+    come from the azure-sdk-for-net DevOps feed which has an upstream set to nuget.org -->
+    <add key="azure-sdk-for-net" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -429,6 +429,11 @@ jobs:
           version: 22.x
         displayName: Use Node.js 22.x
 
+      # Authenticate npm to Azure Artifacts
+      - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+        parameters:
+          npmrcPath: $(Agent.TempDirectory)/analyze-job/.npmrc
+
       - task: PowerShell@2
         displayName: Verify Swagger and TypeSpec Code Generation
         inputs:
@@ -437,6 +442,8 @@ jobs:
           arguments: >
             -ServiceDirectories '$(PRServiceDirectories)'
             -RegenerationType 'All'
+        env:
+          NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/analyze-job/.npmrc
 
       # Authenticate with Azure Artifacts
       - template: /eng/pipelines/templates/steps/maven-authenticate.yml


### PR DESCRIPTION
This pull request updates the CI pipeline configuration to ensure npm commands are properly authenticated with Azure Artifacts during code generation steps. The main changes are focused on securely configuring npm authentication for the analyze job.

**Pipeline authentication improvements:**

* Added a step to generate an authenticated `.npmrc` file using the `create-authenticated-npmrc.yml` template, ensuring npm can access Azure Artifacts feeds in the analyze job.
* Set the `NPM_CONFIG_USERCONFIG` environment variable to point to the authenticated `.npmrc` file for the Swagger and TypeSpec code generation step, so npm uses the correct credentials.