### PR TITLE
Add vnext emulator stages back to public CI pipeline

### DIFF
--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -157,44 +157,43 @@ extends:
                   displayName: "Print ScalaTest report files"
                   errorActionPreference: continue
                   condition: always()
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - ${{ each mode in parameters.VnextEmulatorModes }}:
-          - stage:
-            displayName: Test VNext Emulator with ${{ mode }}
-            dependsOn: [ ]
-            condition: and(succeeded(), ne(variables['Skip.VnextEmulator'], 'true'))
-            variables:
-              - template: /eng/pipelines/templates/variables/globals.yml
-              - template: /eng/pipelines/templates/variables/image.yml
-              - name: ArtifactsJson
-                value: '${{ convertToJson(parameters.Artifacts) }}'
-              - name: AdditionalModulesJson
-                value: '${{ convertToJson(parameters.AdditionalModules) }}'
-            jobs:
-              - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
-                parameters:
-                  JobTemplatePath: /eng/pipelines/templates/jobs/live.tests.yml
-                  MatrixConfigs:
-                    - Name: Cosmos_vnext_emulator_http_integration
-                      Path: eng/pipelines/templates/stages/cosmos-emulator-vnext-matrix.json
-                      Selection: all
-                      GenerateVMJobs: true
-                  MatrixFilters:
-                    - ${{ parameters.LanguageFilter }}
-                    - ${{ parameters.MatrixFilters }}
-                  AdditionalParameters:
-                    BuildParallelization: 2
-                    DisableAzureResourceCreation: true
-                    ServiceDirectory: cosmos
-                    TimeoutInMinutes: 120
-                    ${{ if eq(mode, 'Https') }}:
-                      TestOptions: '$(ProfileFlag) $(AdditionalArgs) -DACCOUNT_HOST=https://localhost:8081/ -DCOSMOS.EMULATOR_SERVER_CERTIFICATE_VALIDATION_DISABLED=true'
-                    ${{ else }}:
-                      TestOptions: '$(ProfileFlag) $(AdditionalArgs) -DACCOUNT_HOST=http://localhost:8081/ -DCOSMOS.HTTP_CONNECTION_WITHOUT_TLS_ALLOWED=true'
-                    PreSteps:
-                      - template: /eng/pipelines/templates/steps/cosmos-vnext-emulator.yml
-                        parameters:
-                          Https: ${{ eq(mode, 'Https') }}
+      - ${{ each mode in parameters.VnextEmulatorModes }}:
+        - stage:
+          displayName: Test VNext Emulator with ${{ mode }}
+          dependsOn: [ ]
+          condition: and(succeeded(), ne(variables['Skip.VnextEmulator'], 'true'))
+          variables:
+            - template: /eng/pipelines/templates/variables/globals.yml
+            - template: /eng/pipelines/templates/variables/image.yml
+            - name: ArtifactsJson
+              value: '${{ convertToJson(parameters.Artifacts) }}'
+            - name: AdditionalModulesJson
+              value: '${{ convertToJson(parameters.AdditionalModules) }}'
+          jobs:
+            - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+              parameters:
+                JobTemplatePath: /eng/pipelines/templates/jobs/live.tests.yml
+                MatrixConfigs:
+                  - Name: Cosmos_vnext_emulator_http_integration
+                    Path: eng/pipelines/templates/stages/cosmos-emulator-vnext-matrix.json
+                    Selection: all
+                    GenerateVMJobs: true
+                MatrixFilters:
+                  - ${{ parameters.LanguageFilter }}
+                  - ${{ parameters.MatrixFilters }}
+                AdditionalParameters:
+                  BuildParallelization: 2
+                  DisableAzureResourceCreation: true
+                  ServiceDirectory: cosmos
+                  TimeoutInMinutes: 120
+                  ${{ if eq(mode, 'Https') }}:
+                    TestOptions: '$(ProfileFlag) $(AdditionalArgs) -DACCOUNT_HOST=https://localhost:8081/ -DCOSMOS.EMULATOR_SERVER_CERTIFICATE_VALIDATION_DISABLED=true'
+                  ${{ else }}:
+                    TestOptions: '$(ProfileFlag) $(AdditionalArgs) -DACCOUNT_HOST=http://localhost:8081/ -DCOSMOS.HTTP_CONNECTION_WITHOUT_TLS_ALLOWED=true'
+                  PreSteps:
+                    - template: /eng/pipelines/templates/steps/cosmos-vnext-emulator.yml
+                      parameters:
+                        Https: ${{ eq(mode, 'Https') }}
 
       # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
       - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/ConflictTests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/ConflictTests.java
@@ -98,4 +98,5 @@ public class ConflictTests {
             assertThat(ex.getMessage()).isEqualTo("sprocName cannot be null");
         }
     }
+
 }


### PR DESCRIPTION
# Description
Since VNext emulator is now used by customers, and some recent changes caused issues on vnext emulator, it is important to have  vNext emulator on CI 

This PR removes the internal-only guard ({{ if eq(variables['System.TeamProject'], 'internal') }}) from the VNext emulator test stages in cosmos-sdk-client.yml so they run on both public and internal CI pipelines.

The Skip.VnextEmulator variable condition is preserved for opt-out.


Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
CI on this PR has vNext emulator jobs
