### PR TITLE
[keyvault] Set release date for azure-security-keyvault-certificates 4.9.0-beta.1

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.9.0-beta.1 (2026-04-07)
+## 4.9.0-beta.1 (2026-04-08)
 
 ### Features Added
 

--- a/sdk/keyvault/azure-security-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.9.0-beta.1 (Unreleased)
+## 4.9.0-beta.1 (2026-04-07)
 
 ### Features Added
 


### PR DESCRIPTION
Sets the release date in CHANGELOG.md for \zure-security-keyvault-certificates:4.9.0-beta.1\ from \(Unreleased)\ to \2026-04-08\ in preparation for release.