### PR TITLE
Enable Change Feed StartTime support for merged partitions

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
+* Fixed an issue where change feed with `startFrom` point-in-time returned `400` on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability.
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/HttpConstants.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/HttpConstants.java
@@ -316,7 +316,7 @@ public class HttpConstants {
         public static final String SUPPORTED_CAPABILITIES;
         public static final String SUPPORTED_CAPABILITIES_NONE;
         static {
-            SUPPORTED_CAPABILITIES = String.valueOf(PARTITION_MERGE);
+            SUPPORTED_CAPABILITIES = String.valueOf(PARTITION_MERGE | CHANGE_FEED_WITH_START_TIME_POST_MERGE);
             SUPPORTED_CAPABILITIES_NONE = String.valueOf(NONE);
         }
     }


### PR DESCRIPTION
## Summary

Enable the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability flag so the backend allows `IfModifiedSince` headers on change feed requests targeting merged partitions.

## Problem

When using change feed with `startFrom=<timestamp>` (point-in-time), the SDK sends the `IfModifiedSince` header on every request. On merged partitions, the backend rejects this with:

```
400/0: "StartTime/IfModifiedSince is not currently supported with merged partitions."
```

This affects Change Feed Processor, Change Feed Pull Model, and the Spark connector when consumers are started after a merge has occurred.

### Root Cause

The SDK defines `CHANGE_FEED_WITH_START_TIME_POST_MERGE` (capability value `2`) but does not include it in `SUPPORTED_CAPABILITIES`. The current value is `"1"` (only `PARTITION_MERGE`), which tells the backend: "I support merge but NOT `IfModifiedSince` on merged partitions."

Meanwhile, `ChangeFeedStateV1.populateStartFrom()` correctly sends `IfModifiedSince` alongside the continuation token on every request — this was intentionally added in [PR #32259](https://github.com/Azure/azure-sdk-for-java/pull/32259) for merge correctness (merged partitions have interleaved LSN/`_ts` ordering, so the backend needs the original start time to filter correctly).

## Fix

Single-line change in `HttpConstants.java`:

```java
// Before: "1" (PARTITION_MERGE only)
SUPPORTED_CAPABILITIES = String.valueOf(PARTITION_MERGE);

// After: "3" (PARTITION_MERGE | CHANGE_FEED_WITH_START_TIME_POST_MERGE)
SUPPORTED_CAPABILITIES = String.valueOf(PARTITION_MERGE | CHANGE_FEED_WITH_START_TIME_POST_MERGE);
```

### Why this is sufficient

1. The SDK already sends `IfModifiedSince` on every change feed request when `startFrom` is a point-in-time (added in PR #32259)
2. The original timestamp is persisted in the serialized `ChangeFeedState` — stored in CFP lease documents and Spark checkpoints since `ChangeFeedStateV1` was introduced (January 2021)
3. No changes needed to lease storage, checkpoint format, or Spark connector — the timestamp is already there
4. The backend has the corresponding feature gate (`EnableChangeFeedRequestWithStartTimePostMerge`) and backend tests (`TestChangeFeedWithStartTime` in `partitionmergev3sdktests.cs`)

### Migration

No migration is needed:
- `ChangeFeedStateV1` is the only state implementation (no V2) and has serialized `startFromSettings` since day 1
- All EPK lease documents and Spark checkpoints contain the `StartFrom` field
- PK-based leases are unaffected (they explicitly set `SUPPORTED_CAPABILITIES_NONE` and do not support merge)

### Cross-SDK comparison

| SDK | `IfModifiedSince` sent with continuation | Status |
|-----|------------------------------------------|--------|
| **Java** | ✅ Yes, always (since 4.40.0) | This PR enables the capability flag |
| **.NET** | ❌ No, only on first request | Has data correctness gap on merged partitions |

## Validation

- Verified with Databricks Spark connector on a container with merged partitions using `startFrom=<timestamp>` — 400 error resolved after the fix.

## Changes

- `sdk/cosmos/azure-cosmos/src/main/java/.../HttpConstants.java` — Enable capability flag
- `sdk/cosmos/azure-cosmos/CHANGELOG.md` — Bug fix entry