### PR TITLE
[Java] Combined settings for signing and release stages

### DIFF
--- a/eng/pipelines/templates/stages/archetype-java-release-batch.yml
+++ b/eng/pipelines/templates/stages/archetype-java-release-batch.yml
@@ -372,6 +372,10 @@ stages:
 
               - template: /eng/pipelines/templates/steps/mvn-linux-repository-settings.yml
 
+              # maven-authenticate.yml cannot be used here because it overwrites ~/.m2/settings.xml
+              # with eng/settings.xml, which would discard the docs-specific repository config
+              # (e.g. docs-public-packages feed) set up by mvn-linux-repository-settings.yml above.
+              # Instead, we only run MavenAuthenticate to inject credentials into the existing settings.
               - task: MavenAuthenticate@0
                 displayName: 'Maven Authenticate'
                 inputs:
@@ -501,6 +505,10 @@ stages:
 
           - template: /eng/pipelines/templates/steps/mvn-linux-repository-settings.yml
 
+          # maven-authenticate.yml cannot be used here because it overwrites ~/.m2/settings.xml
+          # with eng/settings.xml, which would discard the docs-specific repository config
+          # (e.g. docs-public-packages feed) set up by mvn-linux-repository-settings.yml above.
+          # Instead, we only run MavenAuthenticate to inject credentials into the existing settings.
           - task: MavenAuthenticate@0
             displayName: 'Maven Authenticate'
             inputs:

--- a/eng/pipelines/templates/stages/archetype-java-release-batch.yml
+++ b/eng/pipelines/templates/stages/archetype-java-release-batch.yml
@@ -67,6 +67,8 @@ stages:
 
           # Setup Maven mirror settings and authenticate with Azure Artifacts
           - template: /eng/pipelines/templates/steps/maven-authenticate.yml
+            parameters:
+              SourceDirectory: $(Pipeline.Workspace)/azure-sdk-for-java
 
           # gpg-sign and create the flattened directory for ESRP bulk publish
           # Note: The maven release requires the files to be local GPG signed
@@ -264,6 +266,8 @@ stages:
               displayName: 'Download Artifacts'
               artifact: packages-signed
             - template: /eng/pipelines/templates/steps/maven-authenticate.yml
+              parameters:
+                SourceDirectory: $(Pipeline.Workspace)/azure-sdk-for-java
             - template: tools/gpg/gpg.yml@azure-sdk-build-tools
 
             - ${{ if ne(parameters.PublicFeedUrl, 'maven.org') }}:
@@ -463,6 +467,8 @@ stages:
           displayName: Setup TargetFeed
 
         - template: /eng/pipelines/templates/steps/maven-authenticate.yml
+          parameters:
+            SourceDirectory: $(Pipeline.Workspace)/azure-sdk-for-java
         - template: tools/gpg/gpg.yml@azure-sdk-build-tools
 
         - ${{ each artifact in parameters.Artifacts }}:

--- a/eng/pipelines/templates/stages/archetype-java-release-batch.yml
+++ b/eng/pipelines/templates/stages/archetype-java-release-batch.yml
@@ -65,6 +65,9 @@ stages:
             displayName: 'Download Signed Artifacts'
             artifact: packages-signed
 
+          # Setup Maven mirror settings and authenticate with Azure Artifacts
+          - template: /eng/pipelines/templates/steps/maven-authenticate.yml
+
           # gpg-sign and create the flattened directory for ESRP bulk publish
           # Note: The maven release requires the files to be local GPG signed
           # Dev feed publishes use the gpg-sign-and-deply to do it in one step
@@ -260,6 +263,7 @@ stages:
             - download: current
               displayName: 'Download Artifacts'
               artifact: packages-signed
+            - template: /eng/pipelines/templates/steps/maven-authenticate.yml
             - template: tools/gpg/gpg.yml@azure-sdk-build-tools
 
             - ${{ if ne(parameters.PublicFeedUrl, 'maven.org') }}:
@@ -364,6 +368,11 @@ stages:
 
               - template: /eng/pipelines/templates/steps/mvn-linux-repository-settings.yml
 
+              - task: MavenAuthenticate@0
+                displayName: 'Maven Authenticate'
+                inputs:
+                  artifactsFeeds: 'azure-sdk-for-java'
+
               - template: /eng/pipelines/templates/steps/install-rex-validation-tool.yml
 
               - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
@@ -453,6 +462,7 @@ stages:
 
           displayName: Setup TargetFeed
 
+        - template: /eng/pipelines/templates/steps/maven-authenticate.yml
         - template: tools/gpg/gpg.yml@azure-sdk-build-tools
 
         - ${{ each artifact in parameters.Artifacts }}:
@@ -484,6 +494,11 @@ stages:
             displayName: Show visible artifacts
 
           - template: /eng/pipelines/templates/steps/mvn-linux-repository-settings.yml
+
+          - task: MavenAuthenticate@0
+            displayName: 'Maven Authenticate'
+            inputs:
+              artifactsFeeds: 'azure-sdk-for-java'
 
           - template: /eng/pipelines/templates/steps/install-rex-validation-tool.yml
 

--- a/eng/pipelines/templates/steps/maven-authenticate.yml
+++ b/eng/pipelines/templates/steps/maven-authenticate.yml
@@ -1,9 +1,12 @@
+parameters:
+  SourceDirectory: $(Build.SourcesDirectory)
+
 steps:
   # Copy mirror settings to default Maven location so all requests go through CFS
   - pwsh: |
       $m2Dir = if ($env:USERPROFILE) { "$env:USERPROFILE\.m2" } else { "$HOME/.m2" }
       New-Item -ItemType Directory -Force -Path $m2Dir | Out-Null
-      Copy-Item -Path "$(Build.SourcesDirectory)/eng/settings.xml" -Destination "$m2Dir/settings.xml"
+      Copy-Item -Path "${{ parameters.SourceDirectory }}/eng/settings.xml" -Destination "$m2Dir/settings.xml"
     displayName: 'Setup Maven mirror settings'
 
   # Authenticate with Azure Artifacts feeds

--- a/eng/repo-docs/docms/daily.update.setting.xml
+++ b/eng/repo-docs/docms/daily.update.setting.xml
@@ -1,6 +1,14 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                                         https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <mirrors>
+        <mirror>
+            <id>azure-sdk-for-java</id>
+            <name>Azure Artifacts Maven Mirror</name>
+            <url>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1</url>
+            <mirrorOf>external:*,!confluent,!repository.spring.milestone</mirrorOf>
+        </mirror>
+    </mirrors>
     <profiles>
         <profile>
             <id>azure-sdk-for-java</id>

--- a/eng/repo-docs/docms/daily.update.setting.xml
+++ b/eng/repo-docs/docms/daily.update.setting.xml
@@ -17,16 +17,6 @@
             </activation>
             <repositories>
                 <repository>
-                    <id>azure-sdk-for-java</id>
-                    <url>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </repository>
-                <repository>
                     <id>docs-public-packages</id>
                     <url>https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-public-packages/maven/v1</url>
                     <releases>

--- a/eng/repo-docs/docms/daily.update.setting.xml
+++ b/eng/repo-docs/docms/daily.update.setting.xml
@@ -6,7 +6,7 @@
             <id>azure-sdk-for-java</id>
             <name>Azure Artifacts Maven Mirror</name>
             <url>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1</url>
-            <mirrorOf>external:*,!confluent,!repository.spring.milestone</mirrorOf>
+            <mirrorOf>external:*,!confluent,!repository.spring.milestone,!docs-public-packages</mirrorOf>
         </mirror>
     </mirrors>
     <profiles>

--- a/eng/scripts/Publish-MavenPackages.ps1
+++ b/eng/scripts/Publish-MavenPackages.ps1
@@ -166,8 +166,8 @@ foreach ($packageDetail in $packageDetails) {
     Write-Information "URL Option is: $urlOption"
 
     Write-Information "Signing and deploying package to $localRepositoryDirectoryUri"
-    Write-Information "mvn $gpgSignAndDeployWithVer `"--batch-mode`" `"$pomOption`" `"$fileOption`" `"$javadocOption`" `"$sourcesOption`" `"$filesOption`" $classifiersOption `"$typesOption`" `"$urlOption`" `"$gpgexeOption`" `"-DrepositoryId=target-repo`" `"--settings=$PSScriptRoot\..\maven.publish.settings.xml`""
-    mvn $gpgSignAndDeployWithVer "--batch-mode" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" $classifiersOption "$typesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "--settings=$PSScriptRoot\..\maven.publish.settings.xml"
+    Write-Information "mvn $gpgSignAndDeployWithVer `"--batch-mode`" `"$pomOption`" `"$fileOption`" `"$javadocOption`" `"$sourcesOption`" `"$filesOption`" $classifiersOption `"$typesOption`" `"$urlOption`" `"$gpgexeOption`" `"-DrepositoryId=target-repo`" `"--global-settings=$PSScriptRoot\..\maven.publish.settings.xml`""
+    mvn $gpgSignAndDeployWithVer "--batch-mode" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" $classifiersOption "$typesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "--global-settings=$PSScriptRoot\..\maven.publish.settings.xml"
     if ($LASTEXITCODE) { exit $LASTEXITCODE }
   }
 
@@ -178,8 +178,8 @@ foreach ($packageDetail in $packageDetails) {
   }
 
   Write-Information "GPG Signing and deploying package in one step to devops feed: $packageReposityUrl"
-  Write-Information "mvn $gpgSignAndDeployWithVer `"--batch-mode`" `"$pomOption`" `"$fileOption`" `"$javadocOption`" `"$sourcesOption`" `"$filesOption`" $classifiersOption `"$typesOption`" `"-Durl=$packageReposityUrl`" `"$gpgexeOption`" `"-DrepositoryId=target-repo`" `"-Drepo.password=[redacted]`" `"--settings=$PSScriptRoot\..\maven.publish.settings.xml`""
-  mvn $gpgSignAndDeployWithVer "--batch-mode" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" $classifiersOption "$typesOption" "-Durl=$packageReposityUrl" "$gpgexeOption" "-DrepositoryId=target-repo" "-Drepo.password=$RepositoryPassword" "--settings=$PSScriptRoot\..\maven.publish.settings.xml"
+  Write-Information "mvn $gpgSignAndDeployWithVer `"--batch-mode`" `"$pomOption`" `"$fileOption`" `"$javadocOption`" `"$sourcesOption`" `"$filesOption`" $classifiersOption `"$typesOption`" `"-Durl=$packageReposityUrl`" `"$gpgexeOption`" `"-DrepositoryId=target-repo`" `"-Drepo.password=[redacted]`" `"--global-settings=$PSScriptRoot\..\maven.publish.settings.xml`""
+  mvn $gpgSignAndDeployWithVer "--batch-mode" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" $classifiersOption "$typesOption" "-Durl=$packageReposityUrl" "$gpgexeOption" "-DrepositoryId=target-repo" "-Drepo.password=$RepositoryPassword" "--global-settings=$PSScriptRoot\..\maven.publish.settings.xml"
 
   if ($LASTEXITCODE -eq 0) {
     Write-Information "Package $($packageDetail.FullyQualifiedName) deployed"

--- a/eng/scripts/SignAndHash-MavenPackages.ps1
+++ b/eng/scripts/SignAndHash-MavenPackages.ps1
@@ -151,7 +151,7 @@ foreach ($packageDetail in $packageDetails) {
   $urlOption = "-Durl=$destinationPathUri"
   Write-Host "URL Option is: $urlOption"
 
-  $settingsOption = "--settings=$(Join-Path $PSScriptRoot '..' 'maven.publish.settings.xml' -Resolve)"
+  $settingsOption = "--global-settings=$(Join-Path $PSScriptRoot '..' 'maven.publish.settings.xml' -Resolve)"
   Write-Host "Settings Option is: $settingsOption"
 
   Write-Host ""

--- a/eng/scripts/SignAndHash-MavenPackages.ps1
+++ b/eng/scripts/SignAndHash-MavenPackages.ps1
@@ -154,21 +154,25 @@ foreach ($packageDetail in $packageDetails) {
   $settingsOption = "--global-settings=$(Join-Path $PSScriptRoot '..' 'maven.publish.settings.xml' -Resolve)"
   Write-Host "Settings Option is: $settingsOption"
 
+  # Use fully-qualified plugin coordinates to avoid prefix resolution against incomplete
+  # mirror metadata. This matches the approach used in Publish-MavenPackages.ps1.
+  $gpgSignAndDeployGoal = "org.apache.maven.plugins:maven-gpg-plugin:3.2.7:sign-and-deploy-file"
+
   Write-Host ""
   Write-Host "Signing package"
 
   if ($additionalArtifacts) {
     Write-Host @"
-    mvn gpg:sign-and-deploy-file "--batch-mode" "-Daether.checksums.algorithms=SHA-256,MD5,SHA-1" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" "$classifiersOption" "$typesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "$settingsOption"
+    mvn $gpgSignAndDeployGoal "--batch-mode" "-Daether.checksums.algorithms=SHA-256,MD5,SHA-1" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" "$classifiersOption" "$typesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "$settingsOption"
 "@
-    mvn gpg:sign-and-deploy-file "--batch-mode" "-Daether.checksums.algorithms=SHA-256,MD5,SHA-1" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" "$classifiersOption" "$typesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "$settingsOption"
+    mvn $gpgSignAndDeployGoal "--batch-mode" "-Daether.checksums.algorithms=SHA-256,MD5,SHA-1" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" "$classifiersOption" "$typesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "$settingsOption"
   } else {
     # Track 1 libraries do not require $filesOption, $classifiersOption and $typesOption variables which
     # will only be set if there's a changelog for one or more of the libraries being released
     Write-Host @"
-    mvn gpg:sign-and-deploy-file "--batch-mode" "-Daether.checksums.algorithms=SHA-256,MD5,SHA-1" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "$settingsOption"
+    mvn $gpgSignAndDeployGoal "--batch-mode" "-Daether.checksums.algorithms=SHA-256,MD5,SHA-1" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "$settingsOption"
 "@
-      mvn gpg:sign-and-deploy-file "--batch-mode" "-Daether.checksums.algorithms=SHA-256,MD5,SHA-1" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "$settingsOption"
+      mvn $gpgSignAndDeployGoal "--batch-mode" "-Daether.checksums.algorithms=SHA-256,MD5,SHA-1" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "$settingsOption"
   }
 
   if ($LASTEXITCODE) { exit $LASTEXITCODE }


### PR DESCRIPTION
This pull request combines the CFS mirror settings and customized settings for signing stage and release stage.

## Key Changes
* Modified `Publish-MavenPackages.ps1` and `SignAndHash-MavenPackages.ps1` scripts to use the `--global-settings` flag (instead of `--settings`) when specifying the Maven settings file, aligning with best practices and ensuring the correct settings are applied globally. 
* Added the `/eng/pipelines/templates/steps/maven-authenticate.yml` template and `MavenAuthenticate@0` task to multiple stages in the `archetype-java-release-batch.yml` pipeline to ensure proper Maven authentication with Azure Artifacts during artifact download, signing, and publishing steps. 