### PR TITLE
[Spring Data Cosmos] Add version guide and EOL notice to CHANGELOG

### DIFF
--- a/sdk/spring/azure-spring-data-cosmos/CHANGELOG.md
+++ b/sdk/spring/azure-spring-data-cosmos/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Release History
 
+> **Version Guide:** This package maintains multiple version lines for different Spring Boot releases.
+> See the [Spring Boot Version Support](README.md#spring-boot-version-support) section in the README for version mapping.
+>
+> | Version Line | Spring Boot | Status |
+> |---|---|---|
+> | **7.x** | 3.4+ | Current |
+> | **6.x** | 3.3+ | Active |
+> | **5.x** | 3.0+ | Active |
+> | **3.x** | 2.4–2.7 | **End of Life** — Spring Boot 2.x OSS support ended November 2023. Please upgrade to 5.x or later. |
+
 ### 7.2.0-beta.1 (Unreleased)
 
 #### Features Added


### PR DESCRIPTION
## What

Adds a version mapping table and End of Life notice to the `azure-spring-data-cosmos` CHANGELOG header block.

## Why

The CHANGELOG interleaves 4 version tracks (3.x, 5.x, 6.x, 7.x) targeting different Spring Boot versions. Customers have difficulty:

1. Identifying which version line targets their Spring Boot version
2. Knowing that the 3.x line targets Spring Boot 2.x which reached OSS end of life in November 2023

## What Changed

Added a blockquote in the CHANGELOG HeaderBlock (between `## Release History` and the first version entry) containing:

- A link to the README Spring Boot Version Support section
- A version mapping table showing which Spring Boot version each track targets
- An EOL notice for the 3.x line

## Safety

- The HeaderBlock is preserved verbatim by `ChangeLog-Operations.ps1` through `Set-ChangeLogContent` round-trips
- Validated with `Confirm-ChangeLogEntry` — all existing entries parse correctly
- No structural changes to version entries
