### PR TITLE
[Cosmos] Add .pragentrules for PR review automation

### DIFF
--- a/sdk/cosmos/.pragentrules
+++ b/sdk/cosmos/.pragentrules
@@ -1,0 +1,36 @@
+# Java Cosmos SDK PR Review Rules
+# Loaded by the PR review agent via the pragentrules-resolver skill.
+# These add Cosmos-specific constraints that the agent cannot infer on its own.
+# Rules starting with "DO" are required checks. "Do NOT" are suppressions.
+
+# --- Preview API Gating (@Beta) ---
+# This is the highest-value rule. PR #47566 merged a new public enum (QuantizerType)
+# without @Beta, even though vector search was preview. The agent can't know which
+# Cosmos features are GA vs preview — this rule makes it ask.
+- DO check whether newly introduced public classes, enums, interfaces, or newly added public methods need the @Beta annotation. Evidence that @Beta is needed includes: sibling types in the same package already annotated with @Beta, the PR description stating the feature is preview, or the feature area being known-preview (e.g., vector search, GenAI, quantizer). ASK the PR author if the underlying Cosmos DB service feature is fully GA and deployed to production. If not GA, the API MUST have @Beta(value = Beta.SinceVersion.V4_XX_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING). Do NOT flag new public APIs for GA features solely because they share a package with preview APIs.
+
+# --- Public Enum Extensibility ---
+- DO scrutinize new public Java enums. If the set of allowed values may grow over time or the feature is preview, flag as a risk — Java enums are closed sets and adding values later is a breaking change for switch statements. Consider whether a string-constant pattern would be more forward-compatible.
+
+# --- Azure SDK Central Guidelines (for new client surface only) ---
+- DO verify Azure SDK Java design conventions (https://azure.github.io/azure-sdk/java_introduction.html) only when a PR introduces a new top-level service client, builder, or primary operation surface. Check @ServiceClient annotation, @ServiceClientBuilder, fluent builder pattern, sync/async client parity, and package placement. Do NOT apply these checks to additive methods on existing types — the agent already reviews those for codebase consistency.
+
+# --- Java 8 Compatibility ---
+- DO verify that new production code remains compatible with the Java 8 baseline. Do NOT introduce Java 9+ APIs, language features (var, records, sealed classes), or java.util.stream collectors that require Java 9+.
+
+# --- Changelog (Suppression) ---
+- Do NOT flag missing per-PR changelog entries. The Java Cosmos SDK updates CHANGELOG.md at release time (batch per release), not per-PR. This differs from some other Azure SDK packages.
+
+# --- API Contract Artifacts (Suppression) ---
+- Do NOT ask for API signature baselines, contract-tracking artifacts, or public API diff files. The Java Cosmos SDK uses APIView and Revapi in CI for API surface validation, not manually maintained contract files.
+
+# --- Checkstyle / SpotBugs (Suppression) ---
+- Do NOT suggest disabling Checkstyle or SpotBugs rules to resolve linting issues. Fix the underlying code issue instead.
+
+# --- Multi-region & Failover (Domain-Specific Emphasis) ---
+# The agent reviews logic generically, but multi-region is a Cosmos-specific critical area
+# where subtle bugs cause customer-visible outages.
+- DO give extra scrutiny to changes in failover, region-routing, or endpoint-management logic. Verify that both single-write-region and multi-write-region account configurations are handled. Behaviors correct for single-write may silently regress multi-write scenarios (e.g., Per Partition Automatic Failover).
+
+# --- Retry & Exception Handling (Domain-Specific Emphasis) ---
+- DO give extra scrutiny to changes in retry policies, timeout configuration, or exception-mapping logic. Review these changes across success, transient-failure, and non-retryable-failure paths. Retry infrastructure changes can cause cascading failures that are hard to detect in unit tests.


### PR DESCRIPTION
## What

Adds `sdk/cosmos/.pragentrules` — review rules consumed by the PR Deep Reviewer agent as mandatory constraints. These encode Cosmos-specific knowledge the agent cannot infer on its own.

## Why

PR #47566 merged a new public enum (`QuantizerType`) and public methods on `CosmosVectorIndexSpec` without `@Beta` annotation, even though vector search is a preview feature. No existing automation caught this — not CheckStyle, not Revapi, not the PR review agent.

These rules close that gap. Modeled after the [.NET Cosmos SDK precedent](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/main/.pragentrules).

## Rules Added

| Category | Rule | Why Not Redundant with Agent |
|---|---|---|
| **Preview API gating** | Check if new public APIs need `@Beta` — asks if service feature is GA | Agent cannot know Cosmos feature GA status |
| **Public enum extensibility** | Scrutinize new Java enums for closed-set risk | Agent does not check Java enum extensibility patterns |
| **Azure SDK guidelines** | Verify central Java design conventions for new client surface only | Agent does not reference central guidelines |
| **Java 8 compatibility** | No Java 9+ APIs/features in production code | Agent does not enforce language baseline |
| **Changelog (suppress)** | Do NOT flag missing per-PR entries | Prevents false positive — Java Cosmos batches at release |
| **API contracts (suppress)** | Do NOT ask for contract files | Prevents false positive — uses APIView/Revapi in CI |
| **CheckStyle (suppress)** | Do NOT suggest disabling lint rules | Prevents bad advice |
| **Multi-region emphasis** | Extra scrutiny on failover/routing for SW vs MW | Domain-specific critical area |
| **Retry emphasis** | Extra scrutiny on retry/timeout/exception-mapping | Domain-specific critical area |

## Testing

Ran `pragentrules-resolver` against PR #47566 changed files:
- `QuantizerType.java`, `CosmosVectorIndexSpec.java`, `CHANGELOG.md`, `VectorIndexTest.java`
- All 4 files correctly resolve to the 9 rules from `sdk/cosmos/.pragentrules`

## Safety

- `.pragentrules` are consumed only by the PR Deep Reviewer agent — zero CI impact
- No code changes — this is a review-time instruction file only
