### PR TITLE
CFP Time based checkpoint strategy

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/ChangeFeedCheckpointStrategyTests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/ChangeFeedCheckpointStrategyTests.java
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos;
+
+import com.azure.cosmos.models.ChangeFeedProcessorOptions;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+
+public class ChangeFeedCheckpointStrategyTests {
+
+    @Test(groups = {"unit"})
+    public void optionsDefaultCheckpointStrategyIsNull() {
+        ChangeFeedProcessorOptions options = new ChangeFeedProcessorOptions();
+
+        Assert.assertNull(options.getCheckpointStrategy());
+    }
+
+    @Test(groups = {"unit"})
+    public void setCheckpointStrategyNullThrows() {
+        ChangeFeedProcessorOptions options = new ChangeFeedProcessorOptions();
+
+        Assert.assertThrows(NullPointerException.class, () -> options.setCheckpointStrategy(null));
+    }
+
+    @Test(groups = {"unit"})
+    public void timeIntervalCheckpointStrategyRequiresPositiveDuration() {
+        Assert.assertThrows(NullPointerException.class, () -> new TimeIntervalCheckpointStrategy(null));
+        Assert.assertThrows(IllegalArgumentException.class, () -> new TimeIntervalCheckpointStrategy(Duration.ZERO));
+        Assert.assertThrows(IllegalArgumentException.class, () -> new TimeIntervalCheckpointStrategy(Duration.ofSeconds(-1)));
+    }
+
+    @Test(groups = {"unit"})
+    public void builderRejectsTimeIntervalCheckpointDelayGreaterThanOrEqualToLeaseExpirationInterval() {
+        ChangeFeedProcessorOptions options = new ChangeFeedProcessorOptions()
+            .setLeaseExpirationInterval(Duration.ofSeconds(30))
+            .setCheckpointStrategy(new TimeIntervalCheckpointStrategy(Duration.ofSeconds(30)));
+
+        ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder()
+            .hostName("host-1")
+            .feedContainer(Mockito.mock(CosmosAsyncContainer.class))
+            .leaseContainer(Mockito.mock(CosmosAsyncContainer.class))
+            .handleChanges(changes -> {
+            })
+            .options(options);
+
+        Assert.assertThrows(IllegalArgumentException.class, builder::buildChangeFeedProcessor);
+    }
+
+    @Test(groups = {"unit"})
+    public void builderAcceptsTimeIntervalCheckpointDelayLessThanLeaseExpirationInterval() {
+        ChangeFeedProcessorOptions options = new ChangeFeedProcessorOptions()
+            .setLeaseExpirationInterval(Duration.ofSeconds(30))
+            .setCheckpointStrategy(new TimeIntervalCheckpointStrategy(Duration.ofSeconds(10)));
+
+        ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder()
+            .hostName("host-1")
+            .feedContainer(Mockito.mock(CosmosAsyncContainer.class))
+            .leaseContainer(Mockito.mock(CosmosAsyncContainer.class))
+            .handleChanges(changes -> {
+                if (changes == null) {
+                    throw new IllegalStateException("changes should not be null");
+                }
+            })
+            .options(options);
+
+        try {
+            Method method = ChangeFeedProcessorBuilder.class.getDeclaredMethod("validateChangeFeedProcessorOptions");
+            method.setAccessible(true);
+            method.invoke(builder);
+        } catch (InvocationTargetException e) {
+            Assert.fail("Expected no exception but got: " + e.getCause(), e.getCause());
+        } catch (Exception e) {
+            Assert.fail("Expected no exception but got: " + e.getMessage(), e);
+        }
+    }
+}
+
+
+

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/changefeed/common/AutoCheckpointerTests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/changefeed/common/AutoCheckpointerTests.java
@@ -18,7 +18,6 @@ import reactor.core.publisher.Sinks;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -103,21 +102,22 @@ public class AutoCheckpointerTests {
 
     @Test(groups = {"unit"})
     @SuppressWarnings("unchecked")
-    public void intervalCheckpointFailureTerminatesIntervalStream() throws InterruptedException {
+    public void intervalCheckpointFailureDoesNotTerminateIntervalStream() throws InterruptedException {
         ChangeFeedObserver<String> observer = Mockito.mock(ChangeFeedObserver.class);
         ChangeFeedObserverContext<String> context = Mockito.mock(ChangeFeedObserverContext.class);
 
         Mockito.when(observer.processChanges(any(), any())).thenReturn(Mono.empty());
-        Mockito.when(context.checkpoint()).thenReturn(Mono.error(new IllegalStateException("checkpoint failure")));
+        Mockito.when(context.checkpoint())
+            .thenReturn(Mono.error(new IllegalStateException("checkpoint failure")), Mono.empty(), Mono.empty());
 
         AutoCheckpointer<String> autoCheckpointer = new AutoCheckpointer<>(
             new CheckpointFrequency().withTimeInterval(Duration.ofMillis(40)), observer);
         autoCheckpointer.open(context);
 
         autoCheckpointer.processChanges(context, Collections.singletonList("doc")).block();
-        Thread.sleep(200);
+        Thread.sleep(240);
 
-        Mockito.verify(context, times(1)).checkpoint();
+        Mockito.verify(context, Mockito.atLeast(2)).checkpoint();
         autoCheckpointer.close(context, ChangeFeedObserverCloseReason.SHUTDOWN);
     }
 
@@ -136,7 +136,7 @@ public class AutoCheckpointerTests {
         AutoCheckpointer<String> autoCheckpointer = new AutoCheckpointer<>(
             new CheckpointFrequency().withTimeInterval(Duration.ofSeconds(1)), observer);
 
-        setField(autoCheckpointer, "lastCheckpointTime", Instant.now().minusSeconds(2));
+        setField(autoCheckpointer, "lastCheckpointNanoTime", System.nanoTime() - Duration.ofSeconds(2).toNanos());
 
         autoCheckpointer.processChanges(context, Collections.singletonList("batch-1")).subscribe();
         autoCheckpointer.processChanges(context, Collections.singletonList("batch-2")).subscribe();
@@ -146,7 +146,7 @@ public class AutoCheckpointerTests {
         firstCheckpoint.tryEmitValue(Mockito.mock(Lease.class));
         Thread.sleep(30);
 
-        setField(autoCheckpointer, "lastCheckpointTime", Instant.now().minusSeconds(2));
+        setField(autoCheckpointer, "lastCheckpointNanoTime", System.nanoTime() - Duration.ofSeconds(2).toNanos());
         invokeCheckpointIfIntervalElapsed(autoCheckpointer).block();
 
         Mockito.verify(context, times(2)).checkpoint();

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/changefeed/common/AutoCheckpointerTests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/changefeed/common/AutoCheckpointerTests.java
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.changefeed.common;
+
+import com.azure.cosmos.implementation.changefeed.ChangeFeedObserver;
+import com.azure.cosmos.implementation.changefeed.ChangeFeedObserverCloseReason;
+import com.azure.cosmos.implementation.changefeed.ChangeFeedObserverContext;
+import com.azure.cosmos.implementation.changefeed.CheckpointFrequency;
+import com.azure.cosmos.implementation.changefeed.Lease;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+
+public class AutoCheckpointerTests {
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getField(Object target, String fieldName) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (T) field.get(target);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Mono<Void> invokeCheckpointIfIntervalElapsed(AutoCheckpointer<?> autoCheckpointer) throws Exception {
+        Method method = AutoCheckpointer.class.getDeclaredMethod("checkpointIfIntervalElapsed");
+        method.setAccessible(true);
+        return (Mono<Void>) method.invoke(autoCheckpointer);
+    }
+
+    @Test(groups = {"unit"})
+    @SuppressWarnings("unchecked")
+    public void everyBatchCheckpointStrategyCheckpointsAfterEachBatch() {
+        ChangeFeedObserver<String> observer = Mockito.mock(ChangeFeedObserver.class);
+        ChangeFeedObserverContext<String> context = Mockito.mock(ChangeFeedObserverContext.class);
+
+        Mockito.when(observer.processChanges(any(), any())).thenReturn(Mono.empty());
+        Mockito.when(context.checkpoint()).thenReturn(Mono.empty());
+
+        AutoCheckpointer<String> autoCheckpointer = new AutoCheckpointer<>(new CheckpointFrequency(), observer);
+        autoCheckpointer.open(context);
+
+        autoCheckpointer.processChanges(context, Collections.singletonList("doc")).block();
+
+        Mockito.verify(context, times(1)).checkpoint();
+        autoCheckpointer.close(context, ChangeFeedObserverCloseReason.SHUTDOWN);
+    }
+
+    @Test(groups = {"unit"})
+    @SuppressWarnings("unchecked")
+    public void timeIntervalCheckpointStrategyUsesBackgroundTimer() throws InterruptedException {
+        ChangeFeedObserver<String> observer = Mockito.mock(ChangeFeedObserver.class);
+        ChangeFeedObserverContext<String> context = Mockito.mock(ChangeFeedObserverContext.class);
+
+        Mockito.when(observer.processChanges(any(), any())).thenReturn(Mono.empty());
+        Mockito.when(context.checkpoint()).thenReturn(Mono.empty());
+
+        CheckpointFrequency checkpointFrequency = new CheckpointFrequency().withTimeInterval(Duration.ofMillis(50));
+        AutoCheckpointer<String> autoCheckpointer = new AutoCheckpointer<>(checkpointFrequency, observer);
+        autoCheckpointer.open(context);
+
+        autoCheckpointer.processChanges(context, Collections.singletonList("doc")).block();
+        Thread.sleep(150);
+
+        Mockito.verify(context, Mockito.atLeastOnce()).checkpoint();
+        autoCheckpointer.close(context, ChangeFeedObserverCloseReason.SHUTDOWN);
+    }
+
+    @Test(groups = {"unit"})
+    @SuppressWarnings("unchecked")
+    public void openFailureDoesNotStartIntervalTimer() throws Exception {
+        ChangeFeedObserver<String> observer = Mockito.mock(ChangeFeedObserver.class);
+        ChangeFeedObserverContext<String> context = Mockito.mock(ChangeFeedObserverContext.class);
+
+        Mockito.doThrow(new IllegalStateException("open failed")).when(observer).open(any());
+
+        AutoCheckpointer<String> autoCheckpointer = new AutoCheckpointer<>(
+            new CheckpointFrequency().withTimeInterval(Duration.ofMillis(20)), observer);
+
+        Assert.assertThrows(IllegalStateException.class, () -> autoCheckpointer.open(context));
+
+        Disposable intervalDisposable = getField(autoCheckpointer, "intervalCheckpointDisposable");
+        Assert.assertNull(intervalDisposable);
+    }
+
+    @Test(groups = {"unit"})
+    @SuppressWarnings("unchecked")
+    public void intervalCheckpointFailureTerminatesIntervalStream() throws InterruptedException {
+        ChangeFeedObserver<String> observer = Mockito.mock(ChangeFeedObserver.class);
+        ChangeFeedObserverContext<String> context = Mockito.mock(ChangeFeedObserverContext.class);
+
+        Mockito.when(observer.processChanges(any(), any())).thenReturn(Mono.empty());
+        Mockito.when(context.checkpoint()).thenReturn(Mono.error(new IllegalStateException("checkpoint failure")));
+
+        AutoCheckpointer<String> autoCheckpointer = new AutoCheckpointer<>(
+            new CheckpointFrequency().withTimeInterval(Duration.ofMillis(40)), observer);
+        autoCheckpointer.open(context);
+
+        autoCheckpointer.processChanges(context, Collections.singletonList("doc")).block();
+        Thread.sleep(200);
+
+        Mockito.verify(context, times(1)).checkpoint();
+        autoCheckpointer.close(context, ChangeFeedObserverCloseReason.SHUTDOWN);
+    }
+
+    @Test(groups = {"unit"})
+    @SuppressWarnings("unchecked")
+    public void checkpointSuccessDoesNotClearNewerProgressArrivingDuringInFlightCheckpoint() throws Exception {
+        ChangeFeedObserver<String> observer = Mockito.mock(ChangeFeedObserver.class);
+        ChangeFeedObserverContext<String> context = Mockito.mock(ChangeFeedObserverContext.class);
+
+        Mockito.when(observer.processChanges(any(), any())).thenReturn(Mono.empty());
+
+        Sinks.One<Lease> firstCheckpoint = Sinks.one();
+        Mockito.when(context.checkpoint())
+            .thenReturn(firstCheckpoint.asMono(), Mono.just(Mockito.mock(Lease.class)));
+
+        AutoCheckpointer<String> autoCheckpointer = new AutoCheckpointer<>(
+            new CheckpointFrequency().withTimeInterval(Duration.ofSeconds(1)), observer);
+
+        setField(autoCheckpointer, "lastCheckpointTime", Instant.now().minusSeconds(2));
+
+        autoCheckpointer.processChanges(context, Collections.singletonList("batch-1")).subscribe();
+        autoCheckpointer.processChanges(context, Collections.singletonList("batch-2")).subscribe();
+
+        Mockito.verify(context, times(1)).checkpoint();
+
+        firstCheckpoint.tryEmitValue(Mockito.mock(Lease.class));
+        Thread.sleep(30);
+
+        setField(autoCheckpointer, "lastCheckpointTime", Instant.now().minusSeconds(2));
+        invokeCheckpointIfIntervalElapsed(autoCheckpointer).block();
+
+        Mockito.verify(context, times(2)).checkpoint();
+    }
+}

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/ChangeFeedCheckpointStrategy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/ChangeFeedCheckpointStrategy.java
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos;
+
+/**
+ * Base type for checkpoint strategies used by {@link ChangeFeedProcessor}.
+ */
+public abstract class ChangeFeedCheckpointStrategy {
+    ChangeFeedCheckpointStrategy() {
+    }
+}
+

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/ChangeFeedProcessorBuilder.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/ChangeFeedProcessorBuilder.java
@@ -403,6 +403,16 @@ public class ChangeFeedProcessorBuilder {
             //  force a lot of resets and lead to a poor overall performance of ChangeFeedProcessor.
             throw new IllegalArgumentException("changeFeedProcessorOptions: expecting leaseRenewInterval less than leaseExpirationInterval");
         }
+
+        ChangeFeedCheckpointStrategy checkpointStrategy = this.changeFeedProcessorOptions.getCheckpointStrategy();
+        if (checkpointStrategy instanceof TimeIntervalCheckpointStrategy) {
+            if (((TimeIntervalCheckpointStrategy)checkpointStrategy).getMaxCheckpointDelay()
+                .compareTo(this.changeFeedProcessorOptions.getLeaseExpirationInterval()) >= 0) {
+                throw new IllegalArgumentException(
+                    "changeFeedProcessorOptions: expecting checkpointStrategy.maxCheckpointDelay less than leaseExpirationInterval");
+            }
+        }
+
         //  Some extra checks for all versions and deletes mode
         if (ChangeFeedMode.FULL_FIDELITY.equals(changeFeedMode)) {
             if (this.changeFeedProcessorOptions.getStartTime() != null) {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/EveryBatchCheckpointStrategy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/EveryBatchCheckpointStrategy.java
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos;
+
+/**
+ * Checkpoint strategy that writes a checkpoint after each processed batch.
+ */
+public final class EveryBatchCheckpointStrategy extends ChangeFeedCheckpointStrategy {
+    /**
+     * Creates a new every-batch checkpoint strategy.
+     */
+    public EveryBatchCheckpointStrategy() {
+    }
+}
+

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/TimeIntervalCheckpointStrategy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/TimeIntervalCheckpointStrategy.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos;
+
+import java.time.Duration;
+
+import static com.azure.cosmos.implementation.guava25.base.Preconditions.checkNotNull;
+
+/**
+ * Checkpoint strategy that bounds the replay window by a maximum time interval.
+ */
+public final class TimeIntervalCheckpointStrategy extends ChangeFeedCheckpointStrategy {
+    private final Duration maxCheckpointDelay;
+
+    /**
+     * Creates a new time-interval checkpoint strategy.
+     *
+     * @param maxCheckpointDelay the maximum allowed replay window duration.
+     */
+    public TimeIntervalCheckpointStrategy(Duration maxCheckpointDelay) {
+        checkNotNull(maxCheckpointDelay, "Argument 'maxCheckpointDelay' can not be null");
+        if (maxCheckpointDelay.isZero() || maxCheckpointDelay.isNegative()) {
+            throw new IllegalArgumentException("Argument 'maxCheckpointDelay' must be positive");
+        }
+
+        this.maxCheckpointDelay = maxCheckpointDelay;
+    }
+
+    /**
+     * Gets the maximum replay window.
+     *
+     * @return the maximum replay window.
+     */
+    public Duration getMaxCheckpointDelay() {
+        return this.maxCheckpointDelay;
+    }
+}
+

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/AutoCheckpointer.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/AutoCheckpointer.java
@@ -9,11 +9,15 @@ import com.azure.cosmos.implementation.changefeed.CheckpointFrequency;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Auto check-pointer implementation for {@link ChangeFeedObserver}.
@@ -23,6 +27,11 @@ public class AutoCheckpointer<T> implements ChangeFeedObserver<T> {
     private final CheckpointFrequency checkpointFrequency;
     private final ChangeFeedObserver<T> observer;
     private final AtomicInteger processedDocCount;
+    private final AtomicLong latestProgressVersion;
+    private final AtomicReference<Mono<Void>> checkpointInProgress;
+    private final AtomicReference<ChangeFeedObserverContext<T>> latestContext;
+    private volatile boolean hasUncheckpointedProgress;
+    private volatile Disposable intervalCheckpointDisposable;
     private volatile Instant lastCheckpointTime;
 
     public AutoCheckpointer(CheckpointFrequency checkpointFrequency, ChangeFeedObserver<T> observer) {
@@ -38,55 +47,140 @@ public class AutoCheckpointer<T> implements ChangeFeedObserver<T> {
         this.observer = observer;
         this.lastCheckpointTime = Instant.now();
         this.processedDocCount = new AtomicInteger();
+        this.latestProgressVersion = new AtomicLong();
+        this.checkpointInProgress = new AtomicReference<>();
+        this.latestContext = new AtomicReference<>();
+        this.hasUncheckpointedProgress = false;
     }
 
     @Override
     public void open(ChangeFeedObserverContext<T> context) {
+        this.latestContext.set(context);
         this.observer.open(context);
+        this.startIntervalCheckpointing();
     }
 
     @Override
     public void close(ChangeFeedObserverContext<T> context, ChangeFeedObserverCloseReason reason) {
+        this.stopIntervalCheckpointing();
         this.observer.close(context, reason);
     }
 
     @Override
     public Mono<Void> processChanges(ChangeFeedObserverContext<T> context, List<T> docs) {
+        this.latestContext.set(context);
+
         return this.observer.processChanges(context, docs)
-            .doOnError(throwable -> {
-                logger.warn("Unexpected exception from thread: " + Thread.currentThread().getId(), throwable);
-            })
-            .then(this.afterProcessChanges(context));
+            .doOnError(throwable -> logger.warn(
+                "Unexpected exception from thread: " + Thread.currentThread().getId(), throwable))
+            .then(this.afterProcessChanges(context, docs));
     }
 
-    private Mono<Void> afterProcessChanges(ChangeFeedObserverContext<T> context) {
-        this.processedDocCount.incrementAndGet();
+    private Mono<Void> afterProcessChanges(ChangeFeedObserverContext<T> context, List<T> docs) {
+        this.processedDocCount.addAndGet(docs.size());
+        this.latestProgressVersion.incrementAndGet();
+        this.hasUncheckpointedProgress = true;
 
         if (this.isCheckpointNeeded()) {
-            return context.checkpoint()
-                .doOnError(throwable -> {
-                    logger.warn("Checkpoint failed; this worker will be killed", throwable);
-                })
-                .doOnSuccess((Void) -> {
-                    this.processedDocCount.set(0);
-                    this.lastCheckpointTime = Instant.now();
-                })
-                .then();
+            return this.checkpointOnce(context);
         }
+
         return Mono.empty();
     }
 
     private boolean isCheckpointNeeded() {
-        if (this.checkpointFrequency.getProcessedDocumentCount() == 0 && this.checkpointFrequency.getTimeInterval() == null) {
+        if (this.isEveryBatchCheckpoint()) {
             return true;
         }
 
-        if (this.processedDocCount.get() >= this.checkpointFrequency.getProcessedDocumentCount()) {
+        if (this.checkpointFrequency.getProcessedDocumentCount() > 0
+            && this.processedDocCount.get() >= this.checkpointFrequency.getProcessedDocumentCount()) {
             return true;
+        }
+
+        Duration interval = this.checkpointFrequency.getTimeInterval();
+        if (interval == null) {
+            return false;
         }
 
         Duration delta = Duration.between(this.lastCheckpointTime, Instant.now());
 
-        return delta.compareTo(this.checkpointFrequency.getTimeInterval()) >= 0;
+        return delta.compareTo(interval) >= 0;
+    }
+
+    private boolean isEveryBatchCheckpoint() {
+        return this.checkpointFrequency.getProcessedDocumentCount() <= 0
+            && this.checkpointFrequency.getTimeInterval() == null;
+    }
+
+    private void startIntervalCheckpointing() {
+        Duration interval = this.checkpointFrequency.getTimeInterval();
+        if (interval == null) {
+            return;
+        }
+
+        this.intervalCheckpointDisposable = Flux.interval(interval, interval)
+            .concatMap(ignored -> this.checkpointIfIntervalElapsed())
+            .subscribe(
+                ignored -> {
+                },
+                throwable -> logger.warn("Interval checkpointing stream terminated", throwable));
+    }
+
+    private void stopIntervalCheckpointing() {
+        Disposable disposable = this.intervalCheckpointDisposable;
+        if (disposable != null) {
+            disposable.dispose();
+            this.intervalCheckpointDisposable = null;
+        }
+    }
+
+    private Mono<Void> checkpointIfIntervalElapsed() {
+        ChangeFeedObserverContext<T> context = this.latestContext.get();
+        if (context == null || !this.hasUncheckpointedProgress) {
+            return Mono.empty();
+        }
+
+        Duration interval = this.checkpointFrequency.getTimeInterval();
+        if (interval == null || Duration.between(this.lastCheckpointTime, Instant.now()).compareTo(interval) < 0) {
+            return Mono.empty();
+        }
+
+        return this.checkpointOnce(context);
+    }
+
+    private Mono<Void> checkpointOnce(ChangeFeedObserverContext<T> context) {
+        Mono<Void> checkpointMono = this.checkpointInProgress.get();
+        if (checkpointMono != null) {
+            return checkpointMono;
+        }
+
+        long checkpointedProgressVersion = this.latestProgressVersion.get();
+        AtomicReference<Mono<Void>> checkpointAttemptRef = new AtomicReference<>();
+        Mono<Void> checkpointAttempt = context.checkpoint()
+            .doOnError(throwable -> logger.warn("Checkpoint failed", throwable))
+            .doOnSuccess(ignored -> this.onCheckpointSuccess(checkpointedProgressVersion))
+            .then()
+            .cache()
+            .doFinally(ignored -> this.checkpointInProgress.compareAndSet(checkpointAttemptRef.get(), null));
+
+        checkpointAttemptRef.set(checkpointAttempt);
+
+        if (this.checkpointInProgress.compareAndSet(null, checkpointAttempt)) {
+            return checkpointAttempt;
+        }
+
+        Mono<Void> inProgress = this.checkpointInProgress.get();
+        return inProgress != null ? inProgress : Mono.empty();
+    }
+
+    private void onCheckpointSuccess(long checkpointedProgressVersion) {
+        this.lastCheckpointTime = Instant.now();
+
+        // Keep progress markers if newer batches arrived while this checkpoint was in flight.
+        if (this.latestProgressVersion.get() == checkpointedProgressVersion) {
+            this.processedDocCount.set(0);
+            this.hasUncheckpointedProgress = false;
+        }
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/AutoCheckpointer.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/AutoCheckpointer.java
@@ -13,7 +13,6 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -32,7 +31,7 @@ public class AutoCheckpointer<T> implements ChangeFeedObserver<T> {
     private final AtomicReference<ChangeFeedObserverContext<T>> latestContext;
     private volatile boolean hasUncheckpointedProgress;
     private volatile Disposable intervalCheckpointDisposable;
-    private volatile Instant lastCheckpointTime;
+    private volatile long lastCheckpointNanoTime;
 
     public AutoCheckpointer(CheckpointFrequency checkpointFrequency, ChangeFeedObserver<T> observer) {
         if (checkpointFrequency == null) {
@@ -45,7 +44,7 @@ public class AutoCheckpointer<T> implements ChangeFeedObserver<T> {
 
         this.checkpointFrequency = checkpointFrequency;
         this.observer = observer;
-        this.lastCheckpointTime = Instant.now();
+        this.lastCheckpointNanoTime = System.nanoTime();
         this.processedDocCount = new AtomicInteger();
         this.latestProgressVersion = new AtomicLong();
         this.checkpointInProgress = new AtomicReference<>();
@@ -103,9 +102,7 @@ public class AutoCheckpointer<T> implements ChangeFeedObserver<T> {
             return false;
         }
 
-        Duration delta = Duration.between(this.lastCheckpointTime, Instant.now());
-
-        return delta.compareTo(interval) >= 0;
+        return this.hasIntervalElapsed(interval);
     }
 
     private boolean isEveryBatchCheckpoint() {
@@ -120,7 +117,11 @@ public class AutoCheckpointer<T> implements ChangeFeedObserver<T> {
         }
 
         this.intervalCheckpointDisposable = Flux.interval(interval, interval)
-            .concatMap(ignored -> this.checkpointIfIntervalElapsed())
+            .concatMap(ignored -> this.checkpointIfIntervalElapsed()
+                .onErrorResume(throwable -> {
+                    logger.warn("Interval checkpoint attempt failed; will retry on the next interval tick", throwable);
+                    return Mono.empty();
+                }))
             .subscribe(
                 ignored -> {
                 },
@@ -142,7 +143,7 @@ public class AutoCheckpointer<T> implements ChangeFeedObserver<T> {
         }
 
         Duration interval = this.checkpointFrequency.getTimeInterval();
-        if (interval == null || Duration.between(this.lastCheckpointTime, Instant.now()).compareTo(interval) < 0) {
+        if (interval == null || !this.hasIntervalElapsed(interval)) {
             return Mono.empty();
         }
 
@@ -175,12 +176,24 @@ public class AutoCheckpointer<T> implements ChangeFeedObserver<T> {
     }
 
     private void onCheckpointSuccess(long checkpointedProgressVersion) {
-        this.lastCheckpointTime = Instant.now();
+        this.lastCheckpointNanoTime = System.nanoTime();
 
         // Keep progress markers if newer batches arrived while this checkpoint was in flight.
         if (this.latestProgressVersion.get() == checkpointedProgressVersion) {
             this.processedDocCount.set(0);
             this.hasUncheckpointedProgress = false;
         }
+    }
+
+    private boolean hasIntervalElapsed(Duration interval) {
+        long intervalNanos;
+        try {
+            intervalNanos = interval.toNanos();
+        } catch (ArithmeticException arithmeticException) {
+            intervalNanos = Long.MAX_VALUE;
+        }
+
+        long elapsedNanos = System.nanoTime() - this.lastCheckpointNanoTime;
+        return elapsedNanos >= intervalNanos;
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/CheckpointFrequencyFactory.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/CheckpointFrequencyFactory.java
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.changefeed.common;
+
+import com.azure.cosmos.ChangeFeedCheckpointStrategy;
+import com.azure.cosmos.EveryBatchCheckpointStrategy;
+import com.azure.cosmos.TimeIntervalCheckpointStrategy;
+import com.azure.cosmos.implementation.changefeed.CheckpointFrequency;
+import com.azure.cosmos.models.ChangeFeedProcessorOptions;
+
+/**
+ * Maps public checkpoint strategy options to internal checkpoint frequency settings.
+ */
+public final class CheckpointFrequencyFactory {
+    private CheckpointFrequencyFactory() {
+    }
+
+    public static CheckpointFrequency fromOptions(ChangeFeedProcessorOptions options) {
+        if (options == null || options.getCheckpointStrategy() == null) {
+            return new CheckpointFrequency();
+        }
+
+        ChangeFeedCheckpointStrategy strategy = options.getCheckpointStrategy();
+        if (strategy instanceof EveryBatchCheckpointStrategy) {
+            return new CheckpointFrequency();
+        }
+
+        if (strategy instanceof TimeIntervalCheckpointStrategy) {
+            return new CheckpointFrequency().withTimeInterval(
+                ((TimeIntervalCheckpointStrategy) strategy).getMaxCheckpointDelay());
+        }
+
+        throw new IllegalArgumentException("Unsupported checkpoint strategy " + strategy.getClass().getName());
+    }
+}
+

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/epkversion/ChangeFeedProcessorImplBase.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/epkversion/ChangeFeedProcessorImplBase.java
@@ -11,7 +11,6 @@ import com.azure.cosmos.implementation.Strings;
 import com.azure.cosmos.implementation.changefeed.Bootstrapper;
 import com.azure.cosmos.implementation.changefeed.ChangeFeedContextClient;
 import com.azure.cosmos.implementation.changefeed.ChangeFeedObserverFactory;
-import com.azure.cosmos.implementation.changefeed.CheckpointFrequency;
 import com.azure.cosmos.implementation.changefeed.HealthMonitor;
 import com.azure.cosmos.implementation.changefeed.LeaseStoreManager;
 import com.azure.cosmos.implementation.changefeed.PartitionController;
@@ -23,6 +22,7 @@ import com.azure.cosmos.implementation.changefeed.RequestOptionsFactory;
 import com.azure.cosmos.implementation.changefeed.common.ChangeFeedContextClientImpl;
 import com.azure.cosmos.implementation.changefeed.common.ChangeFeedMode;
 import com.azure.cosmos.implementation.changefeed.common.ChangeFeedState;
+import com.azure.cosmos.implementation.changefeed.common.CheckpointFrequencyFactory;
 import com.azure.cosmos.implementation.changefeed.common.CheckpointerObserverFactory;
 import com.azure.cosmos.implementation.changefeed.common.DefaultObserverFactory;
 import com.azure.cosmos.implementation.changefeed.common.EqualPartitionsBalancingStrategy;
@@ -372,7 +372,10 @@ public abstract class ChangeFeedProcessorImplBase<T> implements ChangeFeedProces
     abstract boolean canBootstrapFromPkRangeIdVersionLeaseStore();
 
     private Mono<PartitionManager> buildPartitionManager(LeaseStoreManager leaseStoreManager) {
-        CheckpointerObserverFactory<T> factory = new CheckpointerObserverFactory<>(this.observerFactory, new CheckpointFrequency());
+        CheckpointerObserverFactory<T> factory =
+            new CheckpointerObserverFactory<>(
+                this.observerFactory,
+                CheckpointFrequencyFactory.fromOptions(this.changeFeedProcessorOptions));
 
         PartitionSynchronizerImpl synchronizer = new PartitionSynchronizerImpl(
                 this.feedContextClient,

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/pkversion/IncrementalChangeFeedProcessorImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/pkversion/IncrementalChangeFeedProcessorImpl.java
@@ -10,7 +10,6 @@ import com.azure.cosmos.implementation.apachecommons.lang.tuple.Pair;
 import com.azure.cosmos.implementation.changefeed.Bootstrapper;
 import com.azure.cosmos.implementation.changefeed.ChangeFeedContextClient;
 import com.azure.cosmos.implementation.changefeed.ChangeFeedObserverFactory;
-import com.azure.cosmos.implementation.changefeed.CheckpointFrequency;
 import com.azure.cosmos.implementation.changefeed.HealthMonitor;
 import com.azure.cosmos.implementation.changefeed.LeaseStoreManager;
 import com.azure.cosmos.implementation.changefeed.PartitionController;
@@ -21,6 +20,7 @@ import com.azure.cosmos.implementation.changefeed.PartitionSupervisorFactory;
 import com.azure.cosmos.implementation.changefeed.RequestOptionsFactory;
 import com.azure.cosmos.implementation.changefeed.common.ChangeFeedContextClientImpl;
 import com.azure.cosmos.implementation.changefeed.common.ChangeFeedMode;
+import com.azure.cosmos.implementation.changefeed.common.CheckpointFrequencyFactory;
 import com.azure.cosmos.implementation.changefeed.common.CheckpointerObserverFactory;
 import com.azure.cosmos.implementation.changefeed.common.DefaultObserverFactory;
 import com.azure.cosmos.implementation.changefeed.common.EqualPartitionsBalancingStrategy;
@@ -419,7 +419,10 @@ public class IncrementalChangeFeedProcessorImpl implements ChangeFeedProcessor, 
     }
 
     private Mono<PartitionManager> buildPartitionManager(LeaseStoreManager leaseStoreManager) {
-        CheckpointerObserverFactory<JsonNode> factory = new CheckpointerObserverFactory<>(this.observerFactory, new CheckpointFrequency());
+        CheckpointerObserverFactory<JsonNode> factory =
+            new CheckpointerObserverFactory<>(
+                this.observerFactory,
+                CheckpointFrequencyFactory.fromOptions(this.changeFeedProcessorOptions));
 
         PartitionSynchronizerImpl synchronizer = new PartitionSynchronizerImpl(
             this.feedContextClient,

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/ChangeFeedProcessorOptions.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/ChangeFeedProcessorOptions.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 package com.azure.cosmos.models;
 
+import com.azure.cosmos.ChangeFeedCheckpointStrategy;
 import com.azure.cosmos.ChangeFeedProcessor;
 import com.azure.cosmos.ThroughputControlGroupConfig;
 import reactor.core.scheduler.Scheduler;
@@ -62,6 +63,7 @@ public final class ChangeFeedProcessorOptions {
 
     private Scheduler scheduler;
     private ThroughputControlGroupConfig feedPollThroughputControlGroupConfig;
+    private ChangeFeedCheckpointStrategy checkpointStrategy;
 
     /**
      * Instantiates a new Change feed processor options.
@@ -79,6 +81,7 @@ public final class ChangeFeedProcessorOptions {
 
         this.scheduler = Schedulers.boundedElastic();
         this.feedPollThroughputControlGroupConfig = null;
+        this.checkpointStrategy = null;
         this.leaseVerificationOnRestartEnabled = DEFAULT_LEASE_VERIFICATION_ON_RESTART_ENABLED;
     }
 
@@ -426,7 +429,7 @@ public final class ChangeFeedProcessorOptions {
      * Please use this config with caution. By default, CFP will try to process the changes as fast as possible,
      * only use this config if you want to limit the RU that can be used for your change feed processing.
      * By using this config, it can slow down the process and cause the lag.
-     * 
+     *
      * For direct mode, please configure the throughput control group with the total RU you would allow for changeFeed processing.
      * For gateway mode, please configure the throughput control group with the total RU you would allow for changeFeed processing / total CFP Instances.
      *
@@ -448,6 +451,29 @@ public final class ChangeFeedProcessorOptions {
      */
     public ThroughputControlGroupConfig getFeedPollThroughputControlGroupConfig() {
         return this.feedPollThroughputControlGroupConfig;
+    }
+
+    /**
+     * Sets the checkpoint strategy for the Change Feed Processor.
+     * <p>
+     * If not set, the default behavior checkpoints after each processed batch.
+     *
+     * @param checkpointStrategy the checkpoint strategy.
+     * @return the {@link ChangeFeedProcessorOptions}.
+     */
+    public ChangeFeedProcessorOptions setCheckpointStrategy(ChangeFeedCheckpointStrategy checkpointStrategy) {
+        checkNotNull(checkpointStrategy, "Argument 'checkpointStrategy' can not be null");
+        this.checkpointStrategy = checkpointStrategy;
+        return this;
+    }
+
+    /**
+     * Gets the configured checkpoint strategy.
+     *
+     * @return the configured checkpoint strategy, or null when default every-batch checkpointing is used.
+     */
+    public ChangeFeedCheckpointStrategy getCheckpointStrategy() {
+        return this.checkpointStrategy;
     }
 
     /**


### PR DESCRIPTION
By default, CFP writes a checkpoint after every single batch. This is the safest behavior — the replay window is at most one batch — but every checkpoint is a write that costs RUs on the lease container.

The problem: In high-throughput workloads, the lease container can consume significant RUs just for checkpoint writes. Customers asked for a way to checkpoint less often while still bounding the replay window to a predictable duration.