### PR TITLE
[Spring Data Cosmos] Fix datetime serialization — store as ISO-8601 strings (#34849)

### DIFF
--- a/sdk/spring/azure-spring-data-cosmos/CHANGELOG.md
+++ b/sdk/spring/azure-spring-data-cosmos/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 #### Bugs Fixed
 
+* Fixed date/time types being serialized as epoch numbers instead of ISO-8601 strings. Disabled `WRITE_DATES_AS_TIMESTAMPS` in the default ObjectMapper configuration so `ZonedDateTime`, `LocalDateTime`, `OffsetDateTime`, and `Instant` are now serialized as ISO-8601 strings. Added tolerant deserializers to maintain backward compatibility with existing data stored as epoch numbers. Extended `toCosmosDbValue()` to handle `LocalDateTime`, `OffsetDateTime`, and `Instant` as ISO strings for query parameters. Fixed typo in `ISO_8601_COMPATIBLE_DATE_PATTERN` (colon before millis replaced with dot). - See [PR #34849](https://github.com/Azure/azure-sdk-for-java/issues/34849).
+
 #### Other Changes
 
 ### 7.1.0 (2026-03-11)

--- a/sdk/spring/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/Constants.java
+++ b/sdk/spring/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/Constants.java
@@ -89,7 +89,7 @@ public final class Constants {
     /**
      * ISO-8601 compatible date pattern.
      */
-    public static final String ISO_8601_COMPATIBLE_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss:SSSXXX";
+    public static final String ISO_8601_COMPATIBLE_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
     private Constants() {
     }

--- a/sdk/spring/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/core/convert/MappingCosmosConverter.java
+++ b/sdk/spring/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/core/convert/MappingCosmosConverter.java
@@ -26,6 +26,9 @@ import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 import org.springframework.util.Assert;
 
 import java.lang.reflect.Field;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -324,6 +327,14 @@ public class MappingCosmosConverter
         } else if (fromPropertyValue instanceof ZonedDateTime) {
             fromPropertyValue = ((ZonedDateTime) fromPropertyValue)
                 .format(DateTimeFormatter.ofPattern(ISO_8601_COMPATIBLE_DATE_PATTERN));
+        } else if (fromPropertyValue instanceof LocalDateTime) {
+            fromPropertyValue = ((LocalDateTime) fromPropertyValue)
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        } else if (fromPropertyValue instanceof OffsetDateTime) {
+            fromPropertyValue = ((OffsetDateTime) fromPropertyValue)
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        } else if (fromPropertyValue instanceof Instant) {
+            fromPropertyValue = ((Instant) fromPropertyValue).toString();
         } else if (fromPropertyValue instanceof Enum) {
             fromPropertyValue = fromPropertyValue.toString();
         } else if (fromPropertyValue instanceof Optional<?>) {

--- a/sdk/spring/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/core/convert/ObjectMapperFactory.java
+++ b/sdk/spring/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/core/convert/ObjectMapperFactory.java
@@ -5,6 +5,7 @@ package com.azure.spring.data.cosmos.core.convert;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
@@ -25,8 +26,10 @@ public class ObjectMapperFactory {
     static {
         OBJECT_MAPPER.registerModule(new ParameterNamesModule())
                         .registerModule(new Jdk8Module())
-                        .registerModule(new JavaTimeModule());
+                        .registerModule(new JavaTimeModule())
+                        .registerModule(TolerantDateTimeDeserializers.createModule());
         OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        OBJECT_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 
     /**

--- a/sdk/spring/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/core/convert/TolerantDateTimeDeserializers.java
+++ b/sdk/spring/azure-spring-data-cosmos/src/main/java/com/azure/spring/data/cosmos/core/convert/TolerantDateTimeDeserializers.java
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.azure.spring.data.cosmos.core.convert;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Tolerant deserializers for java.time types that handle both epoch-millis numbers
+ * (backward compatibility) and ISO-8601 strings (new default format).
+ *
+ * <p>This ensures existing data stored as epoch numbers can still be read after the
+ * default serialization format is changed to ISO-8601 strings.</p>
+ */
+final class TolerantDateTimeDeserializers {
+
+    private TolerantDateTimeDeserializers() {
+    }
+
+    /**
+     * Creates a Jackson module with tolerant deserializers for all supported java.time types.
+     *
+     * @return a {@link SimpleModule} with tolerant deserializers registered
+     */
+    static SimpleModule createModule() {
+        SimpleModule module = new SimpleModule("CosmosTolerantDateTimeModule");
+        module.addDeserializer(ZonedDateTime.class, new TolerantZonedDateTimeDeserializer());
+        module.addDeserializer(LocalDateTime.class, new TolerantLocalDateTimeDeserializer());
+        module.addDeserializer(Instant.class, new TolerantInstantDeserializer());
+        module.addDeserializer(OffsetDateTime.class, new TolerantOffsetDateTimeDeserializer());
+        return module;
+    }
+
+    /**
+     * Deserializer for {@link ZonedDateTime} that accepts both epoch-millis and ISO-8601 strings.
+     */
+    static final class TolerantZonedDateTimeDeserializer extends JsonDeserializer<ZonedDateTime> {
+        @Override
+        public ZonedDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            if (p.currentToken() == JsonToken.VALUE_NUMBER_INT
+                || p.currentToken() == JsonToken.VALUE_NUMBER_FLOAT) {
+                long epochMillis = p.getLongValue();
+                return Instant.ofEpochMilli(epochMillis).atZone(ZoneOffset.UTC);
+            }
+            String text = p.getText().trim();
+            return ZonedDateTime.parse(text, DateTimeFormatter.ISO_ZONED_DATE_TIME);
+        }
+    }
+
+    /**
+     * Deserializer for {@link LocalDateTime} that accepts both epoch-millis and ISO-8601 strings.
+     */
+    static final class TolerantLocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+        @Override
+        public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            if (p.currentToken() == JsonToken.VALUE_NUMBER_INT
+                || p.currentToken() == JsonToken.VALUE_NUMBER_FLOAT) {
+                long epochMillis = p.getLongValue();
+                return LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneOffset.UTC);
+            }
+            String text = p.getText().trim();
+            return LocalDateTime.parse(text, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        }
+    }
+
+    /**
+     * Deserializer for {@link Instant} that accepts both epoch-millis and ISO-8601 strings.
+     */
+    static final class TolerantInstantDeserializer extends JsonDeserializer<Instant> {
+        @Override
+        public Instant deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            if (p.currentToken() == JsonToken.VALUE_NUMBER_INT
+                || p.currentToken() == JsonToken.VALUE_NUMBER_FLOAT) {
+                long epochMillis = p.getLongValue();
+                return Instant.ofEpochMilli(epochMillis);
+            }
+            String text = p.getText().trim();
+            return Instant.parse(text);
+        }
+    }
+
+    /**
+     * Deserializer for {@link OffsetDateTime} that accepts both epoch-millis and ISO-8601 strings.
+     */
+    static final class TolerantOffsetDateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
+        @Override
+        public OffsetDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            if (p.currentToken() == JsonToken.VALUE_NUMBER_INT
+                || p.currentToken() == JsonToken.VALUE_NUMBER_FLOAT) {
+                long epochMillis = p.getLongValue();
+                return OffsetDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneOffset.UTC);
+            }
+            String text = p.getText().trim();
+            return OffsetDateTime.parse(text, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
+    }
+}

--- a/sdk/spring/azure-spring-data-cosmos/src/test/java/com/azure/spring/data/cosmos/core/converter/DateTimeSerializationUnitTest.java
+++ b/sdk/spring/azure-spring-data-cosmos/src/test/java/com/azure/spring/data/cosmos/core/converter/DateTimeSerializationUnitTest.java
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.azure.spring.data.cosmos.core.converter;
+
+import com.azure.spring.data.cosmos.core.convert.MappingCosmosConverter;
+import com.azure.spring.data.cosmos.core.convert.ObjectMapperFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for date/time serialization and deserialization behavior,
+ * verifying ISO-8601 string output and backward-compatible epoch-millis reading.
+ */
+public class DateTimeSerializationUnitTest {
+
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getObjectMapper();
+
+    // ===== Serialization tests: verify ISO string output =====
+
+    @Test
+    public void serializeZonedDateTimeAsIsoString() throws JsonProcessingException {
+        ZonedDateTime zdt = ZonedDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneOffset.UTC);
+        String json = objectMapper.writeValueAsString(zdt);
+        assertThat(json).contains("2024-01-15");
+        assertThat(json).contains("10:30:45");
+        // Must NOT be a plain number (epoch)
+        assertThat(json).startsWith("\"");
+    }
+
+    @Test
+    public void serializeLocalDateTimeAsIsoString() throws JsonProcessingException {
+        LocalDateTime ldt = LocalDateTime.of(2024, 3, 20, 14, 0, 0);
+        String json = objectMapper.writeValueAsString(ldt);
+        assertThat(json).contains("2024-03-20");
+        assertThat(json).contains("14:00:00");
+        assertThat(json).startsWith("\"");
+    }
+
+    @Test
+    public void serializeInstantAsIsoString() throws JsonProcessingException {
+        Instant instant = Instant.parse("2024-06-01T12:00:00Z");
+        String json = objectMapper.writeValueAsString(instant);
+        assertThat(json).contains("2024-06-01");
+        assertThat(json).contains("12:00:00");
+        assertThat(json).startsWith("\"");
+    }
+
+    @Test
+    public void serializeOffsetDateTimeAsIsoString() throws JsonProcessingException {
+        OffsetDateTime odt = OffsetDateTime.of(2024, 9, 10, 8, 15, 30, 0, ZoneOffset.ofHours(5));
+        String json = objectMapper.writeValueAsString(odt);
+        assertThat(json).contains("2024-09-10");
+        assertThat(json).contains("08:15:30");
+        assertThat(json).startsWith("\"");
+    }
+
+    // ===== Deserialization tests: epoch-millis backward compat =====
+
+    @Test
+    public void deserializeZonedDateTimeFromEpochMillis() throws JsonProcessingException {
+        // 2024-01-15T10:30:45Z = 1705312245000L
+        long epochMillis = 1705312245000L;
+        ZonedDateTime result = objectMapper.readValue(String.valueOf(epochMillis), ZonedDateTime.class);
+        assertThat(result.toInstant().toEpochMilli()).isEqualTo(epochMillis);
+    }
+
+    @Test
+    public void deserializeLocalDateTimeFromEpochMillis() throws JsonProcessingException {
+        long epochMillis = 1705312245000L;
+        LocalDateTime result = objectMapper.readValue(String.valueOf(epochMillis), LocalDateTime.class);
+        Instant reconverted = result.toInstant(ZoneOffset.UTC);
+        assertThat(reconverted.toEpochMilli()).isEqualTo(epochMillis);
+    }
+
+    @Test
+    public void deserializeInstantFromEpochMillis() throws JsonProcessingException {
+        long epochMillis = 1705312245000L;
+        Instant result = objectMapper.readValue(String.valueOf(epochMillis), Instant.class);
+        assertThat(result.toEpochMilli()).isEqualTo(epochMillis);
+    }
+
+    @Test
+    public void deserializeOffsetDateTimeFromEpochMillis() throws JsonProcessingException {
+        long epochMillis = 1705312245000L;
+        OffsetDateTime result = objectMapper.readValue(String.valueOf(epochMillis), OffsetDateTime.class);
+        assertThat(result.toInstant().toEpochMilli()).isEqualTo(epochMillis);
+    }
+
+    // ===== Deserialization tests: ISO string input =====
+
+    @Test
+    public void deserializeZonedDateTimeFromIsoString() throws JsonProcessingException {
+        String isoString = "\"2024-01-15T10:30:45Z\"";
+        ZonedDateTime result = objectMapper.readValue(isoString, ZonedDateTime.class);
+        assertThat(result.getYear()).isEqualTo(2024);
+        assertThat(result.getMonthValue()).isEqualTo(1);
+        assertThat(result.getDayOfMonth()).isEqualTo(15);
+        assertThat(result.getHour()).isEqualTo(10);
+    }
+
+    @Test
+    public void deserializeLocalDateTimeFromIsoString() throws JsonProcessingException {
+        String isoString = "\"2024-03-20T14:00:00\"";
+        LocalDateTime result = objectMapper.readValue(isoString, LocalDateTime.class);
+        assertThat(result.getYear()).isEqualTo(2024);
+        assertThat(result.getMonthValue()).isEqualTo(3);
+        assertThat(result.getHour()).isEqualTo(14);
+    }
+
+    @Test
+    public void deserializeInstantFromIsoString() throws JsonProcessingException {
+        String isoString = "\"2024-06-01T12:00:00Z\"";
+        Instant result = objectMapper.readValue(isoString, Instant.class);
+        assertThat(result).isEqualTo(Instant.parse("2024-06-01T12:00:00Z"));
+    }
+
+    @Test
+    public void deserializeOffsetDateTimeFromIsoString() throws JsonProcessingException {
+        String isoString = "\"2024-09-10T08:15:30+05:00\"";
+        OffsetDateTime result = objectMapper.readValue(isoString, OffsetDateTime.class);
+        assertThat(result.getYear()).isEqualTo(2024);
+        assertThat(result.getOffset()).isEqualTo(ZoneOffset.ofHours(5));
+    }
+
+    // ===== Round-trip tests: serialize → deserialize → equals =====
+
+    @Test
+    public void roundTripZonedDateTime() throws JsonProcessingException {
+        ZonedDateTime original = ZonedDateTime.of(2024, 7, 4, 16, 30, 0, 0, ZoneId.of("UTC"));
+        String json = objectMapper.writeValueAsString(original);
+        ZonedDateTime restored = objectMapper.readValue(json, ZonedDateTime.class);
+        assertThat(restored.toInstant()).isEqualTo(original.toInstant());
+    }
+
+    @Test
+    public void roundTripLocalDateTime() throws JsonProcessingException {
+        LocalDateTime original = LocalDateTime.of(2024, 11, 25, 9, 45, 15);
+        String json = objectMapper.writeValueAsString(original);
+        LocalDateTime restored = objectMapper.readValue(json, LocalDateTime.class);
+        assertThat(restored).isEqualTo(original);
+    }
+
+    @Test
+    public void roundTripInstant() throws JsonProcessingException {
+        Instant original = Instant.parse("2024-12-31T23:59:59Z");
+        String json = objectMapper.writeValueAsString(original);
+        Instant restored = objectMapper.readValue(json, Instant.class);
+        assertThat(restored).isEqualTo(original);
+    }
+
+    @Test
+    public void roundTripOffsetDateTime() throws JsonProcessingException {
+        OffsetDateTime original = OffsetDateTime.of(2024, 5, 1, 12, 0, 0, 0, ZoneOffset.ofHours(-4));
+        String json = objectMapper.writeValueAsString(original);
+        OffsetDateTime restored = objectMapper.readValue(json, OffsetDateTime.class);
+        assertThat(restored.toInstant()).isEqualTo(original.toInstant());
+    }
+
+    // ===== toCosmosDbValue tests =====
+
+    @Test
+    public void toCosmosDbValueConvertsZonedDateTimeToIsoString() {
+        ZonedDateTime zdt = ZonedDateTime.of(2024, 1, 15, 10, 30, 45, 0, ZoneOffset.UTC);
+        Object result = MappingCosmosConverter.toCosmosDbValue(zdt);
+        assertThat(result).isInstanceOf(String.class);
+        assertThat((String) result).contains("2024-01-15");
+    }
+
+    @Test
+    public void toCosmosDbValueConvertsLocalDateTimeToIsoString() {
+        LocalDateTime ldt = LocalDateTime.of(2024, 3, 20, 14, 0, 0);
+        Object result = MappingCosmosConverter.toCosmosDbValue(ldt);
+        assertThat(result).isInstanceOf(String.class);
+        assertThat((String) result).isEqualTo("2024-03-20T14:00:00");
+    }
+
+    @Test
+    public void toCosmosDbValueConvertsOffsetDateTimeToIsoString() {
+        OffsetDateTime odt = OffsetDateTime.of(2024, 9, 10, 8, 15, 30, 0, ZoneOffset.ofHours(5));
+        Object result = MappingCosmosConverter.toCosmosDbValue(odt);
+        assertThat(result).isInstanceOf(String.class);
+        assertThat((String) result).contains("2024-09-10T08:15:30");
+    }
+
+    @Test
+    public void toCosmosDbValueConvertsInstantToIsoString() {
+        Instant instant = Instant.parse("2024-06-01T12:00:00Z");
+        Object result = MappingCosmosConverter.toCosmosDbValue(instant);
+        assertThat(result).isInstanceOf(String.class);
+        assertThat((String) result).isEqualTo("2024-06-01T12:00:00Z");
+    }
+
+    @Test
+    public void toCosmosDbValueReturnsNullForNull() {
+        Object result = MappingCosmosConverter.toCosmosDbValue(null);
+        assertThat(result).isNull();
+    }
+}


### PR DESCRIPTION
## Issue
Fixes #34849

## Problem
DateTime types (\ZonedDateTime\, \LocalDateTime\, \Instant\, \OffsetDateTime\) are stored as epoch numbers instead of ISO-8601 strings. The \@DateTimeFormat\ annotation (a Spring Web concern) has no effect on Jackson serialization used by the Cosmos converter.

## Fix
1. Disabled \WRITE_DATES_AS_TIMESTAMPS\ in \ObjectMapperFactory\ — dates now serialize as ISO-8601 strings
2. Created \TolerantDateTimeDeserializers\ that can read **both** epoch numbers (backward compat) and ISO strings (new format)
3. Extended \	oCosmosDbValue()\ to handle \LocalDateTime\, \OffsetDateTime\, and \Instant\ as ISO strings in query parameters
4. Fixed typo in existing date pattern: \:SSS\ → \.SSS\

## Backward Compatibility
Tolerant deserializers ensure existing data stored as epoch numbers can still be read. New data will be stored as ISO-8601 strings.

## Testing
- 21 new tests + 10 existing tests pass
- Covers serialization, deserialization, epoch backward compat, round-trip
