### PR TITLE
[Cosmos] Port hub region caching per partition level (#48788)

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ClientRetryPolicyTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ClientRetryPolicyTest.java
@@ -9,6 +9,7 @@ import com.azure.cosmos.ThrottlingRetryOptions;
 import com.azure.cosmos.implementation.directconnectivity.ChannelAcquisitionException;
 import com.azure.cosmos.implementation.directconnectivity.WFConstants;
 import com.azure.cosmos.implementation.perPartitionAutomaticFailover.GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover;
+import com.azure.cosmos.implementation.hubRegionRouting.GlobalPartitionEndpointManagerForHubRegionRouting;
 import com.azure.cosmos.implementation.perPartitionCircuitBreaker.GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker;
 import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
 import io.netty.handler.timeout.ReadTimeoutException;
@@ -93,6 +94,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito
             .doReturn(new RegionalRoutingContext(new URI("http://localhost")))
@@ -105,6 +108,7 @@ public class ClientRetryPolicyTest {
             throttlingRetryOptions,
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            globalPartitionEndpointManagerForHubRegionRouting,
             false);
 
         // Create throttling exception with retry delay
@@ -172,6 +176,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito.doReturn(Mono.empty()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
         ClientRetryPolicy clientRetryPolicy = new ClientRetryPolicy(
@@ -181,6 +187,7 @@ public class ClientRetryPolicyTest {
             throttlingRetryOptions,
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            globalPartitionEndpointManagerForHubRegionRouting,
             false);
 
         Exception exception = new SocketException("Dummy SocketException");
@@ -222,6 +229,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito.doReturn(new RegionalRoutingContext(new URI("http://localhost"))).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
         Mockito.doReturn(Mono.empty()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(true));
@@ -233,6 +242,7 @@ public class ClientRetryPolicyTest {
                 throttlingRetryOptions,
                 globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
                 globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+                globalPartitionEndpointManagerForHubRegionRouting,
                 false);
 
         Exception exception = ReadTimeoutException.INSTANCE;
@@ -269,6 +279,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito.doReturn(new RegionalRoutingContext(new URI("http://localhost"))).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
         Mockito.doReturn(Mono.empty()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
@@ -280,6 +292,7 @@ public class ClientRetryPolicyTest {
             retryOptions,
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            globalPartitionEndpointManagerForHubRegionRouting,
             false);
 
         Exception exception = ReadTimeoutException.INSTANCE;
@@ -327,6 +340,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito.doReturn(new RegionalRoutingContext(new URI("http://localhost"))).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
         Mockito.doReturn(Mono.empty()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
@@ -337,6 +352,7 @@ public class ClientRetryPolicyTest {
             throttlingRetryOptions,
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            globalPartitionEndpointManagerForHubRegionRouting,
             false);
 
         Exception exception = new SocketException("Dummy SocketException");;
@@ -372,6 +388,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito.doReturn(new RegionalRoutingContext(new URI("http://localhost"))).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
         Mockito.doReturn(Mono.empty()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
@@ -383,6 +401,7 @@ public class ClientRetryPolicyTest {
             retryOptions,
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            globalPartitionEndpointManagerForHubRegionRouting,
             false);
 
         //Non retribale exception for write
@@ -442,6 +461,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito.doReturn(new RegionalRoutingContext(new URI("http://localhost"))).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
         Mockito.doReturn(Mono.empty()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
@@ -452,6 +473,7 @@ public class ClientRetryPolicyTest {
             throttlingRetryOptions,
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            globalPartitionEndpointManagerForHubRegionRouting,
             false);
 
         Exception exception = new SocketException("Dummy SocketException");
@@ -485,6 +507,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito.doReturn(new RegionalRoutingContext(new URI("http://localhost"))).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
         Mockito.doReturn(Mono.empty()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
@@ -496,6 +520,7 @@ public class ClientRetryPolicyTest {
             retryOptions,
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            globalPartitionEndpointManagerForHubRegionRouting,
             false);
 
         Exception exception = new SocketException("Dummy SocketException");
@@ -531,6 +556,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito.doReturn(new RegionalRoutingContext(new URI("http://localhost"))).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
         Mockito.doReturn(Mono.empty()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
@@ -541,6 +568,7 @@ public class ClientRetryPolicyTest {
             throttlingRetryOptions,
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            globalPartitionEndpointManagerForHubRegionRouting,
             false);
 
         Exception exception = ReadTimeoutException.INSTANCE;
@@ -575,6 +603,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito.doReturn(new RegionalRoutingContext(new URI("http://localhost"))).when(endpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
         Mockito.doReturn(Mono.empty()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
@@ -586,6 +616,7 @@ public class ClientRetryPolicyTest {
             retryOptions,
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            globalPartitionEndpointManagerForHubRegionRouting,
             false);
 
         Exception exception = ReadTimeoutException.INSTANCE;
@@ -621,6 +652,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito.doReturn(Mono.empty()).when(endpointManager).refreshLocationAsync(Mockito.eq(null), Mockito.eq(false));
         ClientRetryPolicy clientRetryPolicy = new ClientRetryPolicy(
@@ -630,6 +663,7 @@ public class ClientRetryPolicyTest {
             throttlingRetryOptions,
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            globalPartitionEndpointManagerForHubRegionRouting,
             false);
 
         Exception exception = ReadTimeoutException.INSTANCE;
@@ -655,6 +689,8 @@ public class ClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         CosmosException cosmosEx = Mockito.mock(CosmosException.class);
 
@@ -671,6 +707,7 @@ public class ClientRetryPolicyTest {
                 throttlingRetryOptions,
                 globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
                 globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+                globalPartitionEndpointManagerForHubRegionRouting,
                 false);
 
         RxDocumentServiceRequest dsr;
@@ -703,6 +740,8 @@ public class ClientRetryPolicyTest {
 
         GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting
+            = Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class);
 
         Mockito
             .doReturn(new RegionalRoutingContext(new URI("http://localhost")))
@@ -716,6 +755,7 @@ public class ClientRetryPolicyTest {
             throttlingRetryOptions,
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            globalPartitionEndpointManagerForHubRegionRouting,
             disableRetryForThrottledBatchRequest);
 
         // Create throttling exception with retry delay

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/RenameCollectionAwareClientRetryPolicyTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/RenameCollectionAwareClientRetryPolicyTest.java
@@ -4,6 +4,7 @@ package com.azure.cosmos.implementation;
 
 import com.azure.cosmos.BridgeInternal;
 import com.azure.cosmos.implementation.caches.RxClientCollectionCache;
+import com.azure.cosmos.implementation.hubRegionRouting.GlobalPartitionEndpointManagerForHubRegionRouting;
 import com.azure.cosmos.implementation.perPartitionCircuitBreaker.GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker;
 import com.azure.cosmos.implementation.directconnectivity.WFConstants;
 import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
@@ -34,7 +35,7 @@ public class RenameCollectionAwareClientRetryPolicyTest {
             = Mockito.mock(GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover.class);
         Mockito.doReturn(Mono.empty()).when(endpointManager).refreshLocationAsync(eq(null), eq(false));
 
-        IRetryPolicyFactory retryPolicyFactory = new RetryPolicy(mockDiagnosticsClientContext(), endpointManager, ConnectionPolicy.getDefaultPolicy(), globalPartitionEndpointManagerForPerPartitionCircuitBreaker, globalPartitionEndpointManagerForPerPartitionAutomaticFailover);
+        IRetryPolicyFactory retryPolicyFactory = new RetryPolicy(mockDiagnosticsClientContext(), endpointManager, ConnectionPolicy.getDefaultPolicy(), globalPartitionEndpointManagerForPerPartitionCircuitBreaker, globalPartitionEndpointManagerForPerPartitionAutomaticFailover, Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class));
         RxClientCollectionCache rxClientCollectionCache = Mockito.mock(RxClientCollectionCache.class);
 
         ISessionContainer sessionContainer = Mockito.mock(ISessionContainer.class);
@@ -73,7 +74,7 @@ public class RenameCollectionAwareClientRetryPolicyTest {
 
         Mockito.when(endpointManager.resolveServiceEndpoint(Mockito.any())).thenReturn(regionalRoutingContext);
 
-        IRetryPolicyFactory retryPolicyFactory = new RetryPolicy(mockDiagnosticsClientContext(), endpointManager, ConnectionPolicy.getDefaultPolicy(), globalPartitionEndpointManagerForPerPartitionCircuitBreaker, globalPartitionEndpointManagerForPerPartitionAutomaticFailover);
+        IRetryPolicyFactory retryPolicyFactory = new RetryPolicy(mockDiagnosticsClientContext(), endpointManager, ConnectionPolicy.getDefaultPolicy(), globalPartitionEndpointManagerForPerPartitionCircuitBreaker, globalPartitionEndpointManagerForPerPartitionAutomaticFailover, Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class));
         RxClientCollectionCache rxClientCollectionCache = Mockito.mock(RxClientCollectionCache.class);
 
         ISessionContainer sessionContainer = Mockito.mock(ISessionContainer.class);
@@ -110,7 +111,7 @@ public class RenameCollectionAwareClientRetryPolicyTest {
 
         Mockito.when(endpointManager.resolveServiceEndpoint(Mockito.any())).thenReturn(regionalRoutingContext);
 
-        IRetryPolicyFactory retryPolicyFactory = new RetryPolicy(mockDiagnosticsClientContext(), endpointManager, ConnectionPolicy.getDefaultPolicy(), globalPartitionEndpointManagerForPerPartitionCircuitBreaker, globalPartitionEndpointManagerForPerPartitionAutomaticFailover);
+        IRetryPolicyFactory retryPolicyFactory = new RetryPolicy(mockDiagnosticsClientContext(), endpointManager, ConnectionPolicy.getDefaultPolicy(), globalPartitionEndpointManagerForPerPartitionCircuitBreaker, globalPartitionEndpointManagerForPerPartitionAutomaticFailover, Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class));
         RxClientCollectionCache rxClientCollectionCache = Mockito.mock(RxClientCollectionCache.class);
 
         ISessionContainer sessionContainer = Mockito.mock(ISessionContainer.class);
@@ -162,7 +163,8 @@ public class RenameCollectionAwareClientRetryPolicyTest {
             endpointManager,
             ConnectionPolicy.getDefaultPolicy(),
             globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
-            globalPartitionEndpointManagerForPerPartitionAutomaticFailover);
+            globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class));
 
         RxClientCollectionCache rxClientCollectionCache = Mockito.mock(RxClientCollectionCache.class);
 

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/hubRegionRouting/GlobalPartitionEndpointManagerForHubRegionRoutingTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/hubRegionRouting/GlobalPartitionEndpointManagerForHubRegionRoutingTest.java
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.hubRegionRouting;
+
+import com.azure.cosmos.implementation.DocumentServiceRequestContext;
+import com.azure.cosmos.implementation.GlobalEndpointManager;
+import com.azure.cosmos.implementation.OperationType;
+import com.azure.cosmos.implementation.PartitionKeyRange;
+import com.azure.cosmos.implementation.ResourceType;
+import com.azure.cosmos.implementation.RxDocumentServiceRequest;
+import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+
+import static com.azure.cosmos.implementation.TestUtils.mockDiagnosticsClientContext;
+
+public class GlobalPartitionEndpointManagerForHubRegionRoutingTest {
+
+    private static final String COLLECTION_RID = "dbs/db1/colls/col1";
+
+    private GlobalEndpointManager endpointManager;
+    private GlobalPartitionEndpointManagerForHubRegionRouting hubRegionManager;
+
+    @BeforeMethod
+    public void setUp() {
+        System.setProperty("COSMOS.HUB_REGION_PROCESSING_ENABLED", "true");
+        endpointManager = Mockito.mock(GlobalEndpointManager.class);
+        hubRegionManager = new GlobalPartitionEndpointManagerForHubRegionRouting(endpointManager);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        System.clearProperty("COSMOS.HUB_REGION_PROCESSING_ENABLED");
+    }
+
+    @Test(groups = {"unit"})
+    public void featureFlagDisabled_hubRegionRoutingNotActive() {
+        hubRegionManager.resetHubRegionProcessingEnabled(false);
+
+        RxDocumentServiceRequest request = createDocumentReadRequest();
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(request)).thenReturn(false);
+
+        Assert.assertFalse(hubRegionManager.isHubRegionRoutingActive(request));
+    }
+
+    @Test(groups = {"unit"})
+    public void featureFlagEnabled_singleMaster_hubRegionRoutingActive() {
+        RxDocumentServiceRequest request = createDocumentReadRequest();
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(request)).thenReturn(false);
+
+        Assert.assertTrue(hubRegionManager.isHubRegionRoutingActive(request));
+    }
+
+    @Test(groups = {"unit"})
+    public void featureFlagEnabled_multiMaster_hubRegionRoutingNotActive() {
+        RxDocumentServiceRequest request = createDocumentReadRequest();
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(request)).thenReturn(true);
+
+        Assert.assertFalse(hubRegionManager.isHubRegionRoutingActive(request));
+    }
+
+    @Test(groups = {"unit"})
+    public void nonDocumentRequest_hubRegionRoutingNotActive() {
+        RxDocumentServiceRequest request = RxDocumentServiceRequest.createFromName(
+            mockDiagnosticsClientContext(),
+            OperationType.Read,
+            "/dbs/db1",
+            ResourceType.Database);
+        request.requestContext = new DocumentServiceRequestContext();
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(request)).thenReturn(false);
+
+        Assert.assertFalse(hubRegionManager.isHubRegionRoutingActive(request));
+    }
+
+    @Test(groups = {"unit"})
+    public void queryPlanRequest_hubRegionRoutingNotActive() {
+        RxDocumentServiceRequest request = RxDocumentServiceRequest.createFromName(
+            mockDiagnosticsClientContext(),
+            OperationType.QueryPlan,
+            "/dbs/db1/colls/col1/docs/doc1",
+            ResourceType.Document);
+        request.requestContext = new DocumentServiceRequestContext();
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(request)).thenReturn(false);
+
+        Assert.assertFalse(hubRegionManager.isHubRegionRoutingActive(request));
+    }
+
+    @Test(groups = {"unit"})
+    public void cacheAndRetrieveHubRegion() throws Exception {
+        RxDocumentServiceRequest request = createDocumentReadRequest();
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(request)).thenReturn(false);
+
+        URI hubUri = new URI("https://hub-region.cosmos.azure.com");
+        RegionalRoutingContext hubContext = new RegionalRoutingContext(hubUri);
+        request.requestContext.routeToLocation(hubContext);
+
+        hubRegionManager.cacheHubRegionForPartition(request);
+
+        Assert.assertTrue(hubRegionManager.hasCachedHubRegion(request));
+        Assert.assertEquals(1, hubRegionManager.getCacheSize());
+    }
+
+    @Test(groups = {"unit"})
+    public void tryRouteToCachedHubRegion_warmPath() throws Exception {
+        RxDocumentServiceRequest request = createDocumentReadRequest();
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(request)).thenReturn(false);
+
+        URI hubUri = new URI("https://hub-region.cosmos.azure.com");
+        RegionalRoutingContext hubContext = new RegionalRoutingContext(hubUri);
+        request.requestContext.routeToLocation(hubContext);
+
+        hubRegionManager.cacheHubRegionForPartition(request);
+
+        // New request for the same partition
+        RxDocumentServiceRequest newRequest = createDocumentReadRequest();
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(newRequest)).thenReturn(false);
+
+        Assert.assertTrue(hubRegionManager.tryRouteToCachedHubRegion(newRequest));
+        Assert.assertEquals(hubUri, newRequest.requestContext.regionalRoutingContextToRoute.getGatewayRegionalEndpoint());
+    }
+
+    @Test(groups = {"unit"})
+    public void tryRouteToCachedHubRegion_coldPath() {
+        RxDocumentServiceRequest request = createDocumentReadRequest();
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(request)).thenReturn(false);
+
+        Assert.assertFalse(hubRegionManager.tryRouteToCachedHubRegion(request));
+    }
+
+    @Test(groups = {"unit"})
+    public void invalidateCachedHubRegion() throws Exception {
+        RxDocumentServiceRequest request = createDocumentReadRequest();
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(request)).thenReturn(false);
+
+        URI hubUri = new URI("https://hub-region.cosmos.azure.com");
+        request.requestContext.routeToLocation(new RegionalRoutingContext(hubUri));
+
+        hubRegionManager.cacheHubRegionForPartition(request);
+        Assert.assertTrue(hubRegionManager.hasCachedHubRegion(request));
+
+        hubRegionManager.invalidateCachedHubRegion(request);
+        Assert.assertFalse(hubRegionManager.hasCachedHubRegion(request));
+        Assert.assertEquals(0, hubRegionManager.getCacheSize());
+    }
+
+    @Test(groups = {"unit"})
+    public void perPartitionCaching_differentPartitionsDifferentHubs() throws Exception {
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(Mockito.any())).thenReturn(false);
+
+        // Partition 1
+        RxDocumentServiceRequest request1 = createDocumentReadRequestWithPartition("0", "100");
+        URI hub1 = new URI("https://hub1.cosmos.azure.com");
+        request1.requestContext.routeToLocation(new RegionalRoutingContext(hub1));
+        hubRegionManager.cacheHubRegionForPartition(request1);
+
+        // Partition 2
+        RxDocumentServiceRequest request2 = createDocumentReadRequestWithPartition("100", "200");
+        URI hub2 = new URI("https://hub2.cosmos.azure.com");
+        request2.requestContext.routeToLocation(new RegionalRoutingContext(hub2));
+        hubRegionManager.cacheHubRegionForPartition(request2);
+
+        Assert.assertEquals(2, hubRegionManager.getCacheSize());
+
+        // Verify each partition routes to its own hub
+        RxDocumentServiceRequest check1 = createDocumentReadRequestWithPartition("0", "100");
+        Assert.assertTrue(hubRegionManager.tryRouteToCachedHubRegion(check1));
+        Assert.assertEquals(hub1, check1.requestContext.regionalRoutingContextToRoute.getGatewayRegionalEndpoint());
+
+        RxDocumentServiceRequest check2 = createDocumentReadRequestWithPartition("100", "200");
+        Assert.assertTrue(hubRegionManager.tryRouteToCachedHubRegion(check2));
+        Assert.assertEquals(hub2, check2.requestContext.regionalRoutingContextToRoute.getGatewayRegionalEndpoint());
+    }
+
+    @Test(groups = {"unit"})
+    public void clearRemovesAllCachedEntries() throws Exception {
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(Mockito.any())).thenReturn(false);
+
+        RxDocumentServiceRequest request = createDocumentReadRequest();
+        request.requestContext.routeToLocation(new RegionalRoutingContext(new URI("https://hub.cosmos.azure.com")));
+        hubRegionManager.cacheHubRegionForPartition(request);
+
+        Assert.assertEquals(1, hubRegionManager.getCacheSize());
+
+        hubRegionManager.clear();
+        Assert.assertEquals(0, hubRegionManager.getCacheSize());
+    }
+
+    @Test(groups = {"unit"})
+    public void resetDisablingFeatureClearsCacheAndDeactivates() throws Exception {
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(Mockito.any())).thenReturn(false);
+
+        RxDocumentServiceRequest request = createDocumentReadRequest();
+        request.requestContext.routeToLocation(new RegionalRoutingContext(new URI("https://hub.cosmos.azure.com")));
+        hubRegionManager.cacheHubRegionForPartition(request);
+
+        hubRegionManager.resetHubRegionProcessingEnabled(false);
+        Assert.assertFalse(hubRegionManager.isHubRegionProcessingEnabled());
+        Assert.assertEquals(0, hubRegionManager.getCacheSize());
+    }
+
+    @Test(groups = {"unit"})
+    public void nullRequest_noException() {
+        Assert.assertFalse(hubRegionManager.isHubRegionRoutingActive(null));
+        Assert.assertFalse(hubRegionManager.tryRouteToCachedHubRegion(null));
+        Assert.assertFalse(hubRegionManager.hasCachedHubRegion(null));
+        hubRegionManager.invalidateCachedHubRegion(null);
+        hubRegionManager.cacheHubRegionForPartition(null);
+    }
+
+    @Test(groups = {"unit"})
+    public void documentWriteRequest_hubRegionRoutingActive() {
+        RxDocumentServiceRequest request = RxDocumentServiceRequest.createFromName(
+            mockDiagnosticsClientContext(),
+            OperationType.Create,
+            "/dbs/db1/colls/col1/docs/doc1",
+            ResourceType.Document);
+        request.requestContext = new DocumentServiceRequestContext();
+        setPartitionKeyRange(request, "0", "100");
+        Mockito.when(endpointManager.canUseMultipleWriteLocations(request)).thenReturn(false);
+
+        Assert.assertTrue(hubRegionManager.isHubRegionRoutingActive(request));
+    }
+
+    private RxDocumentServiceRequest createDocumentReadRequest() {
+        return createDocumentReadRequestWithPartition("0", "100");
+    }
+
+    private RxDocumentServiceRequest createDocumentReadRequestWithPartition(String minInclusive, String maxExclusive) {
+        RxDocumentServiceRequest request = RxDocumentServiceRequest.createFromName(
+            mockDiagnosticsClientContext(),
+            OperationType.Read,
+            "/dbs/db1/colls/col1/docs/doc1",
+            ResourceType.Document);
+        request.requestContext = new DocumentServiceRequestContext();
+        setPartitionKeyRange(request, minInclusive, maxExclusive);
+        return request;
+    }
+
+    private void setPartitionKeyRange(RxDocumentServiceRequest request, String minInclusive, String maxExclusive) {
+        PartitionKeyRange pkRange = new PartitionKeyRange();
+        pkRange.setMinInclusive(minInclusive);
+        pkRange.setMaxExclusive(maxExclusive);
+        pkRange.setId(minInclusive + "-" + maxExclusive);
+        request.requestContext.resolvedPartitionKeyRange = pkRange;
+        request.requestContext.resolvedCollectionRid = COLLECTION_RID;
+    }
+}

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/query/DocumentProducerTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/query/DocumentProducerTest.java
@@ -25,6 +25,7 @@ import com.azure.cosmos.implementation.guava25.collect.ImmutableList;
 import com.azure.cosmos.implementation.guava25.collect.Iterables;
 import com.azure.cosmos.implementation.guava25.collect.LinkedListMultimap;
 import com.azure.cosmos.implementation.perPartitionAutomaticFailover.GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover;
+import com.azure.cosmos.implementation.hubRegionRouting.GlobalPartitionEndpointManagerForHubRegionRouting;
 import com.azure.cosmos.implementation.perPartitionCircuitBreaker.GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker;
 import com.azure.cosmos.implementation.query.orderbyquery.OrderByRowResult;
 import com.azure.cosmos.implementation.query.orderbyquery.OrderbyRowComparer;
@@ -129,7 +130,7 @@ public class DocumentProducerTest {
 
         Mockito.doReturn(regionalRoutingContext).when(globalEndpointManager).resolveServiceEndpoint(Mockito.any(RxDocumentServiceRequest.class));
         doReturn(false).when(globalEndpointManager).isClosed();
-        return new RetryPolicy(mockDiagnosticsClientContext(), globalEndpointManager, ConnectionPolicy.getDefaultPolicy(), globalPartitionEndpointManagerForPerPartitionCircuitBreaker, globalPartitionEndpointManagerForPerPartitionAutomaticFailover);
+        return new RetryPolicy(mockDiagnosticsClientContext(), globalEndpointManager, ConnectionPolicy.getDefaultPolicy(), globalPartitionEndpointManagerForPerPartitionCircuitBreaker, globalPartitionEndpointManagerForPerPartitionAutomaticFailover, Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class));
     }
 
         @Test(groups = {"unit"}, dataProvider = "splitParamProvider", timeOut = TIMEOUT)

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/routing/ApplicableRegionEvaluatorTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/routing/ApplicableRegionEvaluatorTest.java
@@ -25,6 +25,7 @@ import com.azure.cosmos.implementation.ServiceUnavailableException;
 import com.azure.cosmos.implementation.directconnectivity.ReflectionUtils;
 import com.azure.cosmos.implementation.perPartitionAutomaticFailover.GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover;
 import com.azure.cosmos.implementation.perPartitionAutomaticFailover.PerPartitionAutomaticFailoverInfoHolder;
+import com.azure.cosmos.implementation.hubRegionRouting.GlobalPartitionEndpointManagerForHubRegionRouting;
 import com.azure.cosmos.implementation.perPartitionCircuitBreaker.GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker;
 import com.azure.cosmos.implementation.perPartitionCircuitBreaker.PerPartitionCircuitBreakerInfoHolder;
 import org.assertj.core.api.Assertions;
@@ -211,6 +212,7 @@ public class ApplicableRegionEvaluatorTest {
                 new ThrottlingRetryOptions(),
                 globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
                 globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+                Mockito.mock(GlobalPartitionEndpointManagerForHubRegionRouting.class),
                 false);
 
             for (int i = 0; i < expectedApplicableRegionalRoutingContexts.size(); i++) {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ClientRetryPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ClientRetryPolicy.java
@@ -10,6 +10,7 @@ import com.azure.cosmos.implementation.apachecommons.collections.list.Unmodifiab
 import com.azure.cosmos.implementation.perPartitionCircuitBreaker.GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker;
 import com.azure.cosmos.implementation.directconnectivity.WebExceptionUtility;
 import com.azure.cosmos.implementation.faultinjection.FaultInjectionRequestContext;
+import com.azure.cosmos.implementation.hubRegionRouting.GlobalPartitionEndpointManagerForHubRegionRouting;
 import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
 import com.azure.cosmos.implementation.perPartitionAutomaticFailover.GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover;
 import org.slf4j.Logger;
@@ -55,6 +56,7 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
     private final FaultInjectionRequestContext faultInjectionRequestContext;
     private final GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker globalPartitionEndpointManagerForPerPartitionCircuitBreaker;
     private final GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover;
+    private final GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting;
 
     public ClientRetryPolicy(DiagnosticsClientContext diagnosticsClientContext,
                              GlobalEndpointManager globalEndpointManager,
@@ -62,6 +64,7 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
                              ThrottlingRetryOptions throttlingRetryOptions,
                              GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
                              GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+                             GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting,
                              boolean disableRetryForThrottledBatchRequest) {
 
         this.globalEndpointManager = globalEndpointManager;
@@ -81,6 +84,7 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
         this.faultInjectionRequestContext = new FaultInjectionRequestContext();
         this.globalPartitionEndpointManagerForPerPartitionCircuitBreaker = globalPartitionEndpointManagerForPerPartitionCircuitBreaker;
         this.globalPartitionEndpointManagerForPerPartitionAutomaticFailover = globalPartitionEndpointManagerForPerPartitionAutomaticFailover;
+        this.globalPartitionEndpointManagerForHubRegionRouting = globalPartitionEndpointManagerForHubRegionRouting;
     }
 
     @Override
@@ -108,6 +112,25 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
                 Exceptions.isStatusCode(clientException, HttpConstants.StatusCodes.FORBIDDEN) &&
                 Exceptions.isSubStatusCode(clientException, HttpConstants.SubStatusCodes.FORBIDDEN_WRITEFORBIDDEN)) {
             logger.info("Endpoint not writable. Will refresh cache and retry ", e);
+
+            // Handle 403/3 on read path for hub region routing discovery.
+            // Non-hub regions return 403/3 (WriteForbidden) when hub region processing header is set.
+            // The SDK advances to the next region in the discovery chain.
+            if (this.isReadRequest && this.globalPartitionEndpointManagerForHubRegionRouting.isHubRegionRoutingActive(this.request)) {
+
+                CrossRegionAvailabilityContextForRxDocumentServiceRequest crossRegionAvailabilityContext
+                    = this.request.requestContext != null ? this.request.requestContext.getCrossRegionAvailabilityContext() : null;
+
+                if (crossRegionAvailabilityContext != null && crossRegionAvailabilityContext.shouldAddHubRegionProcessingOnlyHeader()) {
+                    logger.info("Received 403/3 on read path during hub region discovery. Advancing to next region.");
+
+                    // Invalidate any stale cached hub for this partition
+                    this.globalPartitionEndpointManagerForHubRegionRouting.invalidateCachedHubRegion(this.request);
+
+                    // Continue hub region discovery via failover to next region
+                    return this.shouldRetryOnEndpointFailureAsync(true, false, true);
+                }
+            }
 
             this.setPerPartitionAutomaticFailoverOverrideForReads(this.request, true);
             if (this.globalPartitionEndpointManagerForPerPartitionAutomaticFailover.tryMarkEndpointAsUnavailableForPartitionKeyRange(
@@ -279,7 +302,21 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
                                 = request.requestContext.getCrossRegionAvailabilityContext();
 
                             if (crossRegionAvailabilityContext != null && this.sessionTokenRetryCount == 2) {
-                                crossRegionAvailabilityContext.setShouldAddHubRegionProcessingOnlyHeader(true);
+
+                                // Hub region processing: on 2nd consecutive 404/1002, set the hub header
+                                // so the next retry discovers the hub region through the 403/3 chain.
+                                // Only activate if hub region processing feature flag is enabled.
+                                if (this.globalPartitionEndpointManagerForHubRegionRouting.isHubRegionRoutingActive(request)) {
+
+                                    // Warm path: if we already have a cached hub for this partition,
+                                    // route directly to the cached hub instead of discovery chain
+                                    if (this.globalPartitionEndpointManagerForHubRegionRouting.hasCachedHubRegion(request)) {
+                                        logger.info("Hub region cache hit for partition — routing directly to cached hub.");
+                                        // The routing override happens in onBeforeSendRequest via tryRouteToCachedHubRegion
+                                    }
+
+                                    crossRegionAvailabilityContext.setShouldAddHubRegionProcessingOnlyHeader(true);
+                                }
                             }
                         }
                     }
@@ -548,6 +585,11 @@ public class ClientRetryPolicy extends DocumentClientRetryPolicy {
 
         if (request.requestContext != null) {
             request.requestContext.routeToLocation(this.regionalRoutingContext);
+        }
+
+        // Warm path: if hub region is cached for this partition, route directly to the cached hub
+        if (this.globalPartitionEndpointManagerForHubRegionRouting.tryRouteToCachedHubRegion(request)) {
+            this.regionalRoutingContext = request.requestContext.regionalRoutingContextToRoute;
         }
 
         // In case PPAF is enabled and a location override exists for the partition key range assigned to the request

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/Configs.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/Configs.java
@@ -316,6 +316,10 @@ public class Configs {
     private static final String IS_PER_PARTITION_AUTOMATIC_FAILOVER_ENABLED = "COSMOS.IS_PER_PARTITION_AUTOMATIC_FAILOVER_ENABLED";
     private static final String IS_PER_PARTITION_AUTOMATIC_FAILOVER_ENABLED_VARIABLE = "COSMOS_IS_PER_PARTITION_AUTOMATIC_FAILOVER_ENABLED";
 
+    private static final boolean DEFAULT_HUB_REGION_PROCESSING_ENABLED = false;
+    private static final String HUB_REGION_PROCESSING_ENABLED = "COSMOS.HUB_REGION_PROCESSING_ENABLED";
+    private static final String HUB_REGION_PROCESSING_ENABLED_VARIABLE = "COSMOS_HUB_REGION_PROCESSING_ENABLED";
+
     private static final boolean DEFAULT_SESSION_TOKEN_FALSE_PROGRESS_MERGE_ENABLED = true;
     private static final String IS_SESSION_TOKEN_FALSE_PROGRESS_MERGE_ENABLED = "COSMOS.IS_SESSION_TOKEN_FALSE_PROGRESS_MERGE_ENABLED";
     private static final String IS_SESSION_TOKEN_FALSE_PROGRESS_MERGE_ENABLED_VARIABLE = "COSMOS_IS_SESSION_TOKEN_FALSE_PROGRESS_MERGE_ENABLED";
@@ -1446,5 +1450,15 @@ public class Configs {
                 String.valueOf(DEFAULT_IS_NON_PARSEABLE_DOCUMENT_LOGGING_ENABLED)));
 
         return Boolean.parseBoolean(isNonParseableDocumentLoggingEnabledAsString);
+    }
+
+    public static boolean isHubRegionProcessingEnabled() {
+        String isHubRegionProcessingEnabledAsString = System.getProperty(
+            HUB_REGION_PROCESSING_ENABLED,
+            firstNonNull(
+                emptyToNull(System.getenv().get(HUB_REGION_PROCESSING_ENABLED_VARIABLE)),
+                String.valueOf(DEFAULT_HUB_REGION_PROCESSING_ENABLED)));
+
+        return Boolean.parseBoolean(isHubRegionProcessingEnabledAsString);
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RetryPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RetryPolicy.java
@@ -6,6 +6,7 @@ package com.azure.cosmos.implementation;
 import com.azure.cosmos.ThrottlingRetryOptions;
 import com.azure.cosmos.implementation.caches.RxCollectionCache;
 import com.azure.cosmos.implementation.perPartitionCircuitBreaker.GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker;
+import com.azure.cosmos.implementation.hubRegionRouting.GlobalPartitionEndpointManagerForHubRegionRouting;
 import com.azure.cosmos.implementation.perPartitionAutomaticFailover.GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover;
 
 /**
@@ -19,6 +20,7 @@ public class RetryPolicy implements IRetryPolicyFactory {
     private final GlobalEndpointManager globalEndpointManager;
     private final GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker globalPartitionEndpointManagerForPerPartitionCircuitBreaker;
     private final GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover;
+    private final GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting;
     private final boolean enableEndpointDiscovery;
     private final ThrottlingRetryOptions throttlingRetryOptions;
     private RxCollectionCache rxCollectionCache;
@@ -28,7 +30,8 @@ public class RetryPolicy implements IRetryPolicyFactory {
         GlobalEndpointManager globalEndpointManager,
         ConnectionPolicy connectionPolicy,
         GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
-        GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover) {
+        GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+        GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting) {
 
         this.diagnosticsClientContext = diagnosticsClientContext;
         this.enableEndpointDiscovery = connectionPolicy.isEndpointDiscoveryEnabled();
@@ -36,6 +39,7 @@ public class RetryPolicy implements IRetryPolicyFactory {
         this.throttlingRetryOptions = connectionPolicy.getThrottlingRetryOptions();
         this.globalPartitionEndpointManagerForPerPartitionCircuitBreaker = globalPartitionEndpointManagerForPerPartitionCircuitBreaker;
         this.globalPartitionEndpointManagerForPerPartitionAutomaticFailover = globalPartitionEndpointManagerForPerPartitionAutomaticFailover;
+        this.globalPartitionEndpointManagerForHubRegionRouting = globalPartitionEndpointManagerForHubRegionRouting;
     }
 
     @Override
@@ -59,6 +63,7 @@ public class RetryPolicy implements IRetryPolicyFactory {
             this.throttlingRetryOptions,
             this.globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
             this.globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+            this.globalPartitionEndpointManagerForHubRegionRouting,
             disableRetryForThrottledBatchRequest);
 
         return clientRetryPolicy;

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
@@ -51,6 +51,7 @@ import com.azure.cosmos.implementation.http.SharedGatewayHttpClient;
 import com.azure.cosmos.implementation.interceptor.ITransportClientInterceptor;
 import com.azure.cosmos.implementation.patch.PatchUtil;
 import com.azure.cosmos.implementation.perPartitionAutomaticFailover.GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover;
+import com.azure.cosmos.implementation.hubRegionRouting.GlobalPartitionEndpointManagerForHubRegionRouting;
 import com.azure.cosmos.implementation.perPartitionAutomaticFailover.PerPartitionAutomaticFailoverInfoHolder;
 import com.azure.cosmos.implementation.perPartitionCircuitBreaker.GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker;
 import com.azure.cosmos.implementation.perPartitionCircuitBreaker.PartitionLevelCircuitBreakerConfig;
@@ -271,6 +272,7 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
     private final GlobalEndpointManager globalEndpointManager;
     private final GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker globalPartitionEndpointManagerForPerPartitionCircuitBreaker;
     private final GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover;
+    private final GlobalPartitionEndpointManagerForHubRegionRouting globalPartitionEndpointManagerForHubRegionRouting;
     private final RetryPolicy retryPolicy;
     private HttpClient reactorHttpClient;
     private Function<HttpClient, HttpClient> httpClientInterceptor;
@@ -670,6 +672,9 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
             this.globalPartitionEndpointManagerForPerPartitionAutomaticFailover
                 = new GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover(this.globalEndpointManager, false);
 
+            this.globalPartitionEndpointManagerForHubRegionRouting
+                = new GlobalPartitionEndpointManagerForHubRegionRouting(this.globalEndpointManager);
+
             this.cachedCosmosAsyncClientSnapshot = new AtomicReference<>();
 
             this.retryPolicy = new RetryPolicy(
@@ -677,7 +682,8 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
                 this.globalEndpointManager,
                 this.connectionPolicy,
                 this.globalPartitionEndpointManagerForPerPartitionCircuitBreaker,
-                this.globalPartitionEndpointManagerForPerPartitionAutomaticFailover);
+                this.globalPartitionEndpointManagerForPerPartitionAutomaticFailover,
+                this.globalPartitionEndpointManagerForHubRegionRouting);
             this.resetSessionTokenRetryPolicy = retryPolicy;
             CpuMemoryMonitor.register(this);
             this.queryPlanCache = new ConcurrentHashMap<>();
@@ -2863,6 +2869,16 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
                 }
 
                 this.globalPartitionEndpointManagerForPerPartitionAutomaticFailover.resetEndToEndTimeoutErrorCountIfPossible(succeededRequest);
+
+                // On successful response, cache the hub region for this partition
+                // if hub region processing header was set during the request
+                if (succeededRequest.requestContext != null) {
+                    CrossRegionAvailabilityContextForRxDocumentServiceRequest hubContext
+                        = succeededRequest.requestContext.getCrossRegionAvailabilityContext();
+                    if (hubContext != null && hubContext.shouldAddHubRegionProcessingOnlyHeader()) {
+                        this.globalPartitionEndpointManagerForHubRegionRouting.cacheHubRegionForPartition(succeededRequest);
+                    }
+                }
             })
             .doOnError(throwable -> {
                 if (throwable instanceof OperationCancelledException) {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/hubRegionRouting/GlobalPartitionEndpointManagerForHubRegionRouting.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/hubRegionRouting/GlobalPartitionEndpointManagerForHubRegionRouting.java
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.hubRegionRouting;
+
+import com.azure.cosmos.implementation.Configs;
+import com.azure.cosmos.implementation.GlobalEndpointManager;
+import com.azure.cosmos.implementation.OperationType;
+import com.azure.cosmos.implementation.PartitionKeyRange;
+import com.azure.cosmos.implementation.PartitionKeyRangeWrapper;
+import com.azure.cosmos.implementation.ResourceType;
+import com.azure.cosmos.implementation.RxDocumentServiceRequest;
+import com.azure.cosmos.implementation.apachecommons.lang.StringUtils;
+import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Manages per-partition hub region URI caching for single-master accounts.
+ *
+ * When a partition encounters repeated 404/1002 (ReadSessionNotAvailable), the SDK
+ * discovers the hub region through a 403/3 discovery chain and caches the hub URI.
+ * Future requests for the same partition route directly to the cached hub (warm path).
+ *
+ * Feature-flag gated via COSMOS.HUB_REGION_PROCESSING_ENABLED (default: false).
+ */
+public class GlobalPartitionEndpointManagerForHubRegionRouting {
+
+    private static final Logger logger = LoggerFactory.getLogger(GlobalPartitionEndpointManagerForHubRegionRouting.class);
+
+    private final ConcurrentHashMap<PartitionKeyRangeWrapper, RegionalRoutingContext> partitionKeyRangeToHubRegionRoutingContext;
+    private final GlobalEndpointManager globalEndpointManager;
+    private final AtomicBoolean isHubRegionProcessingEnabled;
+
+    public GlobalPartitionEndpointManagerForHubRegionRouting(
+        GlobalEndpointManager globalEndpointManager) {
+
+        this.globalEndpointManager = globalEndpointManager;
+        this.partitionKeyRangeToHubRegionRoutingContext = new ConcurrentHashMap<>();
+        this.isHubRegionProcessingEnabled = new AtomicBoolean(Configs.isHubRegionProcessingEnabled());
+    }
+
+    /**
+     * Check whether hub region routing is active (feature flag enabled + single master account).
+     */
+    public boolean isHubRegionRoutingActive(RxDocumentServiceRequest request) {
+        if (!this.isHubRegionProcessingEnabled.get()) {
+            return false;
+        }
+
+        if (request == null) {
+            return false;
+        }
+
+        // Hub region routing only applies to single-master accounts
+        if (this.globalEndpointManager.canUseMultipleWriteLocations(request)) {
+            return false;
+        }
+
+        return isDocumentRequest(request);
+    }
+
+    /**
+     * Try to route the request to a previously cached hub region for this partition.
+     * Returns true if a cached hub was found and routing was overridden.
+     */
+    public boolean tryRouteToCachedHubRegion(RxDocumentServiceRequest request) {
+        if (!isHubRegionRoutingActive(request)) {
+            return false;
+        }
+
+        PartitionKeyRangeWrapper wrapper = getPartitionKeyRangeWrapper(request);
+        if (wrapper == null) {
+            return false;
+        }
+
+        RegionalRoutingContext cachedHubContext = this.partitionKeyRangeToHubRegionRoutingContext.get(wrapper);
+        if (cachedHubContext != null) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(
+                    "Routing request to cached hub region {} for partition {}",
+                    cachedHubContext.getGatewayRegionalEndpoint(),
+                    wrapper.getPartitionKeyRange().getId());
+            }
+            request.requestContext.routeToLocation(cachedHubContext);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Cache the hub region URI for a partition after a successful hub region discovery.
+     */
+    public void cacheHubRegionForPartition(RxDocumentServiceRequest request) {
+        if (!isHubRegionRoutingActive(request)) {
+            return;
+        }
+
+        PartitionKeyRangeWrapper wrapper = getPartitionKeyRangeWrapper(request);
+        if (wrapper == null) {
+            return;
+        }
+
+        RegionalRoutingContext routingContext = request.requestContext.regionalRoutingContextToRoute;
+        if (routingContext == null) {
+            return;
+        }
+
+        RegionalRoutingContext existing = this.partitionKeyRangeToHubRegionRoutingContext.putIfAbsent(wrapper, routingContext);
+        if (existing == null) {
+            logger.info(
+                "Cached hub region {} for partition {} in collection {}",
+                routingContext.getGatewayRegionalEndpoint(),
+                wrapper.getPartitionKeyRange().getId(),
+                wrapper.getCollectionResourceId());
+        }
+    }
+
+    /**
+     * Invalidate the hub region cache entry for a partition.
+     * Called when the cached hub region becomes unavailable.
+     */
+    public void invalidateCachedHubRegion(RxDocumentServiceRequest request) {
+        if (request == null) {
+            return;
+        }
+
+        PartitionKeyRangeWrapper wrapper = getPartitionKeyRangeWrapper(request);
+        if (wrapper == null) {
+            return;
+        }
+
+        RegionalRoutingContext removed = this.partitionKeyRangeToHubRegionRoutingContext.remove(wrapper);
+        if (removed != null) {
+            logger.info(
+                "Invalidated cached hub region for partition {} in collection {}",
+                wrapper.getPartitionKeyRange().getId(),
+                wrapper.getCollectionResourceId());
+        }
+    }
+
+    /**
+     * Check if there is a cached hub region for the given partition.
+     */
+    public boolean hasCachedHubRegion(RxDocumentServiceRequest request) {
+        if (!isHubRegionRoutingActive(request)) {
+            return false;
+        }
+
+        PartitionKeyRangeWrapper wrapper = getPartitionKeyRangeWrapper(request);
+        if (wrapper == null) {
+            return false;
+        }
+
+        return this.partitionKeyRangeToHubRegionRoutingContext.containsKey(wrapper);
+    }
+
+    /**
+     * Clear all cached hub regions. Called on account topology changes.
+     */
+    public void clear() {
+        this.partitionKeyRangeToHubRegionRoutingContext.clear();
+    }
+
+    /**
+     * Refresh the feature flag state (for testing).
+     */
+    public void resetHubRegionProcessingEnabled(boolean enabled) {
+        this.isHubRegionProcessingEnabled.set(enabled);
+        if (!enabled) {
+            this.clear();
+        }
+    }
+
+    public boolean isHubRegionProcessingEnabled() {
+        return this.isHubRegionProcessingEnabled.get();
+    }
+
+    int getCacheSize() {
+        return this.partitionKeyRangeToHubRegionRoutingContext.size();
+    }
+
+    private PartitionKeyRangeWrapper getPartitionKeyRangeWrapper(RxDocumentServiceRequest request) {
+        if (request.requestContext == null) {
+            return null;
+        }
+
+        PartitionKeyRange partitionKeyRange = request.requestContext.resolvedPartitionKeyRange;
+        String resolvedCollectionRid = request.requestContext.resolvedCollectionRid;
+
+        if (partitionKeyRange == null || StringUtils.isEmpty(resolvedCollectionRid)) {
+            return null;
+        }
+
+        return new PartitionKeyRangeWrapper(partitionKeyRange, resolvedCollectionRid);
+    }
+
+    private boolean isDocumentRequest(RxDocumentServiceRequest request) {
+        if (request.getResourceType() != ResourceType.Document) {
+            return false;
+        }
+
+        if (request.getOperationType() == OperationType.QueryPlan) {
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Issue
Fixes #48788

## Description
Ports the per-partition hub region caching feature from .NET SDK (PR Azure/azure-cosmos-dotnet-v3#5648) to the Java SDK.

## Problem
On single-master accounts, repeated 404/1002 (ReadSessionNotAvailable) errors cause unnecessary retries without discovering the hub region. No caching exists, so every request repeats the full discovery chain.

## Solution
1. After 2 consecutive 404/1002 on a single-master account, set x-ms-cosmos-hub-region-processing-only header
2. Non-hub regions return 403/3 (WriteForbidden) — SDK retries to next region (discovery chain)
3. Hub region responds with 200 OK — SDK caches hub URI for that partition
4. Future requests route directly to cached hub (warm path skips discovery)
5. Works for both PPAF and non-PPAF accounts

## Feature Flag
Gated behind COSMOS.HUB_REGION_PROCESSING_ENABLED (env var: COSMOS_HUB_REGION_PROCESSING_ENABLED). **Disabled by default** per Debdatta Kunda's guidance.

## Key Changes
- New GlobalPartitionEndpointManagerForHubRegionRouting — per-partition hub region cache
- ClientRetryPolicy — hub header trigger after 2x 404/1002, 403/3 handling on read path, cache lookup
- Configs — COSMOS.HUB_REGION_PROCESSING_ENABLED feature flag
- HttpConstants — x-ms-cosmos-hub-region-processing-only header constant

## Testing
- 13 new unit tests covering cold cache discovery, warm cache routing, feature flag gating, non-single-master bypass
- Build compiles clean
