### PR TITLE
Fix Cosmos Spark BannedDependencies enforcer failure - update scala-jackson.version to 2.18.6

### DIFF
--- a/sdk/cosmos/azure-cosmos-spark_3/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3/pom.xml
@@ -51,7 +51,7 @@
     <scalatest-flatspec.version>3.2.3</scalatest-flatspec.version> <!-- {x-version-update;cosmos_org.scalatest:scalatest-flatspec_2.12;external_dependency} -->
     <scalactic.version>3.2.3</scalactic.version> <!-- {x-version-update;cosmos_org.scalactic:scalactic_2.12;external_dependency} -->
     <scalamock.version>5.0.0</scalamock.version> <!-- {x-version-update;cosmos_org.scalamock:scalamock_2.12;external_dependency} -->
-    <scala-jackson.version>2.18.4</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
+    <scala-jackson.version>2.18.6</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
     <pinned-resourcemanager-cosmos.version>2.53.4</pinned-resourcemanager-cosmos.version> <!-- This should not exceed the latest stable version that has been deployed across all clouds - including non-public clouds -->
   </properties>
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/AsyncDocumentClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/AsyncDocumentClient.java
@@ -1651,6 +1651,7 @@ public interface AsyncDocumentClient {
      */
     void enableSDKThroughputControlGroup(SDKThroughputControlGroupInternal group, Mono<Integer> throughputQueryMono);
 
+    
     /***
      * Enable server throughput control group.
      *


### PR DESCRIPTION
## Summary

The recent Jackson dependency update (commit 8a671dd0ca3) bumped Jackson from `2.18.4` to `2.18.6` across all Cosmos Spark child modules but missed updating the `scala-jackson.version` property in the parent POM `sdk/cosmos/azure-cosmos-spark_3/pom.xml`.

## Problem

The maven-enforcer-plugin `BannedDependencies` rule uses `${scala-jackson.version}` in its allowlist for `jackson-module-scala_2.12` and `_2.13`. Since the property remained at `2.18.4`, the actual dependency at `2.18.6` was rejected as banned, causing CI failures:

```
[ERROR] Rule 0: org.apache.maven.enforcer.rules.dependency.BannedDependencies failed
```

Failed build: https://dev.azure.com/azure-sdk/public/_build/results?buildId=6153935

## Fix

Updated `scala-jackson.version` from `2.18.4` to `2.18.6` in `sdk/cosmos/azure-cosmos-spark_3/pom.xml`.

## Verification

Ran `maven-enforcer-plugin:enforce` locally on all four Spark modules (`_3-3_2-12`, `_3-4_2-12`, `_3-5`, `_4-0_2-13`) — all pass.