### PR TITLE
[SparkConnector][No Review]FixNoClassDefFoundError for MetadataVersionUtil

### DIFF
--- a/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/ChangeFeedInitialOffsetWriter.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/ChangeFeedInitialOffsetWriter.scala
@@ -3,7 +3,7 @@
 package com.azure.cosmos.spark
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.execution.streaming.{HDFSMetadataLog, MetadataVersionUtil}
+import org.apache.spark.sql.execution.streaming.HDFSMetadataLog
 
 import java.io.{BufferedWriter, InputStream, InputStreamReader, OutputStream, OutputStreamWriter}
 import java.nio.charset.StandardCharsets
@@ -33,7 +33,7 @@ private class ChangeFeedInitialOffsetWriter
         "Log file was malformed: failed to detect the log file version line.")
     }
 
-    MetadataVersionUtil.validateVersion(content.substring(0, indexOfNewLine), VERSION)
+    ChangeFeedInitialOffsetWriter.validateVersion(content.substring(0, indexOfNewLine), VERSION)
     content.substring(indexOfNewLine + 1)
   }
 
@@ -56,5 +56,37 @@ private class ChangeFeedInitialOffsetWriter
     override def close(): Unit = {}
 
     override def toString: String = stringBuilder.toString()
+  }
+}
+
+private object ChangeFeedInitialOffsetWriter {
+  /**
+   * Validates the version string from the log file.
+   * This is inlined to avoid a runtime dependency on MetadataVersionUtil,
+   * which has been relocated in some Spark distributions (e.g. Databricks Runtime 17.3+).
+   */
+  def validateVersion(versionText: String, maxSupportedVersion: Int): Int = {
+    if (versionText.nonEmpty && versionText(0) == 'v') {
+      val version =
+        try {
+          versionText.substring(1).toInt
+        } catch {
+          case _: NumberFormatException =>
+            throw new IllegalStateException(
+              s"Log file was malformed: failed to read correct log version from $versionText.")
+        }
+      if (version > 0 && version <= maxSupportedVersion) {
+        return version
+      }
+      if (version > maxSupportedVersion) {
+        throw new IllegalStateException(
+          s"UnsupportedLogVersion: maximum supported log version " +
+            s"is v$maxSupportedVersion, but encountered v$version. " +
+            s"The log file was produced by a newer version of Spark and cannot be read by this version. " +
+            s"Please upgrade.")
+      }
+    }
+    throw new IllegalStateException(
+      s"Log file was malformed: failed to read correct log version from $versionText.")
   }
 }

--- a/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/ChangeFeedInitialOffsetWriter.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/ChangeFeedInitialOffsetWriter.scala
@@ -59,7 +59,7 @@ private class ChangeFeedInitialOffsetWriter
   }
 }
 
-private object ChangeFeedInitialOffsetWriter {
+private[spark] object ChangeFeedInitialOffsetWriter {
   /**
    * Validates the version string from the log file.
    * This is inlined to avoid a runtime dependency on MetadataVersionUtil,

--- a/sdk/cosmos/azure-cosmos-spark_3/src/test/scala/com/azure/cosmos/spark/ChangeFeedInitialOffsetWriterSpec.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/src/test/scala/com/azure/cosmos/spark/ChangeFeedInitialOffsetWriterSpec.scala
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.azure.cosmos.spark
+
+class ChangeFeedInitialOffsetWriterSpec extends UnitSpec {
+
+  "validateVersion" should "return version for valid version string within supported range" in {
+    ChangeFeedInitialOffsetWriter.validateVersion("v1", 1) shouldBe 1
+  }
+
+  it should "return version when version is less than max supported" in {
+    ChangeFeedInitialOffsetWriter.validateVersion("v1", 5) shouldBe 1
+  }
+
+  it should "return version when version equals max supported" in {
+    ChangeFeedInitialOffsetWriter.validateVersion("v3", 3) shouldBe 3
+  }
+
+  it should "throw IllegalStateException for version exceeding max supported" in {
+    val exception = intercept[IllegalStateException] {
+      ChangeFeedInitialOffsetWriter.validateVersion("v2", 1)
+    }
+    exception.getMessage should include("UnsupportedLogVersion")
+    exception.getMessage should include("v1")
+    exception.getMessage should include("v2")
+  }
+
+  it should "throw IllegalStateException for non-numeric version" in {
+    val exception = intercept[IllegalStateException] {
+      ChangeFeedInitialOffsetWriter.validateVersion("vabc", 1)
+    }
+    exception.getMessage should include("malformed")
+  }
+
+  it should "throw IllegalStateException for empty string" in {
+    val exception = intercept[IllegalStateException] {
+      ChangeFeedInitialOffsetWriter.validateVersion("", 1)
+    }
+    exception.getMessage should include("malformed")
+  }
+
+  it should "throw IllegalStateException for string without v prefix" in {
+    val exception = intercept[IllegalStateException] {
+      ChangeFeedInitialOffsetWriter.validateVersion("1", 1)
+    }
+    exception.getMessage should include("malformed")
+  }
+
+  it should "throw IllegalStateException for v0 (zero version)" in {
+    val exception = intercept[IllegalStateException] {
+      ChangeFeedInitialOffsetWriter.validateVersion("v0", 1)
+    }
+    exception.getMessage should include("malformed")
+  }
+
+  it should "throw IllegalStateException for negative version" in {
+    val exception = intercept[IllegalStateException] {
+      ChangeFeedInitialOffsetWriter.validateVersion("v-1", 1)
+    }
+    exception.getMessage should include("malformed")
+  }
+
+  it should "throw IllegalStateException for version string with only v" in {
+    val exception = intercept[IllegalStateException] {
+      ChangeFeedInitialOffsetWriter.validateVersion("v", 1)
+    }
+    exception.getMessage should include("malformed")
+  }
+}

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenario.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenario.scala
@@ -111,43 +111,5 @@ df.filter(col("isAlive") === true)
 
 // COMMAND ----------
 
-// Change Feed - micro-batch structured streaming
-// This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
-// that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
-
-val changeFeedCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
-  "spark.cosmos.accountKey" -> cosmosMasterKey,
-  "spark.cosmos.database" -> cosmosDatabaseName,
-  "spark.cosmos.container" -> cosmosContainerName,
-  "spark.cosmos.read.inferSchema.enabled" -> "false",
-  "spark.cosmos.changeFeed.startFrom" -> "Beginning",
-  "spark.cosmos.changeFeed.mode" -> "Incremental",
-  "spark.cosmos.enforceNativeTransport" -> "true"
-)
-
-val testId = java.util.UUID.randomUUID().toString.replace("-", "")
-
-val changeFeedDF = spark
-  .readStream
-  .format("cosmos.oltp.changeFeed")
-  .options(changeFeedCfg)
-  .load()
-
-val microBatchQuery = changeFeedDF
-  .writeStream
-  .format("memory")
-  .queryName(testId)
-  .outputMode("append")
-  .start()
-
-microBatchQuery.processAllAvailable()
-microBatchQuery.stop()
-
-val sinkCount = spark.sql(s"SELECT * FROM $testId").count()
-println(s"Change Feed micro-batch streaming: $sinkCount records read via change feed")
-assert(sinkCount >= 2, s"Expected at least 2 records from change feed but found $sinkCount")
-
-// COMMAND ----------
-
 // cleanup
 spark.sql(s"DROP TABLE cosmosCatalog.${cosmosDatabaseName}.${cosmosContainerName};")

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenario.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenario.scala
@@ -115,8 +115,6 @@ df.filter(col("isAlive") === true)
 // This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
 // that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
 
-import org.apache.spark.sql.streaming.Trigger
-
 val sinkContainerName = cosmosContainerName + "Sink"
 spark.sql(s"CREATE TABLE IF NOT EXISTS cosmosCatalog.${cosmosDatabaseName}.${sinkContainerName} using cosmos.oltp " +
   s"TBLPROPERTIES(partitionKeyPath = '/id', manualThroughput = '400')")
@@ -153,11 +151,12 @@ val microBatchQuery = changeFeedDF
   .format("cosmos.oltp")
   .queryName(testId)
   .options(writeCfg)
-  .option("checkpointLocation", s"/tmp/$testId/")
+  .option("checkpointLocation", s"file:/tmp/$testId/")
   .outputMode("append")
   .start()
 
 microBatchQuery.processAllAvailable()
+microBatchQuery.stop()
 
 val sinkCount = spark.read.format("cosmos.oltp").options(Map(
   "spark.cosmos.accountEndpoint" -> cosmosEndpoint,
@@ -169,8 +168,6 @@ val sinkCount = spark.read.format("cosmos.oltp").options(Map(
 
 println(s"Change Feed micro-batch streaming: $sinkCount records copied to sink container")
 assert(sinkCount >= 2, s"Expected at least 2 records in sink container but found $sinkCount")
-
-microBatchQuery.stop()
 
 // COMMAND ----------
 

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenario.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenario.scala
@@ -111,5 +111,69 @@ df.filter(col("isAlive") === true)
 
 // COMMAND ----------
 
+// Change Feed - micro-batch structured streaming
+// This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
+// that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
+
+import org.apache.spark.sql.streaming.Trigger
+
+val sinkContainerName = cosmosContainerName + "Sink"
+spark.sql(s"CREATE TABLE IF NOT EXISTS cosmosCatalog.${cosmosDatabaseName}.${sinkContainerName} using cosmos.oltp " +
+  s"TBLPROPERTIES(partitionKeyPath = '/id', manualThroughput = '400')")
+
+val changeFeedCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
+  "spark.cosmos.accountKey" -> cosmosMasterKey,
+  "spark.cosmos.database" -> cosmosDatabaseName,
+  "spark.cosmos.container" -> cosmosContainerName,
+  "spark.cosmos.read.inferSchema.enabled" -> "false",
+  "spark.cosmos.changeFeed.startFrom" -> "Beginning",
+  "spark.cosmos.changeFeed.mode" -> "Incremental",
+  "spark.cosmos.enforceNativeTransport" -> "true"
+)
+
+val writeCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
+  "spark.cosmos.accountKey" -> cosmosMasterKey,
+  "spark.cosmos.database" -> cosmosDatabaseName,
+  "spark.cosmos.container" -> sinkContainerName,
+  "spark.cosmos.write.strategy" -> "ItemOverwrite",
+  "spark.cosmos.write.bulk.enabled" -> "true",
+  "spark.cosmos.enforceNativeTransport" -> "true"
+)
+
+val testId = java.util.UUID.randomUUID().toString.replace("-", "")
+
+val changeFeedDF = spark
+  .readStream
+  .format("cosmos.oltp.changeFeed")
+  .options(changeFeedCfg)
+  .load()
+
+val microBatchQuery = changeFeedDF
+  .writeStream
+  .format("cosmos.oltp")
+  .queryName(testId)
+  .options(writeCfg)
+  .option("checkpointLocation", s"/tmp/$testId/")
+  .outputMode("append")
+  .start()
+
+microBatchQuery.processAllAvailable()
+
+val sinkCount = spark.read.format("cosmos.oltp").options(Map(
+  "spark.cosmos.accountEndpoint" -> cosmosEndpoint,
+  "spark.cosmos.accountKey" -> cosmosMasterKey,
+  "spark.cosmos.database" -> cosmosDatabaseName,
+  "spark.cosmos.container" -> sinkContainerName,
+  "spark.cosmos.enforceNativeTransport" -> "true"
+)).load().count()
+
+println(s"Change Feed micro-batch streaming: $sinkCount records copied to sink container")
+assert(sinkCount >= 2, s"Expected at least 2 records in sink container but found $sinkCount")
+
+microBatchQuery.stop()
+
+// COMMAND ----------
+
 // cleanup
+spark.sql(s"DROP TABLE cosmosCatalog.${cosmosDatabaseName}.${sinkContainerName};")
 spark.sql(s"DROP TABLE cosmosCatalog.${cosmosDatabaseName}.${cosmosContainerName};")

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenario.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenario.scala
@@ -115,10 +115,6 @@ df.filter(col("isAlive") === true)
 // This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
 // that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
 
-val sinkContainerName = cosmosContainerName + "Sink"
-spark.sql(s"CREATE TABLE IF NOT EXISTS cosmosCatalog.${cosmosDatabaseName}.${sinkContainerName} using cosmos.oltp " +
-  s"TBLPROPERTIES(partitionKeyPath = '/id', manualThroughput = '400')")
-
 val changeFeedCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
   "spark.cosmos.accountKey" -> cosmosMasterKey,
   "spark.cosmos.database" -> cosmosDatabaseName,
@@ -126,15 +122,6 @@ val changeFeedCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
   "spark.cosmos.read.inferSchema.enabled" -> "false",
   "spark.cosmos.changeFeed.startFrom" -> "Beginning",
   "spark.cosmos.changeFeed.mode" -> "Incremental",
-  "spark.cosmos.enforceNativeTransport" -> "true"
-)
-
-val writeCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
-  "spark.cosmos.accountKey" -> cosmosMasterKey,
-  "spark.cosmos.database" -> cosmosDatabaseName,
-  "spark.cosmos.container" -> sinkContainerName,
-  "spark.cosmos.write.strategy" -> "ItemOverwrite",
-  "spark.cosmos.write.bulk.enabled" -> "true",
   "spark.cosmos.enforceNativeTransport" -> "true"
 )
 
@@ -148,29 +135,19 @@ val changeFeedDF = spark
 
 val microBatchQuery = changeFeedDF
   .writeStream
-  .format("cosmos.oltp")
+  .format("memory")
   .queryName(testId)
-  .options(writeCfg)
-  .option("checkpointLocation", s"file:/tmp/$testId/")
   .outputMode("append")
   .start()
 
 microBatchQuery.processAllAvailable()
 microBatchQuery.stop()
 
-val sinkCount = spark.read.format("cosmos.oltp").options(Map(
-  "spark.cosmos.accountEndpoint" -> cosmosEndpoint,
-  "spark.cosmos.accountKey" -> cosmosMasterKey,
-  "spark.cosmos.database" -> cosmosDatabaseName,
-  "spark.cosmos.container" -> sinkContainerName,
-  "spark.cosmos.enforceNativeTransport" -> "true"
-)).load().count()
-
-println(s"Change Feed micro-batch streaming: $sinkCount records copied to sink container")
-assert(sinkCount >= 2, s"Expected at least 2 records in sink container but found $sinkCount")
+val sinkCount = spark.sql(s"SELECT * FROM $testId").count()
+println(s"Change Feed micro-batch streaming: $sinkCount records read via change feed")
+assert(sinkCount >= 2, s"Expected at least 2 records from change feed but found $sinkCount")
 
 // COMMAND ----------
 
 // cleanup
-spark.sql(s"DROP TABLE cosmosCatalog.${cosmosDatabaseName}.${sinkContainerName};")
 spark.sql(s"DROP TABLE cosmosCatalog.${cosmosDatabaseName}.${cosmosContainerName};")

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenario.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenario.scala
@@ -111,5 +111,39 @@ df.filter(col("isAlive") === true)
 
 // COMMAND ----------
 
+// Change Feed - micro-batch structured streaming
+// This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
+// that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
+
+val changeFeedCfg = cfg ++ Map(
+  "spark.cosmos.read.inferSchema.enabled" -> "false",
+  "spark.cosmos.changeFeed.startFrom" -> "Beginning",
+  "spark.cosmos.changeFeed.mode" -> "Incremental"
+)
+
+val testId = java.util.UUID.randomUUID().toString.replace("-", "")
+
+val changeFeedDF = spark
+  .readStream
+  .format("cosmos.oltp.changeFeed")
+  .options(changeFeedCfg)
+  .load()
+
+val microBatchQuery = changeFeedDF
+  .writeStream
+  .format("memory")
+  .queryName(testId)
+  .outputMode("append")
+  .start()
+
+microBatchQuery.processAllAvailable()
+microBatchQuery.stop()
+
+val sinkCount = spark.sql(s"SELECT * FROM $testId").count()
+println(s"Change Feed micro-batch streaming: $sinkCount records read via change feed")
+assert(sinkCount >= 2, s"Expected at least 2 records from change feed but found $sinkCount")
+
+// COMMAND ----------
+
 // cleanup
 spark.sql(s"DROP TABLE cosmosCatalog.${cosmosDatabaseName}.${cosmosContainerName};")

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
@@ -96,5 +96,81 @@ df.filter(col("isAlive") === true)
 
 // COMMAND ----------
 
+// Change Feed - micro-batch structured streaming
+// This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
+// that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
+
+import org.apache.spark.sql.streaming.Trigger
+
+val sinkContainerName = cosmosContainerName + "Sink"
+spark.sql(s"CREATE TABLE IF NOT EXISTS cosmosCatalogMI.${cosmosDatabaseName}.${sinkContainerName} using cosmos.oltp " +
+  s"TBLPROPERTIES(partitionKeyPath = '/id', manualThroughput = '400')")
+
+val changeFeedCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
+  "spark.cosmos.auth.type" -> authType,
+  "spark.cosmos.account.subscriptionId" -> subscriptionId,
+  "spark.cosmos.account.tenantId" -> tenantId,
+  "spark.cosmos.account.resourceGroupName" -> resourceGroupName,
+  "spark.cosmos.database" -> cosmosDatabaseName,
+  "spark.cosmos.container" -> cosmosContainerName,
+  "spark.cosmos.read.inferSchema.enabled" -> "false",
+  "spark.cosmos.changeFeed.startFrom" -> "Beginning",
+  "spark.cosmos.changeFeed.mode" -> "Incremental",
+  "spark.cosmos.enforceNativeTransport" -> "true",
+  "spark.cosmos.read.consistencyStrategy" -> "LatestCommitted",
+)
+
+val writeCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
+  "spark.cosmos.auth.type" -> authType,
+  "spark.cosmos.account.subscriptionId" -> subscriptionId,
+  "spark.cosmos.account.tenantId" -> tenantId,
+  "spark.cosmos.account.resourceGroupName" -> resourceGroupName,
+  "spark.cosmos.database" -> cosmosDatabaseName,
+  "spark.cosmos.container" -> sinkContainerName,
+  "spark.cosmos.write.strategy" -> "ItemOverwrite",
+  "spark.cosmos.write.bulk.enabled" -> "true",
+  "spark.cosmos.enforceNativeTransport" -> "true",
+  "spark.cosmos.read.consistencyStrategy" -> "LatestCommitted",
+)
+
+val testId = java.util.UUID.randomUUID().toString.replace("-", "")
+
+val changeFeedDF = spark
+  .readStream
+  .format("cosmos.oltp.changeFeed")
+  .options(changeFeedCfg)
+  .load()
+
+val microBatchQuery = changeFeedDF
+  .writeStream
+  .format("cosmos.oltp")
+  .queryName(testId)
+  .options(writeCfg)
+  .option("checkpointLocation", s"/tmp/$testId/")
+  .outputMode("append")
+  .start()
+
+microBatchQuery.processAllAvailable()
+
+val sinkCount = spark.read.format("cosmos.oltp").options(Map(
+  "spark.cosmos.accountEndpoint" -> cosmosEndpoint,
+  "spark.cosmos.auth.type" -> authType,
+  "spark.cosmos.account.subscriptionId" -> subscriptionId,
+  "spark.cosmos.account.tenantId" -> tenantId,
+  "spark.cosmos.account.resourceGroupName" -> resourceGroupName,
+  "spark.cosmos.database" -> cosmosDatabaseName,
+  "spark.cosmos.container" -> sinkContainerName,
+  "spark.cosmos.enforceNativeTransport" -> "true",
+  "spark.cosmos.read.consistencyStrategy" -> "LatestCommitted",
+)).load().count()
+
+println(s"Change Feed micro-batch streaming: $sinkCount records copied to sink container")
+assert(sinkCount >= 2, s"Expected at least 2 records in sink container but found $sinkCount")
+
+microBatchQuery.stop()
+
+// COMMAND ----------
+
 // cleanup
+spark.sql(s"DROP TABLE cosmosCatalogMI.${cosmosDatabaseName}.${sinkContainerName};")
 spark.sql(s"DROP TABLE cosmosCatalogMI.${cosmosDatabaseName}.${cosmosContainerName};")

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
@@ -96,39 +96,5 @@ df.filter(col("isAlive") === true)
 
 // COMMAND ----------
 
-// Change Feed - micro-batch structured streaming
-// This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
-// that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
-
-val changeFeedCfg = cfg ++ Map(
-  "spark.cosmos.read.inferSchema.enabled" -> "false",
-  "spark.cosmos.changeFeed.startFrom" -> "Beginning",
-  "spark.cosmos.changeFeed.mode" -> "Incremental"
-)
-
-val testId = java.util.UUID.randomUUID().toString.replace("-", "")
-
-val changeFeedDF = spark
-  .readStream
-  .format("cosmos.oltp.changeFeed")
-  .options(changeFeedCfg)
-  .load()
-
-val microBatchQuery = changeFeedDF
-  .writeStream
-  .format("memory")
-  .queryName(testId)
-  .outputMode("append")
-  .start()
-
-microBatchQuery.processAllAvailable()
-microBatchQuery.stop()
-
-val sinkCount = spark.sql(s"SELECT * FROM $testId").count()
-println(s"Change Feed micro-batch streaming: $sinkCount records read via change feed")
-assert(sinkCount >= 2, s"Expected at least 2 records from change feed but found $sinkCount")
-
-// COMMAND ----------
-
 // cleanup
 spark.sql(s"DROP TABLE cosmosCatalogMI.${cosmosDatabaseName}.${cosmosContainerName};")

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
@@ -100,8 +100,6 @@ df.filter(col("isAlive") === true)
 // This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
 // that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
 
-import org.apache.spark.sql.streaming.Trigger
-
 val sinkContainerName = cosmosContainerName + "Sink"
 spark.sql(s"CREATE TABLE IF NOT EXISTS cosmosCatalogMI.${cosmosDatabaseName}.${sinkContainerName} using cosmos.oltp " +
   s"TBLPROPERTIES(partitionKeyPath = '/id', manualThroughput = '400')")
@@ -146,11 +144,12 @@ val microBatchQuery = changeFeedDF
   .format("cosmos.oltp")
   .queryName(testId)
   .options(writeCfg)
-  .option("checkpointLocation", s"/tmp/$testId/")
+  .option("checkpointLocation", s"file:/tmp/$testId/")
   .outputMode("append")
   .start()
 
 microBatchQuery.processAllAvailable()
+microBatchQuery.stop()
 
 val sinkCount = spark.read.format("cosmos.oltp").options(Map(
   "spark.cosmos.accountEndpoint" -> cosmosEndpoint,
@@ -166,8 +165,6 @@ val sinkCount = spark.read.format("cosmos.oltp").options(Map(
 
 println(s"Change Feed micro-batch streaming: $sinkCount records copied to sink container")
 assert(sinkCount >= 2, s"Expected at least 2 records in sink container but found $sinkCount")
-
-microBatchQuery.stop()
 
 // COMMAND ----------
 

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
@@ -100,10 +100,6 @@ df.filter(col("isAlive") === true)
 // This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
 // that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
 
-val sinkContainerName = cosmosContainerName + "Sink"
-spark.sql(s"CREATE TABLE IF NOT EXISTS cosmosCatalogMI.${cosmosDatabaseName}.${sinkContainerName} using cosmos.oltp " +
-  s"TBLPROPERTIES(partitionKeyPath = '/id', manualThroughput = '400')")
-
 val changeFeedCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
   "spark.cosmos.auth.type" -> authType,
   "spark.cosmos.account.subscriptionId" -> subscriptionId,
@@ -118,19 +114,6 @@ val changeFeedCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
   "spark.cosmos.read.consistencyStrategy" -> "LatestCommitted",
 )
 
-val writeCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
-  "spark.cosmos.auth.type" -> authType,
-  "spark.cosmos.account.subscriptionId" -> subscriptionId,
-  "spark.cosmos.account.tenantId" -> tenantId,
-  "spark.cosmos.account.resourceGroupName" -> resourceGroupName,
-  "spark.cosmos.database" -> cosmosDatabaseName,
-  "spark.cosmos.container" -> sinkContainerName,
-  "spark.cosmos.write.strategy" -> "ItemOverwrite",
-  "spark.cosmos.write.bulk.enabled" -> "true",
-  "spark.cosmos.enforceNativeTransport" -> "true",
-  "spark.cosmos.read.consistencyStrategy" -> "LatestCommitted",
-)
-
 val testId = java.util.UUID.randomUUID().toString.replace("-", "")
 
 val changeFeedDF = spark
@@ -141,33 +124,19 @@ val changeFeedDF = spark
 
 val microBatchQuery = changeFeedDF
   .writeStream
-  .format("cosmos.oltp")
+  .format("memory")
   .queryName(testId)
-  .options(writeCfg)
-  .option("checkpointLocation", s"file:/tmp/$testId/")
   .outputMode("append")
   .start()
 
 microBatchQuery.processAllAvailable()
 microBatchQuery.stop()
 
-val sinkCount = spark.read.format("cosmos.oltp").options(Map(
-  "spark.cosmos.accountEndpoint" -> cosmosEndpoint,
-  "spark.cosmos.auth.type" -> authType,
-  "spark.cosmos.account.subscriptionId" -> subscriptionId,
-  "spark.cosmos.account.tenantId" -> tenantId,
-  "spark.cosmos.account.resourceGroupName" -> resourceGroupName,
-  "spark.cosmos.database" -> cosmosDatabaseName,
-  "spark.cosmos.container" -> sinkContainerName,
-  "spark.cosmos.enforceNativeTransport" -> "true",
-  "spark.cosmos.read.consistencyStrategy" -> "LatestCommitted",
-)).load().count()
-
-println(s"Change Feed micro-batch streaming: $sinkCount records copied to sink container")
-assert(sinkCount >= 2, s"Expected at least 2 records in sink container but found $sinkCount")
+val sinkCount = spark.sql(s"SELECT * FROM $testId").count()
+println(s"Change Feed micro-batch streaming: $sinkCount records read via change feed")
+assert(sinkCount >= 2, s"Expected at least 2 records from change feed but found $sinkCount")
 
 // COMMAND ----------
 
 // cleanup
-spark.sql(s"DROP TABLE cosmosCatalogMI.${cosmosDatabaseName}.${sinkContainerName};")
 spark.sql(s"DROP TABLE cosmosCatalogMI.${cosmosDatabaseName}.${cosmosContainerName};")

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
@@ -96,59 +96,5 @@ df.filter(col("isAlive") === true)
 
 // COMMAND ----------
 
-// Change Feed - micro-batch structured streaming
-// This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
-// that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
-
-val changeFeedCfg = cfg ++ Map(
-  "spark.cosmos.read.inferSchema.enabled" -> "false",
-  "spark.cosmos.changeFeed.startFrom" -> "Beginning",
-  "spark.cosmos.changeFeed.mode" -> "Incremental"
-)
-
-val testId = java.util.UUID.randomUUID().toString.replace("-", "")
-
-println(s"Change Feed test: using endpoint=${cosmosEndpoint}")
-println(s"Change Feed test: database=${cosmosDatabaseName}, container=${cosmosContainerName}")
-println(s"Change Feed test: authType=${authType}")
-println(s"Change Feed test: changeFeedCfg keys=${changeFeedCfg.keys.mkString(", ")}")
-
-// Verify the source container is accessible before starting streaming
-val verifyDf = spark.read.format("cosmos.oltp").options(cfg).load()
-val verifyCount = verifyDf.count()
-println(s"Change Feed test: source container has $verifyCount records before streaming")
-
-try {
-  val changeFeedDF = spark
-    .readStream
-    .format("cosmos.oltp.changeFeed")
-    .options(changeFeedCfg)
-    .load()
-
-  val microBatchQuery = changeFeedDF
-    .writeStream
-    .format("memory")
-    .queryName(testId)
-    .outputMode("append")
-    .start()
-
-  println(s"Change Feed test: streaming query started, id=${microBatchQuery.id}")
-  microBatchQuery.processAllAvailable()
-  microBatchQuery.stop()
-
-  val sinkCount = spark.sql(s"SELECT * FROM $testId").count()
-  println(s"Change Feed micro-batch streaming: $sinkCount records read via change feed")
-  assert(sinkCount >= 2, s"Expected at least 2 records from change feed but found $sinkCount")
-} catch {
-  case e: Exception =>
-    println(s"Change Feed test FAILED: ${e.getClass.getName}: ${e.getMessage}")
-    if (e.getCause != null) {
-      println(s"Change Feed test cause: ${e.getCause.getClass.getName}: ${e.getCause.getMessage}")
-    }
-    throw e
-}
-
-// COMMAND ----------
-
 // cleanup
 spark.sql(s"DROP TABLE cosmosCatalogMI.${cosmosDatabaseName}.${cosmosContainerName};")

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
@@ -96,5 +96,59 @@ df.filter(col("isAlive") === true)
 
 // COMMAND ----------
 
+// Change Feed - micro-batch structured streaming
+// This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
+// that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
+
+val changeFeedCfg = cfg ++ Map(
+  "spark.cosmos.read.inferSchema.enabled" -> "false",
+  "spark.cosmos.changeFeed.startFrom" -> "Beginning",
+  "spark.cosmos.changeFeed.mode" -> "Incremental"
+)
+
+val testId = java.util.UUID.randomUUID().toString.replace("-", "")
+
+println(s"Change Feed test: using endpoint=${cosmosEndpoint}")
+println(s"Change Feed test: database=${cosmosDatabaseName}, container=${cosmosContainerName}")
+println(s"Change Feed test: authType=${authType}")
+println(s"Change Feed test: changeFeedCfg keys=${changeFeedCfg.keys.mkString(", ")}")
+
+// Verify the source container is accessible before starting streaming
+val verifyDf = spark.read.format("cosmos.oltp").options(cfg).load()
+val verifyCount = verifyDf.count()
+println(s"Change Feed test: source container has $verifyCount records before streaming")
+
+try {
+  val changeFeedDF = spark
+    .readStream
+    .format("cosmos.oltp.changeFeed")
+    .options(changeFeedCfg)
+    .load()
+
+  val microBatchQuery = changeFeedDF
+    .writeStream
+    .format("memory")
+    .queryName(testId)
+    .outputMode("append")
+    .start()
+
+  println(s"Change Feed test: streaming query started, id=${microBatchQuery.id}")
+  microBatchQuery.processAllAvailable()
+  microBatchQuery.stop()
+
+  val sinkCount = spark.sql(s"SELECT * FROM $testId").count()
+  println(s"Change Feed micro-batch streaming: $sinkCount records read via change feed")
+  assert(sinkCount >= 2, s"Expected at least 2 records from change feed but found $sinkCount")
+} catch {
+  case e: Exception =>
+    println(s"Change Feed test FAILED: ${e.getClass.getName}: ${e.getMessage}")
+    if (e.getCause != null) {
+      println(s"Change Feed test cause: ${e.getCause.getClass.getName}: ${e.getCause.getMessage}")
+    }
+    throw e
+}
+
+// COMMAND ----------
+
 // cleanup
 spark.sql(s"DROP TABLE cosmosCatalogMI.${cosmosDatabaseName}.${cosmosContainerName};")

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
@@ -96,5 +96,39 @@ df.filter(col("isAlive") === true)
 
 // COMMAND ----------
 
+// Change Feed - micro-batch structured streaming
+// This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
+// that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
+
+val changeFeedCfg = cfg ++ Map(
+  "spark.cosmos.read.inferSchema.enabled" -> "false",
+  "spark.cosmos.changeFeed.startFrom" -> "Beginning",
+  "spark.cosmos.changeFeed.mode" -> "Incremental"
+)
+
+val testId = java.util.UUID.randomUUID().toString.replace("-", "")
+
+val changeFeedDF = spark
+  .readStream
+  .format("cosmos.oltp.changeFeed")
+  .options(changeFeedCfg)
+  .load()
+
+val microBatchQuery = changeFeedDF
+  .writeStream
+  .format("memory")
+  .queryName(testId)
+  .outputMode("append")
+  .start()
+
+microBatchQuery.processAllAvailable()
+microBatchQuery.stop()
+
+val sinkCount = spark.sql(s"SELECT * FROM $testId").count()
+println(s"Change Feed micro-batch streaming: $sinkCount records read via change feed")
+assert(sinkCount >= 2, s"Expected at least 2 records from change feed but found $sinkCount")
+
+// COMMAND ----------
+
 // cleanup
 spark.sql(s"DROP TABLE cosmosCatalogMI.${cosmosDatabaseName}.${cosmosContainerName};")

--- a/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/test-databricks/notebooks/basicScenarioAadManagedIdentity.scala
@@ -96,47 +96,5 @@ df.filter(col("isAlive") === true)
 
 // COMMAND ----------
 
-// Change Feed - micro-batch structured streaming
-// This exercises the ChangeFeedInitialOffsetWriter and HDFSMetadataLog code paths
-// that can break on certain Spark distributions (e.g. Databricks Runtime 17.3+)
-
-val changeFeedCfg = Map("spark.cosmos.accountEndpoint" -> cosmosEndpoint,
-  "spark.cosmos.auth.type" -> authType,
-  "spark.cosmos.account.subscriptionId" -> subscriptionId,
-  "spark.cosmos.account.tenantId" -> tenantId,
-  "spark.cosmos.account.resourceGroupName" -> resourceGroupName,
-  "spark.cosmos.database" -> cosmosDatabaseName,
-  "spark.cosmos.container" -> cosmosContainerName,
-  "spark.cosmos.read.inferSchema.enabled" -> "false",
-  "spark.cosmos.changeFeed.startFrom" -> "Beginning",
-  "spark.cosmos.changeFeed.mode" -> "Incremental",
-  "spark.cosmos.enforceNativeTransport" -> "true",
-  "spark.cosmos.read.consistencyStrategy" -> "LatestCommitted",
-)
-
-val testId = java.util.UUID.randomUUID().toString.replace("-", "")
-
-val changeFeedDF = spark
-  .readStream
-  .format("cosmos.oltp.changeFeed")
-  .options(changeFeedCfg)
-  .load()
-
-val microBatchQuery = changeFeedDF
-  .writeStream
-  .format("memory")
-  .queryName(testId)
-  .outputMode("append")
-  .start()
-
-microBatchQuery.processAllAvailable()
-microBatchQuery.stop()
-
-val sinkCount = spark.sql(s"SELECT * FROM $testId").count()
-println(s"Change Feed micro-batch streaming: $sinkCount records read via change feed")
-assert(sinkCount >= 2, s"Expected at least 2 records from change feed but found $sinkCount")
-
-// COMMAND ----------
-
 // cleanup
 spark.sql(s"DROP TABLE cosmosCatalogMI.${cosmosDatabaseName}.${cosmosContainerName};")


### PR DESCRIPTION
## Description

Fixes a `NoClassDefFoundError` for `MetadataVersionUtil` in the Cosmos Spark connector that occurs on certain Spark distributions (e.g., Databricks Runtime 17.3+) where `MetadataVersionUtil` has been relocated or removed.

### Problem

`ChangeFeedInitialOffsetWriter` directly references `org.apache.spark.sql.execution.streaming.MetadataVersionUtil`, which is an internal Spark class. Some Spark distributions relocate or remove this class, causing a `NoClassDefFoundError` at runtime when the change feed offset writer attempts to deserialize a log file.

### Solution

Inline the `validateVersion` logic from `MetadataVersionUtil` into a private companion object (`ChangeFeedInitialOffsetWriter` object) to eliminate the runtime dependency on `MetadataVersionUtil`. The inlined implementation preserves the same validation semantics:

- Parses the version string (e.g., `"v1"`) from the log file header
- Validates the version is within the supported range
- Throws `IllegalStateException` with descriptive messages for malformed or unsupported versions

### Changes

- **`ChangeFeedInitialOffsetWriter.scala`**: Removed the import of `MetadataVersionUtil`, replaced the call to `MetadataVersionUtil.validateVersion(...)` with a local `ChangeFeedInitialOffsetWriter.validateVersion(...)`, and added a companion object with the inlined validation logic.


### Tests
- Added spark live test for change feed streaming
- Manual testing on spark Databricks with 17.3 runtime
- Also confirmed the path for `HDFSMetadataLog`
<img width="944" height="382" alt="image" src="https://github.com/user-attachments/assets/38ad3a80-0f7d-4994-ab4e-67d6f9768608" />
