### PR TITLE
Release azure-cosmos-spark 4.47.0

### DIFF
--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -113,11 +113,11 @@ com.azure.cosmos.spark:azure-cosmos-spark_3-5;0.0.1-beta.1;0.0.1-beta.1
 com.azure:azure-cosmos-encryption;2.28.0;2.29.0-beta.1
 com.azure.cosmos.spark:azure-cosmos-spark-account-data-resolver-sample;1.0.0-beta.1;1.0.0-beta.1
 com.azure:azure-cosmos-test;1.0.0-beta.18;1.0.0-beta.19
-com.azure.cosmos.spark:azure-cosmos-spark_3-3_2-12;4.46.0;4.47.0-beta.1
-com.azure.cosmos.spark:azure-cosmos-spark_3-4_2-12;4.46.0;4.47.0-beta.1
-com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;4.46.0;4.47.0-beta.1
-com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-13;4.46.0;4.47.0-beta.1
-com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13;4.46.0;4.47.0-beta.1
+com.azure.cosmos.spark:azure-cosmos-spark_3-3_2-12;4.46.0;4.47.0
+com.azure.cosmos.spark:azure-cosmos-spark_3-4_2-12;4.46.0;4.47.0
+com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;4.46.0;4.47.0
+com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-13;4.46.0;4.47.0
+com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13;4.46.0;4.47.0
 com.azure.cosmos.spark:fabric-cosmos-spark-auth_3;1.1.0;1.2.0-beta.1
 com.azure:azure-cosmos-tests;1.0.0-beta.1;1.0.0-beta.1
 com.azure:azure-data-appconfiguration;1.9.1;1.10.0-beta.1

--- a/sdk/cosmos/azure-cosmos-spark-account-data-resolver-sample/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark-account-data-resolver-sample/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>com.azure.cosmos.spark</groupId>
       <artifactId>azure-cosmos-spark_3-5_2-12</artifactId>
-      <version>4.47.0-beta.1</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;current} -->
+      <version>4.47.0</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;current} -->
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -290,7 +290,7 @@
                 <include>com.fasterxml.jackson.core:jackson-databind:[2.18.6]</include> <!-- {x-include-update;com.fasterxml.jackson.core:jackson-databind;external_dependency} -->
                 <include>com.fasterxml.jackson.module:jackson-module-scala_2.12:[2.18.6]</include> <!-- {x-include-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
                 <include>com.globalmentor:hadoop-bare-naked-local-fs:[0.1.0]</include> <!-- {x-include-update;cosmos_com.globalmentor:hadoop-bare-naked-local-fs;external_dependency} -->
-                <include>com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:[4.47.0-beta.1]</include> <!-- {x-include-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;current} -->
+                <include>com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:[4.47.0]</include> <!-- {x-include-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;current} -->
               </includes>
             </bannedDependencies>
           </rules>

--- a/sdk/cosmos/azure-cosmos-spark_3-3_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-3_2-12/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release History
 
-### 4.47.0 (2026-04-16)
+### 4.47.0 (2026-04-17)
 
 #### Features Added
 * Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)

--- a/sdk/cosmos/azure-cosmos-spark_3-3_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-3_2-12/CHANGELOG.md
@@ -1,15 +1,12 @@
 ## Release History
 
-### 4.47.0-beta.1 (Unreleased)
+### 4.47.0 (2026-04-16)
 
 #### Features Added
-
-#### Breaking Changes
+* Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)
 
 #### Bugs Fixed
 * Fixed an issue where `readContainerThroughput` was always called even when `targetThroughput` is explicitly configured, requiring unnecessary `throughputSettings/read` permission for AAD principals. - See [PR 48800](https://github.com/Azure/azure-sdk-for-java/pull/48800)
-
-#### Other Changes
 
 ### 4.46.0 (2026-03-27)
 

--- a/sdk/cosmos/azure-cosmos-spark_3-3_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-3_2-12/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Bugs Fixed
 * Fixed an issue where `readContainerThroughput` was always called even when `targetThroughput` is explicitly configured, requiring unnecessary `throughputSettings/read` permission for AAD principals. - See [PR 48800](https://github.com/Azure/azure-sdk-for-java/pull/48800)
+* Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
 
 ### 4.46.0 (2026-03-27)
 

--- a/sdk/cosmos/azure-cosmos-spark_3-3_2-12/README.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-3_2-12/README.md
@@ -28,6 +28,7 @@ https://github.com/Azure/azure-sdk-for-java/issues/new
 #### azure-cosmos-spark_3-3_2-12
 | Connector | Supported Spark Versions | Supported JVM Versions | Supported Scala Versions | Supported Databricks Runtimes |
 |-----------|--------------------------|------------------------|--------------------------|-------------------------------|
+| 4.47.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.46.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.45.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.44.2    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
@@ -84,6 +85,7 @@ https://github.com/Azure/azure-sdk-for-java/issues/new
 #### azure-cosmos-spark_3-4_2-12
 | Connector | Supported Spark Versions | Supported JVM Versions | Supported Scala Versions | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|------------------------|--------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.46.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.45.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.44.2    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
@@ -131,6 +133,7 @@ https://github.com/Azure/azure-sdk-for-java/issues/new
 #### azure-cosmos-spark_3-5_2-12
 | Connector | Supported Spark Versions | Minimum Java Version | Supported Scala Versions   | Supported Databricks Runtimes | Supported Fabric Runtimes    |
 |-----------|--------------------------|----------------------|----------------------------|-------------------------------|------------------------------|
+| 4.47.0    | 3.5.0                    | [8, 11, 17]          | 2.12                       | 14.\*, 15.\*, 16.4 LTS         | 1.3.\*                       |
 | 4.46.0    | 3.5.0                    | [8, 11, 17]          | 2.12                       | 14.\*, 15.\*, 16.4 LTS         | 1.3.\*                       |
 | 4.45.0    | 3.5.0                    | [8, 11, 17]          | 2.12                       | 14.*, 15.\*, 16.4 LTS         | 1.3.\*                       |
 | 4.44.2    | 3.5.0                    | [8, 11, 17]          | 2.12                       | 14.*, 15.\*, 16.4 LTS         | 1.3.\*                       |
@@ -164,6 +167,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_3-5_2-13
 | Connector | Supported Spark Versions | Minimum Java Version  | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|-----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.46.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.45.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.44.2    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
@@ -175,6 +179,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_4-0_2-13
 | Connector | Supported Spark Versions | Minimum Java Version | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.46.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.45.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.44.2    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
@@ -186,11 +191,11 @@ to use the same version of Scala that Spark was compiled for.
 ### Download
 
 You can use the maven coordinate of the jar to auto install the Spark Connector to your Databricks Runtime from Maven:
-`com.azure.cosmos.spark:azure-cosmos-spark_3-3_2-12:4.46.0`
+`com.azure.cosmos.spark:azure-cosmos-spark_3-3_2-12:4.47.0`
 
 You can also integrate against Cosmos DB Spark Connector in your SBT project:
 ```scala
-libraryDependencies += "com.azure.cosmos.spark" % "azure-cosmos-spark_3-3_2-12" % "4.46.0"
+libraryDependencies += "com.azure.cosmos.spark" % "azure-cosmos-spark_3-3_2-12" % "4.47.0"
 ```
 
 Cosmos DB Spark Connector is available on [Maven Central Repo](https://central.sonatype.com/search?namespace=com.azure.cosmos.spark).

--- a/sdk/cosmos/azure-cosmos-spark_3-3_2-12/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3-3_2-12/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.azure.cosmos.spark</groupId>
   <artifactId>azure-cosmos-spark_3-3_2-12</artifactId>
-  <version>4.47.0-beta.1</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-3_2-12;current} -->
+  <version>4.47.0</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-3_2-12;current} -->
   <packaging>jar</packaging>
   <url>https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_3-3_2-12</url>
   <name>OLTP Spark 3.3 Connector for Azure Cosmos DB SQL API</name>

--- a/sdk/cosmos/azure-cosmos-spark_3-4_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-4_2-12/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release History
 
-### 4.47.0 (2026-04-16)
+### 4.47.0 (2026-04-17)
 
 #### Features Added
 * Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)

--- a/sdk/cosmos/azure-cosmos-spark_3-4_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-4_2-12/CHANGELOG.md
@@ -1,15 +1,12 @@
 ## Release History
 
-### 4.47.0-beta.1 (Unreleased)
+### 4.47.0 (2026-04-16)
 
 #### Features Added
-
-#### Breaking Changes
+* Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)
 
 #### Bugs Fixed
 * Fixed an issue where `readContainerThroughput` was always called even when `targetThroughput` is explicitly configured, requiring unnecessary `throughputSettings/read` permission for AAD principals. - See [PR 48800](https://github.com/Azure/azure-sdk-for-java/pull/48800)
-
-#### Other Changes
 
 ### 4.46.0 (2026-03-27)
 

--- a/sdk/cosmos/azure-cosmos-spark_3-4_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-4_2-12/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Bugs Fixed
 * Fixed an issue where `readContainerThroughput` was always called even when `targetThroughput` is explicitly configured, requiring unnecessary `throughputSettings/read` permission for AAD principals. - See [PR 48800](https://github.com/Azure/azure-sdk-for-java/pull/48800)
+* Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
 
 ### 4.46.0 (2026-03-27)
 

--- a/sdk/cosmos/azure-cosmos-spark_3-4_2-12/README.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-4_2-12/README.md
@@ -28,6 +28,7 @@ https://github.com/Azure/azure-sdk-for-java/issues/new
 #### azure-cosmos-spark_3-4_2-12
 | Connector | Supported Spark Versions | Supported JVM Versions | Supported Scala Versions | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|------------------------|--------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.46.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.45.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.44.2    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
@@ -75,6 +76,7 @@ https://github.com/Azure/azure-sdk-for-java/issues/new
 #### azure-cosmos-spark_3-3_2-12
 | Connector | Supported Spark Versions | Supported JVM Versions | Supported Scala Versions | Supported Databricks Runtimes |
 |-----------|--------------------------|------------------------|--------------------------|-------------------------------|
+| 4.47.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.46.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.45.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.44.2    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
@@ -131,6 +133,7 @@ https://github.com/Azure/azure-sdk-for-java/issues/new
 #### azure-cosmos-spark_3-5_2-12
 | Connector | Supported Spark Versions | Minimum Java Version | Supported Scala Versions | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|----------------------|--------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.5.0                    | [8, 11, 17]          | 2.12                     | 14.\*, 15.\*, 16.4 LTS         | 1.3.\*                    |
 | 4.46.0    | 3.5.0                    | [8, 11, 17]          | 2.12                     | 14.\*, 15.\*, 16.4 LTS         | 1.3.\*                    |
 | 4.45.0    | 3.5.0                    | [8, 11, 17]          | 2.12                     | 14.*, 15.\*, 16.4 LTS         | 1.3.\*                    |
 | 4.44.2    | 3.5.0                    | [8, 11, 17]          | 2.12                     | 14.*, 15.\*, 16.4 LTS         | 1.3.\*                    |
@@ -164,6 +167,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_3-5_2-13
 | Connector | Supported Spark Versions | Minimum Java Version  | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|-----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.46.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.45.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.44.2    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
@@ -175,6 +179,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_4-0_2-13
 | Connector | Supported Spark Versions | Minimum Java Version | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.46.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.45.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.44.2    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
@@ -186,11 +191,11 @@ to use the same version of Scala that Spark was compiled for.
 ### Download
 
 You can use the maven coordinate of the jar to auto install the Spark Connector to your Databricks Runtime from Maven:
-`com.azure.cosmos.spark:azure-cosmos-spark_3-4_2-12:4.46.0`
+`com.azure.cosmos.spark:azure-cosmos-spark_3-4_2-12:4.47.0`
 
 You can also integrate against Cosmos DB Spark Connector in your SBT project:
 ```scala
-libraryDependencies += "com.azure.cosmos.spark" % "azure-cosmos-spark_3-4_2-12" % "4.46.0"
+libraryDependencies += "com.azure.cosmos.spark" % "azure-cosmos-spark_3-4_2-12" % "4.47.0"
 ```
 
 Cosmos DB Spark Connector is available on [Maven Central Repo](https://central.sonatype.com/search?namespace=com.azure.cosmos.spark).

--- a/sdk/cosmos/azure-cosmos-spark_3-4_2-12/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3-4_2-12/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.azure.cosmos.spark</groupId>
   <artifactId>azure-cosmos-spark_3-4_2-12</artifactId>
-  <version>4.47.0-beta.1</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-4_2-12;current} -->
+  <version>4.47.0</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-4_2-12;current} -->
   <packaging>jar</packaging>
   <url>https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_3-4_2-12</url>
   <name>OLTP Spark 3.4 Connector for Azure Cosmos DB SQL API</name>

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-12/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release History
 
-### 4.47.0 (2026-04-16)
+### 4.47.0 (2026-04-17)
 
 #### Features Added
 * Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-12/CHANGELOG.md
@@ -1,15 +1,12 @@
 ## Release History
 
-### 4.47.0-beta.1 (Unreleased)
+### 4.47.0 (2026-04-16)
 
 #### Features Added
-
-#### Breaking Changes
+* Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)
 
 #### Bugs Fixed
 * Fixed an issue where `readContainerThroughput` was always called even when `targetThroughput` is explicitly configured, requiring unnecessary `throughputSettings/read` permission for AAD principals. - See [PR 48800](https://github.com/Azure/azure-sdk-for-java/pull/48800)
-
-#### Other Changes
 
 ### 4.46.0 (2026-03-27)
 

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-12/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Bugs Fixed
 * Fixed an issue where `readContainerThroughput` was always called even when `targetThroughput` is explicitly configured, requiring unnecessary `throughputSettings/read` permission for AAD principals. - See [PR 48800](https://github.com/Azure/azure-sdk-for-java/pull/48800)
+* Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
 
 ### 4.46.0 (2026-03-27)
 

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-12/README.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-12/README.md
@@ -28,6 +28,7 @@ https://github.com/Azure/azure-sdk-for-java/issues/new
 #### azure-cosmos-spark_3-5_2-12
 | Connector | Supported Spark Versions | Minimum Java Version  | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|-----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
 | 4.46.0    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
 | 4.45.0    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
 | 4.44.2    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
@@ -61,6 +62,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_3-3_2-12
 | Connector | Supported Spark Versions | Supported JVM Versions | Supported Scala Versions | Supported Databricks Runtimes |
 |-----------|--------------------------|------------------------|--------------------------|-------------------------------|
+| 4.47.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.46.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.45.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.44.2    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
@@ -117,6 +119,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_3-4_2-12
 | Connector | Supported Spark Versions | Supported JVM Versions | Supported Scala Versions | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|------------------------|--------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.46.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.45.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.44.2    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
@@ -164,6 +167,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_3-5_2-13
 | Connector | Supported Spark Versions | Minimum Java Version  | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|-----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.46.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.45.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.44.2    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
@@ -175,6 +179,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_4-0_2-13
 | Connector | Supported Spark Versions | Minimum Java Version | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.46.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.45.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.44.2    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
@@ -186,11 +191,11 @@ to use the same version of Scala that Spark was compiled for.
 ### Download
 
 You can use the maven coordinate of the jar to auto install the Spark Connector to your Databricks Runtime from Maven:
-`com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:4.46.0`
+`com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:4.47.0`
 
 You can also integrate against Cosmos DB Spark Connector in your SBT project:
 ```scala
-libraryDependencies += "com.azure.cosmos.spark" % "azure-cosmos-spark_3-5_2-12" % "4.46.0"
+libraryDependencies += "com.azure.cosmos.spark" % "azure-cosmos-spark_3-5_2-12" % "4.47.0"
 ```
 
 Cosmos DB Spark Connector is available on [Maven Central Repo](https://central.sonatype.com/search?namespace=com.azure.cosmos.spark).

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-12/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-12/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.azure.cosmos.spark</groupId>
   <artifactId>azure-cosmos-spark_3-5_2-12</artifactId>
-  <version>4.47.0-beta.1</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;current} -->
+  <version>4.47.0</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;current} -->
   <packaging>jar</packaging>
   <url>https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_3-5_2-12</url>
   <name>OLTP Spark 3.5 Connector for Azure Cosmos DB SQL API</name>

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-13/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-13/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release History
 
-### 4.47.0 (2026-04-16)
+### 4.47.0 (2026-04-17)
 
 #### Features Added
 * Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-13/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-13/CHANGELOG.md
@@ -1,15 +1,12 @@
 ## Release History
 
-### 4.47.0-beta.1 (Unreleased)
+### 4.47.0 (2026-04-16)
 
 #### Features Added
-
-#### Breaking Changes
+* Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)
 
 #### Bugs Fixed
 * Fixed an issue where `readContainerThroughput` was always called even when `targetThroughput` is explicitly configured, requiring unnecessary `throughputSettings/read` permission for AAD principals. - See [PR 48800](https://github.com/Azure/azure-sdk-for-java/pull/48800)
-
-#### Other Changes
 
 ### 4.46.0 (2026-03-27)
 

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-13/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-13/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Bugs Fixed
 * Fixed an issue where `readContainerThroughput` was always called even when `targetThroughput` is explicitly configured, requiring unnecessary `throughputSettings/read` permission for AAD principals. - See [PR 48800](https://github.com/Azure/azure-sdk-for-java/pull/48800)
+* Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
 
 ### 4.46.0 (2026-03-27)
 

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-13/README.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-13/README.md
@@ -28,6 +28,7 @@ https://github.com/Azure/azure-sdk-for-java/issues/new
 #### azure-cosmos-spark_3-5_2-13
 | Connector | Supported Spark Versions | Minimum Java Version  | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|-----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.46.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.45.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.44.2    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
@@ -42,6 +43,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_3-3_2-12
 | Connector | Supported Spark Versions | Supported JVM Versions | Supported Scala Versions | Supported Databricks Runtimes |
 |-----------|--------------------------|------------------------|--------------------------|-------------------------------|
+| 4.47.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.46.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.45.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.44.2    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
@@ -98,6 +100,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_3-4_2-12
 | Connector | Supported Spark Versions | Supported JVM Versions | Supported Scala Versions | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|------------------------|--------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.46.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.45.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.44.2    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
@@ -145,6 +148,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_3-5_2-12
 | Connector | Supported Spark Versions | Minimum Java Version  | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|-----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
 | 4.46.0    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
 | 4.45.0    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
 | 4.44.2    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
@@ -178,6 +182,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_4-0_2-13
 | Connector | Supported Spark Versions | Minimum Java Version | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.46.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.45.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.44.2    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
@@ -192,11 +197,11 @@ to use Scala 2.13 that Spark 4.0 was compiled for.
 ### Download
 
 You can use the maven coordinate of the jar to auto install the Spark Connector to your Databricks Runtime from Maven:
-`com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-13:4.46.0`
+`com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-13:4.47.0`
 
 You can also integrate against Cosmos DB Spark Connector in your SBT project:
 ```scala
-libraryDependencies += "com.azure.cosmos.spark" % "azure-cosmos-spark_3-5_2-13" % "4.46.0"
+libraryDependencies += "com.azure.cosmos.spark" % "azure-cosmos-spark_3-5_2-13" % "4.47.0"
 ```
 
 Cosmos DB Spark Connector is available on [Maven Central Repo](https://central.sonatype.com/search?namespace=com.azure.cosmos.spark).

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-13/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-13/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.azure.cosmos.spark</groupId>
   <artifactId>azure-cosmos-spark_3-5_2-13</artifactId>
-  <version>4.47.0-beta.1</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-13;current} -->
+  <version>4.47.0</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-13;current} -->
   <packaging>jar</packaging>
   <url>https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_3-5_2-13</url>
   <name>OLTP Spark 3.5 Connector for Azure Cosmos DB SQL API</name>

--- a/sdk/cosmos/azure-cosmos-spark_3/docs/quick-start.md
+++ b/sdk/cosmos/azure-cosmos-spark_3/docs/quick-start.md
@@ -29,19 +29,19 @@ You can use any other Spark 3.5 spark offering as well, also you should be able 
 SLF4J is only needed if you plan to use logging, please also download an SLF4J binding which will link the SLF4J API with the logging implementation of your choice. See the [SLF4J user manual](https://www.slf4j.org/manual.html) for more information.
 
 For Spark 3.3:
-- Install Cosmos DB Spark Connector, in your spark Cluster [com.azure.cosmos.spark:azure-cosmos-spark_3-3_2-12:4.46.0](https://search.maven.org/artifact/com.azure.cosmos.spark/azure-cosmos-spark_3-3_2-12/4.46.0/jar)
+- Install Cosmos DB Spark Connector, in your spark Cluster [com.azure.cosmos.spark:azure-cosmos-spark_3-3_2-12:4.47.0](https://search.maven.org/artifact/com.azure.cosmos.spark/azure-cosmos-spark_3-3_2-12/4.47.0/jar)
   
 For Spark 3.4:
-- Install Cosmos DB Spark Connector, in your spark Cluster [com.azure.cosmos.spark:azure-cosmos-spark_3-4_2-12:4.46.0](https://search.maven.org/artifact/com.azure.cosmos.spark/azure-cosmos-spark_3-4_2-12/4.46.0/jar)
+- Install Cosmos DB Spark Connector, in your spark Cluster [com.azure.cosmos.spark:azure-cosmos-spark_3-4_2-12:4.47.0](https://search.maven.org/artifact/com.azure.cosmos.spark/azure-cosmos-spark_3-4_2-12/4.47.0/jar)
 
 For Spark 3.5 (Scala 2.12):
-- Install Cosmos DB Spark Connector, in your spark Cluster [com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:4.46.0](https://search.maven.org/artifact/com.azure.cosmos.spark/azure-cosmos-spark_3-5_2-12/4.46.0/jar)
+- Install Cosmos DB Spark Connector, in your spark Cluster [com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:4.47.0](https://search.maven.org/artifact/com.azure.cosmos.spark/azure-cosmos-spark_3-5_2-12/4.47.0/jar)
 
 For Spark 3.5 (Scala 2.13):
-- Install Cosmos DB Spark Connector, in your spark Cluster [com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-13:4.46.0](https://search.maven.org/artifact/com.azure.cosmos.spark/azure-cosmos-spark_3-5_2-13/4.46.0/jar)
+- Install Cosmos DB Spark Connector, in your spark Cluster [com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-13:4.47.0](https://search.maven.org/artifact/com.azure.cosmos.spark/azure-cosmos-spark_3-5_2-13/4.47.0/jar)
 
 For Spark 4.0:
-- Install Cosmos DB Spark Connector, in your spark Cluster [com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13:4.46.0](https://search.maven.org/artifact/com.azure.cosmos.spark/azure-cosmos-spark_4-0_2-13/4.46.0/jar)
+- Install Cosmos DB Spark Connector, in your spark Cluster [com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13:4.47.0](https://search.maven.org/artifact/com.azure.cosmos.spark/azure-cosmos-spark_4-0_2-13/4.47.0/jar)
 
 
 The getting started guide is based on PySpark however you can use the equivalent scala version as well, and you can run the following code snippet in an Azure Databricks PySpark notebook.

--- a/sdk/cosmos/azure-cosmos-spark_4-0_2-13/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_4-0_2-13/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Features Added
 * Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)
 
+#### Bugs Fixed
+* Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
+
 ### 4.46.0 (2026-03-27)
 
 #### Bugs Fixed

--- a/sdk/cosmos/azure-cosmos-spark_4-0_2-13/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_4-0_2-13/CHANGELOG.md
@@ -1,14 +1,9 @@
 ## Release History
 
-### 4.47.0-beta.1 (Unreleased)
+### 4.47.0 (2026-04-16)
 
 #### Features Added
-
-#### Breaking Changes
-
-#### Bugs Fixed
-
-#### Other Changes
+* Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)
 
 ### 4.46.0 (2026-03-27)
 

--- a/sdk/cosmos/azure-cosmos-spark_4-0_2-13/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_4-0_2-13/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)
 
 #### Bugs Fixed
+* Fixed `NoClassDefFoundError` for `MetadataVersionUtil` when using change feed Spark Structured Streaming on Databricks Runtime 17.3+ by inlining the version validation logic. - See [PR 48837](https://github.com/Azure/azure-sdk-for-java/pull/48837)
 * Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
 
 ### 4.46.0 (2026-03-27)

--- a/sdk/cosmos/azure-cosmos-spark_4-0_2-13/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_4-0_2-13/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release History
 
-### 4.47.0 (2026-04-16)
+### 4.47.0 (2026-04-17)
 
 #### Features Added
 * Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)

--- a/sdk/cosmos/azure-cosmos-spark_4-0_2-13/README.md
+++ b/sdk/cosmos/azure-cosmos-spark_4-0_2-13/README.md
@@ -20,6 +20,7 @@ https://github.com/Azure/azure-sdk-for-java/issues/new
 #### azure-cosmos-spark_4-0_2-13
 | Connector | Supported Spark Versions | Minimum Java Version | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.46.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.45.0    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
 | 4.44.2    | 4.0.0                    | [17, 21]             | 2.13                      | 17.\*                         | TBD                       |
@@ -34,6 +35,7 @@ to use Scala 2.13 that Spark 4.0 was compiled for.
 #### azure-cosmos-spark_3-3_2-12
 | Connector | Supported Spark Versions | Supported JVM Versions | Supported Scala Versions | Supported Databricks Runtimes |
 |-----------|--------------------------|------------------------|--------------------------|-------------------------------|
+| 4.47.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.46.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.45.0    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
 | 4.44.2    | 3.3.0 - 3.3.2            | [8, 11]                | 2.12                     | 11.\*, 12.\*                  |
@@ -90,6 +92,7 @@ to use Scala 2.13 that Spark 4.0 was compiled for.
 #### azure-cosmos-spark_3-4_2-12
 | Connector | Supported Spark Versions | Supported JVM Versions | Supported Scala Versions | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|------------------------|--------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.46.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.45.0    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
 | 4.44.2    | 3.4.0 - 3.4.1            | [8, 11]                | 2.12                     | 13.\*                         |                           |
@@ -137,6 +140,7 @@ to use Scala 2.13 that Spark 4.0 was compiled for.
 #### azure-cosmos-spark_3-5_2-12
 | Connector | Supported Spark Versions | Minimum Java Version  | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|-----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
 | 4.46.0    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
 | 4.45.0    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
 | 4.44.2    | 3.5.0                    | [8, 11, 17]           | 2.12                      | 14.\*, 15.\*, 16.4 LTS        | 1.3.\*                    |
@@ -170,6 +174,7 @@ to use the same version of Scala that Spark was compiled for.
 #### azure-cosmos-spark_3-5_2-13
 | Connector | Supported Spark Versions | Minimum Java Version  | Supported Scala Versions  | Supported Databricks Runtimes | Supported Fabric Runtimes |
 |-----------|--------------------------|-----------------------|---------------------------|-------------------------------|---------------------------|
+| 4.47.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.46.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.45.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.44.2    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
@@ -181,11 +186,11 @@ to use the same version of Scala that Spark was compiled for.
 ### Download
 
 You can use the maven coordinate of the jar to auto install the Spark Connector to your Databricks Runtime from Maven:
-`com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13:4.46.0`
+`com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13:4.47.0`
 
 You can also integrate against Cosmos DB Spark Connector in your SBT project:
 ```scala
-libraryDependencies += "com.azure.cosmos.spark" % "azure-cosmos-spark_4-0_2-13" % "4.46.0"
+libraryDependencies += "com.azure.cosmos.spark" % "azure-cosmos-spark_4-0_2-13" % "4.47.0"
 ```
 
 Cosmos DB Spark Connector is available on [Maven Central Repo](https://central.sonatype.com/search?namespace=com.azure.cosmos.spark).

--- a/sdk/cosmos/azure-cosmos-spark_4-0_2-13/README.md
+++ b/sdk/cosmos/azure-cosmos-spark_4-0_2-13/README.md
@@ -183,11 +183,6 @@ to use the same version of Scala that Spark was compiled for.
 | 4.43.1    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.43.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 
-### Known Issues
-
-#### Spark Structured Streaming does not work with Databricks Runtime 17.3
-Databricks Runtime 17.3 LTS includes internal API changes from Spark 4.1 (specifically the removal of `org.apache.spark.sql.execution.streaming.MetadataVersionUtil$`) while still reporting Spark 4.0.0 compatibility. This causes a `java.lang.NoClassDefFoundError` when using Spark Structured Streaming with the Cosmos DB change feed on DBR 17.3. We recommend remaining on a previous Databricks LTS version until Databricks 18 LTS releases, at which point the Spark 4.1-compatible connector can be used.
-
 ### Download
 
 You can use the maven coordinate of the jar to auto install the Spark Connector to your Databricks Runtime from Maven:

--- a/sdk/cosmos/azure-cosmos-spark_4-0_2-13/README.md
+++ b/sdk/cosmos/azure-cosmos-spark_4-0_2-13/README.md
@@ -186,7 +186,7 @@ to use the same version of Scala that Spark was compiled for.
 ### Known Issues
 
 #### Spark Structured Streaming does not work with Databricks Runtime 17.3
-Databricks Runtime 17.3 uses Spark 4.0.0-preview2, which relocated the internal class `org.apache.spark.sql.connector.read.streaming.SparkDataStream` to a different package starting in Spark 4.1. This causes a `NoClassDefFoundError` when using Spark Structured Streaming with the Cosmos DB Spark connector on DBR 17.3. This issue affects all Spark connectors that depend on this internal API. We are tracking the upstream Spark issue and will provide a fix once a public API is available.
+Databricks Runtime 17.3 LTS includes internal API changes from Spark 4.1 (specifically the removal of `org.apache.spark.sql.execution.streaming.MetadataVersionUtil$`) while still reporting Spark 4.0.0 compatibility. This causes a `java.lang.NoClassDefFoundError` when using Spark Structured Streaming with the Cosmos DB change feed on DBR 17.3. We recommend remaining on a previous Databricks LTS version until Databricks 18 LTS releases, at which point the Spark 4.1-compatible connector can be used.
 
 ### Download
 

--- a/sdk/cosmos/azure-cosmos-spark_4-0_2-13/README.md
+++ b/sdk/cosmos/azure-cosmos-spark_4-0_2-13/README.md
@@ -183,6 +183,11 @@ to use the same version of Scala that Spark was compiled for.
 | 4.43.1    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 | 4.43.0    | 3.5.0                    | [17]                  | 2.13                      | 16.4 LTS                      | TBD                       |
 
+### Known Issues
+
+#### Spark Structured Streaming does not work with Databricks Runtime 17.3
+Databricks Runtime 17.3 uses Spark 4.0.0-preview2, which relocated the internal class `org.apache.spark.sql.connector.read.streaming.SparkDataStream` to a different package starting in Spark 4.1. This causes a `NoClassDefFoundError` when using Spark Structured Streaming with the Cosmos DB Spark connector on DBR 17.3. This issue affects all Spark connectors that depend on this internal API. We are tracking the upstream Spark issue and will provide a fix once a public API is available.
+
 ### Download
 
 You can use the maven coordinate of the jar to auto install the Spark Connector to your Databricks Runtime from Maven:

--- a/sdk/cosmos/azure-cosmos-spark_4-0_2-13/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_4-0_2-13/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.azure.cosmos.spark</groupId>
   <artifactId>azure-cosmos-spark_4-0_2-13</artifactId>
-  <version>4.47.0-beta.1</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13;current} -->
+  <version>4.47.0</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13;current} -->
   <packaging>jar</packaging>
   <url>https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_4-0_2-13</url>
   <name>OLTP Spark 4.0 Connector for Azure Cosmos DB SQL API</name>

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -3,12 +3,12 @@
 ### 4.80.0-beta.1 (Unreleased)
 
 #### Features Added
+* Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)
 
 #### Breaking Changes
 
 #### Bugs Fixed
 * Fixed an issue where the throughput control `throughputQueryMono` was always subscribed even when `targetThroughput` is used (not `targetThroughputThreshold`), causing unnecessary `throughputSettings/read` permission requirement for AAD principals. - See [PR 48800](https://github.com/Azure/azure-sdk-for-java/pull/48800)
-* Fixed an issue where change feed with `startFrom` point-in-time returned `400` on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability.
 * Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
 
 #### Other Changes

--- a/sdk/cosmos/fabric-cosmos-spark-auth_3/pom.xml
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_3/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>com.azure.cosmos.spark</groupId>
       <artifactId>azure-cosmos-spark_3-5_2-12</artifactId>
-      <version>4.47.0-beta.1</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;current} -->
+      <version>4.47.0</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;current} -->
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -183,7 +183,7 @@
                 <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310:[2.18.6]</include> <!-- {x-include-update;com.fasterxml.jackson.datatype:jackson-datatype-jsr310;external_dependency} -->
                 <include>com.fasterxml.jackson.core:jackson-databind:[2.18.6]</include> <!-- {x-include-update;com.fasterxml.jackson.core:jackson-databind;external_dependency} -->
                 <include>com.fasterxml.jackson.module:jackson-module-scala_2.12:[2.18.6]</include> <!-- {x-include-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
-                <include>com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:[4.47.0-beta.1]</include> <!-- {x-include-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;current} -->
+                <include>com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12:[4.47.0]</include> <!-- {x-include-update;com.azure.cosmos.spark:azure-cosmos-spark_3-5_2-12;current} -->
                 <include>com.microsoft.azure.synapse:synapseutils_2.12:[1.5.4]</include> <!-- {x-include-update;cosmos_com.microsoft.azure.synapse:synapseutils_2.12;external_dependency} -->
               </includes>
             </bannedDependencies>


### PR DESCRIPTION
## Release azure-cosmos-spark 4.47.0

Version bumps and CHANGELOG updates for:
- azure-cosmos-spark_3-3_2-12 4.47.0
- azure-cosmos-spark_3-4_2-12 4.47.0
- azure-cosmos-spark_3-5_2-12 4.47.0
- azure-cosmos-spark_3-5_2-13 4.47.0
- azure-cosmos-spark_4-0_2-13 4.47.0

### Features Added
- Added support for change feed with `startFrom` point-in-time on merged partitions by enabling the `CHANGE_FEED_WITH_START_TIME_POST_MERGE` SDK capability in the azure-cosmos SDK. - See [PR 48752](https://github.com/Azure/azure-sdk-for-java/pull/48752)

### Bugs Fixed
- Fixed an issue where `readContainerThroughput` was always called even when `targetThroughput` is explicitly configured, requiring unnecessary `throughputSettings/read` permission for AAD principals. - See [PR 48800](https://github.com/Azure/azure-sdk-for-java/pull/48800)

### Other Changes
- Updated azure-cosmos CHANGELOG to reclassify the startFrom fix as a feature with PR link
- Updated README compatibility tables with 4.47.0 rows
- Updated quick-start.md connector links to 4.47.0
- Propagated version to dependent pom files (account-data-resolver-sample, fabric-cosmos-spark-auth_3)
