### PR TITLE
Fix Netty ByteBuf leak in GatewayServerErrorInjector fault injection delay paths

### DIFF
--- a/sdk/cosmos/azure-cosmos-test/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-test/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
+* Fixed Netty ByteBuf leak in `GatewayServerErrorInjector` fault injection delay paths under HTTP/2. - See [PR 48880](https://github.com/Azure/azure-sdk-for-java/pull/48880)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/faultinjection/GatewayServerErrorInjector.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/faultinjection/GatewayServerErrorInjector.java
@@ -21,6 +21,7 @@ import com.azure.cosmos.implementation.routing.PartitionKeyInternal;
 import com.azure.cosmos.implementation.routing.PartitionKeyInternalHelper;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.handler.timeout.ReadTimeoutException;
+import io.netty.util.ReferenceCountUtil;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
@@ -174,11 +175,18 @@ public class GatewayServerErrorInjector {
                 if (this.injectGatewayServerResponseDelayAfterProcessing(faultInjectionRequestArgs, delayToBeInjected)) {
                     if (delayToBeInjected.v.toMillis() >= effectiveResponseTimeout.toMillis()) {
                         return originalResponseMono
+                            .doOnNext(GatewayServerErrorInjector::releaseResponseBody)
                             .delayElement(delayToBeInjected.v)
                             .then(Mono.error(new ReadTimeoutException()));
                     } else {
+                        // In the happy path the response flows downstream after the delay
+                        // and the caller drains the body normally. However, if the downstream
+                        // cancels during delayElement (e.g., an outer timeout fires),
+                        // delayElement silently drops the buffered HttpResponse. doOnDiscard
+                        // catches that discard and releases the body ByteBuf to prevent leaks.
                         return originalResponseMono
-                            .delayElement(delayToBeInjected.v);
+                            .delayElement(delayToBeInjected.v)
+                            .doOnDiscard(HttpResponse.class, GatewayServerErrorInjector::releaseResponseBody);
                     }
                 }
 
@@ -242,5 +250,18 @@ public class GatewayServerErrorInjector {
             requestUri,
             serviceRequest,
             partitionKeyRangeIds);
+    }
+
+    /**
+     * Drains and releases the response body to prevent Netty ByteBuf leaks.
+     * Called when a fault-injected path discards the real HTTP response (e.g.,
+     * simulating a timeout after the response has already arrived).
+     */
+    private static void releaseResponseBody(HttpResponse httpResponse) {
+        httpResponse.body()
+            .subscribe(
+                buf -> ReferenceCountUtil.safeRelease(buf),
+                ex -> { },
+                () -> { });
     }
 }


### PR DESCRIPTION
## Description

Fixes Netty ByteBuf leaks in `GatewayServerErrorInjector` when fault injection simulates response delays under HTTP/2.

### Root Cause

When fault injection simulates a response delay via `delayElement`, the real HTTP response body was discarded without draining its ByteBuf content. Under HTTP/1.1, connection closure masks this because all ByteBufs are released when the channel closes. Under HTTP/2, the parent connection stays pooled and the undrained ByteBufs accumulate on the parent channel's allocator — causing growing memory leaks.

### Fix

Two leak paths in `injectGatewayServerResponseError`:

| Path | Scenario | Fix |
|------|----------|-----|
| `delay >= timeout` | Response arrives but is discarded by `.then(Mono.error(ReadTimeoutException))` — body is never consumed | `doOnNext` drains and releases the body **before** `delayElement` buffers the response |
| `delay < timeout` | In the happy path the response flows downstream after the delay and the caller drains the body normally. However, if the downstream **cancels during** `delayElement` (e.g., an outer timeout fires), `delayElement` silently drops the buffered HttpResponse without emitting it | `doOnDiscard(HttpResponse.class, ...)` catches that discard and releases the body ByteBuf to prevent leaks |

Both paths call `releaseResponseBody()` which subscribes to the body flux and `ReferenceCountUtil.safeRelease()`s each ByteBuf — consistent with existing patterns in `ReactorNettyClient.java`.

### Testing

- Needs validation with `PerPartitionCircuitBreakerE2ETests` (thin-client + HTTP/2 path)
- Prior run with similar fix reduced leaks from 72 to 2 (remaining were pre-existing NIO/SslHandler leaks)

### Related

- Prior investigation: #47290 (closed — different approach, identified handler placement issue but didn't fix the application-layer drain)
