### PR TITLE
[cosmos] Fix ClientTelemetry static-init NPE when IMDS access is disabled

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
 * Fixed an issue where `CustomItemSerializer` was incorrectly applied to internal SDK query pipeline structures (e.g., `OrderByRowResult`, `Document`), causing deserialization failures in ORDER BY, GROUP BY, aggregate, DISTINCT, and hybrid search queries. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
 * Fixed an issue where `SqlParameter` ignored the configured `CustomItemSerializer`, always using the internal default serializer instead. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
-* Fixed `NullPointerException` during `ClientTelemetry` static initialization when IMDS access is disabled (`COSMOS_DISABLE_IMDS_ACCESS=true`), which made every `CosmosAsyncClient` build fail with `NoClassDefFoundError`. - See [PR ####](https://github.com/Azure/azure-sdk-for-java/pull/####)
+* Fixed `NullPointerException` during `ClientTelemetry` static initialization when IMDS access is disabled (`COSMOS_DISABLE_IMDS_ACCESS=true`), which made every `CosmosAsyncClient` build fail with `NoClassDefFoundError`. - See [PR 48887](https://github.com/Azure/azure-sdk-for-java/pull/48887)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
 * Fixed an issue where `CustomItemSerializer` was incorrectly applied to internal SDK query pipeline structures (e.g., `OrderByRowResult`, `Document`), causing deserialization failures in ORDER BY, GROUP BY, aggregate, DISTINCT, and hybrid search queries. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
 * Fixed an issue where `SqlParameter` ignored the configured `CustomItemSerializer`, always using the internal default serializer instead. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
-* Fixed `NullPointerException` during `ClientTelemetry` static initialization when IMDS access is disabled (`COSMOS_DISABLE_IMDS_ACCESS=true`), which made every `CosmosAsyncClient` build fail with `NoClassDefFoundError`. Caused by `METADATA_NOT_AVAILABLE` being declared after `CACHED_METADATA`.
+* Fixed `NullPointerException` during `ClientTelemetry` static initialization when IMDS access is disabled (`COSMOS_DISABLE_IMDS_ACCESS=true`), which made every `CosmosAsyncClient` build fail with `NoClassDefFoundError`. - See [PR ####](https://github.com/Azure/azure-sdk-for-java/pull/####)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
 * Fixed an issue where `CustomItemSerializer` was incorrectly applied to internal SDK query pipeline structures (e.g., `OrderByRowResult`, `Document`), causing deserialization failures in ORDER BY, GROUP BY, aggregate, DISTINCT, and hybrid search queries. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
 * Fixed an issue where `SqlParameter` ignored the configured `CustomItemSerializer`, always using the internal default serializer instead. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
+* Fixed `NullPointerException` during `ClientTelemetry` static initialization when IMDS access is disabled (`COSMOS_DISABLE_IMDS_ACCESS=true`), which made every `CosmosAsyncClient` build fail with `NoClassDefFoundError`. Caused by `METADATA_NOT_AVAILABLE` being declared after `CACHED_METADATA`.
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/clienttelemetry/ClientTelemetry.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/clienttelemetry/ClientTelemetry.java
@@ -47,14 +47,17 @@ public class ClientTelemetry {
     private static final Logger logger = LoggerFactory.getLogger(ClientTelemetry.class);
     private static final String USER_AGENT = Utils.getUserAgent();
 
+    // Sentinel for "not on Azure VM" or "IMDS unreachable".
+    // Must be declared before CACHED_METADATA so that fetchAzureVmMetadata()
+    // never reads a null value during class initialization (e.g. when IMDS
+    // access is disabled via COSMOS_DISABLE_IMDS_ACCESS).
+    private static final AzureVMMetadata METADATA_NOT_AVAILABLE = new AzureVMMetadata();
+
     // Cached IMDS metadata Mono. Reactor's cache() ensures:
     // - The fetch executes at most once
     // - All concurrent subscribers share the single result
     // - The HTTP client is created and disposed within the fetch
     private static final Mono<AzureVMMetadata> CACHED_METADATA = fetchAzureVmMetadata().cache();
-
-    // Sentinel for "not on Azure VM" or "IMDS unreachable"
-    private static final AzureVMMetadata METADATA_NOT_AVAILABLE = new AzureVMMetadata();
 
     // IMDS Constants
     private static final String IMDS_AZURE_VM_METADATA = "http://169.254.169.254:80/metadata/instance?api-version=2020-06-01";


### PR DESCRIPTION
## Description

Fixes a `NullPointerException` thrown during `ClientTelemetry.<clinit>` when IMDS access is disabled via `COSMOS_DISABLE_IMDS_ACCESS=true` (env var) or `-DCOSMOS.DISABLE_IMDS_ACCESS=true` (system property). The error makes `ClientTelemetry` permanently un-loadable for the lifetime of the JVM, so every subsequent `CosmosClientBuilder.buildAsyncClient()` fails with `NoClassDefFoundError`.

First shipped in **4.79.0** when `CACHED_METADATA` was introduced as a statically-initialized field; 4.78.0 is unaffected.

### Root cause

In `ClientTelemetry` the fields are declared in this order:

```java
private static final Mono<AzureVMMetadata> CACHED_METADATA = fetchAzureVmMetadata().cache();  // (1)
private static final AzureVMMetadata METADATA_NOT_AVAILABLE = new AzureVMMetadata();          // (2)
```

`<clinit>` evaluates them top-down. At (1), `fetchAzureVmMetadata()` runs and, when IMDS is disabled, eagerly returns:

```java
return Mono.just(METADATA_NOT_AVAILABLE);
```

But `METADATA_NOT_AVAILABLE` hasn't been assigned yet, so `Mono.just(null)` throws NPE via `Objects.requireNonNull`. This escapes as `ExceptionInInitializerError`, and every later reference to the class surfaces as `NoClassDefFoundError: Could not initialize class ... ClientTelemetry`.

### Fix

Declare `METADATA_NOT_AVAILABLE` before `CACHED_METADATA` so the sentinel exists before `fetchAzureVmMetadata()` can read it. A short comment documents the ordering invariant.

Diff is 2 files, +7/-3 , reordering only, no behavioral change.

### Why it matters

`COSMOS_DISABLE_IMDS_ACCESS` is the documented opt-out for non-Azure environments (local dev, CI, other clouds), where IMDS at `169.254.169.254` is not routable and the blind probe costs a multi-second timeout per cold start. Users who set it today on 4.79.x cannot build a Cosmos client at all.

### Reproduction

```java
System.setProperty("COSMOS.DISABLE_IMDS_ACCESS", "true");

new CosmosClientBuilder()
    .endpoint("https://localhost:8081")
    .key("dGVzdA==")
    .buildAsyncClient();
```

**On 4.79.0 / 4.79.1 (before this PR):**
```
java.lang.NoClassDefFoundError: Could not initialize class
  com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry
Caused by: java.lang.ExceptionInInitializerError
Caused by: java.lang.NullPointerException: value
    at java.util.Objects.requireNonNull(Objects.java:259)
    at reactor.core.publisher.MonoJust.<init>(MonoJust.java:35)
    at reactor.core.publisher.Mono.just(Mono.java:754)
    at com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry.fetchAzureVmMetadata(ClientTelemetry.java:178)
    at com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry.<clinit>(ClientTelemetry.java:54)
```

**With this PR:** the client builds normally; `fetchAzureVmMetadata()` returns a `Mono.just(METADATA_NOT_AVAILABLE)` that resolves to the sentinel on subscription, exactly as intended.

### Note for reviewers (out of scope)

The same declaration-order pattern affects `IMDS_AZURE_VM_METADATA` and the three `IMDS_DEFAULT_*` timeout fields, they are also read inside `fetchAzureVmMetadata()` and declared after `CACHED_METADATA`. Today that path only runs when IMDS is *enabled* and happens to tolerate `null`/`0` values at config build time, so it doesn't NPE; but the invariant is fragile. I kept this PR strictly minimal (single-field move + comment). Happy to move those fields too, or replace both declarations with a `static { … }` block, in a follow-up if you prefer.

## All SDK Contribution checklist

- [x] The pull request does not introduce [breaking changes]
- [x] CHANGELOG is updated for new features, bug fixes or other significant changes.
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).

### General Guidelines and Best Practices

- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.

### Testing Guidelines

- [ ] Pull request includes test coverage for the included changes.

  Rationale: the bug lives in class-static-initializer ordering. A test that reliably exercises it would need to fork a JVM with `COSMOS.DISABLE_IMDS_ACCESS=true` *before* `ClientTelemetry` is first referenced, then observe a successful `buildAsyncClient()`. Happy to add such a harness (e.g. a `@TempJvmProperty` + separate JUnit test process) if maintainers think it's worth the complexity for a one-line ordering fix, otherwise the existing integration tests running in an environment where `COSMOS.DISABLE_IMDS_ACCESS=true` is set will cover it implicitly.