### PR TITLE
[cosmos] Fix ClientTelemetry static-init NPE when IMDS access is disabled

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ClientConfigDiagnosticsTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ClientConfigDiagnosticsTest.java
@@ -11,6 +11,7 @@ import com.azure.cosmos.DirectConnectionConfig;
 import com.azure.cosmos.CosmosRegionSwitchHint;
 import com.azure.cosmos.SessionRetryOptions;
 import com.azure.cosmos.SessionRetryOptionsBuilder;
+import com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry;
 import com.azure.cosmos.implementation.perPartitionCircuitBreaker.PartitionLevelCircuitBreakerConfig;
 import com.azure.cosmos.implementation.directconnectivity.RntbdTransportClient;
 import com.azure.cosmos.implementation.guava25.collect.ImmutableList;
@@ -40,6 +41,8 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClientConfigDiagnosticsTest {
+    private static final String vmInstanceMachineId = ClientTelemetry.getMachineId(null);
+
     private final ObjectMapper objectMapper = new ObjectMapper();
     private static final ImplementationBridgeHelpers.CosmosContainerIdentityHelper.CosmosContainerIdentityAccessor containerIdentityAccessor = ImplementationBridgeHelpers
         .CosmosContainerIdentityHelper
@@ -165,7 +168,7 @@ public class ClientConfigDiagnosticsTest {
         ObjectNode objectNode = (ObjectNode) objectMapper.readTree(jsonWriter.toString());
 
         assertThat(objectNode.get("id").asInt()).isEqualTo(1);
-        assertThat(objectNode.get("machineId").asText()).isEqualTo(machineId);
+        assertThat(objectNode.get("machineId").asText()).isEqualTo(Strings.isNullOrEmpty(vmInstanceMachineId) ? machineId : vmInstanceMachineId);
         assertThat(objectNode.get("numberOfClients").asInt()).isEqualTo(2);
         assertThat(objectNode.get("consistencyCfg").asText()).isEqualTo("(consistency: null, readConsistencyStrategy: null,  mm: false, prgns: [null])");
         assertThat(objectNode.get("connCfg").get("rntbd").asText()).isEqualTo("null");
@@ -198,7 +201,7 @@ public class ClientConfigDiagnosticsTest {
         ObjectNode objectNode = (ObjectNode) objectMapper.readTree(jsonWriter.toString());
 
         assertThat(objectNode.get("id").asInt()).isEqualTo(1);
-        assertThat(objectNode.get("machineId").asText()).isEqualTo(machineId);
+        assertThat(objectNode.get("machineId").asText()).isEqualTo(Strings.isNullOrEmpty(vmInstanceMachineId) ? machineId : vmInstanceMachineId);
         assertThat(objectNode.get("numberOfClients").asInt()).isEqualTo(2);
         assertThat(objectNode.get("consistencyCfg").asText()).isEqualTo("(consistency: null, readConsistencyStrategy: null,  mm: false, prgns: [null])");
         assertThat(objectNode.get("connCfg").get("rntbd").asText()).isEqualTo("(cto:PT5S, nrto:PT5S, icto:PT0S, ieto:PT1H, mcpe:130, mrpc:30, cer:true)");
@@ -235,7 +238,7 @@ public class ClientConfigDiagnosticsTest {
         ObjectNode objectNode = (ObjectNode) objectMapper.readTree(jsonWriter.toString());
 
         assertThat(objectNode.get("id").asInt()).isEqualTo(1);
-        assertThat(objectNode.get("machineId").asText()).isEqualTo(machineId);
+        assertThat(objectNode.get("machineId").asText()).isEqualTo(Strings.isNullOrEmpty(vmInstanceMachineId) ? machineId : vmInstanceMachineId);
         assertThat(objectNode.get("numberOfClients").asInt()).isEqualTo(2);
         assertThat(objectNode.get("consistencyCfg").asText()).isEqualTo("(consistency: null, readConsistencyStrategy: null,  mm: false, prgns: [null])");
         assertThat(objectNode.get("connCfg").get("rntbd").asText()).isEqualTo("null");
@@ -309,7 +312,7 @@ public class ClientConfigDiagnosticsTest {
         ObjectNode objectNode = (ObjectNode) objectMapper.readTree(jsonWriter.toString());
 
         assertThat(objectNode.get("id").asInt()).isEqualTo(1);
-        assertThat(objectNode.get("machineId").asText()).isEqualTo(machineId);
+        assertThat(objectNode.get("machineId").asText()).isEqualTo(Strings.isNullOrEmpty(vmInstanceMachineId) ? machineId : vmInstanceMachineId);
         assertThat(objectNode.get("numberOfClients").asInt()).isEqualTo(2);
         assertThat(objectNode.get("consistencyCfg").asText()).isEqualTo("(consistency: null, readConsistencyStrategy: null,  mm: false, prgns: [westus1,westus2])");
         assertThat(objectNode.get("connCfg").get("rntbd").asText()).isEqualTo("null");
@@ -362,7 +365,7 @@ public class ClientConfigDiagnosticsTest {
         ObjectNode objectNode = (ObjectNode) objectMapper.readTree(jsonWriter.toString());
 
         assertThat(objectNode.get("id").asInt()).isEqualTo(1);
-        assertThat(objectNode.get("machineId").asText()).isEqualTo(machineId);
+        assertThat(objectNode.get("machineId").asText()).isEqualTo(Strings.isNullOrEmpty(vmInstanceMachineId) ? machineId : vmInstanceMachineId);
         assertThat(objectNode.get("numberOfClients").asInt()).isEqualTo(2);
         assertThat(objectNode.get("consistencyCfg").asText()).isEqualTo("(consistency: null, readConsistencyStrategy: null,  mm: false, prgns: [null])");
         assertThat(objectNode.get("connCfg").get("rntbd").asText()).isEqualTo("null");

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ImplementationBridgeHelpersTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ImplementationBridgeHelpersTest.java
@@ -286,6 +286,106 @@ public class ImplementationBridgeHelpersTest {
     }
 
     /**
+     * Regression test for the ClientTelemetry static-init failure when IMDS access is disabled.
+     * A fresh JVM is required so the system property is in effect before any Cosmos classes load.
+     */
+    @Test(groups = { "unit" })
+    public void cosmosClientBuildShouldSucceedWhenImdsAccessIsDisabled() throws Exception {
+        String javaHome = System.getProperty("java.home");
+        String javaBin = javaHome + java.io.File.separator + "bin" + java.io.File.separator + "java";
+        String classpath = System.getProperty("java.class.path");
+
+        List<String> command = new ArrayList<>();
+        command.add(javaBin);
+        command.add("-DCOSMOS.DISABLE_IMDS_ACCESS=true");
+
+        try {
+            int majorVersion = Integer.parseInt(System.getProperty("java.specification.version").split("\\.")[0]);
+            if (majorVersion >= 9) {
+                command.add("--add-opens");
+                command.add("java.base/java.lang=ALL-UNNAMED");
+            }
+        } catch (NumberFormatException e) {
+            // JDK 8
+        }
+
+        command.add("-cp");
+        command.add(classpath);
+        command.add(ClientTelemetryImdsDisabledChildProcess.class.getName());
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+
+        StringBuilder output = new StringBuilder();
+        Thread gobbler = new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    output.append(line).append(System.lineSeparator());
+                    logger.info("[client-telemetry-imds-disabled] {}", line);
+                }
+            } catch (Exception e) {
+                // Process destroyed
+            }
+        });
+        gobbler.setDaemon(true);
+        gobbler.start();
+
+        boolean completed = process.waitFor(60, TimeUnit.SECONDS);
+        if (!completed) {
+            process.destroyForcibly();
+            gobbler.join(5000);
+            fail("ClientTelemetry IMDS-disabled regression check timed out after 60s. Output:\n" + output);
+        }
+
+        gobbler.join(5000);
+        int exitCode = process.exitValue();
+        assertThat(exitCode)
+            .as("Child JVM exited with non-zero code. Output:\n" + output)
+            .isEqualTo(0);
+    }
+
+    public static final class ClientTelemetryImdsDisabledChildProcess {
+        public static void main(String[] args) {
+            try {
+                com.azure.cosmos.CosmosAsyncClient client = new com.azure.cosmos.CosmosClientBuilder()
+                    .endpoint(TestConfigurations.HOST)
+                    .key(TestConfigurations.MASTER_KEY)
+                    .buildAsyncClient();
+
+                client.close();
+                System.out.println("Client built successfully with IMDS access disabled.");
+                System.exit(0);
+            } catch (Throwable throwable) {
+                if (containsClientTelemetryStaticInitFailure(throwable)) {
+                    throwable.printStackTrace(System.err);
+                    System.exit(1);
+                }
+
+                System.out.println("Client reached the expected network/auth path without a ClientTelemetry static-init failure.");
+                throwable.printStackTrace(System.out);
+                System.exit(0);
+            }
+        }
+
+        private static boolean containsClientTelemetryStaticInitFailure(Throwable throwable) {
+            Throwable current = throwable;
+            while (current != null) {
+                if (current instanceof ExceptionInInitializerError
+                    || current instanceof NoClassDefFoundError
+                    || (current.getMessage() != null && current.getMessage().contains("ClientTelemetry"))) {
+                    return true;
+                }
+
+                current = current.getCause();
+            }
+
+            return false;
+        }
+    }
+
+    /**
      * Verifies that every {@code *Helper} inner class in
      * {@link ImplementationBridgeHelpers} has a resolvable accessor — i.e., calling
      * {@code getXxxAccessor()} returns a non-null value in a clean JVM.

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
 * Fixed an issue where `CustomItemSerializer` was incorrectly applied to internal SDK query pipeline structures (e.g., `OrderByRowResult`, `Document`), causing deserialization failures in ORDER BY, GROUP BY, aggregate, DISTINCT, and hybrid search queries. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
 * Fixed an issue where `SqlParameter` ignored the configured `CustomItemSerializer`, always using the internal default serializer instead. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
+* Fixed a `ClientTelemetry` static initialization failure when IMDS access is disabled, preventing `NoClassDefFoundError` during Cosmos client creation in non-Azure environments. - See [PR 48887](https://github.com/Azure/azure-sdk-for-java/pull/48887)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Fixed JVM `<clinit>` deadlock when multiple threads concurrently trigger Cosmos SDK class loading for the first time. - See [PR 48689](https://github.com/Azure/azure-sdk-for-java/pull/48689)
 * Fixed an issue where `CustomItemSerializer` was incorrectly applied to internal SDK query pipeline structures (e.g., `OrderByRowResult`, `Document`), causing deserialization failures in ORDER BY, GROUP BY, aggregate, DISTINCT, and hybrid search queries. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
 * Fixed an issue where `SqlParameter` ignored the configured `CustomItemSerializer`, always using the internal default serializer instead. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
-* Fixed a `ClientTelemetry` static initialization failure when IMDS access is disabled, preventing `NoClassDefFoundError` during Cosmos client creation in non-Azure environments. - See [PR 48887](https://github.com/Azure/azure-sdk-for-java/pull/48887)
+* Fixed a `ClientTelemetry` static initialization failure when IMDS access is disabled, preventing `NoClassDefFoundError` during Cosmos client creation in non-Azure environments. - See [PR 48888](https://github.com/Azure/azure-sdk-for-java/pull/48888)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/clienttelemetry/ClientTelemetry.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/clienttelemetry/ClientTelemetry.java
@@ -51,17 +51,29 @@ public class ClientTelemetry {
     // - The fetch executes at most once
     // - All concurrent subscribers share the single result
     // - The HTTP client is created and disposed within the fetch
-    private static final Mono<AzureVMMetadata> CACHED_METADATA = fetchAzureVmMetadata().cache();
+    private static final Mono<AzureVMMetadata> CACHED_METADATA;
 
     // Sentinel for "not on Azure VM" or "IMDS unreachable"
-    private static final AzureVMMetadata METADATA_NOT_AVAILABLE = new AzureVMMetadata();
+    private static final AzureVMMetadata METADATA_NOT_AVAILABLE;
 
     // IMDS Constants
-    private static final String IMDS_AZURE_VM_METADATA = "http://169.254.169.254:80/metadata/instance?api-version=2020-06-01";
-    private static final Duration IMDS_DEFAULT_NETWORK_REQUEST_TIMEOUT = Duration.ofSeconds(5);
-    private static final Duration IMDS_DEFAULT_IDLE_CONNECTION_TIMEOUT = Duration.ofSeconds(60);
-    private static final Duration IMDS_DEFAULT_CONNECTION_ACQUIRE_TIMEOUT = Duration.ofSeconds(5);
-    private static final int IMDS_DEFAULT_MAX_CONNECTION_POOL_SIZE = 5;
+    private static final String IMDS_AZURE_VM_METADATA;
+    private static final Duration IMDS_DEFAULT_NETWORK_REQUEST_TIMEOUT;
+    private static final Duration IMDS_DEFAULT_IDLE_CONNECTION_TIMEOUT;
+    private static final Duration IMDS_DEFAULT_CONNECTION_ACQUIRE_TIMEOUT;
+    private static final int IMDS_DEFAULT_MAX_CONNECTION_POOL_SIZE;
+
+    static {
+        // Initialize the sentinel and IMDS defaults before creating the cached Mono,
+        // because fetchAzureVmMetadata() reads them during class initialization.
+        METADATA_NOT_AVAILABLE = new AzureVMMetadata();
+        IMDS_AZURE_VM_METADATA = "http://169.254.169.254:80/metadata/instance?api-version=2020-06-01";
+        IMDS_DEFAULT_NETWORK_REQUEST_TIMEOUT = Duration.ofSeconds(5);
+        IMDS_DEFAULT_IDLE_CONNECTION_TIMEOUT = Duration.ofSeconds(60);
+        IMDS_DEFAULT_CONNECTION_ACQUIRE_TIMEOUT = Duration.ofSeconds(5);
+        IMDS_DEFAULT_MAX_CONNECTION_POOL_SIZE = 5;
+        CACHED_METADATA = fetchAzureVmMetadata().cache();
+    }
 
     // Per-instance fields
     private final ClientTelemetryInfo clientTelemetryInfo;


### PR DESCRIPTION
## Description

Fixes a `NullPointerException` thrown during `ClientTelemetry.<clinit>` when IMDS access is disabled via `COSMOS_DISABLE_IMDS_ACCESS=true` (env var) or `-DCOSMOS.DISABLE_IMDS_ACCESS=true` (system property). The error makes `ClientTelemetry` permanently un-loadable for the lifetime of the JVM, so every subsequent `CosmosClientBuilder.buildAsyncClient()` fails with `NoClassDefFoundError`.

First shipped in **4.79.0** when `CACHED_METADATA` was introduced as a statically-initialized field; 4.78.0 is unaffected.

### Root cause

In `ClientTelemetry` the fields are declared in this order:

```java
private static final Mono<AzureVMMetadata> CACHED_METADATA = fetchAzureVmMetadata().cache();  // (1)
private static final AzureVMMetadata METADATA_NOT_AVAILABLE = new AzureVMMetadata();          // (2)
```

`<clinit>` evaluates them top-down. At (1), `fetchAzureVmMetadata()` runs and, when IMDS is disabled, eagerly returns:

```java
return Mono.just(METADATA_NOT_AVAILABLE);
```

But `METADATA_NOT_AVAILABLE` hasn't been assigned yet, so `Mono.just(null)` throws NPE via `Objects.requireNonNull`. This escapes as `ExceptionInInitializerError`, and every later reference to the class surfaces as `NoClassDefFoundError: Could not initialize class ... ClientTelemetry`.

### Fix

Declare `METADATA_NOT_AVAILABLE` before `CACHED_METADATA` so the sentinel exists before `fetchAzureVmMetadata()` can read it. A short comment documents the ordering invariant.

Diff is 2 files, +7/-3 , reordering only, no behavioral change.

### Why it matters

`COSMOS_DISABLE_IMDS_ACCESS` is the documented opt-out for non-Azure environments (local dev, CI, other clouds), where IMDS at `169.254.169.254` is not routable and the blind probe costs a multi-second timeout per cold start. Users who set it today on 4.79.x cannot build a Cosmos client at all.

### Reproduction

```java
System.setProperty("COSMOS.DISABLE_IMDS_ACCESS", "true");

new CosmosClientBuilder()
    .endpoint("https://localhost:8081")
    .key("dGVzdA==")
    .buildAsyncClient();
```

**On 4.79.0 / 4.79.1 (before this PR):**
```
java.lang.NoClassDefFoundError: Could not initialize class
  com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry
Caused by: java.lang.ExceptionInInitializerError
Caused by: java.lang.NullPointerException: value
    at java.util.Objects.requireNonNull(Objects.java:259)
    at reactor.core.publisher.MonoJust.<init>(MonoJust.java:35)
    at reactor.core.publisher.Mono.just(Mono.java:754)
    at com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry.fetchAzureVmMetadata(ClientTelemetry.java:178)
    at com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry.<clinit>(ClientTelemetry.java:54)
```

**With this PR:** the client builds normally; `fetchAzureVmMetadata()` returns a `Mono.just(METADATA_NOT_AVAILABLE)` that resolves to the sentinel on subscription, exactly as intended.

### Note for reviewers (out of scope)

The same declaration-order pattern affects `IMDS_AZURE_VM_METADATA` and the three `IMDS_DEFAULT_*` timeout fields, they are also read inside `fetchAzureVmMetadata()` and declared after `CACHED_METADATA`. Today that path only runs when IMDS is *enabled* and happens to tolerate `null`/`0` values at config build time, so it doesn't NPE; but the invariant is fragile. I kept this PR strictly minimal (single-field move + comment). Happy to move those fields too, or replace both declarations with a `static { … }` block, in a follow-up if you prefer.

## All SDK Contribution checklist

- [x] The pull request does not introduce [breaking changes]
- [x] CHANGELOG is updated for new features, bug fixes or other significant changes.
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).

### General Guidelines and Best Practices

- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.

### Testing Guidelines

- [x] Pull request includes test coverage for the included changes.

  Rationale: the bug lives in class-static-initializer ordering. A test that reliably exercises it would need to fork a JVM with `COSMOS.DISABLE_IMDS_ACCESS=true` *before* `ClientTelemetry` is first referenced, then observe a successful `buildAsyncClient()`. Happy to add such a harness (e.g. a `@TempJvmProperty` + separate JUnit test process) if maintainers think it's worth the complexity for a one-line ordering fix, otherwise the existing integration tests running in an environment where `COSMOS.DISABLE_IMDS_ACCESS=true` is set will cover it implicitly.