### PR TITLE
Add exception handler on HTTP/2 parent channel to suppress WARN logs

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/pom.xml
+++ b/sdk/cosmos/azure-cosmos-tests/pom.xml
@@ -252,7 +252,7 @@ Licensed under the MIT License.
               <value>com.azure.cosmos.CosmosNettyLeakDetectorFactory</value>
             </property>
           </properties>
-          <skipTests>false</skipTests>
+          <skipTests>true</skipTests>
         </configuration>
       </plugin>
 
@@ -934,9 +934,3 @@ Licensed under the MIT License.
     </profile>
   </profiles>
 </project>
-
-
-
-
-
-

--- a/sdk/cosmos/azure-cosmos-tests/pom.xml
+++ b/sdk/cosmos/azure-cosmos-tests/pom.xml
@@ -252,7 +252,7 @@ Licensed under the MIT License.
               <value>com.azure.cosmos.CosmosNettyLeakDetectorFactory</value>
             </property>
           </properties>
-          <skipTests>true</skipTests>
+          <skipTests>false</skipTests>
         </configuration>
       </plugin>
 
@@ -934,3 +934,9 @@ Licensed under the MIT License.
     </profile>
   </profiles>
 </project>
+
+
+
+
+
+

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
@@ -189,7 +189,7 @@ public class Http2ParentChannelExceptionHandlerTest {
     @Test(groups = "unit")
     public void withHandler_codecAbsent_fallsBackToWarnPath() {
         EmbeddedChannel channel = new EmbeddedChannel(
-            new Http2ParentChannelExceptionHandler());
+            Http2ParentChannelExceptionHandler.INSTANCE);
 
         assertThat(channel.pipeline().get(Http2FrameCodec.class)).isNull();
         assertThat(channel.isActive()).isTrue();
@@ -238,7 +238,7 @@ public class Http2ParentChannelExceptionHandlerTest {
 
         if (withExceptionHandler) {
             return new EmbeddedChannel(codec, multiplexHandler,
-                new Http2ParentChannelExceptionHandler());
+                Http2ParentChannelExceptionHandler.INSTANCE);
         } else {
             return new EmbeddedChannel(codec, multiplexHandler);
         }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
@@ -189,7 +189,7 @@ public class Http2ParentChannelExceptionHandlerTest {
     @Test(groups = "unit")
     public void withHandler_codecAbsent_fallsBackToWarnPath() {
         EmbeddedChannel channel = new EmbeddedChannel(
-            Http2ParentChannelExceptionHandler.getOrCreateInstance());
+            new Http2ParentChannelExceptionHandler(""));
 
         assertThat(channel.pipeline().get(Http2FrameCodec.class)).isNull();
         assertThat(channel.isActive()).isTrue();
@@ -238,7 +238,7 @@ public class Http2ParentChannelExceptionHandlerTest {
 
         if (withExceptionHandler) {
             return new EmbeddedChannel(codec, multiplexHandler,
-                Http2ParentChannelExceptionHandler.getOrCreateInstance());
+                new Http2ParentChannelExceptionHandler(""));
         } else {
             return new EmbeddedChannel(codec, multiplexHandler);
         }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
@@ -130,6 +130,56 @@ public class Http2ParentChannelExceptionHandlerTest {
     }
 
     /**
+     * With handler — exception on a connection with active streams is
+     * consumed (does not reach TailContext). The handler logs at WARN
+     * instead of DEBUG because in-flight requests may be affected.
+     */
+    @Test(groups = "unit")
+    public void withHandler_activeStreams_consumedAtWarn() throws Exception {
+        EmbeddedChannel channel = createH2ParentChannel(true);
+
+        Http2FrameCodec codec = channel.pipeline().get(Http2FrameCodec.class);
+        assertThat(codec).isNotNull();
+
+        // Create an active stream (client-initiated, odd stream ID)
+        codec.connection().local().createStream(1, false);
+        assertThat(codec.connection().numActiveStreams()).isEqualTo(1);
+        assertThat(channel.isActive()).isTrue();
+
+        channel.pipeline().fireExceptionCaught(
+            new IOException("Connection reset by peer"));
+
+        // Exception consumed — does NOT reach tail, even with active streams
+        channel.checkException();
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Handler does not close the channel even when active streams exist —
+     * connection lifecycle is managed by reactor-netty's pool eviction.
+     */
+    @Test(groups = "unit")
+    public void withHandler_activeStreams_channelNotClosed() throws Exception {
+        EmbeddedChannel channel = createH2ParentChannel(true);
+
+        Http2FrameCodec codec = channel.pipeline().get(Http2FrameCodec.class);
+        assertThat(codec).isNotNull();
+
+        codec.connection().local().createStream(1, false);
+        assertThat(codec.connection().numActiveStreams()).isEqualTo(1);
+        assertThat(channel.isActive()).isTrue();
+
+        channel.pipeline().fireExceptionCaught(
+            new IOException("Connection reset by peer"));
+
+        channel.checkException();
+        assertThat(channel.isOpen()).isTrue();
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
      * Creates an EmbeddedChannel matching the production HTTP/2 parent channel
      * pipeline (minus SslHandler): Http2FrameCodec → Http2MultiplexHandler →
      * Http2ParentChannelExceptionHandler.

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
@@ -189,7 +189,7 @@ public class Http2ParentChannelExceptionHandlerTest {
     @Test(groups = "unit")
     public void withHandler_codecAbsent_fallsBackToWarnPath() {
         EmbeddedChannel channel = new EmbeddedChannel(
-            Http2ParentChannelExceptionHandler.INSTANCE);
+            Http2ParentChannelExceptionHandler.getOrCreateInstance());
 
         assertThat(channel.pipeline().get(Http2FrameCodec.class)).isNull();
         assertThat(channel.isActive()).isTrue();
@@ -238,7 +238,7 @@ public class Http2ParentChannelExceptionHandlerTest {
 
         if (withExceptionHandler) {
             return new EmbeddedChannel(codec, multiplexHandler,
-                Http2ParentChannelExceptionHandler.INSTANCE);
+                Http2ParentChannelExceptionHandler.getOrCreateInstance());
         } else {
             return new EmbeddedChannel(codec, multiplexHandler);
         }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
@@ -189,7 +189,7 @@ public class Http2ParentChannelExceptionHandlerTest {
     @Test(groups = "unit")
     public void withHandler_codecAbsent_fallsBackToWarnPath() {
         EmbeddedChannel channel = new EmbeddedChannel(
-            new Http2ParentChannelExceptionHandler(""));
+            Http2ParentChannelExceptionHandler.INSTANCE);
 
         assertThat(channel.pipeline().get(Http2FrameCodec.class)).isNull();
         assertThat(channel.isActive()).isTrue();
@@ -238,7 +238,7 @@ public class Http2ParentChannelExceptionHandlerTest {
 
         if (withExceptionHandler) {
             return new EmbeddedChannel(codec, multiplexHandler,
-                new Http2ParentChannelExceptionHandler(""));
+                Http2ParentChannelExceptionHandler.INSTANCE);
         } else {
             return new EmbeddedChannel(codec, multiplexHandler);
         }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
@@ -181,10 +181,10 @@ public class Http2ParentChannelExceptionHandlerTest {
 
     /**
      * With handler — when Http2FrameCodec is absent from the pipeline,
-     * getActiveStreamCount() returns -1. Since -1 != 0 and the channel
-     * is active, the handler takes the safe WARN path. This covers the
-     * fallback behavior when the codec is unavailable (e.g., torn down
-     * during shutdown).
+     * getActiveStreamCount() returns null. Since the active stream count
+     * is unknown and the channel is active, the handler takes the safe
+     * WARN path. This covers the fallback behavior when the codec is
+     * unavailable (e.g., torn down during shutdown).
      */
     @Test(groups = "unit")
     public void withHandler_codecAbsent_fallsBackToWarnPath() {
@@ -200,6 +200,25 @@ public class Http2ParentChannelExceptionHandlerTest {
         // Exception consumed — does NOT reach tail
         channel.checkException();
         assertThat(channel.isOpen()).isTrue();
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Error types (e.g., OutOfMemoryError) are NOT consumed by the handler —
+     * they propagate to TailContext. This ensures JVM-level errors are never
+     * silently swallowed.
+     */
+    @Test(groups = "unit")
+    public void withHandler_errorNotConsumed_propagatesToTail() {
+        EmbeddedChannel channel = createH2ParentChannel(true);
+
+        channel.pipeline().fireExceptionCaught(
+            new OutOfMemoryError("test OOM"));
+
+        assertThatThrownBy(channel::checkException)
+            .isInstanceOf(OutOfMemoryError.class)
+            .hasMessageContaining("test OOM");
 
         channel.finishAndReleaseAll();
     }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
@@ -34,27 +34,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class Http2ParentChannelExceptionHandlerTest {
 
     /**
-     * Creates an EmbeddedChannel matching the production HTTP/2 parent channel
-     * pipeline (minus SslHandler): Http2FrameCodec → Http2MultiplexHandler →
-     * Http2ParentChannelExceptionHandler.
-     */
-    private static EmbeddedChannel createH2ParentChannel(boolean withExceptionHandler) {
-        Http2FrameCodec codec = Http2FrameCodecBuilder.forClient()
-            .autoAckSettingsFrame(true)
-            .build();
-
-        Http2MultiplexHandler multiplexHandler = new Http2MultiplexHandler(
-            new ChannelInboundHandlerAdapter());
-
-        if (withExceptionHandler) {
-            return new EmbeddedChannel(codec, multiplexHandler,
-                new Http2ParentChannelExceptionHandler());
-        } else {
-            return new EmbeddedChannel(codec, multiplexHandler);
-        }
-    }
-
-    /**
      * BEFORE fix — without the handler, exceptions reach the pipeline tail.
      * EmbeddedChannel's checkException() re-throws the unhandled exception,
      * proving it reached Netty's TailContext (which in production logs as WARN).
@@ -148,5 +127,26 @@ public class Http2ParentChannelExceptionHandlerTest {
         channel.checkException();
 
         channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Creates an EmbeddedChannel matching the production HTTP/2 parent channel
+     * pipeline (minus SslHandler): Http2FrameCodec → Http2MultiplexHandler →
+     * Http2ParentChannelExceptionHandler.
+     */
+    private static EmbeddedChannel createH2ParentChannel(boolean withExceptionHandler) {
+        Http2FrameCodec codec = Http2FrameCodecBuilder.forClient()
+            .autoAckSettingsFrame(true)
+            .build();
+
+        Http2MultiplexHandler multiplexHandler = new Http2MultiplexHandler(
+            new ChannelInboundHandlerAdapter());
+
+        if (withExceptionHandler) {
+            return new EmbeddedChannel(codec, multiplexHandler,
+                new Http2ParentChannelExceptionHandler());
+        } else {
+            return new EmbeddedChannel(codec, multiplexHandler);
+        }
     }
 }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.http;
+
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http2.Http2FrameCodec;
+import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
+import io.netty.handler.codec.http2.Http2MultiplexHandler;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies that {@link Http2ParentChannelExceptionHandler} uses connection
+ * state — active stream count and channel activity — to determine whether
+ * exceptions are logged at DEBUG (suppressed) or WARN (preserved).
+ * Exception type is NOT a filtering dimension.
+ *
+ * The EmbeddedChannel is configured to mirror the production HTTP/2 parent
+ * channel pipeline:
+ * <pre>
+ *   Http2FrameCodec → Http2MultiplexHandler → Http2ParentChannelExceptionHandler → TailContext
+ * </pre>
+ * (SslHandler is omitted because it requires an SSLContext and is not relevant
+ * to exception propagation behavior.)
+ *
+ * {@code checkException()} re-throws any exception that reached the pipeline tail.
+ */
+public class Http2ParentChannelExceptionHandlerTest {
+
+    /**
+     * Creates an EmbeddedChannel matching the production HTTP/2 parent channel
+     * pipeline (minus SslHandler): Http2FrameCodec → Http2MultiplexHandler →
+     * Http2ParentChannelExceptionHandler.
+     */
+    private static EmbeddedChannel createH2ParentChannel(boolean withExceptionHandler) {
+        Http2FrameCodec codec = Http2FrameCodecBuilder.forClient()
+            .autoAckSettingsFrame(true)
+            .build();
+
+        Http2MultiplexHandler multiplexHandler = new Http2MultiplexHandler(
+            new ChannelInboundHandlerAdapter());
+
+        if (withExceptionHandler) {
+            return new EmbeddedChannel(codec, multiplexHandler,
+                new Http2ParentChannelExceptionHandler());
+        } else {
+            return new EmbeddedChannel(codec, multiplexHandler);
+        }
+    }
+
+    /**
+     * BEFORE fix — without the handler, exceptions reach the pipeline tail.
+     * EmbeddedChannel's checkException() re-throws the unhandled exception,
+     * proving it reached Netty's TailContext (which in production logs as WARN).
+     */
+    @Test(groups = "unit")
+    public void withoutHandler_exceptionReachesTail() {
+        EmbeddedChannel channel = createH2ParentChannel(false);
+
+        channel.pipeline().fireExceptionCaught(
+            new IOException("Connection reset by peer"));
+
+        assertThatThrownBy(channel::checkException)
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("Connection reset by peer");
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * With handler — exception on idle connection (0 active streams) is
+     * consumed at DEBUG. The suppression is based on connection state
+     * (no active streams), not exception type.
+     *
+     * In production, channel.isActive() transitions to false during the
+     * RST handling cycle, satisfying the OR condition. In EmbeddedChannel
+     * we can only verify the activeStreams == 0 branch.
+     */
+    @Test(groups = "unit")
+    public void withHandler_zeroActiveStreams_consumedAtDebug() {
+        EmbeddedChannel channel = createH2ParentChannel(true);
+
+        Http2FrameCodec codec = channel.pipeline().get(Http2FrameCodec.class);
+        assertThat(codec).isNotNull();
+        assertThat(codec.connection().numActiveStreams()).isEqualTo(0);
+
+        channel.pipeline().fireExceptionCaught(
+            new IOException("recvAddress(..) failed with error(-104): Connection reset by peer"));
+
+        // Exception consumed — does NOT reach tail
+        channel.checkException();
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Handler does not close the channel — connection lifecycle is managed
+     * by reactor-netty's pool eviction, not by this handler.
+     */
+    @Test(groups = "unit")
+    public void withHandler_exceptionDoesNotCloseChannel() {
+        EmbeddedChannel channel = createH2ParentChannel(true);
+
+        assertThat(channel.isActive()).isTrue();
+
+        channel.pipeline().fireExceptionCaught(
+            new IOException("Connection reset by peer"));
+
+        channel.checkException();
+        assertThat(channel.isOpen()).isTrue();
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * RuntimeException on idle connection is also consumed — suppression
+     * is based on connection state, not exception type.
+     */
+    @Test(groups = "unit")
+    public void withHandler_runtimeException_zeroActiveStreams_consumed() {
+        EmbeddedChannel channel = createH2ParentChannel(true);
+
+        channel.pipeline().fireExceptionCaught(
+            new RuntimeException("Unexpected state error"));
+
+        channel.checkException();
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * NullPointerException on idle connection is also consumed — same
+     * connection-state-based suppression regardless of exception type.
+     */
+    @Test(groups = "unit")
+    public void withHandler_npe_zeroActiveStreams_consumed() {
+        EmbeddedChannel channel = createH2ParentChannel(true);
+
+        channel.pipeline().fireExceptionCaught(
+            new NullPointerException("handler bug"));
+
+        channel.checkException();
+
+        channel.finishAndReleaseAll();
+    }
+}

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandlerTest.java
@@ -180,6 +180,31 @@ public class Http2ParentChannelExceptionHandlerTest {
     }
 
     /**
+     * With handler — when Http2FrameCodec is absent from the pipeline,
+     * getActiveStreamCount() returns -1. Since -1 != 0 and the channel
+     * is active, the handler takes the safe WARN path. This covers the
+     * fallback behavior when the codec is unavailable (e.g., torn down
+     * during shutdown).
+     */
+    @Test(groups = "unit")
+    public void withHandler_codecAbsent_fallsBackToWarnPath() {
+        EmbeddedChannel channel = new EmbeddedChannel(
+            new Http2ParentChannelExceptionHandler());
+
+        assertThat(channel.pipeline().get(Http2FrameCodec.class)).isNull();
+        assertThat(channel.isActive()).isTrue();
+
+        channel.pipeline().fireExceptionCaught(
+            new IOException("Connection reset by peer"));
+
+        // Exception consumed — does NOT reach tail
+        channel.checkException();
+        assertThat(channel.isOpen()).isTrue();
+
+        channel.finishAndReleaseAll();
+    }
+
+    /**
      * Creates an EmbeddedChannel matching the production HTTP/2 parent channel
      * pipeline (minus SslHandler): Http2FrameCodec → Http2MultiplexHandler →
      * Http2ParentChannelExceptionHandler.

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fixed an issue where `CustomItemSerializer` was incorrectly applied to internal SDK query pipeline structures (e.g., `OrderByRowResult`, `Document`), causing deserialization failures in ORDER BY, GROUP BY, aggregate, DISTINCT, and hybrid search queries. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
 * Fixed an issue where `SqlParameter` ignored the configured `CustomItemSerializer`, always using the internal default serializer instead. - See [PR 48811](https://github.com/Azure/azure-sdk-for-java/pull/48811)
 * Fixed a `ClientTelemetry` static initialization failure when IMDS access is disabled, preventing `NoClassDefFoundError` during Cosmos client creation in non-Azure environments. - See [PR 48888](https://github.com/Azure/azure-sdk-for-java/pull/48888)
+* Fixed an issue where Netty could log "An exceptionCaught() event was fired, and it reached at the tail of the pipeline" on HTTP/2 connections when the server resets idle TCP connections by adding an exception handler on the HTTP/2 parent channel to handle these connection-level exceptions more appropriately. - See [PR 48890](https://github.com/Azure/azure-sdk-for-java/pull/48890)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/clienttelemetry/ClientTelemetry.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/clienttelemetry/ClientTelemetry.java
@@ -121,6 +121,21 @@ public class ClientTelemetry {
         return clientTelemetryConfig;
     }
 
+    // Non-blocking cache for machine ID. Populated by getMachineId() on first
+    // successful IMDS resolution (called during client init on non-event-loop threads).
+    // Read by components that cannot block (e.g., Netty channel handlers).
+    private static volatile String cachedMachineId;
+
+    /**
+     * Returns the cached machine ID without blocking.
+     * Returns empty string if the machine ID has not yet been resolved
+     * (i.e., getMachineId() has not been called yet from a non-event-loop thread).
+     */
+    public static String getCachedMachineId() {
+        String id = cachedMachineId;
+        return id != null ? id : "";
+    }
+
     /**
      * Blocking version of machine ID lookup. Used by Spark connector (CosmosClientCache.scala).
      * Delegates to getMachineId which waits up to 5s for IMDS metadata.
@@ -136,6 +151,7 @@ public class ClientTelemetry {
             AzureVMMetadata metadata = CACHED_METADATA.block(Duration.ofSeconds(5));
             if (metadata != null && metadata != METADATA_NOT_AVAILABLE && metadata.getVmId() != null) {
                 String machineId = VM_ID_PREFIX + metadata.getVmId();
+                cachedMachineId = machineId;
                 if (diagnosticsClientConfig != null) {
                     diagnosticsClientConfig.withMachineId(machineId);
                 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/clienttelemetry/ClientTelemetry.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/clienttelemetry/ClientTelemetry.java
@@ -133,7 +133,7 @@ public class ClientTelemetry {
      */
     public static String getCachedMachineId() {
         String id = cachedMachineId;
-        return id != null ? id : "";
+        return id != null ? id : "n/a";
     }
 
     /**

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
@@ -48,26 +48,10 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
 
     private static final Logger logger = LoggerFactory.getLogger(Http2ParentChannelExceptionHandler.class);
 
-    private static volatile Http2ParentChannelExceptionHandler instance;
-
     private final String clientVmId;
 
-    private Http2ParentChannelExceptionHandler(String clientVmId) {
+    Http2ParentChannelExceptionHandler(String clientVmId) {
         this.clientVmId = clientVmId;
-    }
-
-    // Must be called from a non-event-loop thread (e.g., during client setup)
-    // because ClientTelemetry.getMachineId() may block on first IMDS fetch.
-    static Http2ParentChannelExceptionHandler getOrCreateInstance() {
-        if (instance != null) {
-            return instance;
-        }
-        synchronized (Http2ParentChannelExceptionHandler.class) {
-            if (instance == null) {
-                instance = new Http2ParentChannelExceptionHandler(ClientTelemetry.getMachineId(null));
-            }
-        }
-        return instance;
     }
 
     @Override

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
@@ -69,9 +69,9 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
             // (e.g., TCP RST from LB idle timeout, post-close cleanup).
             if (logger.isDebugEnabled()) {
                 logger.debug(
-                    "Exception on HTTP/2 parent connection "
-                        + ctx.channel()
-                        + " [activeStreams=" + activeStreams
+                    "Exception on HTTP/2 parent connection"
+                        + " [channel=" + ctx.channel()
+                        + ", activeStreams=" + activeStreams
                         + ", channelActive=" + channelActive + "]",
                     cause);
             }
@@ -79,9 +79,9 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
             // Active streams on a live channel, or stream count unknown (null) —
             // exception may affect in-flight requests.
             logger.warn(
-                "Exception on HTTP/2 parent connection "
-                    + ctx.channel()
-                    + " [activeStreams=" + activeStreams
+                "Exception on HTTP/2 parent connection"
+                    + " [channel=" + ctx.channel()
+                    + ", activeStreams=" + activeStreams
                     + ", channelActive=" + channelActive + "]",
                 cause);
         }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
@@ -3,6 +3,7 @@
 
 package com.azure.cosmos.implementation.http;
 
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http2.Http2FrameCodec;
@@ -39,11 +40,17 @@ import org.slf4j.LoggerFactory;
  *
  * @see ReactorNettyClient#configureChannelPipelineHandlers()
  */
+@ChannelHandler.Sharable
 final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdapter {
+
+    static final Http2ParentChannelExceptionHandler INSTANCE = new Http2ParentChannelExceptionHandler();
 
     static final String HANDLER_NAME = "cosmosH2ParentExceptionHandler";
 
     private static final Logger logger = LoggerFactory.getLogger(Http2ParentChannelExceptionHandler.class);
+
+    private Http2ParentChannelExceptionHandler() {
+    }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
@@ -62,15 +69,17 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
             // (e.g., TCP RST from LB idle timeout, post-close cleanup).
             if (logger.isDebugEnabled()) {
                 logger.debug(
-                    "Exception on HTTP/2 parent connection [id:{}, activeStreams={}, channelActive={}]",
-                    ctx.channel().id().asShortText(), activeStreams, channelActive, cause);
+                    "Exception on HTTP/2 parent connection [id:{}, local:{}, remote:{}, activeStreams={}, channelActive={}]",
+                    ctx.channel().id().asShortText(), ctx.channel().localAddress(), ctx.channel().remoteAddress(),
+                    activeStreams, channelActive, cause);
             }
         } else {
             // Active streams on a live channel, or stream count unknown (null) —
             // exception may affect in-flight requests.
             logger.warn(
-                "Exception on HTTP/2 parent connection [id:{}, activeStreams={}, channelActive={}]",
-                ctx.channel().id().asShortText(), activeStreams, channelActive, cause);
+                "Exception on HTTP/2 parent connection [id:{}, local:{}, remote:{}, activeStreams={}, channelActive={}]",
+                ctx.channel().id().asShortText(), ctx.channel().localAddress(), ctx.channel().remoteAddress(),
+                activeStreams, channelActive, cause);
         }
     }
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
@@ -7,6 +7,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http2.Http2FrameCodec;
+import com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,13 +44,30 @@ import org.slf4j.LoggerFactory;
 @ChannelHandler.Sharable
 final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdapter {
 
-    static final Http2ParentChannelExceptionHandler INSTANCE = new Http2ParentChannelExceptionHandler();
-
     static final String HANDLER_NAME = "cosmosH2ParentExceptionHandler";
 
     private static final Logger logger = LoggerFactory.getLogger(Http2ParentChannelExceptionHandler.class);
 
-    private Http2ParentChannelExceptionHandler() {
+    private static volatile Http2ParentChannelExceptionHandler instance;
+
+    private final String clientVmId;
+
+    private Http2ParentChannelExceptionHandler(String clientVmId) {
+        this.clientVmId = clientVmId;
+    }
+
+    // Must be called from a non-event-loop thread (e.g., during client setup)
+    // because ClientTelemetry.getMachineId() may block on first IMDS fetch.
+    static Http2ParentChannelExceptionHandler getOrCreateInstance() {
+        if (instance != null) {
+            return instance;
+        }
+        synchronized (Http2ParentChannelExceptionHandler.class) {
+            if (instance == null) {
+                instance = new Http2ParentChannelExceptionHandler(ClientTelemetry.getMachineId(null));
+            }
+        }
+        return instance;
     }
 
     @Override
@@ -72,7 +90,8 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
                     "Exception on HTTP/2 parent connection"
                         + " [channel=" + ctx.channel()
                         + ", activeStreams=" + activeStreams
-                        + ", channelActive=" + channelActive + "]",
+                        + ", channelActive=" + channelActive
+                        + ", clientVmId=" + this.clientVmId + "]",
                     cause);
             }
         } else {
@@ -82,7 +101,8 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
                 "Exception on HTTP/2 parent connection"
                     + " [channel=" + ctx.channel()
                     + ", activeStreams=" + activeStreams
-                    + ", channelActive=" + channelActive + "]",
+                    + ", channelActive=" + channelActive
+                    + ", clientVmId=" + this.clientVmId + "]",
                 cause);
         }
     }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.http;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http2.Http2FrameCodec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Exception handler for the HTTP/2 parent (TCP) channel pipeline.
+ * <p>
+ * In HTTP/2, reactor-netty multiplexes streams on a shared parent TCP connection.
+ * Child stream channels have {@code ChannelOperationsHandler} which catches exceptions
+ * and fails the active subscriber (matching HTTP/1.1 behavior). However, the parent
+ * channel has no such handler — exceptions propagate to Netty's {@code TailContext}
+ * which logs them as WARN ("An exceptionCaught() event was fired, and it reached at
+ * the tail of the pipeline").
+ * <p>
+ * This handler consumes all exceptions on the parent channel and uses connection
+ * state to decide the log level:
+ * <ul>
+ *   <li><b>DEBUG</b> — when {@code activeStreams == 0} OR {@code !channelActive}.
+ *       No in-flight requests are affected (e.g., TCP RST from LB idle timeout,
+ *       post-close cleanup).</li>
+ *   <li><b>WARN</b> — when active streams exist on a live channel. The exception
+ *       may affect in-flight requests and is worth alerting on.</li>
+ * </ul>
+ * <p>
+ * The handler does NOT close the channel or alter connection lifecycle — reactor-netty
+ * and the connection pool's eviction predicate ({@code !channel.isActive()}) handle that
+ * independently.
+ *
+ * @see ReactorNettyClient#configureChannelPipelineHandlers()
+ */
+final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdapter {
+
+    static final String HANDLER_NAME = "cosmosH2ParentExceptionHandler";
+
+    private static final Logger logger = LoggerFactory.getLogger(Http2ParentChannelExceptionHandler.class);
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        int activeStreams = getActiveStreamCount(ctx);
+        boolean channelActive = ctx.channel().isActive();
+
+        if (activeStreams == 0 || !channelActive) {
+            // No active streams OR channel already inactive — exception is noise
+            // (e.g., TCP RST from LB idle timeout, post-close cleanup).
+            if (logger.isDebugEnabled()) {
+                logger.debug(
+                    "Exception on HTTP/2 parent connection [id:{}, activeStreams={}, channelActive={}]: {}",
+                    ctx.channel().id().asShortText(), activeStreams, channelActive, cause.toString(), cause);
+            }
+        } else {
+            // Active streams on a live channel — exception may affect in-flight requests.
+            logger.warn(
+                "Exception on HTTP/2 parent connection [id:{}, activeStreams={}, channelActive={}]: {}",
+                ctx.channel().id().asShortText(), activeStreams, channelActive, cause.toString(), cause);
+        }
+    }
+
+    private static int getActiveStreamCount(ChannelHandlerContext ctx) {
+        try {
+            Http2FrameCodec codec = ctx.pipeline().get(Http2FrameCodec.class);
+            if (codec != null) {
+                return codec.connection().numActiveStreams();
+            }
+        } catch (Exception ignored) {
+            // Codec not available or connection already torn down
+        }
+        return -1;
+    }
+}

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
@@ -51,14 +51,14 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
             // (e.g., TCP RST from LB idle timeout, post-close cleanup).
             if (logger.isDebugEnabled()) {
                 logger.debug(
-                    "Exception on HTTP/2 parent connection [id:{}, activeStreams={}, channelActive={}]: {}",
-                    ctx.channel().id().asShortText(), activeStreams, channelActive, cause.toString(), cause);
+                    "Exception on HTTP/2 parent connection [id:{}, activeStreams={}, channelActive={}]",
+                    ctx.channel().id().asShortText(), activeStreams, channelActive, cause);
             }
         } else {
             // Active streams on a live channel — exception may affect in-flight requests.
             logger.warn(
-                "Exception on HTTP/2 parent connection [id:{}, activeStreams={}, channelActive={}]: {}",
-                ctx.channel().id().asShortText(), activeStreams, channelActive, cause.toString(), cause);
+                "Exception on HTTP/2 parent connection [id:{}, activeStreams={}, channelActive={}]",
+                ctx.channel().id().asShortText(), activeStreams, channelActive, cause);
         }
     }
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
@@ -69,17 +69,21 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
             // (e.g., TCP RST from LB idle timeout, post-close cleanup).
             if (logger.isDebugEnabled()) {
                 logger.debug(
-                    "Exception on HTTP/2 parent connection [id:{}, local:{}, remote:{}, activeStreams={}, channelActive={}]",
-                    ctx.channel().id().asShortText(), ctx.channel().localAddress(), ctx.channel().remoteAddress(),
-                    activeStreams, channelActive, cause);
+                    "Exception on HTTP/2 parent connection "
+                        + ctx.channel()
+                        + " [activeStreams=" + activeStreams
+                        + ", channelActive=" + channelActive + "]",
+                    cause);
             }
         } else {
             // Active streams on a live channel, or stream count unknown (null) —
             // exception may affect in-flight requests.
             logger.warn(
-                "Exception on HTTP/2 parent connection [id:{}, local:{}, remote:{}, activeStreams={}, channelActive={}]",
-                ctx.channel().id().asShortText(), ctx.channel().localAddress(), ctx.channel().remoteAddress(),
-                activeStreams, channelActive, cause);
+                "Exception on HTTP/2 parent connection "
+                    + ctx.channel()
+                    + " [activeStreams=" + activeStreams
+                    + ", channelActive=" + channelActive + "]",
+                cause);
         }
     }
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
@@ -44,14 +44,13 @@ import org.slf4j.LoggerFactory;
 @ChannelHandler.Sharable
 final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdapter {
 
+    static final Http2ParentChannelExceptionHandler INSTANCE = new Http2ParentChannelExceptionHandler();
+
     static final String HANDLER_NAME = "cosmosH2ParentExceptionHandler";
 
     private static final Logger logger = LoggerFactory.getLogger(Http2ParentChannelExceptionHandler.class);
 
-    private final String clientVmId;
-
-    Http2ParentChannelExceptionHandler(String clientVmId) {
-        this.clientVmId = clientVmId;
+    private Http2ParentChannelExceptionHandler() {
     }
 
     @Override
@@ -75,7 +74,7 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
                         + " [channel=" + ctx.channel()
                         + ", activeStreams=" + activeStreams
                         + ", channelActive=" + channelActive
-                        + ", clientVmId=" + this.clientVmId + "]",
+                        + ", clientVmId=" + ClientTelemetry.getCachedMachineId() + "]",
                     cause);
             }
         } else {
@@ -86,7 +85,7 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
                     + " [channel=" + ctx.channel()
                     + ", activeStreams=" + activeStreams
                     + ", channelActive=" + channelActive
-                    + ", clientVmId=" + this.clientVmId + "]",
+                    + ", clientVmId=" + ClientTelemetry.getCachedMachineId() + "]",
                 cause);
         }
     }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/Http2ParentChannelExceptionHandler.java
@@ -19,15 +19,19 @@ import org.slf4j.LoggerFactory;
  * which logs them as WARN ("An exceptionCaught() event was fired, and it reached at
  * the tail of the pipeline").
  * <p>
- * This handler consumes all exceptions on the parent channel and uses connection
+ * This handler consumes {@link Exception}s on the parent channel and uses connection
  * state to decide the log level:
  * <ul>
  *   <li><b>DEBUG</b> — when {@code activeStreams == 0} OR {@code !channelActive}.
  *       No in-flight requests are affected (e.g., TCP RST from LB idle timeout,
  *       post-close cleanup).</li>
- *   <li><b>WARN</b> — when active streams exist on a live channel. The exception
- *       may affect in-flight requests and is worth alerting on.</li>
+ *   <li><b>WARN</b> — when active streams exist on a live channel, or when the
+ *       active stream count cannot be determined. The exception may affect
+ *       in-flight requests and is worth alerting on.</li>
  * </ul>
+ * <p>
+ * {@link Error} types (e.g., {@code OutOfMemoryError}) are never consumed — they
+ * propagate to {@code TailContext} for standard Netty handling.
  * <p>
  * The handler does NOT close the channel or alter connection lifecycle — reactor-netty
  * and the connection pool's eviction predicate ({@code !channel.isActive()}) handle that
@@ -43,10 +47,17 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        int activeStreams = getActiveStreamCount(ctx);
+        // Do not consume JVM-level errors (OOM, StackOverflow, etc.) — let them
+        // propagate to TailContext for standard Netty handling.
+        if (cause instanceof Error) {
+            ctx.fireExceptionCaught(cause);
+            return;
+        }
+
+        Integer activeStreams = getActiveStreamCount(ctx);
         boolean channelActive = ctx.channel().isActive();
 
-        if (activeStreams == 0 || !channelActive) {
+        if ((activeStreams != null && activeStreams == 0) || !channelActive) {
             // No active streams OR channel already inactive — exception is noise
             // (e.g., TCP RST from LB idle timeout, post-close cleanup).
             if (logger.isDebugEnabled()) {
@@ -55,22 +66,23 @@ final class Http2ParentChannelExceptionHandler extends ChannelInboundHandlerAdap
                     ctx.channel().id().asShortText(), activeStreams, channelActive, cause);
             }
         } else {
-            // Active streams on a live channel — exception may affect in-flight requests.
+            // Active streams on a live channel, or stream count unknown (null) —
+            // exception may affect in-flight requests.
             logger.warn(
                 "Exception on HTTP/2 parent connection [id:{}, activeStreams={}, channelActive={}]",
                 ctx.channel().id().asShortText(), activeStreams, channelActive, cause);
         }
     }
 
-    private static int getActiveStreamCount(ChannelHandlerContext ctx) {
+    private static Integer getActiveStreamCount(ChannelHandlerContext ctx) {
         try {
             Http2FrameCodec codec = ctx.pipeline().get(Http2FrameCodec.class);
             if (codec != null) {
                 return codec.connection().numActiveStreams();
             }
-        } catch (Exception ignored) {
-            // Codec not available or connection already torn down
+        } catch (Exception e) {
+            logger.debug("Failed to retrieve active stream count from Http2FrameCodec", e);
         }
-        return -1;
+        return null;
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -177,7 +177,7 @@ public class ReactorNettyClient implements HttpClient {
                         try {
                             channelPipeline.addLast(
                                 Http2ParentChannelExceptionHandler.HANDLER_NAME,
-                                new Http2ParentChannelExceptionHandler());
+                                Http2ParentChannelExceptionHandler.INSTANCE);
                         } catch (IllegalArgumentException ignored) {
                             // TOCTOU race: between the get()==null check above and addLast(),
                             // a concurrent doOnConnected may have installed the handler.

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -177,7 +177,7 @@ public class ReactorNettyClient implements HttpClient {
                         try {
                             channelPipeline.addLast(
                                 Http2ParentChannelExceptionHandler.HANDLER_NAME,
-                                Http2ParentChannelExceptionHandler.INSTANCE);
+                                Http2ParentChannelExceptionHandler.getOrCreateInstance());
                         } catch (IllegalArgumentException ignored) {
                             // TOCTOU race: between the get()==null check above and addLast(),
                             // a concurrent doOnConnected may have installed the handler.

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -5,6 +5,7 @@ package com.azure.cosmos.implementation.http;
 import com.azure.cosmos.Http2ConnectionConfig;
 import com.azure.cosmos.implementation.Configs;
 import com.azure.cosmos.implementation.ImplementationBridgeHelpers;
+import com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelId;
@@ -142,6 +143,12 @@ public class ReactorNettyClient implements HttpClient {
 
         Http2ConnectionConfig http2Cfg = httpClientConfig.getHttp2ConnectionConfig();
         if (httpCfgAccessor().isEffectivelyEnabled(http2Cfg)) {
+
+            // Resolve vmId eagerly on the caller's thread (non-event-loop).
+            // ClientTelemetry.getMachineId() may block on first IMDS fetch.
+            Http2ParentChannelExceptionHandler h2ExceptionHandler =
+                new Http2ParentChannelExceptionHandler(ClientTelemetry.getMachineId(null));
+
             this.httpClient = this.httpClient
                 .secure(sslContextSpec ->
                     sslContextSpec.sslContext(
@@ -177,7 +184,7 @@ public class ReactorNettyClient implements HttpClient {
                         try {
                             channelPipeline.addLast(
                                 Http2ParentChannelExceptionHandler.HANDLER_NAME,
-                                Http2ParentChannelExceptionHandler.getOrCreateInstance());
+                                h2ExceptionHandler);
                         } catch (IllegalArgumentException ignored) {
                             // TOCTOU race: between the get()==null check above and addLast(),
                             // a concurrent doOnConnected may have installed the handler.

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -5,7 +5,6 @@ package com.azure.cosmos.implementation.http;
 import com.azure.cosmos.Http2ConnectionConfig;
 import com.azure.cosmos.implementation.Configs;
 import com.azure.cosmos.implementation.ImplementationBridgeHelpers;
-import com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelId;
@@ -143,12 +142,6 @@ public class ReactorNettyClient implements HttpClient {
 
         Http2ConnectionConfig http2Cfg = httpClientConfig.getHttp2ConnectionConfig();
         if (httpCfgAccessor().isEffectivelyEnabled(http2Cfg)) {
-
-            // Resolve vmId eagerly on the caller's thread (non-event-loop).
-            // ClientTelemetry.getMachineId() may block on first IMDS fetch.
-            Http2ParentChannelExceptionHandler h2ExceptionHandler =
-                new Http2ParentChannelExceptionHandler(ClientTelemetry.getMachineId(null));
-
             this.httpClient = this.httpClient
                 .secure(sslContextSpec ->
                     sslContextSpec.sslContext(
@@ -184,7 +177,7 @@ public class ReactorNettyClient implements HttpClient {
                         try {
                             channelPipeline.addLast(
                                 Http2ParentChannelExceptionHandler.HANDLER_NAME,
-                                h2ExceptionHandler);
+                                Http2ParentChannelExceptionHandler.INSTANCE);
                         } catch (IllegalArgumentException ignored) {
                             // TOCTOU race: between the get()==null check above and addLast(),
                             // a concurrent doOnConnected may have installed the handler.

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -166,6 +166,25 @@ public class ReactorNettyClient implements HttpClient {
                             "customHeaderCleaner",
                             new Http2ResponseHeaderCleanerHandler());
                     }
+
+                    // Install exception handler on the HTTP/2 parent (TCP) channel.
+                    // In H2, doOnConnected fires for stream (child) channels — channel.parent()
+                    // is the TCP connection. The parent pipeline has no ChannelOperationsHandler
+                    // (unlike H1.1), so TCP-level exceptions (RST, broken pipe) propagate to
+                    // Netty's TailContext and get logged as WARN. This handler matches H1.1
+                    // behavior by consuming exceptions at DEBUG level.
+                    Channel parent = connection.channel().parent();
+                    if (parent != null
+                        && parent.pipeline().get(Http2ParentChannelExceptionHandler.HANDLER_NAME) == null) {
+
+                        try {
+                            parent.pipeline().addLast(
+                                Http2ParentChannelExceptionHandler.HANDLER_NAME,
+                                new Http2ParentChannelExceptionHandler());
+                        } catch (IllegalArgumentException ignored) {
+                            // Duplicate handler — already installed by a concurrent stream
+                        }
+                    }
                 }));
         }
     }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -182,7 +182,10 @@ public class ReactorNettyClient implements HttpClient {
                                 Http2ParentChannelExceptionHandler.HANDLER_NAME,
                                 new Http2ParentChannelExceptionHandler());
                         } catch (IllegalArgumentException ignored) {
-                            // Duplicate handler — already installed by a concurrent stream
+                            // TOCTOU race: between the get()==null check above and addLast(),
+                            // a concurrent stream's doOnConnected may have installed the handler.
+                            // Since we always pass a fresh instance (never null, never shared
+                            // across pipelines), duplicate handler name is the only possible cause.
                         }
                     }
                 }));

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -168,23 +168,26 @@ public class ReactorNettyClient implements HttpClient {
                     }
 
                     // Install exception handler on the HTTP/2 parent (TCP) channel.
-                    // In H2, doOnConnected fires for stream (child) channels — channel.parent()
-                    // is the TCP connection. The parent pipeline has no ChannelOperationsHandler
-                    // (unlike H1.1), so TCP-level exceptions (RST, broken pipe) propagate to
-                    // Netty's TailContext. This handler aligns the logging with connection state:
-                    // DEBUG when the parent channel is idle or inactive, WARN when the channel
-                    // is active and in-flight streams may be impacted.
-                    Channel parent = connection.channel().parent();
-                    if (parent != null
-                        && parent.pipeline().get(Http2ParentChannelExceptionHandler.HANDLER_NAME) == null) {
+                    // In reactor-netty's H2 path, doOnConnected fires once per TCP
+                    // connection — connection.channel() IS the parent (TCP) channel,
+                    // so channel.parent() is null. We handle both cases:
+                    //   - parent != null → child/stream channel, install on parent
+                    //   - parent == null → this IS the parent, install on it directly
+                    // The parent pipeline has no ChannelOperationsHandler (unlike H1.1),
+                    // so TCP-level exceptions (RST, broken pipe) propagate to Netty's
+                    // TailContext. This handler consumes them with connection-state-based
+                    // log levels: DEBUG when idle, WARN when active streams exist.
+                    Channel channel = connection.channel();
+                    Channel h2Parent = channel.parent() != null ? channel.parent() : channel;
 
+                    if (h2Parent.pipeline().get(Http2ParentChannelExceptionHandler.HANDLER_NAME) == null) {
                         try {
-                            parent.pipeline().addLast(
+                            h2Parent.pipeline().addLast(
                                 Http2ParentChannelExceptionHandler.HANDLER_NAME,
                                 new Http2ParentChannelExceptionHandler());
                         } catch (IllegalArgumentException ignored) {
                             // TOCTOU race: between the get()==null check above and addLast(),
-                            // a concurrent stream's doOnConnected may have installed the handler.
+                            // a concurrent doOnConnected may have installed the handler.
                             // Since we always pass a fresh instance (never null, never shared
                             // across pipelines), duplicate handler name is the only possible cause.
                         }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -167,29 +167,21 @@ public class ReactorNettyClient implements HttpClient {
                             new Http2ResponseHeaderCleanerHandler());
                     }
 
-                    // Install exception handler on the HTTP/2 parent (TCP) channel.
-                    // In reactor-netty's H2 path, doOnConnected fires once per TCP
-                    // connection — connection.channel() IS the parent (TCP) channel,
-                    // so channel.parent() is null. We handle both cases:
-                    //   - parent != null → child/stream channel, install on parent
-                    //   - parent == null → this IS the parent, install on it directly
-                    // The parent pipeline has no ChannelOperationsHandler (unlike H1.1),
-                    // so TCP-level exceptions (RST, broken pipe) propagate to Netty's
-                    // TailContext. This handler consumes them with connection-state-based
-                    // log levels: DEBUG when idle, WARN when active streams exist.
-                    Channel channel = connection.channel();
-                    Channel h2Parent = channel.parent() != null ? channel.parent() : channel;
-
-                    if (h2Parent.pipeline().get(Http2ParentChannelExceptionHandler.HANDLER_NAME) == null) {
+                    // Install exception handler at the tail of the HTTP/2 parent (TCP)
+                    // channel pipeline. This pipeline has no ChannelOperationsHandler
+                    // (unlike H1.1), so TCP-level exceptions (RST, broken pipe) propagate
+                    // to Netty's TailContext. This handler consumes them with
+                    // connection-state-based log levels: DEBUG when idle, WARN when
+                    // active streams exist.
+                    if (channelPipeline.get(Http2ParentChannelExceptionHandler.HANDLER_NAME) == null) {
                         try {
-                            h2Parent.pipeline().addLast(
+                            channelPipeline.addLast(
                                 Http2ParentChannelExceptionHandler.HANDLER_NAME,
                                 new Http2ParentChannelExceptionHandler());
                         } catch (IllegalArgumentException ignored) {
                             // TOCTOU race: between the get()==null check above and addLast(),
                             // a concurrent doOnConnected may have installed the handler.
-                            // Since we always pass a fresh instance (never null, never shared
-                            // across pipelines), duplicate handler name is the only possible cause.
+                            // Duplicate handler name is the only possible cause.
                         }
                     }
                 }));

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -171,8 +171,9 @@ public class ReactorNettyClient implements HttpClient {
                     // In H2, doOnConnected fires for stream (child) channels — channel.parent()
                     // is the TCP connection. The parent pipeline has no ChannelOperationsHandler
                     // (unlike H1.1), so TCP-level exceptions (RST, broken pipe) propagate to
-                    // Netty's TailContext and get logged as WARN. This handler matches H1.1
-                    // behavior by consuming exceptions at DEBUG level.
+                    // Netty's TailContext. This handler aligns the logging with connection state:
+                    // DEBUG when the parent channel is idle or inactive, WARN when the channel
+                    // is active and in-flight streams may be impacted.
                     Channel parent = connection.channel().parent();
                     if (parent != null
                         && parent.pipeline().get(Http2ParentChannelExceptionHandler.HANDLER_NAME) == null) {


### PR DESCRIPTION
## Problem

Customers see noisy Netty WARN logs in HTTP/2 scenarios:

```
An exceptionCaught() event was fired, and it reached at the tail of the pipeline.
io.netty.channel.unix.Errors$NativeIoException: recvAddress(..) failed with error(-104): Connection reset by peer
```

## Root Cause

In HTTP/2, reactor-netty multiplexes streams on a shared parent TCP connection. The parent and child channels have different pipeline structures:

### HTTP/1.1 pipeline (single channel — no leak to TailContext):
```
SslHandler → HttpClientCodec → ChannelOperationsHandler → [TAIL]
                                         ↑
                            Catches exceptions, bridges to
                            Reactor subscriber. Exception
                            never reaches TailContext.
```

### HTTP/2 parent channel pipeline (BEFORE fix — leak to TailContext):
```
SslHandler → Http2FrameCodec → Http2MultiplexHandler → [TAIL]
                                                          ↑
                                            No handler catches it.
                                            TailContext logs WARN.
```

### HTTP/2 parent channel pipeline (AFTER fix):
```
SslHandler → Http2FrameCodec → Http2MultiplexHandler → Http2ParentChannelExceptionHandler → [TAIL]
                                                                   ↑
                                                       Consumes Exception types.
                                                       Log level based on connection state.
                                                       Error types propagate to TailContext.
```

### HTTP/2 child stream channel pipeline (unchanged):
```
H2ToHttp11Codec → IdleStateHandler → ChannelOperationsHandler → [TAIL]
                                              ↑
                               Same as HTTP/1.1 — catches exceptions,
                               bridges to Reactor subscriber.
```

## Design: Connection-State-Based Log Level

The handler consumes **`Exception` types** on the parent channel (no exception type filtering within `Exception`). `Error` types (e.g., `OutOfMemoryError`) are **not consumed** — they propagate to TailContext for standard Netty handling.

The log level for `Exception` types is determined by connection state:

- **DEBUG** — when `activeStreams == 0` OR `!channelActive`.
- **WARN** — when active streams exist on a live channel, or when the active stream count cannot be determined (`null`).

| Active streams | Channel active | Log level | Rationale |
|---|---|---|---|
| 0 | true/false | **DEBUG** | Idle connection — no in-flight requests affected |
| >0 | false | **DEBUG** | Channel already dead — streams will fail via subscriber |
| >0 | true | **WARN** | Live requests may be affected |
| null (codec unavailable) | true | **WARN** | Cannot determine state — safe default |
| null (codec unavailable) | false | **DEBUG** | Channel already dead regardless |

Active stream count is retrieved via `Http2FrameCodec.connection().numActiveStreams()` on the same parent channel pipeline. Returns `null` (not `-1`) if the codec is unavailable, making the unknown-state case explicit. Failures to retrieve the stream count are logged at DEBUG.

### Why no exception type filtering?

By the time any exception reaches our handler, all upstream handlers (`Http2FrameCodec`, `Http2MultiplexHandler`) have already handled the protocol actions (GOAWAY, stream reset, child channel error delivery). The exception reaching TailContext is an echo of already-handled work, regardless of type. Connection state (active streams + channel activity) is the only dimension that determines whether the exception has diagnostic value.

### Why OR (not AND) for the DEBUG condition?

Either condition alone is sufficient:
- `activeStreams == 0` — no in-flight requests affected, regardless of channel state
- `!channelActive` — channel is already dead, any active streams will fail through their Reactor subscribers independently

### Why no `ctx.close()`?

The handler does NOT close the channel. Connection lifecycle is owned by:
- **Netty transport layer** — detects TCP RST/EOF, transitions channel to inactive
- **Http2FrameCodec** — processes GOAWAY, resets streams
- **Http2Pool** (`reactor-netty`) — evicts connections based on `!channel.isActive()`, GOAWAY, maxIdleTime, maxLifeTime

Our handler is the last in the pipeline with the least protocol context. Closing here would race with reactor-netty's pool management and could prematurely kill connections after non-fatal errors.

### Why propagate `Error` but not `Exception`?

`Error` types (OOM, StackOverflowError) represent JVM-level failures that should not be silently consumed. Re-throwing `Exception` to TailContext provides no functional value — TailContext just logs WARN and swallows, which is what our handler already does with better context (connection state in the log message).

## Testing

9 EmbeddedChannel unit tests with production-matching pipeline (`Http2FrameCodec` → `Http2MultiplexHandler` → handler):

| Test | What it proves |
|------|----------------|
| `withoutHandler_exceptionReachesTail` | BEFORE: exception reaches TailContext → WARN |
| `withHandler_zeroActiveStreams_consumedAtDebug` | 0 active streams → consumed at DEBUG |
| `withHandler_exceptionDoesNotCloseChannel` | Handler does NOT close channel |
| `withHandler_runtimeException_zeroActiveStreams_consumed` | RuntimeException also consumed (no type filtering) |
| `withHandler_npe_zeroActiveStreams_consumed` | NPE also consumed (no type filtering) |
| `withHandler_activeStreams_consumedAtWarn` | Active streams → consumed at WARN |
| `withHandler_activeStreams_channelNotClosed` | Active streams + exception → channel NOT closed |
| `withHandler_codecAbsent_fallsBackToWarnPath` | Codec absent → null stream count → safe WARN path |
| `withHandler_errorNotConsumed_propagatesToTail` | Error types propagate to TailContext (not consumed) |

### WARN path log (`activeStreams=1, channelActive=true`)

```
2026-04-23 14:08:17,278       [main] WARN  com.azure.cosmos.implementation.http.Http2ParentChannelExceptionHandler - Exception on HTTP/2 parent connection [channel=[id: 0xembedded, L:embedded - R:embedded], activeStreams=1, channelActive=true, clientVmId=n/a]
java.io.IOException: Connection reset by peer
at com.azure.cosmos.implementation.http.Http2ParentChannelExceptionHandlerTest.withHandler_activeStreams_consumedAtWarn(Http2ParentChannelExceptionHandlerTest.java:149) ~[test-classes/:?]
at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
at java.lang.reflect.Method.invoke(Method.java:577) ~[?:?]
```

Note: The `!channelActive` branch cannot be unit-tested with EmbeddedChannel because `disconnect()` tears down the pipeline before `fireExceptionCaught` can reach handlers. In production, `exceptionCaught()` fires while the channel is transitioning to inactive.

## Impact

- Handler only overrides `exceptionCaught()` — Netty `@Skip` optimization bypasses it for all hot-path events
- Handler does NOT close the channel
- `Error` types are propagated, not consumed
- Exceptions with active streams on a live channel still log at WARN
- Unknown stream count (codec unavailable) takes safe WARN path