### PR TITLE
[Java] Re-ordered the publish steps to avoid re-publish errors

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -266,20 +266,6 @@ jobs:
           workingDirectory: $(Pipeline.Workspace)
         displayName: Update package properties with namespaces
 
-      - template: /eng/common/pipelines/templates/steps/create-apireview.yml
-        parameters:
-          PackageInfoFiles:
-            - ${{ each artifact in parameters.ReleaseArtifacts }}:
-              - $(Build.ArtifactStagingDirectory)/PackageInfo/${{artifact.name}}.json
-
-      - template: /eng/common/pipelines/templates/steps/detect-api-changes.yml
-
-      - template: /eng/common/pipelines/templates/steps/validate-all-packages.yml
-        parameters:
-          PackageInfoFiles:
-            - ${{ each artifact in parameters.ReleaseArtifacts }}:
-              - $(Build.ArtifactStagingDirectory)/PackageInfo/${{artifact.name}}.json
-
       - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
         parameters:
           ArtifactPath: $(Build.ArtifactStagingDirectory)
@@ -301,6 +287,20 @@ jobs:
           ArtifactPath: '$(System.DefaultWorkingDirectory)'
           SbomEnabled: false
           CustomCondition: or(eq(variables['CaptureRepositoryOnFailure'], 'true'), and(failed(), eq(variables['Build.Reason'],'Schedule')))
+
+      - template: /eng/common/pipelines/templates/steps/create-apireview.yml
+        parameters:
+          PackageInfoFiles:
+            - ${{ each artifact in parameters.ReleaseArtifacts }}:
+              - $(Build.ArtifactStagingDirectory)/PackageInfo/${{artifact.name}}.json
+
+      - template: /eng/common/pipelines/templates/steps/detect-api-changes.yml
+
+      - template: /eng/common/pipelines/templates/steps/validate-all-packages.yml
+        parameters:
+          PackageInfoFiles:
+            - ${{ each artifact in parameters.ReleaseArtifacts }}:
+              - $(Build.ArtifactStagingDirectory)/PackageInfo/${{artifact.name}}.json
 
       - template: /eng/pipelines/templates/steps/post-job-cleanup.yml
 

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -266,6 +266,20 @@ jobs:
           workingDirectory: $(Pipeline.Workspace)
         displayName: Update package properties with namespaces
 
+      - template: /eng/common/pipelines/templates/steps/create-apireview.yml
+        parameters:
+          PackageInfoFiles:
+            - ${{ each artifact in parameters.ReleaseArtifacts }}:
+              - $(Build.ArtifactStagingDirectory)/PackageInfo/${{artifact.name}}.json
+
+      - template: /eng/common/pipelines/templates/steps/detect-api-changes.yml
+
+      - template: /eng/common/pipelines/templates/steps/validate-all-packages.yml
+        parameters:
+          PackageInfoFiles:
+            - ${{ each artifact in parameters.ReleaseArtifacts }}:
+              - $(Build.ArtifactStagingDirectory)/PackageInfo/${{artifact.name}}.json
+
       - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
         parameters:
           ArtifactPath: $(Build.ArtifactStagingDirectory)
@@ -287,20 +301,6 @@ jobs:
           ArtifactPath: '$(System.DefaultWorkingDirectory)'
           SbomEnabled: false
           CustomCondition: or(eq(variables['CaptureRepositoryOnFailure'], 'true'), and(failed(), eq(variables['Build.Reason'],'Schedule')))
-
-      - template: /eng/common/pipelines/templates/steps/create-apireview.yml
-        parameters:
-          PackageInfoFiles:
-            - ${{ each artifact in parameters.ReleaseArtifacts }}:
-              - $(Build.ArtifactStagingDirectory)/PackageInfo/${{artifact.name}}.json
-
-      - template: /eng/common/pipelines/templates/steps/detect-api-changes.yml
-
-      - template: /eng/common/pipelines/templates/steps/validate-all-packages.yml
-        parameters:
-          PackageInfoFiles:
-            - ${{ each artifact in parameters.ReleaseArtifacts }}:
-              - $(Build.ArtifactStagingDirectory)/PackageInfo/${{artifact.name}}.json
 
       - template: /eng/pipelines/templates/steps/post-job-cleanup.yml
 

--- a/eng/pipelines/templates/stages/archetype-java-release-batch.yml
+++ b/eng/pipelines/templates/stages/archetype-java-release-batch.yml
@@ -53,18 +53,6 @@ stages:
               Artifacts: ${{parameters.Artifacts}}
               ArtifactDirectory: $(Pipeline.Workspace)/packages
 
-          # Publish the ESRP signed directory. This will still be used by the
-          # Dev feed publish.
-          - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-            parameters:
-              ArtifactPath: '$(Pipeline.Workspace)/packages'
-              ArtifactName: 'packages-signed'
-
-          # Downloading the ESRP signed artifacts
-          - download: current
-            displayName: 'Download Signed Artifacts'
-            artifact: packages-signed
-
           # Setup Maven mirror settings and authenticate with Azure Artifacts
           - template: /eng/pipelines/templates/steps/maven-authenticate.yml
             parameters:
@@ -76,9 +64,16 @@ stages:
           - template: tools/gpg/gpg.yml@azure-sdk-build-tools
           - template: /eng/pipelines/templates/steps/gpg-sign-and-flatten.yml
             parameters:
-              ArtifactDirectory: $(Pipeline.Workspace)/packages-signed
+              ArtifactDirectory: $(Pipeline.Workspace)/packages
               OutputDirectory: $(Pipeline.Workspace)/packages-esrp-gpg-signed
               FlattenedESRPDirectory: $(Pipeline.Workspace)/packages-esrp-flattened
+
+          # Publish the ESRP signed directory. This will still be used by the
+          # Dev feed publish.
+          - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+            parameters:
+              ArtifactPath: '$(Pipeline.Workspace)/packages'
+              ArtifactName: 'packages-signed'
 
           # The packages-esrp-flattened will be used for the ESRP publish
           - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml

--- a/sdk/template/azure-sdk-template-three/README.md
+++ b/sdk/template/azure-sdk-template-three/README.md
@@ -113,7 +113,7 @@ If the package, or a related package supports it, include tips for logging or en
 
 Azure SDKs for Java provide a consistent logging story to help aid in troubleshooting application errors and expedite
 their resolution. The logs produced will capture the flow of an application before reaching the terminal state to help
-locate the root issue. View the [logging][logging] wiki for guidance about enabling logging.
+locate the root issue.
 
 ### Default HTTP Client
 
@@ -148,7 +148,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For m
 <!-- LINKS -->
 [style-guide-msft]: https://learn.microsoft.com/style-guide/capitalization
 [jdk]: https://learn.microsoft.com/java/azure/jdk/?view=azure-java-stable
-[logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-in-Azure-SDK
 [cla]: https://cla.microsoft.com
 [coc]: https://opensource.microsoft.com/codeofconduct/
 [coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/

--- a/sdk/template/azure-sdk-template-two/README.md
+++ b/sdk/template/azure-sdk-template-two/README.md
@@ -113,7 +113,7 @@ If the package, or a related package supports it, include tips for logging or en
 
 Azure SDKs for Java provide a consistent logging story to help aid in troubleshooting application errors and expedite
 their resolution. The logs produced will capture the flow of an application before reaching the terminal state to help
-locate the root issue. View the [logging][logging] wiki for guidance about enabling logging.
+locate the root issue.
 
 ### Default HTTP Client
 
@@ -148,7 +148,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For m
 <!-- LINKS -->
 [style-guide-msft]: https://learn.microsoft.com/style-guide/capitalization
 [jdk]: https://learn.microsoft.com/java/azure/jdk/?view=azure-java-stable
-[logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-in-Azure-SDK
 [cla]: https://cla.microsoft.com
 [coc]: https://opensource.microsoft.com/codeofconduct/
 [coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/

--- a/sdk/template/azure-sdk-template/README.md
+++ b/sdk/template/azure-sdk-template/README.md
@@ -113,7 +113,7 @@ If the package, or a related package supports it, include tips for logging or en
 
 Azure SDKs for Java provide a consistent logging story to help aid in troubleshooting application errors and expedite
 their resolution. The logs produced will capture the flow of an application before reaching the terminal state to help
-locate the root issue. View the [logging][logging] wiki for guidance about enabling logging.
+locate the root issue.
 
 ### Default HTTP Client
 
@@ -148,7 +148,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For m
 <!-- LINKS -->
 [style-guide-msft]: https://learn.microsoft.com/style-guide/capitalization
 [jdk]: https://learn.microsoft.com/java/azure/jdk/?view=azure-java-stable
-[logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-in-Azure-SDK
 [cla]: https://cla.microsoft.com
 [coc]: https://opensource.microsoft.com/codeofconduct/
 [coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/

--- a/sdk/template/azure-template-stress/README.md
+++ b/sdk/template/azure-template-stress/README.md
@@ -171,8 +171,6 @@ You may also control the verbosity of logs that go to Application Insights - see
 
 Since logs are hard to query and are extremely verbose (in case of high-scale stress tests), we're relying on metrics and workbooks for test result analysis.
 
-See also [Logging in Azure SDK][logging-azure-sdk].
-
 ### Metrics
 
 While some Azure SDKs provide custom metrics, we're going to collect generic test metrics and build queries/workbooks on top of them,
@@ -254,4 +252,3 @@ thread pool issues, or other performance issues in the code. So make sure to con
 [deploy_stress_test]: https://github.com/Azure/azure-sdk-tools/blob/main/tools/stress-cluster/chaos/README.md#deploying-a-stress-test
 [stress_test_layout]: https://github.com/Azure/azure-sdk-tools/blob/main/tools/stress-cluster/chaos/README.md#layout
 [opentelemetry-logback]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/logback/logback-appender-1.0/library
-[logging-azure-sdk]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-in-Azure-SDK

--- a/sdk/template/azure-template-stress/README.md
+++ b/sdk/template/azure-template-stress/README.md
@@ -200,7 +200,7 @@ This would allow you to distinguish telemetry coming from different containers.
 You would need to adjust the workbook to accommodate those changes.
 
 In addition to `test.run_duration`, we're also collecting:
-- [JVM metrics](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/runtime-telemetry/runtime-telemetry-java8/library/README.md) measured by OpenTelemetry:
+- [JVM metrics](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/runtime-telemetry/README.md) measured by OpenTelemetry:
     - CPU and memory usage
     - GC stats
     - Thread count


### PR DESCRIPTION
Resolved issue#1 in https://github.com/Azure/azure-sdk-tools/issues/14986

This pull request updates the `archetype-java-release-batch.yml` pipeline template to streamline the handling of signed artifacts. The main changes involve reordering steps related to artifact publishing and adjusting which directories are used for GPG signing and artifact publication.

## Changes
* The steps to publish the `packages-signed` artifact have been moved to later in the pipeline, after the GPG signing and flattening steps, to ensure the correct artifacts are processed and published.
* The `gpg-sign-and-flatten.yml` step now uses `$(Pipeline.Workspace)/packages` as its input directory instead of `$(Pipeline.Workspace)/packages-signed`, reflecting the updated artifact flow.
* The publishing of the `packages-signed` artifact now occurs after GPG signing, aligning with the new process order.