### PR TITLE
Patch Sparse Checkout

### DIFF
--- a/eng/scripts/Generate-ServiceDirectories-From-Project-List.ps1
+++ b/eng/scripts/Generate-ServiceDirectories-From-Project-List.ps1
@@ -77,6 +77,12 @@ foreach($file in Get-ChildItem -Path $SourcesDirectory -Filter pom*.xml -Recurse
 $sparseCheckoutDirectories = @()
 $serviceDirectories = @()
 $sparseCheckoutDirectories += "/sdk/parents"
+# in place until we can come up with a better path to honoring ExcludePaths
+# in archetype-sdk-client. Given that the validation for these is triggered for outside paths, but `analyze` still needs to 
+# process those folders, we'll just include them in the sparse checkout and service directory lists for now.
+# This is only two additional folders and it allows us to avoid a lot of complexity around trying to special case the ExcludePaths in archetype-sdk-client.
+$sparseCheckoutDirectories += "/sdk/cosmos"
+$sparseCheckoutDirectories += "/sdk/spring"
 foreach ($project in $ProjectList) {
     if ($sparseCheckoutDirHash.ContainsKey($project)) {
         $sparseCheckoutDirectories += $sparseCheckoutDirHash[$project]

--- a/eng/scripts/Generate-ServiceDirectories-From-Project-List.ps1
+++ b/eng/scripts/Generate-ServiceDirectories-From-Project-List.ps1
@@ -78,7 +78,7 @@ $sparseCheckoutDirectories = @()
 $serviceDirectories = @()
 $sparseCheckoutDirectories += "/sdk/parents"
 # in place until we can come up with a better path to honoring ExcludePaths
-# in archetype-sdk-client. Given that the validation for these is triggered for outside paths, but `analyze` still needs to 
+# in archetype-sdk-client. Given that the validation for these is triggered for outside paths, but `analyze` still needs to
 # process those folders, we'll just include them in the sparse checkout and service directory lists for now.
 # This is only two additional folders and it allows us to avoid a lot of complexity around trying to special case the ExcludePaths in archetype-sdk-client.
 $sparseCheckoutDirectories += "/sdk/cosmos"


### PR DESCRIPTION
To include `cosmos` and `spring`. 

Right now these folders excluded, as are incompatible with the `pullrequest` pipeline. However, when files that have changed in them get statically analyzed in `pullrequest` pipeline, we hit a failure because `excluded` paths aren't added to sparse checkout.

This is a quick option that doesn't worsen checkout by much more than a couple seconds. Following up on #48900 will also offer another opportunity to refine this.