### PR TITLE
increment version after azure-resourcemanager-compute release

### DIFF
--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -280,7 +280,7 @@ com.azure.resourcemanager:azure-resourcemanager-appplatform;2.51.0;2.52.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-appservice;2.55.1;2.56.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-authorization;2.53.8;2.54.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-cdn;2.53.7;2.54.0-beta.1
-com.azure.resourcemanager:azure-resourcemanager-compute;2.56.3;2.57.0
+com.azure.resourcemanager:azure-resourcemanager-compute;2.57.0;2.58.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-containerinstance;2.53.9;2.54.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-containerregistry;2.55.1;2.56.0-beta.2
 com.azure.resourcemanager:azure-resourcemanager-containerservice;2.59.0;2.60.0-beta.1

--- a/sdk/compute/azure-resourcemanager-compute/CHANGELOG.md
+++ b/sdk/compute/azure-resourcemanager-compute/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 2.58.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 2.57.0 (2026-04-21)
 
 ### Breaking Changes

--- a/sdk/compute/azure-resourcemanager-compute/pom.xml
+++ b/sdk/compute/azure-resourcemanager-compute/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>com.azure.resourcemanager</groupId>
   <artifactId>azure-resourcemanager-compute</artifactId>
-  <version>2.57.0</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-compute;current} -->
+  <version>2.58.0-beta.1</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-compute;current} -->
   <packaging>jar</packaging>
 
   <name>Microsoft Azure SDK for Compute Management</name>

--- a/sdk/monitor/azure-resourcemanager-monitor/pom.xml
+++ b/sdk/monitor/azure-resourcemanager-monitor/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>
       <artifactId>azure-resourcemanager-compute</artifactId>
-      <version>2.56.3</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-compute;dependency} -->
+      <version>2.57.0</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-compute;dependency} -->
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sdk/resourcehealth/azure-resourcemanager-resourcehealth/pom.xml
+++ b/sdk/resourcehealth/azure-resourcemanager-resourcehealth/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>
       <artifactId>azure-resourcemanager-compute</artifactId>
-      <version>2.56.3</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-compute;dependency} -->
+      <version>2.57.0</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-compute;dependency} -->
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sdk/resourcemanager/azure-resourcemanager/pom.xml
+++ b/sdk/resourcemanager/azure-resourcemanager/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>
       <artifactId>azure-resourcemanager-compute</artifactId>
-      <version>2.56.3</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-compute;dependency} -->
+      <version>2.57.0</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-compute;dependency} -->
     </dependency>
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>

--- a/sdk/standbypool/azure-resourcemanager-standbypool/pom.xml
+++ b/sdk/standbypool/azure-resourcemanager-standbypool/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>
       <artifactId>azure-resourcemanager-compute</artifactId>
-      <version>2.56.3</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-compute;dependency} -->
+      <version>2.57.0</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-compute;dependency} -->
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
# Description

Manual version bump after release, due to java feed failure:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6221367&view=results

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
