### PR TITLE
OperationPoliciesTest Pipelines Failures

### DIFF
--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/batch/BulkExecutor.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/batch/BulkExecutor.java
@@ -874,6 +874,7 @@ public final class BulkExecutor<TContext> implements Disposable {
         options.setThroughputControlGroupName(cosmosBulkExecutionOptions.getThroughputControlGroupName());
         options.setExcludedRegions(cosmosBulkExecutionOptions.getExcludedRegions());
         options.setKeywordIdentifiers(cosmosBulkExecutionOptions.getKeywordIdentifiers());
+        options.setEffectiveItemSerializer(this.effectiveItemSerializer);
 
         CosmosEndToEndOperationLatencyPolicyConfig e2eLatencyPolicySnapshot =
             cosmosBulkExecutionOptions.getCosmosEndToEndLatencyPolicyConfig();


### PR DESCRIPTION
Fixes the recurring `OperationPoliciesTest` failures caused by custom serializer propagation/identity handling in operation policies (especially visible in bulk and batch paths) in pipelines.

following test were failing in multiple pipelines repeatedly:

java.lang.AssertionError: Expecting actual: com.azure.cosmos.implementation.DefaultCosmosItemSerializer@55f7229c and: com.azure.cosmos.implementation.DefaultCosmosItemSerializer@24144ce5 to refer to the same object
Stack trace
reactor.core.Exceptions<span>ReactiveException: java.lang.AssertionError: Expecting actual: com.azure.cosmos.implementation.DefaultCosmosItemSerializer@55f7229c and: com.azure.cosmos.implementation.DefaultCosmosItemSerializer@24144ce5 to refer to the same object at reactor.core.Exceptions.propagate(Exceptions.java:410) at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:102) at reactor.core.publisher.Flux.blockLast(Flux.java:2817) at com.azure.cosmos.OperationPoliciesTest.bulk(OperationPoliciesTest.java:503) at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) at java.base/java.lang.reflect.Method.invoke(Method.java:565) at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:136) at org.testng.internal.invokers.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:44) at org.testng.internal.invokers.InvokeMethodRunnable.call(InvokeMethodRunnable.java:72) at org.testng.internal.invokers.InvokeMethodRunnable.call(InvokeMethodRunnable.java:10) at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328) at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090) at java.base/java.util.concurrent.ThreadPoolExecutor</span>Worker.run(ThreadPoolExecutor.java:614)
at java.base/java.lang.Thread.run(Thread.java:1474)
Suppressed: java.lang.Exception: #block terminated with an error
at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:104)
... 12 more
Caused by: java.lang.AssertionError:
Expecting actual:
com.azure.cosmos.implementation.DefaultCosmosItemSerializer@55f7229c
and:
com.azure.cosmos.implementation.DefaultCosmosItemSerializer@24144ce5
to refer to the same object
at com.azure.cosmos.OperationPoliciesTest.validateOptions(OperationPoliciesTest.java:747)
at com.azure.cosmos.OperationPoliciesTest.lambda<span>bulk</span>2(OperationPoliciesTest.java:500)
at reactor.core.publisher.FluxFlatMap<span>FlatMapMain.onNext(FluxFlatMap.java:388) at reactor.core.publisher.FluxPublishOn</span>PublishOnSubscriber.runAsync(FluxPublishOn.java:446)
at reactor.core.publisher.FluxPublishOn<span>PublishOnSubscriber.run(FluxPublishOn.java:533) at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84) at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37) at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328) at java.base/java.util.concurrent.ScheduledThreadPoolExecutor</span>ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:309)
... 3 more


java.lang.AssertionError:
Expecting actual:
com.azure.cosmos.implementation.DefaultCosmosItemSerializer@2149ba49
and:
com.azure.cosmos.implementation.DefaultCosmosItemSerializer@2ebc29c1
to refer to the same object
Stack trace
reactor.core.Exceptions<span>ReactiveException: java.lang.AssertionError: Expecting actual: com.azure.cosmos.implementation.DefaultCosmosItemSerializer@2149ba49 and: com.azure.cosmos.implementation.DefaultCosmosItemSerializer@2ebc29c1 to refer to the same object at reactor.core.Exceptions.propagate(Exceptions.java:410) at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:102) at reactor.core.publisher.Flux.blockLast(Flux.java:2817) at com.azure.cosmos.OperationPoliciesTest.bulk(OperationPoliciesTest.java:503) at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) at java.base/java.lang.reflect.Method.invoke(Method.java:565) at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:136) at org.testng.internal.invokers.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:44) at org.testng.internal.invokers.InvokeMethodRunnable.call(InvokeMethodRunnable.java:72) at org.testng.internal.invokers.InvokeMethodRunnable.call(InvokeMethodRunnable.java:10) at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328) at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090) at java.base/java.util.concurrent.ThreadPoolExecutor</span>Worker.run(ThreadPoolExecutor.java:614)
at java.base/java.lang.Thread.run(Thread.java:1474)
Suppressed: java.lang.Exception: #block terminated with an error
at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:104)
... 12 more
Caused by: java.lang.AssertionError:
Expecting actual:
com.azure.cosmos.implementation.DefaultCosmosItemSerializer@2149ba49
and:
com.azure.cosmos.implementation.DefaultCosmosItemSerializer@2ebc29c1
to refer to the same object
at com.azure.cosmos.OperationPoliciesTest.validateOptions(OperationPoliciesTest.java:747)
at com.azure.cosmos.OperationPoliciesTest.lambda<span>bulk</span>2(OperationPoliciesTest.java:500)
at reactor.core.publisher.FluxFlatMap<span>FlatMapMain.onNext(FluxFlatMap.java:388) at reactor.core.publisher.FluxPublishOn</span>PublishOnSubscriber.runAsync(FluxPublishOn.java:446)
at reactor.core.publisher.FluxPublishOn<span>PublishOnSubscriber.run(FluxPublishOn.java:533) at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84) at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37) at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328) at java.base/java.util.concurrent.ScheduledThreadPoolExecutor</span>ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:309)

