### PR TITLE
Remove opentelemetry packages from IllegalImport checkstyle rule

### DIFF
--- a/eng/lintingconfigs/checkstyle/clientcore/checkstyle.xml
+++ b/eng/lintingconfigs/checkstyle/clientcore/checkstyle.xml
@@ -66,7 +66,7 @@
     <module name="AvoidStarImport"/>
     <module name="IllegalImport">
       <property name="regexp" value="true"/>
-      <property name="illegalPkgs" value="^(com\.)?sun\.\w*, ^io.opentelemetry"/>
+      <property name="illegalPkgs" value="^(com\.)?sun\.\w*"/>
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>

--- a/eng/lintingconfigs/checkstyle/track2/checkstyle.xml
+++ b/eng/lintingconfigs/checkstyle/track2/checkstyle.xml
@@ -66,7 +66,7 @@
     <module name="AvoidStarImport"/>
     <module name="IllegalImport">
       <property name="regexp" value="true"/>
-      <property name="illegalPkgs" value="^(com\.)?sun\.\w*, ^io.opentelemetry"/>
+      <property name="illegalPkgs" value="^(com\.)?sun\.\w*"/>
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>

--- a/eng/lintingconfigs/checkstyle/vnext/checkstyle.xml
+++ b/eng/lintingconfigs/checkstyle/vnext/checkstyle.xml
@@ -65,7 +65,7 @@
     <module name="AvoidStarImport"/>
     <module name="IllegalImport">
       <property name="regexp" value="true"/>
-      <property name="illegalPkgs" value="^(com\.)?sun\.\w*, ^io.opentelemetry"/>
+      <property name="illegalPkgs" value="^(com\.)?sun\.\w*"/>
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>


### PR DESCRIPTION
This pull request updates the Checkstyle configuration for multiple modules to allow imports from the `io.opentelemetry` package, which were previously flagged as illegal. This change will make it possible to use OpenTelemetry instrumentation libraries in the codebase without triggering linting errors.

**Linting configuration updates:**

* [`eng/lintingconfigs/checkstyle/clientcore/checkstyle.xml`](diffhunk://#diff-70efdca697b874722b1278dc4bfda613b037b061e5131e1149876df21503939bL69-R69): Removed `^io.opentelemetry` from the `illegalPkgs` property, allowing imports from the `io.opentelemetry` package.
* [`eng/lintingconfigs/checkstyle/track2/checkstyle.xml`](diffhunk://#diff-e09a0ff58fe74d31d5a8da1bfba6a08a1807008b3e509b4e446448ab2bfd2f49L69-R69): Removed `^io.opentelemetry` from the `illegalPkgs` property, allowing imports from the `io.opentelemetry` package.
* [`eng/lintingconfigs/checkstyle/vnext/checkstyle.xml`](diffhunk://#diff-ceac9cc8dbbe27eaff22914ae48a006cb139886933918678935de7141e0e61b3L68-R68): Removed `^io.opentelemetry` from the `illegalPkgs` property, allowing imports from the `io.opentelemetry` package.