### PR TITLE
Fix patch release detection for Maven-only core dependencies

### DIFF
--- a/eng/scripts/bomhelpers.ps1
+++ b/eng/scripts/bomhelpers.ps1
@@ -59,7 +59,6 @@ function NormalizeVersionFileForPatching([string[]]$PatchedArtifactNames, [strin
   }
 
   if ($depsToNormalize.Count -eq 0) {
-    Write-Host "No non-patched {;current} dependencies found to normalize."
     return
   }
 
@@ -494,12 +493,12 @@ function GeneratePatch($PatchInfo, [string]$BranchName, [string]$RemoteName, [st
       Write-Output "Failed to fetch new tag format. Trying old tag format: $oldReleaseTag"
       Write-Host "git fetch $RemoteName $oldReleaseTag"
       $cmdOutput = git fetch $RemoteName $oldReleaseTag
-      
+
       if ($LASTEXITCODE -ne 0) {
         LogError "Could not restore the tags for release tag $releaseTag or $oldReleaseTag"
         exit $LASTEXITCODE
       }
-      
+
       $releaseTag = $oldReleaseTag
     }
 

--- a/eng/scripts/patchhelpers.ps1
+++ b/eng/scripts/patchhelpers.ps1
@@ -107,13 +107,78 @@ function UpdateCIInformation($ArtifactInfos) {
     }
 }
 
+<#
+.SYNOPSIS
+Adds a missing Azure dependency's latest GA/patch version to the patch comparison map.
+
+.DESCRIPTION
+Returns $true when $LatestVersions[$DependencyId] is available after this function runs:
+either it was already present, or it was resolved from Maven and added to $LatestVersions.
+
+Returns $false when the dependency should not participate in patch-version comparison:
+it is already known to be unresolved, is not an Azure artifact, has no usable GA/patch
+version on Maven, or returns 404 from Maven metadata lookup. Other Maven/feed errors are
+re-thrown because they can make patch analysis unreliable.
+#>
+function TryAddLatestDependencyVersionFromMaven($DependencyId, [hashtable]$LatestVersions, [hashtable]$UnresolvedDependencies) {
+    # Dependency versions already in the patch graph take precedence. This includes
+    # artifacts from patch_release_client.txt and artifacts already selected for a
+    # patch in the current fixed-point pass.
+    if ($LatestVersions.ContainsKey($DependencyId)) {
+        return $true
+    }
+
+    # Cache missing dependencies so repeated references from multiple artifacts do
+    # not repeatedly call the Maven feed during each fixed-point pass.
+    if ($UnresolvedDependencies.ContainsKey($DependencyId)) {
+        return $false
+    }
+
+    # Keep the original behavior for third-party packages: only Azure artifacts can
+    # cause automated patch releases.
+    if ($DependencyId -notlike "azure-*") {
+        $UnresolvedDependencies[$DependencyId] = $true
+        return $false
+    }
+
+    try {
+        # Some common Azure dependencies (for example azure-core and azure-identity)
+        # are not listed in patch_release_client.txt. Resolve their latest GA/patch
+        # version from the Maven feed so dependents can still be detected.
+        $dependencyInfo = GetVersionInfoForMavenArtifact -ArtifactId $DependencyId -GroupId "com.azure"
+        if ($dependencyInfo -and -not [String]::IsNullOrWhiteSpace($dependencyInfo.LatestGAOrPatchVersion)) {
+            $LatestVersions[$DependencyId] = $dependencyInfo.LatestGAOrPatchVersion
+            return $true
+        }
+
+        $UnresolvedDependencies[$DependencyId] = $true
+        return $false
+    } catch {
+        $statusCode = $null
+        if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+            $statusCode = [int]$_.Exception.Response.StatusCode
+        }
+
+        # A 404 means the dependency is not published as a com.azure Maven artifact,
+        # so it should be treated like an ignored external dependency.
+        if ($statusCode -eq 404) {
+            Write-Verbose "Could not find Maven metadata for dependency '$DependencyId' in group 'com.azure'."
+            $UnresolvedDependencies[$DependencyId] = $true
+            return $false
+        }
+
+        throw
+    }
+}
+
 # Find all the artifacts that will need to be patched based on dependency analysis.
 # Iterates until no more patches are found (fixed-point), so the result is correct
 # regardless of artifact ordering in patch_release_client.txt.
-# Only dependencies that are themselves in the patch list are checked — external
-# dependencies (reactor-core, jackson, etc.) are ignored.
+# Dependencies in the patch list are checked directly; missing Azure dependencies
+# are resolved from Maven. External dependencies (reactor-core, jackson, etc.) are ignored.
 function FindArtifactsThatNeedPatching($ArtifactInfos) {
     $latestVersions = @{}
+    $unresolvedDependencies = @{}
     foreach ($arId in $ArtifactInfos.Keys) {
         $latestVersions[$arId] = $ArtifactInfos[$arId].LatestGAOrPatchVersion
     }
@@ -124,7 +189,11 @@ function FindArtifactsThatNeedPatching($ArtifactInfos) {
             $arInfo = $ArtifactInfos[$arId]
             if ($arInfo.FutureReleasePatchVersion) { continue }
             foreach ($depId in $arInfo.Dependencies.Keys) {
-                if (-not $latestVersions.ContainsKey($depId)) { continue }
+                if (-not $latestVersions.ContainsKey($depId) -and
+                    -not (TryAddLatestDependencyVersionFromMaven -DependencyId $depId -LatestVersions $latestVersions -UnresolvedDependencies $unresolvedDependencies)) {
+                    continue
+                }
+
                 if ($arInfo.Dependencies[$depId] -ne $latestVersions[$depId]) {
                     $patchVersion = GetPatchVersion -ReleaseVersion $arInfo.LatestGAOrPatchVersion
                     $arInfo.FutureReleasePatchVersion = $patchVersion

--- a/eng/scripts/tests/patchhelpers.tests.ps1
+++ b/eng/scripts/tests/patchhelpers.tests.ps1
@@ -99,6 +99,10 @@ Describe "FindArtifactsThatNeedPatching" {
     It "External dependency version difference is ignored (no false positive)" {
         # azure-core uses reactor-core 3.5.0, azure-identity uses 3.6.0.
         # reactor-core is NOT in the patch list → should NOT trigger patching.
+        Mock GetVersionInfoForMavenArtifact {
+            throw "External dependencies should not be queried from Maven."
+        }
+
         $infos = [ordered]@{
             "azure-core" = (New-TestArtifactInfo -ArtifactId "azure-core" -LatestGAOrPatchVersion "1.41.0" -Dependencies @{
                 "reactor-core" = "3.5.0"
@@ -111,6 +115,84 @@ Describe "FindArtifactsThatNeedPatching" {
         FindArtifactsThatNeedPatching -ArtifactInfos $infos
         $infos["azure-core"].FutureReleasePatchVersion | Should -BeNullOrEmpty
         $infos["azure-identity"].FutureReleasePatchVersion | Should -BeNullOrEmpty
+    }
+
+    It "Released azure-core missing from patch list triggers dependent patch" {
+        $script:mavenLookupCalls = 0
+        Mock GetVersionInfoForMavenArtifact {
+            param($ArtifactId, $GroupId)
+            $script:mavenLookupCalls++
+            return [ArtifactInfo]::new($ArtifactId, $GroupId, "1.41.0")
+        } -ParameterFilter { $ArtifactId -eq "azure-core" -and $GroupId -eq "com.azure" }
+
+        $infos = [ordered]@{
+            "azure-storage-blob" = (New-TestArtifactInfo -ArtifactId "azure-storage-blob" -LatestGAOrPatchVersion "12.33.2" -Dependencies @{
+                "azure-core" = "1.40.0"
+            })
+        }
+
+        FindArtifactsThatNeedPatching -ArtifactInfos $infos
+
+        $infos["azure-storage-blob"].FutureReleasePatchVersion | Should -Be "12.33.3"
+        $script:mavenLookupCalls | Should -Be 1
+    }
+
+    It "Released azure-identity missing from patch list triggers dependent patch" {
+        Mock GetVersionInfoForMavenArtifact {
+            param($ArtifactId, $GroupId)
+            return [ArtifactInfo]::new($ArtifactId, $GroupId, "1.10.0")
+        } -ParameterFilter { $ArtifactId -eq "azure-identity" -and $GroupId -eq "com.azure" }
+
+        $infos = [ordered]@{
+            "azure-security-keyvault-secrets" = (New-TestArtifactInfo -ArtifactId "azure-security-keyvault-secrets" -LatestGAOrPatchVersion "4.9.0" -Dependencies @{
+                "azure-identity" = "1.9.0"
+            })
+        }
+
+        FindArtifactsThatNeedPatching -ArtifactInfos $infos
+
+        $infos["azure-security-keyvault-secrets"].FutureReleasePatchVersion | Should -Be "4.9.1"
+    }
+
+    It "Missing Azure dependency without Maven GA version is ignored" {
+        Mock GetVersionInfoForMavenArtifact {
+            param($ArtifactId, $GroupId)
+            return [ArtifactInfo]::new($ArtifactId, $GroupId, $null)
+        } -ParameterFilter { $ArtifactId -eq "azure-missing-dependency" -and $GroupId -eq "com.azure" }
+
+        $infos = [ordered]@{
+            "azure-storage-blob" = (New-TestArtifactInfo -ArtifactId "azure-storage-blob" -LatestGAOrPatchVersion "12.33.2" -Dependencies @{
+                "azure-missing-dependency" = "1.0.0"
+            })
+        }
+
+        FindArtifactsThatNeedPatching -ArtifactInfos $infos
+
+        $infos["azure-storage-blob"].FutureReleasePatchVersion | Should -BeNullOrEmpty
+    }
+
+    It "Caches Maven lookup for missing dependency shared by multiple artifacts" {
+        $script:mavenLookupCalls = 0
+        Mock GetVersionInfoForMavenArtifact {
+            param($ArtifactId, $GroupId)
+            $script:mavenLookupCalls++
+            return [ArtifactInfo]::new($ArtifactId, $GroupId, "1.41.0")
+        } -ParameterFilter { $ArtifactId -eq "azure-core" -and $GroupId -eq "com.azure" }
+
+        $infos = [ordered]@{
+            "azure-storage-blob" = (New-TestArtifactInfo -ArtifactId "azure-storage-blob" -LatestGAOrPatchVersion "12.33.2" -Dependencies @{
+                "azure-core" = "1.40.0"
+            })
+            "azure-storage-queue" = (New-TestArtifactInfo -ArtifactId "azure-storage-queue" -LatestGAOrPatchVersion "12.26.0" -Dependencies @{
+                "azure-core" = "1.40.0"
+            })
+        }
+
+        FindArtifactsThatNeedPatching -ArtifactInfos $infos
+
+        $infos["azure-storage-blob"].FutureReleasePatchVersion | Should -Be "12.33.3"
+        $infos["azure-storage-queue"].FutureReleasePatchVersion | Should -Be "12.26.1"
+        $script:mavenLookupCalls | Should -Be 1
     }
 
     It "Independent release of a dependency triggers dependent patch (seeding loop regression)" {


### PR DESCRIPTION
## Summary
- Fix patch release dependency analysis so Azure dependencies missing from `patch_release_client.txt`, such as `azure-core` and `azure-identity`, can still be resolved from the Maven feed.
- Cache resolved and unresolved missing dependencies during fixed-point patch detection to avoid repeated Maven lookups.
- Add regression coverage for Maven-resolved missing dependencies, ignored external dependencies, unresolved Azure dependencies, and lookup caching.

## Bug
`FindArtifactsThatNeedPatching` seeded its comparison map only from artifacts listed in `eng/pipelines/patch_release_client.txt`. Because `azure-core` and `azure-identity` are not in that file, a dependent package whose published POM referenced an older `azure-core` or `azure-identity` version skipped the comparison entirely. When only one of those core dependencies was released, the automation could fail to find downstream artifacts that need dependency-only patch releases.

## Solution
When a dependency is absent from the current patch graph, the helper now attempts to resolve `azure-*` dependencies from the configured Maven feed using the existing version metadata lookup. If a latest GA/patch version is found, it is added to the comparison map and participates in the existing version comparison and fixed-point cascade. Non-Azure dependencies and Maven 404s remain out of scope, while other Maven/feed errors are re-thrown so patch analysis does not silently proceed with unreliable data.

## Verification
- `pwsh -NoLogo -NoProfile -Command '$result = Invoke-Pester ./eng/scripts/tests/patchhelpers.tests.ps1 -PassThru; if ($result.FailedCount -gt 0) { exit 1 }'`

local run result: https://github.com/Azure/azure-sdk-for-java/compare/users/raych1/update-maven-pkg-feed...release/patches-for-auto-release_cab4ce54-ea65-4a19-8d20-a940db116c02