### PR TITLE
Network Isolation - CFSClean

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -377,14 +377,11 @@ jobs:
         parameters:
           npmrcPath: $(Agent.TempDirectory)/analyze-job/.npmrc
 
-      - pwsh: |
-          Write-Host "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Agent.TempDirectory)/analyze-job/.npmrc"
-        displayName: Configure npm user config
-
       - template: /eng/common/pipelines/templates/steps/check-spelling.yml
         parameters:
           CspellConfigPath: .vscode/cspell.json
           ContinueOnError: false
+          NpmConfigUserConfig: $(Agent.TempDirectory)/analyze-job/.npmrc
 
       - ${{ if eq(parameters.TestPipeline, true) }}:
         - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
@@ -450,7 +447,7 @@ jobs:
             -ServiceDirectories '$(PRServiceDirectories)'
             -RegenerationType 'All'
         env:
-          NPM_CONFIG_USERCONFIG: $(Agent.TempDirectory)/analyze-job/.npmrc
+          npm_config_userconfig: $(Agent.TempDirectory)/analyze-job/.npmrc
 
       - template: /eng/pipelines/templates/steps/run-and-validate-linting.yml
         parameters:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -367,6 +367,20 @@ jobs:
             Paths: $(SparseCheckoutDirectories)
             SkipCheckoutNone: true
 
+      - task: UseNode@1
+        inputs:
+          version: 22.x
+        displayName: Use Node.js 22.x
+
+      # Authenticate npm to Azure Artifacts before any npm-backed Analyze steps run.
+      - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+        parameters:
+          npmrcPath: $(Agent.TempDirectory)/analyze-job/.npmrc
+
+      - pwsh: |
+          Write-Host "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Agent.TempDirectory)/analyze-job/.npmrc"
+        displayName: Configure npm user config
+
       - template: /eng/common/pipelines/templates/steps/check-spelling.yml
         parameters:
           CspellConfigPath: .vscode/cspell.json
@@ -423,16 +437,6 @@ jobs:
         parameters:
           SourceDirectory: $(Build.SourcesDirectory)
           BasePathLength: 38
-
-      - task: UseNode@1
-        inputs:
-          version: 22.x
-        displayName: Use Node.js 22.x
-
-      # Authenticate npm to Azure Artifacts
-      - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-        parameters:
-          npmrcPath: $(Agent.TempDirectory)/analyze-job/.npmrc
 
       # Authenticate with Azure Artifacts
       - template: /eng/pipelines/templates/steps/maven-authenticate.yml


### PR DESCRIPTION
Move create-authenticated-npmrc.yml step to before cspell so that all npm in cspell calls use DevOps feed.