### PR TITLE
Fix regression in `patch-release-prepare`

### DIFF
--- a/eng/pipelines/patch-release-prepare.yml
+++ b/eng/pipelines/patch-release-prepare.yml
@@ -41,6 +41,8 @@ extends:
                 workingDirectory: $(Build.SourcesDirectory)
                 displayName: 'Create release branch'
 
+              - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
               # Push the release branch to the repo
               - task: PowerShell@2
                 displayName: 'Push release branch to the repo'
@@ -51,7 +53,7 @@ extends:
                   arguments: >
                     -PRBranchName $(BaseBranchName)
                     -CommitMsg "none"
-                    -GitUrl "https://$(azuresdk-github-pat)@github.com/Azure/azure-sdk-for-java.git"
+                    -GitUrl "https://x-access-token:$(GH_TOKEN)@github.com/Azure/azure-sdk-for-java.git"
                     -SkipCommit $true
 
               # Run the script to generate patches for automatic releases
@@ -73,5 +75,6 @@ extends:
                   BaseBranchName: refs/heads/$(BaseBranchName)
                   PRBranchName: prepare-patch-release-$(PatchDate)-$(Build.BuildId)
                   PROwner: Azure
+                  AuthToken: $(GH_TOKEN)
                   CommitMsg: "Patch release preparation $(PatchDate)"
                   PRTitle: "Prepare patch release $(PatchDate)"


### PR DESCRIPTION
Hey java folks, thought I was able to make this totally backwards compatible. Unbeknownst to me, you cannot pull from old-style url and push to new-style.

<img width="1129" height="242" alt="image" src="https://github.com/user-attachments/assets/8300f49e-ce46-460c-b68e-8bcfd5809b13" />

[occurring build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6251501&view=logs&j=8bb51529-1249-55cf-9f87-6cebd7062aae&t=46a7fb17-5065-5ab7-6178-b54af2740fc3)

This is not actually an auth error, I thought by leaving behind the default to `$(azuresdk-github-pat)`, we were totally inured to issues like this.

Well TIL this would error 👎  I'll work to identify others in this repo that follow a similar pattern. 

Figured if I'm in here I might as well convert this workflow to github app based so I don't need to come through it again later, so that's the change to add `login-to-github.yml`.

[Proved working](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6251994&view=logs&j=8bb51529-1249-55cf-9f87-6cebd7062aae&t=46a7fb17-5065-5ab7-6178-b54af2740fc3)

Related to Azure/azure-sdk-tools#9842