### PR TITLE
Fix Changelog Entry Bug in Prepare Patch Pipeline

### DIFF
--- a/eng/scripts/Generate-Patches-For-Automatic-Releases.ps1
+++ b/eng/scripts/Generate-Patches-For-Automatic-Releases.ps1
@@ -71,6 +71,34 @@ try {
     }
     NormalizeVersionFileForPatching -PatchedArtifactNames $patchedArtifactNames -PatchedPomFilePaths $patchedPomPaths
 
+    # Capture each patched package's current pom.xml version BEFORE the per-package loop runs.
+    # The first iteration's call to UpdateDependencyOfClientSDK invokes update_versions.py, which
+    # rewrites every pom.xml in the repo from version_client.txt — including the as-yet-unprocessed
+    # patched packages. By the time GeneratePatch reaches a sibling later in the loop, that
+    # sibling's pom.xml on disk already shows the GA version, which causes the
+    # "$currentPomFileVersion -ne $releaseVersion" reset gate in GeneratePatch to evaluate to
+    # false and skip the source reset (commit "Reset sources for <artifactId> ..."). Capturing
+    # the original pom version here and passing it through to GeneratePatch ensures the gate
+    # sees the actual pre-patch version (typically an in-progress -beta) so the reset runs.
+    $CurrentPomFileVersions = @{}
+    foreach ($packageData in $packagesData) {
+        $pkgArtifactId = $packageData["name"]
+        $pkgGroupId = $packageData["groupId"]
+        $pkgKey = "${pkgGroupId}:${pkgArtifactId}"
+        $pomPath = Join-Path $SourcesDirectory "sdk" $packageData["ServiceDirectory"] $pkgArtifactId "pom.xml"
+        if (Test-Path $pomPath) {
+            try {
+                $pomXml = [xml](Get-Content -Path $pomPath -Raw)
+                $pomVersion = $pomXml.project.version
+                if (![string]::IsNullOrWhiteSpace($pomVersion)) {
+                    $CurrentPomFileVersions[$pkgKey] = $pomVersion.Trim()
+                }
+            } catch {
+                Write-Warning "Could not read current pom.xml version for ${pkgArtifactId} from ${pomPath}: $_"
+            }
+        }
+    }
+
     # Build PatchVersionOverrides: map of "${groupId}:${artifactId}" → patch version for all
     # artifacts being patched. This is passed to generatepatch.ps1 so changelogs show the
     # correct version when a sibling dependency is also being patched in the same run.
@@ -90,7 +118,9 @@ try {
 
     # Reset each package to the latest stable release and update CHANGELOG, POM and README for patch release.
     foreach ($packageData in $packagesData) {
-        . "${PSScriptRoot}/generatepatch.ps1" -ArtifactIds $packageData["name"] -ServiceDirectoryName $packageData["ServiceDirectory"] -BranchName $branchName -GroupId $packageData["groupId"] -UseCurrentBranch:$UseCurrentBranch -PatchVersionOverrides $PatchVersionOverrides
+        $pkgKey = $packageData["groupId"] + ":" + $packageData["name"]
+        $capturedPomVersion = $CurrentPomFileVersions[$pkgKey]
+        . "${PSScriptRoot}/generatepatch.ps1" -ArtifactIds $packageData["name"] -ServiceDirectoryName $packageData["ServiceDirectory"] -BranchName $branchName -GroupId $packageData["groupId"] -UseCurrentBranch:$UseCurrentBranch -PatchVersionOverrides $PatchVersionOverrides -CurrentPomFileVersion $capturedPomVersion
         $libraryList += $packageData["groupId"] + ":" + $packageData["name"] + ","
     }
 

--- a/eng/scripts/bomhelpers.ps1
+++ b/eng/scripts/bomhelpers.ps1
@@ -479,9 +479,21 @@ function GeneratePatch($PatchInfo, [string]$BranchName, [string]$RemoteName, [st
   $releaseTag = "$($GroupId)+$($artifactId)_$($releaseVersion)"
   if (!$currentPomFileVersion -or !$artifactDirPath -or !$changelogPath) {
     $pkgProperties = [PackageProps](Get-PkgProperties -PackageName $artifactId -ServiceDirectory $serviceDirectoryName -GroupId $GroupId)
-    $artifactDirPath = $pkgProperties.DirectoryPath
-    $currentPomFileVersion = $pkgProperties.Version
-    $changelogPath = $pkgProperties.ChangeLogPath
+    # Only fill in fields that weren't supplied by the caller. In particular, do NOT overwrite
+    # an explicitly-passed $currentPomFileVersion: when called from
+    # Generate-Patches-For-Automatic-Releases.ps1, that value was captured from pom.xml BEFORE
+    # any sibling iteration's UpdateDependencyOfClientSDK / update_versions.py rewrote this
+    # package's pom on disk. Re-reading pom.xml here would clobber that with the (already
+    # mutated) GA version and cause the source-reset gate below to be skipped.
+    if (!$artifactDirPath) {
+      $artifactDirPath = $pkgProperties.DirectoryPath
+    }
+    if (!$currentPomFileVersion) {
+      $currentPomFileVersion = $pkgProperties.Version
+    }
+    if (!$changelogPath) {
+      $changelogPath = $pkgProperties.ChangeLogPath
+    }
   }
 
   if (!$artifactDirPath) {

--- a/eng/scripts/generatepatch.ps1
+++ b/eng/scripts/generatepatch.ps1
@@ -49,7 +49,13 @@ param(
   [switch]$UseCurrentBranch,
   # Optional map of artifactId → version for sibling artifacts being patched in the same run.
   # Passed to GeneratePatch so changelogs show the correct version for sibling dependencies.
-  [hashtable]$PatchVersionOverrides = @{}
+  [hashtable]$PatchVersionOverrides = @{},
+  # Optional captured current pom.xml version for the (single) artifact being patched. The orchestrator
+  # (Generate-Patches-For-Automatic-Releases.ps1) reads each pom version up-front BEFORE any sibling
+  # iteration mutates pom.xml files via update_versions.py, then passes that original value here so
+  # GeneratePatch's reset gate ($currentPomFileVersion -ne $releaseVersion) sees the true pre-patch
+  # version and the source-reset block executes as expected.
+  [string]$CurrentPomFileVersion
 )
 
 $RepoRoot = Resolve-Path "${PSScriptRoot}..\..\.."
@@ -105,6 +111,9 @@ foreach ($artifactId in $ArtifactIds) {
     $patchInfo = [ArtifactPatchInfo]::new()
     $patchInfo.ArtifactId = $artifactId
     $patchInfo.ServiceDirectoryName = $ServiceDirectoryName
+    if (-not [string]::IsNullOrWhiteSpace($CurrentPomFileVersion)) {
+        $patchInfo.CurrentPomFileVersion = $CurrentPomFileVersion
+    }
     GeneratePatch -PatchInfo $patchInfo -BranchName $BranchName -RemoteName $RemoteName -GroupId $GroupId -UseCurrentBranch $UseCurrentBranch -PatchVersionOverrides $PatchVersionOverrides
     #TriggerPipeline -PatchInfos $patchInfo -BranchName $BranchName
 }


### PR DESCRIPTION
This pull request improves the reliability of the patch generation process for Java SDKs by ensuring that the original `pom.xml` version for each package is captured before any updates occur. This prevents issues where the source reset logic is skipped due to premature version changes by sibling package updates. The changes introduce a mechanism to capture and pass the pre-patch version of each package through the patching scripts, ensuring accurate source resets and correct changelog updates.

**Enhancements to patch version handling and orchestration:**

* In `Generate-Patches-For-Automatic-Releases.ps1`, the script now captures the current `pom.xml` version for each package before any per-package processing. This original version is stored and used throughout the patching process to ensure the source reset logic works correctly, even if sibling packages are updated first.
* When invoking `generatepatch.ps1` for each package, the captured pre-patch `pom.xml` version is passed as a new parameter, ensuring that the reset gate compares against the true original version.

**Script and parameter updates:**

* `generatepatch.ps1` now accepts an optional `CurrentPomFileVersion` parameter, allowing the orchestrator to provide the pre-patch version for accurate processing.
* The per-artifact loop in `generatepatch.ps1` sets the `CurrentPomFileVersion` in the patch info object if provided, ensuring downstream logic uses the correct version.

**Safeguards in helper functions:**

* In `bomhelpers.ps1`, the logic for filling in package properties is updated to only overwrite fields not supplied by the caller, preventing accidental overwriting of the explicitly passed `CurrentPomFileVersion`.