### PR TITLE
Fix Spring sub-level event-hub-name override and EventContext checkpoint offsetString propagation

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Bugs Fixed
 
+- Fixed `BlobCheckpointStore.updateCheckpoint` so that it falls back to the deprecated
+  `Checkpoint.getOffset()` (Long) value when `Checkpoint.getOffsetString()` is not populated. This restores writing of
+  the `offset` blob metadata for callers that still build `Checkpoint` instances using the legacy long offset, fixing
+  a regression introduced in 1.21.0 that broke partition switch-over and consumer-group lag monitoring.
+  ([#46752](https://github.com/Azure/azure-sdk-for-java/issues/46752))
+
 ### Other Changes
 
 ## 1.21.4 (2026-03-02)

--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/src/main/java/com/azure/messaging/eventhubs/checkpointstore/blob/BlobCheckpointStore.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/src/main/java/com/azure/messaging/eventhubs/checkpointstore/blob/BlobCheckpointStore.java
@@ -243,9 +243,12 @@ public class BlobCheckpointStore implements CheckpointStore {
      */
     @Override
     public Mono<Void> updateCheckpoint(Checkpoint checkpoint) {
-        if (checkpoint == null || (checkpoint.getSequenceNumber() == null && checkpoint.getOffset() == null)) {
+        if (checkpoint == null
+            || (checkpoint.getSequenceNumber() == null
+                && checkpoint.getOffset() == null
+                && CoreUtils.isNullOrEmpty(checkpoint.getOffsetString()))) {
             throw LOGGER.logExceptionAsWarning(Exceptions.propagate(new IllegalStateException(
-                "Both sequence number and offset cannot be null when updating a checkpoint")));
+                "At least one of sequence number, offset, or offsetString must be provided when updating a checkpoint")));
         }
 
         String partitionId = checkpoint.getPartitionId();
@@ -259,8 +262,14 @@ public class BlobCheckpointStore implements CheckpointStore {
         String sequenceNumber
             = checkpoint.getSequenceNumber() == null ? null : String.valueOf(checkpoint.getSequenceNumber());
 
+        // Prefer offsetString when populated; otherwise fall back to the deprecated offset (Long) so callers that
+        // still build Checkpoint instances using setOffset(Long) continue to persist the offset metadata.
+        String offset = CoreUtils.isNullOrEmpty(checkpoint.getOffsetString())
+            ? Objects.toString(checkpoint.getOffset(), null)
+            : checkpoint.getOffsetString();
+
         metadata.put(SEQUENCE_NUMBER, sequenceNumber);
-        metadata.put(OFFSET, checkpoint.getOffsetString());
+        metadata.put(OFFSET, offset);
         BlobAsyncClient blobAsyncClient = blobClients.get(blobName);
 
         return blobAsyncClient.exists().flatMap(exists -> {

--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/src/main/java/com/azure/messaging/eventhubs/checkpointstore/blob/BlobCheckpointStore.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/src/main/java/com/azure/messaging/eventhubs/checkpointstore/blob/BlobCheckpointStore.java
@@ -244,7 +244,7 @@ public class BlobCheckpointStore implements CheckpointStore {
      *
      * @param checkpoint Checkpoint information containing the sequence number and/or offset (as {@code offsetString}
      * or the deprecated {@code offset}) to be stored for this partition.
-     * @return The new ETag on successful update.
+     * @return A {@link Mono} that completes when the checkpoint metadata has been persisted.
      */
     @Override
     public Mono<Void> updateCheckpoint(Checkpoint checkpoint) {

--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/src/main/java/com/azure/messaging/eventhubs/checkpointstore/blob/BlobCheckpointStore.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/src/main/java/com/azure/messaging/eventhubs/checkpointstore/blob/BlobCheckpointStore.java
@@ -238,7 +238,12 @@ public class BlobCheckpointStore implements CheckpointStore {
     /**
      * Updates the checkpoint in Storage Blobs for a partition.
      *
-     * @param checkpoint Checkpoint information containing sequence number and offset to be stored for this partition.
+     * <p>At least one of {@code sequenceNumber}, {@code offsetString}, or the deprecated {@code offset} must be
+     * populated on the supplied {@link Checkpoint}. When both {@code offsetString} and the deprecated {@code offset}
+     * are populated, {@code offsetString} is preferred and persisted as the offset metadata value.</p>
+     *
+     * @param checkpoint Checkpoint information containing the sequence number and/or offset (as {@code offsetString}
+     * or the deprecated {@code offset}) to be stored for this partition.
      * @return The new ETag on successful update.
      */
     @Override

--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/src/test/java/com/azure/messaging/eventhubs/checkpointstore/blob/BlobCheckpointStoreTests.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/src/test/java/com/azure/messaging/eventhubs/checkpointstore/blob/BlobCheckpointStoreTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -46,6 +47,7 @@ import static com.azure.messaging.eventhubs.checkpointstore.blob.BlobCheckpointS
 import static com.azure.messaging.eventhubs.checkpointstore.blob.BlobCheckpointStore.OWNER_ID;
 import static com.azure.messaging.eventhubs.checkpointstore.blob.BlobCheckpointStore.SEQUENCE_NUMBER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -259,6 +261,107 @@ public class BlobCheckpointStoreTests {
         // Act & Assert
         assertThrows(IllegalStateException.class, () -> blobCheckpointStore.updateCheckpoint(null));
         assertThrows(IllegalStateException.class, () -> blobCheckpointStore.updateCheckpoint(new Checkpoint()));
+    }
+
+    /**
+     * Tests that {@link BlobCheckpointStore#updateCheckpoint(Checkpoint)} falls back to the deprecated
+     * {@link Checkpoint#getOffset()} value when {@link Checkpoint#getOffsetString()} is not provided. Reproduces the
+     * regression reported in https://github.com/Azure/azure-sdk-for-java/issues/46752.
+     */
+    @Test
+    public void testUpdateCheckpointFallsBackToOffsetWhenOffsetStringMissing() {
+        Map<String, String> captured = captureUpdateCheckpointMetadata(new Checkpoint().setFullyQualifiedNamespace("ns")
+            .setEventHubName("eh")
+            .setConsumerGroup("cg")
+            .setPartitionId("0")
+            .setSequenceNumber(2L)
+            .setOffset(100L));
+
+        assertEquals("2", captured.get(SEQUENCE_NUMBER));
+        assertEquals("100", captured.get(OFFSET));
+    }
+
+    /**
+     * Tests that {@link BlobCheckpointStore#updateCheckpoint(Checkpoint)} writes the {@code offsetString} value into
+     * blob metadata when only {@link Checkpoint#setOffsetString(String)} has been populated.
+     */
+    @Test
+    public void testUpdateCheckpointUsesOffsetStringWhenProvided() {
+        Map<String, String> captured = captureUpdateCheckpointMetadata(new Checkpoint().setFullyQualifiedNamespace("ns")
+            .setEventHubName("eh")
+            .setConsumerGroup("cg")
+            .setPartitionId("0")
+            .setSequenceNumber(2L)
+            .setOffsetString("offset-string-value"));
+
+        assertEquals("2", captured.get(SEQUENCE_NUMBER));
+        assertEquals("offset-string-value", captured.get(OFFSET));
+    }
+
+    /**
+     * Tests that when both {@code offset} and {@code offsetString} are populated, {@code offsetString} is preferred.
+     */
+    @Test
+    public void testUpdateCheckpointPrefersOffsetStringOverOffset() {
+        Map<String, String> captured = captureUpdateCheckpointMetadata(new Checkpoint().setFullyQualifiedNamespace("ns")
+            .setEventHubName("eh")
+            .setConsumerGroup("cg")
+            .setPartitionId("0")
+            .setSequenceNumber(2L)
+            .setOffset(100L)
+            .setOffsetString("offset-string-value"));
+
+        assertEquals("offset-string-value", captured.get(OFFSET));
+    }
+
+    /**
+     * Tests that an offsetString-only checkpoint is accepted by the validation guard (preserving previous behavior).
+     */
+    @Test
+    public void testUpdateCheckpointOffsetStringOnlyIsValid() {
+        Map<String, String> captured = captureUpdateCheckpointMetadata(new Checkpoint().setFullyQualifiedNamespace("ns")
+            .setEventHubName("eh")
+            .setConsumerGroup("cg")
+            .setPartitionId("0")
+            .setOffsetString("offset-string-value"));
+
+        assertNull(captured.get(SEQUENCE_NUMBER));
+        assertEquals("offset-string-value", captured.get(OFFSET));
+    }
+
+    /**
+     * Tests that a checkpoint with only {@code sequenceNumber} populated still succeeds and writes a {@code null}
+     * offset metadata value, preserving prior behavior.
+     */
+    @Test
+    public void testUpdateCheckpointSequenceNumberOnly() {
+        Map<String, String> captured = captureUpdateCheckpointMetadata(new Checkpoint().setFullyQualifiedNamespace("ns")
+            .setEventHubName("eh")
+            .setConsumerGroup("cg")
+            .setPartitionId("0")
+            .setSequenceNumber(2L));
+
+        assertEquals("2", captured.get(SEQUENCE_NUMBER));
+        assertNull(captured.get(OFFSET));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> captureUpdateCheckpointMetadata(Checkpoint checkpoint) {
+        final String legacyPrefix = getLegacyPrefix(checkpoint.getFullyQualifiedNamespace(),
+            checkpoint.getEventHubName(), checkpoint.getConsumerGroup());
+        final String blobName = legacyPrefix + CHECKPOINT_PATH + checkpoint.getPartitionId();
+
+        when(blobContainerAsyncClient.getBlobAsyncClient(blobName)).thenReturn(blobAsyncClient);
+        when(blobAsyncClient.getBlockBlobAsyncClient()).thenReturn(blockBlobAsyncClient);
+        when(blobAsyncClient.exists()).thenReturn(Mono.just(true));
+        when(blobAsyncClient.setMetadata(ArgumentMatchers.<Map<String, String>>any())).thenReturn(Mono.empty());
+
+        BlobCheckpointStore store = new BlobCheckpointStore(blobContainerAsyncClient);
+        StepVerifier.create(store.updateCheckpoint(checkpoint)).verifyComplete();
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(blobAsyncClient).setMetadata(captor.capture());
+        return captor.getValue();
     }
 
     /**

--- a/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/src/test/java/com/azure/messaging/eventhubs/checkpointstore/blob/BlobCheckpointStoreTests.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/src/test/java/com/azure/messaging/eventhubs/checkpointstore/blob/BlobCheckpointStoreTests.java
@@ -315,7 +315,9 @@ public class BlobCheckpointStoreTests {
     }
 
     /**
-     * Tests that an offsetString-only checkpoint is accepted by the validation guard (preserving previous behavior).
+     * Tests that an {@code offsetString}-only checkpoint is accepted by the validation guard. This is a behavior
+     * change from the prior implementation, which only inspected {@code sequenceNumber} and the deprecated
+     * {@code offset} (Long) and would have rejected a checkpoint that supplied only {@code offsetString}.
      */
     @Test
     public void testUpdateCheckpointOffsetStringOnlyIsValid() {

--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Bugs Fixed
 
+- Fixed `EventContext.updateCheckpointAsync()` so that the `offsetString` from the received `EventData` is propagated
+  to the `Checkpoint` passed to the `CheckpointStore`. Previously only the deprecated `offset` (Long) was set, which
+  caused checkpoint stores that read `offsetString` (such as `BlobCheckpointStore`) to persist a `null` offset, breaking
+  partition switch-over and consumer-group lag monitoring.
+  ([#46752](https://github.com/Azure/azure-sdk-for-java/issues/46752))
+
 ### Other Changes
 
 ## 5.21.3 (2026-01-29)

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/main/java/com/azure/messaging/eventhubs/models/EventContext.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/main/java/com/azure/messaging/eventhubs/models/EventContext.java
@@ -94,6 +94,7 @@ public class EventContext {
                 .setConsumerGroup(partitionContext.getConsumerGroup())
                 .setPartitionId(partitionContext.getPartitionId())
                 .setSequenceNumber(eventData.getSequenceNumber())
+                .setOffsetString(eventData.getOffsetString())
                 .setOffset(eventData.getOffset());
         return this.checkpointStore.updateCheckpoint(checkpoint);
     }

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/test/java/com/azure/messaging/eventhubs/models/EventContextTest.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/test/java/com/azure/messaging/eventhubs/models/EventContextTest.java
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.messaging.eventhubs.models;
+
+import com.azure.messaging.eventhubs.CheckpointStore;
+import com.azure.messaging.eventhubs.EventData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link EventContext}.
+ */
+class EventContextTest {
+    private final PartitionContext partitionContext
+        = new PartitionContext("TEST_NAMESPACE", "TEST_EVENT_HUB", "TEST_DEFAULT_GROUP", "TEST_PARTITION_ID");
+
+    @Mock
+    private CheckpointStore checkpointStore;
+    @Mock
+    private EventData eventData;
+
+    @BeforeEach
+    void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    /**
+     * Verifies that updateCheckpointAsync sets offsetString on the checkpoint.
+     * Regression test for https://github.com/Azure/azure-sdk-for-java/issues/46752
+     * where only setOffset(Long) was called, causing BlobCheckpointStore to store
+     * null offset because it reads getOffsetString().
+     */
+    @Test
+    void updateCheckpointAsyncSetsOffsetString() {
+        // Arrange
+        final Long sequenceNumber = 10L;
+        final Long offset = 15L;
+        final String offsetString = "15";
+
+        when(eventData.getSequenceNumber()).thenReturn(sequenceNumber);
+        when(eventData.getOffset()).thenReturn(offset);
+        when(eventData.getOffsetString()).thenReturn(offsetString);
+        when(checkpointStore.updateCheckpoint(any(Checkpoint.class))).thenReturn(Mono.empty());
+
+        final EventContext context = new EventContext(partitionContext, eventData, checkpointStore, null);
+
+        // Act
+        StepVerifier.create(context.updateCheckpointAsync()).verifyComplete();
+
+        // Assert - offsetString must be set on the checkpoint passed to the store
+        ArgumentCaptor<Checkpoint> captor = ArgumentCaptor.forClass(Checkpoint.class);
+        verify(checkpointStore).updateCheckpoint(captor.capture());
+
+        Checkpoint captured = captor.getValue();
+        assertEquals(partitionContext.getFullyQualifiedNamespace(), captured.getFullyQualifiedNamespace());
+        assertEquals(partitionContext.getEventHubName(), captured.getEventHubName());
+        assertEquals(partitionContext.getConsumerGroup(), captured.getConsumerGroup());
+        assertEquals(partitionContext.getPartitionId(), captured.getPartitionId());
+        assertEquals(sequenceNumber, captured.getSequenceNumber());
+        assertEquals(offset, captured.getOffset());
+        assertNotNull(captured.getOffsetString(), "offsetString must not be null - BlobCheckpointStore depends on it");
+        assertEquals(offsetString, captured.getOffsetString());
+    }
+}

--- a/sdk/spring/CHANGELOG.md
+++ b/sdk/spring/CHANGELOG.md
@@ -3,6 +3,13 @@
 Upgrade Spring Boot dependencies version to 4.0.5 and Spring Cloud dependencies version to 2025.1.1
 Upgrade Spring Boot dependencies version to 4.0.4 and Spring Cloud dependencies version to 2025.1.1
 
+### Spring Cloud Azure Autoconfigure
+This section includes changes in `spring-cloud-azure-autoconfigure` module.
+
+#### Bugs Fixed
+
+- Fixed a bug where the sub-level `event-hub-name` property under `spring.cloud.azure.eventhubs.consumer` or `spring.cloud.azure.eventhubs.producer` was ignored when the base-level `spring.cloud.azure.eventhubs.event-hub-name` was also configured, causing the produced clients to connect to the base event hub instead of the overridden one. [#43593](https://github.com/Azure/azure-sdk-for-java/issues/43593)
+
 ## 6.2.0 (2026-03-25)
 - This release is compatible with Spring Boot 3.5.0-3.5.8. (Note: 3.5.x (x>8) should be supported, but they aren't tested with this release.)
 - This release is compatible with Spring Cloud 2025.0.0. (Note: 2025.0.x (x>0) should be supported, but they aren't tested with this release.)

--- a/sdk/spring/spring-cloud-azure-autoconfigure/CHANGELOG.md
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### Bugs Fixed
 
-- Fixed a bug where the sub-level `event-hub-name` property under `spring.cloud.azure.eventhubs.consumer` or `spring.cloud.azure.eventhubs.producer` was ignored when the base-level `spring.cloud.azure.eventhubs.event-hub-name` was also configured, causing the produced clients to connect to the base event hub instead of the overridden one. [#43593](https://github.com/Azure/azure-sdk-for-java/issues/43593)
-
 ### Other Changes
 
 ## 7.1.0 (2026-03-11)

--- a/sdk/spring/spring-cloud-azure-autoconfigure/CHANGELOG.md
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where the sub-level `event-hub-name` property under `spring.cloud.azure.eventhubs.consumer` or `spring.cloud.azure.eventhubs.producer` was ignored when the base-level `spring.cloud.azure.eventhubs.event-hub-name` was also configured, causing the produced clients to connect to the base event hub instead of the overridden one. [#43593](https://github.com/Azure/azure-sdk-for-java/issues/43593)
+
 ### Other Changes
 
 ## 7.1.0 (2026-03-11)

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/eventhubs/AzureEventHubsConsumerClientConfiguration.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/eventhubs/AzureEventHubsConsumerClientConfiguration.java
@@ -42,7 +42,7 @@ import static com.azure.spring.cloud.autoconfigure.implementation.context.AzureC
 @ConditionalOnProperty(prefix = "spring.cloud.azure.eventhubs.consumer", name = "consumer-group")
 class AzureEventHubsConsumerClientConfiguration {
 
-    @ConditionalOnMissingProperty(prefix = "spring.cloud.azure.eventhubs.consumer", name = { "connection-string", "namespace" })
+    @ConditionalOnMissingProperty(prefix = "spring.cloud.azure.eventhubs.consumer", name = { "connection-string", "namespace", "event-hub-name" })
     @ConditionalOnBean(EventHubClientBuilder.class)
     @Configuration(proxyBeanMethods = false)
     static class SharedConsumerConnectionConfiguration {
@@ -69,7 +69,7 @@ class AzureEventHubsConsumerClientConfiguration {
         }
     }
 
-    @ConditionalOnAnyProperty(prefix = "spring.cloud.azure.eventhubs.consumer", name = { "connection-string", "namespace" })
+    @ConditionalOnAnyProperty(prefix = "spring.cloud.azure.eventhubs.consumer", name = { "connection-string", "namespace", "event-hub-name" })
     @Configuration(proxyBeanMethods = false)
     static class DedicatedConsumerConnectionConfiguration {
 

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/eventhubs/AzureEventHubsProducerClientConfiguration.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/eventhubs/AzureEventHubsProducerClientConfiguration.java
@@ -34,7 +34,7 @@ import static com.azure.spring.cloud.autoconfigure.implementation.context.AzureC
 @ConditionalOnAnyProperty(prefix = "spring.cloud.azure.eventhubs", name = { "event-hub-name", "producer.event-hub-name" })
 class AzureEventHubsProducerClientConfiguration {
 
-    @ConditionalOnMissingProperty(prefix = "spring.cloud.azure.eventhubs.producer", name = { "connection-string", "namespace" })
+    @ConditionalOnMissingProperty(prefix = "spring.cloud.azure.eventhubs.producer", name = { "connection-string", "namespace", "event-hub-name" })
     @ConditionalOnBean(EventHubClientBuilder.class)
     @Configuration(proxyBeanMethods = false)
     static class SharedProducerConnectionConfiguration {
@@ -51,7 +51,7 @@ class AzureEventHubsProducerClientConfiguration {
         }
     }
 
-    @ConditionalOnAnyProperty(prefix = "spring.cloud.azure.eventhubs.producer", name = { "connection-string", "namespace" })
+    @ConditionalOnAnyProperty(prefix = "spring.cloud.azure.eventhubs.producer", name = { "connection-string", "namespace", "event-hub-name" })
     @Configuration(proxyBeanMethods = false)
     static class DedicatedProducerConnectionConfiguration {
 

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/eventhubs/AzureEventHubsConsumerClientConfigurationTests.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/eventhubs/AzureEventHubsConsumerClientConfigurationTests.java
@@ -10,6 +10,7 @@ import com.azure.messaging.eventhubs.EventHubConsumerClient;
 import com.azure.spring.cloud.autoconfigure.implementation.TestBuilderCustomizer;
 import com.azure.spring.cloud.autoconfigure.implementation.context.AzureContextUtils;
 import com.azure.spring.cloud.autoconfigure.implementation.context.properties.AzureGlobalProperties;
+import com.azure.spring.cloud.autoconfigure.implementation.eventhubs.properties.AzureEventHubsProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -32,18 +33,6 @@ class AzureEventHubsConsumerClientConfigurationTests {
         contextRunner
             .withPropertyValues(
                 "spring.cloud.azure.eventhubs.event-hub-name=test-eventhub",
-                "spring.cloud.azure.eventhubs.consumer.consumer-group=test-consumer-group"
-            )
-            .withUserConfiguration(AzureEventHubsPropertiesTestConfiguration.class)
-            .run(context -> {
-                assertThat(context).hasSingleBean(AzureEventHubsConsumerClientConfiguration.class);
-                assertThat(context).doesNotHaveBean(AzureEventHubsConsumerClientConfiguration.SharedConsumerConnectionConfiguration.class);
-                assertThat(context).doesNotHaveBean(AzureEventHubsConsumerClientConfiguration.DedicatedConsumerConnectionConfiguration.class);
-            });
-
-        contextRunner
-            .withPropertyValues(
-                "spring.cloud.azure.eventhubs.consumer.event-hub-name=test-eventhub",
                 "spring.cloud.azure.eventhubs.consumer.consumer-group=test-consumer-group"
             )
             .withUserConfiguration(AzureEventHubsPropertiesTestConfiguration.class)
@@ -101,6 +90,33 @@ class AzureEventHubsConsumerClientConfigurationTests {
                     assertThat(context).hasSingleBean(EventHubConsumerClient.class);
                     assertThat(context).hasBean(AzureContextUtils.EVENT_HUB_CONSUMER_CLIENT_BUILDER_FACTORY_BEAN_NAME);
                     assertThat(context).hasBean(AzureContextUtils.EVENT_HUB_CONSUMER_CLIENT_BUILDER_BEAN_NAME);
+                }
+            );
+    }
+
+    @Test
+    void consumerEventHubNameOverrideShouldConfigureDedicated() {
+        contextRunner
+            .withPropertyValues(
+                "spring.cloud.azure.eventhubs.namespace=test-namespace",
+                "spring.cloud.azure.eventhubs.event-hub-name=base-eventhub",
+                "spring.cloud.azure.eventhubs.consumer.event-hub-name=override-eventhub",
+                "spring.cloud.azure.eventhubs.consumer.consumer-group=test-consumer-group",
+                "spring.cloud.azure.eventhubs.producer.event-hub-name=base-eventhub"
+            )
+            .withBean(AzureGlobalProperties.class, AzureGlobalProperties::new)
+            .withUserConfiguration(AzureEventHubsAutoConfiguration.class)
+            .run(
+                context -> {
+                    assertThat(context).doesNotHaveBean(AzureEventHubsConsumerClientConfiguration.SharedConsumerConnectionConfiguration.class);
+                    assertThat(context).hasSingleBean(AzureEventHubsConsumerClientConfiguration.DedicatedConsumerConnectionConfiguration.class);
+                    assertThat(context).hasSingleBean(EventHubConsumerAsyncClient.class);
+                    assertThat(context).hasSingleBean(EventHubConsumerClient.class);
+
+                    AzureEventHubsProperties properties = context.getBean(AzureEventHubsProperties.class);
+                    AzureEventHubsProperties.Consumer consumer = properties.buildConsumerProperties();
+                    assertThat(consumer.getEventHubName()).isEqualTo("override-eventhub");
+                    assertThat(consumer.getNamespace()).isEqualTo("test-namespace");
                 }
             );
     }

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/eventhubs/AzureEventHubsProducerClientConfigurationTests.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/eventhubs/AzureEventHubsProducerClientConfigurationTests.java
@@ -10,6 +10,7 @@ import com.azure.messaging.eventhubs.EventHubProducerClient;
 import com.azure.spring.cloud.autoconfigure.implementation.TestBuilderCustomizer;
 import com.azure.spring.cloud.autoconfigure.implementation.context.AzureContextUtils;
 import com.azure.spring.cloud.autoconfigure.implementation.context.properties.AzureGlobalProperties;
+import com.azure.spring.cloud.autoconfigure.implementation.eventhubs.properties.AzureEventHubsProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -32,17 +33,6 @@ class AzureEventHubsProducerClientConfigurationTests {
         contextRunner
             .withPropertyValues(
                 "spring.cloud.azure.eventhubs.event-hub-name=test-eventhub"
-            )
-            .withUserConfiguration(AzureEventHubsPropertiesTestConfiguration.class)
-            .run(context -> {
-                assertThat(context).hasSingleBean(AzureEventHubsProducerClientConfiguration.class);
-                assertThat(context).doesNotHaveBean(AzureEventHubsProducerClientConfiguration.SharedProducerConnectionConfiguration.class);
-                assertThat(context).doesNotHaveBean(AzureEventHubsProducerClientConfiguration.DedicatedProducerConnectionConfiguration.class);
-            });
-
-        contextRunner
-            .withPropertyValues(
-                "spring.cloud.azure.eventhubs.producer.event-hub-name=test-eventhub"
             )
             .withUserConfiguration(AzureEventHubsPropertiesTestConfiguration.class)
             .run(context -> {
@@ -97,6 +87,31 @@ class AzureEventHubsProducerClientConfigurationTests {
                     assertThat(context).hasSingleBean(EventHubProducerAsyncClient.class);
                     assertThat(context).hasBean(AzureContextUtils.EVENT_HUB_PRODUCER_CLIENT_BUILDER_FACTORY_BEAN_NAME);
                     assertThat(context).hasBean(AzureContextUtils.EVENT_HUB_PRODUCER_CLIENT_BUILDER_BEAN_NAME);
+                }
+            );
+    }
+
+    @Test
+    void producerEventHubNameOverrideShouldConfigureDedicated() {
+        contextRunner
+            .withPropertyValues(
+                "spring.cloud.azure.eventhubs.namespace=test-namespace",
+                "spring.cloud.azure.eventhubs.event-hub-name=base-eventhub",
+                "spring.cloud.azure.eventhubs.producer.event-hub-name=override-eventhub"
+            )
+            .withBean(AzureGlobalProperties.class, AzureGlobalProperties::new)
+            .withUserConfiguration(AzureEventHubsAutoConfiguration.class)
+            .run(
+                context -> {
+                    assertThat(context).doesNotHaveBean(AzureEventHubsProducerClientConfiguration.SharedProducerConnectionConfiguration.class);
+                    assertThat(context).hasSingleBean(AzureEventHubsProducerClientConfiguration.DedicatedProducerConnectionConfiguration.class);
+                    assertThat(context).hasSingleBean(EventHubProducerAsyncClient.class);
+                    assertThat(context).hasSingleBean(EventHubProducerClient.class);
+
+                    AzureEventHubsProperties properties = context.getBean(AzureEventHubsProperties.class);
+                    AzureEventHubsProperties.Producer producer = properties.buildProducerProperties();
+                    assertThat(producer.getEventHubName()).isEqualTo("override-eventhub");
+                    assertThat(producer.getNamespace()).isEqualTo("test-namespace");
                 }
             );
     }


### PR DESCRIPTION
Fixes #43593.
Fixes #46752.

This PR contains two related Event Hubs fixes that were developed together; they are kept in one PR because the second fix is required for any partition checkpoint that uses the sub-level `event-hub-name` override exercised by the first fix.

---

## Fix 1: Spring sub-level `event-hub-name` override (#43593)

### Problem

When using `spring-cloud-azure-starter-eventhubs` with both base-level and sub-level `event-hub-name` configured:

```yaml
spring:
  cloud:
    azure:
      eventhubs:
        namespace: evhns-sample
        event-hub-name: bbbb
        consumer:
          consumer-group: $Default
          event-hub-name: aaaa
        producer:
          event-hub-name: aaaa
```

the injected `EventHubProducerClient` / `EventHubConsumerClient` connect to `bbbb` instead of the override `aaaa`.

### Root cause

The property merge in `AzureEventHubsProperties.build{Consumer,Producer}Properties()` is correct (sub-level wins). The defect is in the autoconfiguration path selection:

`AzureEventHubs{Consumer,Producer}ClientConfiguration` only switches to the *Dedicated* (per-section builder) inner configuration when `connection-string` or `namespace` is set under the sub-prefix. With only `event-hub-name` overridden, it falls through to the *Shared* configuration, which reuses the parent `EventHubClientBuilder` already pinned to `bbbb`. `EventHubClientBuilder` is per-hub, so the shared path cannot represent a different hub.

### Fix

Add `"event-hub-name"` to the `@ConditionalOnMissingProperty` / `@ConditionalOnAnyProperty` `name` arrays in both consumer and producer client configurations. Any sub-level `event-hub-name` override now routes to the Dedicated path, which already calls `build{Consumer,Producer}Properties()` with the correct precedence — no merge-logic changes required.

---

## Fix 2: `EventContext.updateCheckpointAsync()` offsetString propagation (#46752)

### Problem

`EventContext.updateCheckpointAsync()` only populated the deprecated `Checkpoint.offset` (Long) from the received `EventData`, leaving `offsetString` unset. Checkpoint stores that read `offsetString` (such as `BlobCheckpointStore`) then persisted a `null` offset, breaking partition switch-over and consumer-group lag monitoring.

### Fix

- `EventContext` now also propagates `EventData.getOffsetString()` onto the constructed `Checkpoint`.
- `BlobCheckpointStore.updateCheckpoint` now accepts `offsetString`-only checkpoints and prefers `offsetString` over the deprecated `offset` when both are populated. The validation guard was widened accordingly; the JavaDoc was updated to document the new contract.

---

## Tests

- Added `consumerEventHubNameOverrideShouldConfigureDedicated` and `producerEventHubNameOverrideShouldConfigureDedicated` reproducing the Spring issue scenario and asserting the merged properties resolve to the override and to the parent namespace.
- Pruned the obsolete sub-scenarios in `eventHubNameAndConsumerGroupProvidedShouldConfigure` / `eventHubNameProvidedShouldConfigure` that were asserting the old (buggy) behavior.
- Added `EventContextTest` coverage for `offsetString` propagation through `updateCheckpointAsync()`.
- Added `BlobCheckpointStoreTests` coverage for `offsetString`-only checkpoints, `offsetString`-preferred-over-`offset` precedence, and the widened validation guard.
- All affected modules' tests pass locally.

## How to verify

```
mvn -f sdk/spring/spring-cloud-azure-autoconfigure/pom.xml `
    -Dtest='AzureEventHubsConsumerClientConfigurationTests,AzureEventHubsProducerClientConfigurationTests,AzureEventHubsAutoConfigurationTests' `
    -DfailIfNoTests=false test

mvn -f sdk/eventhubs/azure-messaging-eventhubs/pom.xml -Dtest=EventContextTest -DfailIfNoTests=false test

mvn -f sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/pom.xml -Dtest=BlobCheckpointStoreTests -DfailIfNoTests=false test
```
