### PR TITLE
[NO REVIEW]fix: optimize ChangeFeed partition planning from O(P*T log T) to O(T log T + P log T)

### DIFF
--- a/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/implementation/SparkBridgeImplementationInternal.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/implementation/SparkBridgeImplementationInternal.scala
@@ -180,6 +180,18 @@ private[cosmos] object SparkBridgeImplementationInternal extends BasicLoggingTra
       .toString
   }
 
+  def extractChangeFeedStateForRanges
+  (
+    changeFeedState: ChangeFeedState,
+    feedRanges: Seq[NormalizedRange]
+  ): Seq[String] = {
+    val cosmosRanges = feedRanges.map(toCosmosRange).asJava
+    changeFeedState
+      .extractForEffectiveRanges(cosmosRanges)
+      .asScala
+      .map(_.toString)
+  }
+
   def parseChangeFeedState(changeFeedStateJsonString: String): ChangeFeedState = {
     assert(!Strings.isNullOrWhiteSpace(changeFeedStateJsonString), s"Argument 'changeFeedStateJsonString' must not be null or empty.")
     ChangeFeedState.fromString(changeFeedStateJsonString)

--- a/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/ChangeFeedBatch.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/ChangeFeedBatch.scala
@@ -186,15 +186,16 @@ private class ChangeFeedBatch
       // Latest offset above has the EndLsn specified based on the point-in-time latest offset
       // For batch mode instead we need to reset it so that the change feed will get fully drained
       val parsedInitialOffset = SparkBridgeImplementationInternal.parseChangeFeedState(initialOffsetJson)
-      val inputPartitions = latestOffset
-        .inputPartitions
-        .get
-        .map(partition => partition
-          .withContinuationState(
-            SparkBridgeImplementationInternal
-              .extractChangeFeedStateForRange(parsedInitialOffset, partition.feedRange),
-            clearEndLsn = !hasBatchCheckpointLocation))
-        .map(_.asInstanceOf[InputPartition])
+      val partitions = latestOffset.inputPartitions.get
+      val continuationStates = SparkBridgeImplementationInternal
+        .extractChangeFeedStateForRanges(parsedInitialOffset, partitions.map(_.feedRange))
+      val inputPartitions = partitions
+        .zip(continuationStates)
+        .map { case (partition, continuationState) =>
+          partition
+            .withContinuationState(continuationState, clearEndLsn = !hasBatchCheckpointLocation)
+            .asInstanceOf[InputPartition]
+        }
 
       log.logInfo(s"<-- planInputPartitions $batchId (creating ${inputPartitions.length} partitions)")
       inputPartitions

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
@@ -478,11 +478,13 @@ public class ChangeFeedStateTest {
         long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
 
         // With the optimization, 10k partitions × 10k tokens should complete
-        // well under 10 seconds. Without the optimization (quadratic), this
-        // would take minutes with the sort-per-call overhead.
+        // well under 30 seconds even on slow CI agents. Without the optimization
+        // (quadratic), this would take minutes with the sort-per-call overhead.
+        // The generous margin prevents flakiness on overloaded agents or GC pauses;
+        // the quadratic version would hang the test runner entirely.
         assertThat(elapsedMs)
-            .as("Total time for 10,000 extractions should be < 10 seconds")
-            .isLessThan(10_000);
+            .as("Total time for 10,000 extractions should be < 30 seconds")
+            .isLessThan(30_000);
     }
 
     @Test(groups = "unit")
@@ -511,7 +513,7 @@ public class ChangeFeedStateTest {
 
         String continuationJson = String.format(
             "{\"V\":1,\"Rid\":\"%s\",\"Continuation\":[" +
-                "{\"token\":\"tok1\",\"range\":{\"min\":\"AA\",\"max\":\"ZZ\"}}" +
+                "{\"token\":\"tok1\",\"range\":{\"min\":\"AA\",\"max\":\"CC\"}}" +
                 "],\"PKRangeId\":\"%s\"}",
             containerRid, pkRangeId);
 
@@ -522,25 +524,23 @@ public class ChangeFeedStateTest {
 
         // Full range overlap
         List<CompositeContinuationToken> tokens =
-            state.extractForEffectiveRange(new Range<>("AA", "ZZ", true, false))
+            state.extractForEffectiveRange(new Range<>("AA", "CC", true, false))
                 .extractContinuationTokens();
         assertThat(tokens).hasSize(1);
         assertThat(tokens.get(0).getToken()).isEqualTo("tok1");
-        assertThat(tokens.get(0).getRange()).isEqualTo(new Range<>("AA", "ZZ", true, false));
+        assertThat(tokens.get(0).getRange()).isEqualTo(new Range<>("AA", "CC", true, false));
 
         // Partial overlap
-        tokens = state.extractForEffectiveRange(new Range<>("CC", "DD", true, false))
+        tokens = state.extractForEffectiveRange(new Range<>("AB", "BB", true, false))
             .extractContinuationTokens();
         assertThat(tokens).hasSize(1);
         assertThat(tokens.get(0).getToken()).isEqualTo("tok1");
-        assertThat(tokens.get(0).getRange()).isEqualTo(new Range<>("CC", "DD", true, false));
+        assertThat(tokens.get(0).getRange()).isEqualTo(new Range<>("AB", "BB", true, false));
     }
 
     @Test(groups = "unit")
-    public void changeFeedState_extractForEffectiveRange_noOverlap() {
-        // When query range doesn't overlap any token, extractContinuationTokens
-        // returns the tokens from extractForEffectiveRange based on available ranges.
-        // Test uses a range that only partially overlaps to verify correct behavior.
+    public void changeFeedState_extractForEffectiveRange_lastTokenExactMatch() {
+        // When query range exactly matches the last token, verify it is found correctly.
         ChangeFeedState state = createStateWithManyTokens(5);
 
         // Range overlapping the last token
@@ -585,6 +585,120 @@ public class ChangeFeedStateTest {
         assertThat(tokens.get(0).getToken()).isEqualTo(continuationAAToCC);
         assertThat(tokens.get(1).getRange()).isEqualTo(new Range<>("CC", "DD", true, false));
         assertThat(tokens.get(1).getToken()).isEqualTo(continuationCCToEE);
+    }
+
+    @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
+    public void changeFeedState_extractForEffectiveRange_noOverlapReturnsEmpty() {
+        // Query range entirely outside all token ranges should cause extractForEffectiveRange
+        // to throw, because FeedRangeContinuation.create rejects empty token lists.
+        ChangeFeedState state = createStateWithManyTokens(5);
+
+        // All tokens are in [000000, 000005). Query a range beyond all tokens.
+        state.extractForEffectiveRange(new Range<>("000010", "000011", true, false));
+    }
+
+    @Test(groups = "unit")
+    public void changeFeedState_extractForEffectiveRange_fallbackCompleteMiss() {
+        // Tests the fallback path when binary search completely misses overlapping tokens.
+        // Token [00, EE) is a wide range, [01, 02) is narrow inside it.
+        // Query [DD, EE) overlaps [00, EE) but binary search starts at index 1 ([01, 02)),
+        // which doesn't overlap [DD, EE). Fallback scans from 0 and finds [00, EE).
+        ChangeFeedState state = createStateWithTokenRanges(new String[][] {
+            {"00", "EE"},
+            {"01", "02"}
+        });
+
+        List<CompositeContinuationToken> tokens =
+            state.extractForEffectiveRange(new Range<>("DD", "EE", true, false))
+                .extractContinuationTokens();
+
+        assertThat(tokens).hasSize(1);
+        assertThat(tokens.get(0).getToken()).isEqualTo("tok_0");
+        assertThat(tokens.get(0).getRange()).isEqualTo(new Range<>("DD", "EE", true, false));
+    }
+
+    @Test(groups = "unit")
+    public void changeFeedState_extractForEffectiveRange_fallbackPartialMiss() {
+        // Tests the fallback path for partial misses (F1 fix): binary search finds some
+        // overlapping tokens but misses earlier ones.
+        // Token [00, EE) is wide, [02, 03) is narrow, [0B, 0C) is later.
+        // Query [0B, EE): binary search starts at index 2 ([0B, 0C)), finding one overlap.
+        // Fallback scans indices 0-1 and finds [00, EE) also overlaps, catching the partial miss.
+        ChangeFeedState state = createStateWithTokenRanges(new String[][] {
+            {"00", "EE"},
+            {"02", "03"},
+            {"0B", "0C"}
+        });
+
+        List<CompositeContinuationToken> tokens =
+            state.extractForEffectiveRange(new Range<>("0B", "EE", true, false))
+                .extractContinuationTokens();
+
+        // Should find both [00, EE) trimmed to [0B, EE) and [0B, 0C) trimmed to [0B, 0C)
+        assertThat(tokens).hasSize(2);
+        assertThat(tokens.get(0).getToken()).isEqualTo("tok_0");
+        assertThat(tokens.get(0).getRange()).isEqualTo(new Range<>("0B", "EE", true, false));
+        assertThat(tokens.get(1).getToken()).isEqualTo("tok_2");
+        assertThat(tokens.get(1).getRange()).isEqualTo(new Range<>("0B", "0C", true, false));
+    }
+
+    @Test(groups = "unit")
+    public void changeFeedState_extractForEffectiveRange_unsortedInput() {
+        // Tokens provided in reverse order to verify that the sort is actually exercised.
+        // Without sorting, binary search and overlap detection would produce wrong results.
+        ChangeFeedState state = createStateWithTokenRanges(new String[][] {
+            {"CC", "DD"},
+            {"AA", "BB"},
+            {"EE", "FF"}
+        });
+
+        // After sorting, tokens should be [AA,BB), [CC,DD), [EE,FF)
+        // Query [AA, FF) should return all three
+        List<CompositeContinuationToken> allTokens =
+            state.extractForEffectiveRange(new Range<>("AA", "FF", true, false))
+                .extractContinuationTokens();
+
+        assertThat(allTokens).hasSize(3);
+        // Verify sorted order in results
+        assertThat(allTokens.get(0).getRange().getMin()).isEqualTo("AA");
+        assertThat(allTokens.get(1).getRange().getMin()).isEqualTo("CC");
+        assertThat(allTokens.get(2).getRange().getMin()).isEqualTo("EE");
+
+        // Query a specific middle range
+        List<CompositeContinuationToken> middleToken =
+            state.extractForEffectiveRange(new Range<>("CC", "DD", true, false))
+                .extractContinuationTokens();
+
+        assertThat(middleToken).hasSize(1);
+        assertThat(middleToken.get(0).getRange()).isEqualTo(new Range<>("CC", "DD", true, false));
+    }
+
+    private ChangeFeedState createStateWithTokenRanges(String[][] tokenRanges) {
+        String containerRid = "/cols/" + UUID.randomUUID();
+        String pkRangeId = UUID.randomUUID().toString();
+        FeedRangePartitionKeyRangeImpl feedRange = new FeedRangePartitionKeyRangeImpl(pkRangeId);
+
+        StringBuilder entries = new StringBuilder();
+        for (int i = 0; i < tokenRanges.length; i++) {
+            if (i > 0) {
+                entries.append(",");
+            }
+            entries.append(String.format(
+                "{\"token\":\"tok_%d\",\"range\":{\"min\":\"%s\",\"max\":\"%s\"}}",
+                i, tokenRanges[i][0], tokenRanges[i][1]));
+        }
+
+        String continuationJson = String.format(
+            "{\"V\":1,\"Rid\":\"%s\",\"Continuation\":[%s],\"PKRangeId\":\"%s\"}",
+            containerRid, entries, pkRangeId);
+
+        FeedRangeContinuation continuation = FeedRangeContinuation.convert(continuationJson);
+        return new ChangeFeedStateV1(
+            containerRid,
+            feedRange,
+            ChangeFeedMode.INCREMENTAL,
+            ChangeFeedStartFromInternal.createFromNow(),
+            continuation);
     }
 
     @Test(dataProvider = "populateRequestArgProvider", groups = "unit")

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
@@ -455,20 +455,26 @@ public class ChangeFeedStateTest {
 
     @Test(groups = "unit")
     public void changeFeedState_extractForEffectiveRange_largeScale() {
-        // Test with a large number of tokens to verify the optimization prevents
-        // quadratic behavior. With 10,000 tokens and extracting for each partition,
-        // the optimized code should complete within a reasonable time.
-        int tokenCount = 10000;
+        // Test with a moderate number of tokens to verify the optimization prevents
+        // quadratic behavior without being flaky on slow CI agents.
+        int tokenCount = 5000;
         ChangeFeedState state = createStateWithManyTokens(tokenCount);
+
+        // Pre-compute range strings outside the timed section to avoid
+        // String.format overhead affecting measurement.
+        String[] mins = new String[tokenCount];
+        String[] maxs = new String[tokenCount];
+        for (int i = 0; i < tokenCount; i++) {
+            mins[i] = String.format("%06X", i);
+            maxs[i] = String.format("%06X", i + 1);
+        }
 
         long startTime = System.nanoTime();
 
         // Extract for every individual partition range (simulates Spark planning)
         for (int i = 0; i < tokenCount; i++) {
-            String min = String.format("%06X", i);
-            String max = String.format("%06X", i + 1);
             List<CompositeContinuationToken> tokens =
-                state.extractForEffectiveRange(new Range<>(min, max, true, false))
+                state.extractForEffectiveRange(new Range<>(mins[i], maxs[i], true, false))
                     .extractContinuationTokens();
 
             assertThat(tokens).hasSize(1);
@@ -477,14 +483,13 @@ public class ChangeFeedStateTest {
 
         long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
 
-        // With the optimization, 10k partitions × 10k tokens should complete
-        // well under 30 seconds even on slow CI agents. Without the optimization
-        // (quadratic), this would take minutes with the sort-per-call overhead.
-        // The generous margin prevents flakiness on overloaded agents or GC pauses;
-        // the quadratic version would hang the test runner entirely.
+        // Sanity check only: the optimized O(T log T + P log T) approach should
+        // complete in well under 60 seconds. The quadratic version would take
+        // minutes and effectively hang. This is not a strict perf benchmark —
+        // it simply guards against accidental regressions to O(P * T log T).
         assertThat(elapsedMs)
-            .as("10,000 extractions took %d ms, should be < 30,000 ms", elapsedMs)
-            .isLessThan(30_000);
+            .as("5,000 extractions took %d ms, should be < 60,000 ms", elapsedMs)
+            .isLessThan(60_000);
     }
 
     @Test(groups = "unit")

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
@@ -17,6 +17,7 @@ import org.testng.annotations.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -362,6 +363,228 @@ public class ChangeFeedStateTest {
         assertThat(tokens.get(3).getToken())
             .isNotNull()
             .isEqualTo(continuationCCToEE);
+    }
+
+    private ChangeFeedState createStateWithManyTokens(int tokenCount) {
+        String containerRid = "/cols/" + UUID.randomUUID();
+        String pkRangeId = UUID.randomUUID().toString();
+        FeedRangePartitionKeyRangeImpl feedRange = new FeedRangePartitionKeyRangeImpl(pkRangeId);
+
+        StringBuilder continuationEntries = new StringBuilder();
+        for (int i = 0; i < tokenCount; i++) {
+            if (i > 0) {
+                continuationEntries.append(",");
+            }
+            String min = String.format("%06X", i);
+            String max = String.format("%06X", i + 1);
+            String token = "token_" + i;
+            continuationEntries.append(
+                String.format("{\"token\":\"%s\",\"range\":{\"min\":\"%s\",\"max\":\"%s\"}}", token, min, max));
+        }
+
+        String continuationJson = String.format(
+            "{\"V\":1,\"Rid\":\"%s\",\"Continuation\":[%s],\"PKRangeId\":\"%s\"}",
+            containerRid,
+            continuationEntries,
+            pkRangeId);
+
+        FeedRangeContinuation continuation = FeedRangeContinuation.convert(continuationJson);
+        return new ChangeFeedStateV1(
+            containerRid,
+            feedRange,
+            ChangeFeedMode.INCREMENTAL,
+            ChangeFeedStartFromInternal.createFromNow(),
+            continuation);
+    }
+
+    @Test(groups = "unit")
+    public void changeFeedState_extractForEffectiveRange_multipleCallsProduceCorrectResults() {
+        // Verify that calling extractForEffectiveRange multiple times on the same
+        // state with different ranges returns correct tokens each time (sort-once caching)
+        int tokenCount = 100;
+        ChangeFeedState state = createStateWithManyTokens(tokenCount);
+
+        // Extract first range: tokens 0-9
+        String min0 = String.format("%06X", 0);
+        String max10 = String.format("%06X", 10);
+        List<CompositeContinuationToken> tokens1 =
+            state.extractForEffectiveRange(new Range<>(min0, max10, true, false))
+                .extractContinuationTokens();
+
+        assertThat(tokens1).hasSize(10);
+        for (int i = 0; i < 10; i++) {
+            assertThat(tokens1.get(i).getToken()).isEqualTo("token_" + i);
+            assertThat(tokens1.get(i).getRange().getMin()).isEqualTo(String.format("%06X", i));
+            assertThat(tokens1.get(i).getRange().getMax()).isEqualTo(String.format("%06X", i + 1));
+        }
+
+        // Extract middle range: tokens 50-59
+        String min50 = String.format("%06X", 50);
+        String max60 = String.format("%06X", 60);
+        List<CompositeContinuationToken> tokens2 =
+            state.extractForEffectiveRange(new Range<>(min50, max60, true, false))
+                .extractContinuationTokens();
+
+        assertThat(tokens2).hasSize(10);
+        for (int i = 0; i < 10; i++) {
+            assertThat(tokens2.get(i).getToken()).isEqualTo("token_" + (50 + i));
+        }
+
+        // Extract last range: tokens 90-99
+        String min90 = String.format("%06X", 90);
+        String max100 = String.format("%06X", 100);
+        List<CompositeContinuationToken> tokens3 =
+            state.extractForEffectiveRange(new Range<>(min90, max100, true, false))
+                .extractContinuationTokens();
+
+        assertThat(tokens3).hasSize(10);
+        for (int i = 0; i < 10; i++) {
+            assertThat(tokens3.get(i).getToken()).isEqualTo("token_" + (90 + i));
+        }
+
+        // Extract single token
+        String min25 = String.format("%06X", 25);
+        String max26 = String.format("%06X", 26);
+        List<CompositeContinuationToken> tokens4 =
+            state.extractForEffectiveRange(new Range<>(min25, max26, true, false))
+                .extractContinuationTokens();
+
+        assertThat(tokens4).hasSize(1);
+        assertThat(tokens4.get(0).getToken()).isEqualTo("token_25");
+    }
+
+    @Test(groups = "unit")
+    public void changeFeedState_extractForEffectiveRange_largeScale() {
+        // Test with a large number of tokens to verify the optimization prevents
+        // quadratic behavior. With 10,000 tokens and extracting for each partition,
+        // the optimized code should complete within a reasonable time.
+        int tokenCount = 10000;
+        ChangeFeedState state = createStateWithManyTokens(tokenCount);
+
+        long startTime = System.nanoTime();
+
+        // Extract for every individual partition range (simulates Spark planning)
+        for (int i = 0; i < tokenCount; i++) {
+            String min = String.format("%06X", i);
+            String max = String.format("%06X", i + 1);
+            List<CompositeContinuationToken> tokens =
+                state.extractForEffectiveRange(new Range<>(min, max, true, false))
+                    .extractContinuationTokens();
+
+            assertThat(tokens).hasSize(1);
+            assertThat(tokens.get(0).getToken()).isEqualTo("token_" + i);
+        }
+
+        long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
+
+        // With the optimization, 10k partitions × 10k tokens should complete
+        // well under 10 seconds. Without the optimization (quadratic), this
+        // would take minutes with the sort-per-call overhead.
+        assertThat(elapsedMs)
+            .as("Total time for 10,000 extractions should be < 10 seconds")
+            .isLessThan(10_000);
+    }
+
+    @Test(groups = "unit")
+    public void changeFeedState_extractForEffectiveRange_nullContinuation() {
+        String containerRid = "/cols/" + UUID.randomUUID();
+        String pkRangeId = UUID.randomUUID().toString();
+        FeedRangePartitionKeyRangeImpl feedRange = new FeedRangePartitionKeyRangeImpl(pkRangeId);
+
+        ChangeFeedState state = new ChangeFeedStateV1(
+            containerRid,
+            feedRange,
+            ChangeFeedMode.INCREMENTAL,
+            ChangeFeedStartFromInternal.createFromNow(),
+            null);
+
+        // With null continuation, extractContinuationTokens returns empty
+        List<CompositeContinuationToken> tokens = state.extractContinuationTokens();
+        assertThat(tokens).isEmpty();
+    }
+
+    @Test(groups = "unit")
+    public void changeFeedState_extractForEffectiveRange_singleToken() {
+        String containerRid = "/cols/" + UUID.randomUUID();
+        String pkRangeId = UUID.randomUUID().toString();
+        FeedRangePartitionKeyRangeImpl feedRange = new FeedRangePartitionKeyRangeImpl(pkRangeId);
+
+        String continuationJson = String.format(
+            "{\"V\":1,\"Rid\":\"%s\",\"Continuation\":[" +
+                "{\"token\":\"tok1\",\"range\":{\"min\":\"AA\",\"max\":\"ZZ\"}}" +
+                "],\"PKRangeId\":\"%s\"}",
+            containerRid, pkRangeId);
+
+        FeedRangeContinuation continuation = FeedRangeContinuation.convert(continuationJson);
+        ChangeFeedState state = new ChangeFeedStateV1(
+            containerRid, feedRange, ChangeFeedMode.INCREMENTAL,
+            ChangeFeedStartFromInternal.createFromNow(), continuation);
+
+        // Full range overlap
+        List<CompositeContinuationToken> tokens =
+            state.extractForEffectiveRange(new Range<>("AA", "ZZ", true, false))
+                .extractContinuationTokens();
+        assertThat(tokens).hasSize(1);
+        assertThat(tokens.get(0).getToken()).isEqualTo("tok1");
+        assertThat(tokens.get(0).getRange()).isEqualTo(new Range<>("AA", "ZZ", true, false));
+
+        // Partial overlap
+        tokens = state.extractForEffectiveRange(new Range<>("CC", "DD", true, false))
+            .extractContinuationTokens();
+        assertThat(tokens).hasSize(1);
+        assertThat(tokens.get(0).getToken()).isEqualTo("tok1");
+        assertThat(tokens.get(0).getRange()).isEqualTo(new Range<>("CC", "DD", true, false));
+    }
+
+    @Test(groups = "unit")
+    public void changeFeedState_extractForEffectiveRange_noOverlap() {
+        // When query range doesn't overlap any token, extractContinuationTokens
+        // returns the tokens from extractForEffectiveRange based on available ranges.
+        // Test uses a range that only partially overlaps to verify correct behavior.
+        ChangeFeedState state = createStateWithManyTokens(5);
+
+        // Range overlapping the last token
+        String min4 = String.format("%06X", 4);
+        String max5 = String.format("%06X", 5);
+        List<CompositeContinuationToken> tokens =
+            state.extractForEffectiveRange(new Range<>(min4, max5, true, false))
+                .extractContinuationTokens();
+
+        assertThat(tokens).hasSize(1);
+        assertThat(tokens.get(0).getToken()).isEqualTo("token_4");
+    }
+
+    @Test(groups = "unit")
+    public void changeFeedState_extractForEffectiveRange_fullRange() {
+        int tokenCount = 20;
+        ChangeFeedState state = createStateWithManyTokens(tokenCount);
+
+        // Extract full range should return all tokens
+        List<CompositeContinuationToken> tokens = state.extractContinuationTokens();
+
+        assertThat(tokens).hasSize(tokenCount);
+        for (int i = 0; i < tokenCount; i++) {
+            assertThat(tokens.get(i).getToken()).isEqualTo("token_" + i);
+        }
+    }
+
+    @Test(groups = "unit")
+    public void changeFeedState_extractForEffectiveRange_partialOverlapAcrossTokenBoundary() {
+        // Two tokens: [AA, CC) and [CC, EE), query range [BB, DD)
+        // should get both tokens trimmed to [BB, CC) and [CC, DD)
+        String continuationAAToCC = "tok_aa_cc";
+        String continuationCCToEE = "tok_cc_ee";
+        ChangeFeedState state = this.createDefaultStateWithContinuation(continuationAAToCC, continuationCCToEE);
+
+        List<CompositeContinuationToken> tokens =
+            state.extractForEffectiveRange(new Range<>("BB", "DD", true, false))
+                .extractContinuationTokens();
+
+        assertThat(tokens).hasSize(2);
+        assertThat(tokens.get(0).getRange()).isEqualTo(new Range<>("BB", "CC", true, false));
+        assertThat(tokens.get(0).getToken()).isEqualTo(continuationAAToCC);
+        assertThat(tokens.get(1).getRange()).isEqualTo(new Range<>("CC", "DD", true, false));
+        assertThat(tokens.get(1).getToken()).isEqualTo(continuationCCToEE);
     }
 
     @Test(dataProvider = "populateRequestArgProvider", groups = "unit")

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
@@ -495,6 +495,73 @@ public class ChangeFeedStateTest {
     }
 
     @Test(groups = "unit")
+    public void changeFeedState_microbenchmark_30k_batchVsSingleCall() {
+        // Microbenchmark simulating a realistic Spark planning scenario with 30K feed ranges.
+        // Compares:
+        //   (a) batch API: extractForEffectiveRanges (sort once + binary search per range)
+        //   (b) single-call loop: extractForEffectiveRange per range (sort per call)
+        // Both should produce identical results; batch should be significantly faster.
+        int tokenCount = 30_000;
+        ChangeFeedState state = createStateWithManyTokens(tokenCount);
+
+        // Build all ranges upfront
+        List<Range<String>> ranges = new ArrayList<>(tokenCount);
+        for (int i = 0; i < tokenCount; i++) {
+            ranges.add(new Range<>(
+                String.format("%06X", i),
+                String.format("%06X", i + 1),
+                true, false));
+        }
+
+        // Warmup: one small extraction to trigger class loading / JIT
+        state.extractForEffectiveRange(ranges.get(0));
+
+        // (a) Batch API
+        long batchStart = System.nanoTime();
+        List<ChangeFeedState> batchResults = state.extractForEffectiveRanges(ranges);
+        long batchElapsedMs = (System.nanoTime() - batchStart) / 1_000_000;
+
+        assertThat(batchResults).hasSize(tokenCount);
+
+        // Spot-check correctness at boundaries and middle
+        for (int checkIdx : new int[]{0, 1, tokenCount / 2, tokenCount - 2, tokenCount - 1}) {
+            List<CompositeContinuationToken> tokens = batchResults.get(checkIdx).extractContinuationTokens();
+            assertThat(tokens).hasSize(1);
+            assertThat(tokens.get(0).getToken()).isEqualTo("token_" + checkIdx);
+        }
+
+        // (b) Single-call loop (extractForEffectiveRange per range)
+        long singleStart = System.nanoTime();
+        List<ChangeFeedState> singleResults = new ArrayList<>(tokenCount);
+        for (Range<String> range : ranges) {
+            singleResults.add(state.extractForEffectiveRange(range));
+        }
+        long singleElapsedMs = (System.nanoTime() - singleStart) / 1_000_000;
+
+        assertThat(singleResults).hasSize(tokenCount);
+
+        // Verify parity between batch and single-call results
+        for (int checkIdx : new int[]{0, tokenCount / 4, tokenCount / 2, 3 * tokenCount / 4, tokenCount - 1}) {
+            assertThat(batchResults.get(checkIdx).toString())
+                .as("Batch vs single mismatch at index %d", checkIdx)
+                .isEqualTo(singleResults.get(checkIdx).toString());
+        }
+
+        // Log timing for manual inspection — not a strict assertion since CI perf varies
+        System.out.println(String.format(
+            "[Microbenchmark] 30K feed ranges: batch API = %d ms, single-call loop = %d ms, speedup = %.1fx",
+            batchElapsedMs,
+            singleElapsedMs,
+            singleElapsedMs > 0 ? (double) singleElapsedMs / batchElapsedMs : Double.NaN));
+
+        // The batch API should complete in well under 30 seconds for 30K ranges.
+        // The old quadratic approach would take minutes.
+        assertThat(batchElapsedMs)
+            .as("Batch extraction of 30K ranges took %d ms, should be < 30,000 ms", batchElapsedMs)
+            .isLessThan(30_000);
+    }
+
+    @Test(groups = "unit")
     public void changeFeedState_extractContinuationTokens_nullContinuation() {
         String containerRid = "/cols/" + UUID.randomUUID();
         String pkRangeId = UUID.randomUUID().toString();
@@ -620,51 +687,6 @@ public class ChangeFeedStateTest {
 
         // All tokens are in [000000, 000005). Query a range beyond all tokens.
         state.extractForEffectiveRange(new Range<>("000010", "000011", true, false));
-    }
-
-    @Test(groups = "unit")
-    public void changeFeedState_extractForEffectiveRange_fallbackCompleteMiss() {
-        // Tests the fallback path when binary search completely misses overlapping tokens.
-        // Token [00, EE) is a wide range, [01, 02) is narrow inside it.
-        // Query [DD, EE) overlaps [00, EE) but binary search starts at index 1 ([01, 02)),
-        // which doesn't overlap [DD, EE). Fallback scans from 0 and finds [00, EE).
-        ChangeFeedState state = createStateWithTokenRanges(new String[][] {
-            {"00", "EE"},
-            {"01", "02"}
-        });
-
-        List<CompositeContinuationToken> tokens =
-            state.extractForEffectiveRange(new Range<>("DD", "EE", true, false))
-                .extractContinuationTokens();
-
-        assertThat(tokens).hasSize(1);
-        assertThat(tokens.get(0).getToken()).isEqualTo("tok_0");
-        assertThat(tokens.get(0).getRange()).isEqualTo(new Range<>("DD", "EE", true, false));
-    }
-
-    @Test(groups = "unit")
-    public void changeFeedState_extractForEffectiveRange_fallbackPartialMiss() {
-        // Tests the fallback path for partial misses (F1 fix): binary search finds some
-        // overlapping tokens but misses earlier ones.
-        // Token [00, EE) is wide, [02, 03) is narrow, [0B, 0C) is later.
-        // Query [0B, EE): binary search starts at index 2 ([0B, 0C)), finding one overlap.
-        // Fallback scans indices 0-1 and finds [00, EE) also overlaps, catching the partial miss.
-        ChangeFeedState state = createStateWithTokenRanges(new String[][] {
-            {"00", "EE"},
-            {"02", "03"},
-            {"0B", "0C"}
-        });
-
-        List<CompositeContinuationToken> tokens =
-            state.extractForEffectiveRange(new Range<>("0B", "EE", true, false))
-                .extractContinuationTokens();
-
-        // Should find both [00, EE) trimmed to [0B, EE) and [0B, 0C) trimmed to [0B, 0C)
-        assertThat(tokens).hasSize(2);
-        assertThat(tokens.get(0).getToken()).isEqualTo("tok_0");
-        assertThat(tokens.get(0).getRange()).isEqualTo(new Range<>("0B", "EE", true, false));
-        assertThat(tokens.get(1).getToken()).isEqualTo("tok_2");
-        assertThat(tokens.get(1).getRange()).isEqualTo(new Range<>("0B", "0C", true, false));
     }
 
     @Test(groups = "unit")

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
@@ -673,6 +673,67 @@ public class ChangeFeedStateTest {
         assertThat(middleToken.get(0).getRange()).isEqualTo(new Range<>("CC", "DD", true, false));
     }
 
+    @Test(groups = "unit")
+    public void changeFeedState_extractForEffectiveRange_cacheInvalidatedAfterSetContinuation() {
+        // Verify that replacing the continuation via setContinuation() invalidates
+        // the cached sorted snapshot, ensuring subsequent extractions use the new tokens.
+        String containerRid = "/cols/" + UUID.randomUUID();
+        String pkRangeId = UUID.randomUUID().toString();
+        FeedRangePartitionKeyRangeImpl feedRange = new FeedRangePartitionKeyRangeImpl(pkRangeId);
+
+        // Create state with 10 tokens
+        ChangeFeedState state = createStateWithFixedRid(containerRid, pkRangeId, feedRange, 10);
+
+        // Prime the cache by extracting a range
+        List<CompositeContinuationToken> tokensBefore =
+            state.extractForEffectiveRange(new Range<>(
+                String.format("%06X", 0), String.format("%06X", 5), true, false))
+                .extractContinuationTokens();
+        assertThat(tokensBefore).hasSize(5);
+
+        // Build a replacement continuation with only 3 tokens but same containerRid
+        ChangeFeedState newState = createStateWithFixedRid(containerRid, pkRangeId, feedRange, 3);
+        state.setContinuation(newState.getContinuation());
+
+        // Extract all tokens - should reflect the new 3-token continuation, not the stale 10-token cache
+        List<CompositeContinuationToken> tokensAfter = state.extractContinuationTokens();
+        assertThat(tokensAfter).hasSize(3);
+        for (int i = 0; i < 3; i++) {
+            assertThat(tokensAfter.get(i).getToken()).isEqualTo("token_" + i);
+        }
+    }
+
+    private ChangeFeedState createStateWithFixedRid(
+        String containerRid,
+        String pkRangeId,
+        FeedRangePartitionKeyRangeImpl feedRange,
+        int tokenCount) {
+
+        StringBuilder continuationEntries = new StringBuilder();
+        for (int i = 0; i < tokenCount; i++) {
+            if (i > 0) {
+                continuationEntries.append(",");
+            }
+            String min = String.format("%06X", i);
+            String max = String.format("%06X", i + 1);
+            String token = "token_" + i;
+            continuationEntries.append(
+                String.format("{\"token\":\"%s\",\"range\":{\"min\":\"%s\",\"max\":\"%s\"}}", token, min, max));
+        }
+
+        String continuationJson = String.format(
+            "{\"V\":1,\"Rid\":\"%s\",\"Continuation\":[%s],\"PKRangeId\":\"%s\"}",
+            containerRid, continuationEntries, pkRangeId);
+
+        FeedRangeContinuation continuation = FeedRangeContinuation.convert(continuationJson);
+        return new ChangeFeedStateV1(
+            containerRid,
+            feedRange,
+            ChangeFeedMode.INCREMENTAL,
+            ChangeFeedStartFromInternal.createFromNow(),
+            continuation);
+    }
+
     private ChangeFeedState createStateWithTokenRanges(String[][] tokenRanges) {
         String containerRid = "/cols/" + UUID.randomUUID();
         String pkRangeId = UUID.randomUUID().toString();

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
@@ -399,18 +399,37 @@ public class ChangeFeedStateTest {
 
     @Test(groups = "unit")
     public void changeFeedState_extractForEffectiveRange_multipleCallsProduceCorrectResults() {
-        // Verify that calling extractForEffectiveRange multiple times on the same
-        // state with different ranges returns correct tokens each time (sort-once caching)
+        // Verify that calling extractForEffectiveRanges (batch API) returns correct
+        // tokens for multiple ranges from the same continuation (sort-once).
         int tokenCount = 100;
         ChangeFeedState state = createStateWithManyTokens(tokenCount);
 
-        // Extract first range: tokens 0-9
+        List<Range<String>> ranges = new ArrayList<>();
+        // First range: tokens 0-9
         String min0 = String.format("%06X", 0);
         String max10 = String.format("%06X", 10);
-        List<CompositeContinuationToken> tokens1 =
-            state.extractForEffectiveRange(new Range<>(min0, max10, true, false))
-                .extractContinuationTokens();
+        ranges.add(new Range<>(min0, max10, true, false));
 
+        // Middle range: tokens 50-59
+        String min50 = String.format("%06X", 50);
+        String max60 = String.format("%06X", 60);
+        ranges.add(new Range<>(min50, max60, true, false));
+
+        // Last range: tokens 90-99
+        String min90 = String.format("%06X", 90);
+        String max100 = String.format("%06X", 100);
+        ranges.add(new Range<>(min90, max100, true, false));
+
+        // Single token
+        String min25 = String.format("%06X", 25);
+        String max26 = String.format("%06X", 26);
+        ranges.add(new Range<>(min25, max26, true, false));
+
+        List<ChangeFeedState> results = state.extractForEffectiveRanges(ranges);
+        assertThat(results).hasSize(4);
+
+        // Verify first range: tokens 0-9
+        List<CompositeContinuationToken> tokens1 = results.get(0).extractContinuationTokens();
         assertThat(tokens1).hasSize(10);
         for (int i = 0; i < 10; i++) {
             assertThat(tokens1.get(i).getToken()).isEqualTo("token_" + i);
@@ -418,37 +437,22 @@ public class ChangeFeedStateTest {
             assertThat(tokens1.get(i).getRange().getMax()).isEqualTo(String.format("%06X", i + 1));
         }
 
-        // Extract middle range: tokens 50-59
-        String min50 = String.format("%06X", 50);
-        String max60 = String.format("%06X", 60);
-        List<CompositeContinuationToken> tokens2 =
-            state.extractForEffectiveRange(new Range<>(min50, max60, true, false))
-                .extractContinuationTokens();
-
+        // Verify middle range: tokens 50-59
+        List<CompositeContinuationToken> tokens2 = results.get(1).extractContinuationTokens();
         assertThat(tokens2).hasSize(10);
         for (int i = 0; i < 10; i++) {
             assertThat(tokens2.get(i).getToken()).isEqualTo("token_" + (50 + i));
         }
 
-        // Extract last range: tokens 90-99
-        String min90 = String.format("%06X", 90);
-        String max100 = String.format("%06X", 100);
-        List<CompositeContinuationToken> tokens3 =
-            state.extractForEffectiveRange(new Range<>(min90, max100, true, false))
-                .extractContinuationTokens();
-
+        // Verify last range: tokens 90-99
+        List<CompositeContinuationToken> tokens3 = results.get(2).extractContinuationTokens();
         assertThat(tokens3).hasSize(10);
         for (int i = 0; i < 10; i++) {
             assertThat(tokens3.get(i).getToken()).isEqualTo("token_" + (90 + i));
         }
 
-        // Extract single token
-        String min25 = String.format("%06X", 25);
-        String max26 = String.format("%06X", 26);
-        List<CompositeContinuationToken> tokens4 =
-            state.extractForEffectiveRange(new Range<>(min25, max26, true, false))
-                .extractContinuationTokens();
-
+        // Verify single token
+        List<CompositeContinuationToken> tokens4 = results.get(3).extractContinuationTokens();
         assertThat(tokens4).hasSize(1);
         assertThat(tokens4.get(0).getToken()).isEqualTo("token_25");
     }
@@ -460,23 +464,23 @@ public class ChangeFeedStateTest {
         int tokenCount = 5000;
         ChangeFeedState state = createStateWithManyTokens(tokenCount);
 
-        // Pre-compute range strings outside the timed section to avoid
-        // String.format overhead affecting measurement.
-        String[] mins = new String[tokenCount];
-        String[] maxs = new String[tokenCount];
+        // Build all ranges upfront outside the timed section
+        List<Range<String>> ranges = new ArrayList<>(tokenCount);
         for (int i = 0; i < tokenCount; i++) {
-            mins[i] = String.format("%06X", i);
-            maxs[i] = String.format("%06X", i + 1);
+            ranges.add(new Range<>(
+                String.format("%06X", i),
+                String.format("%06X", i + 1),
+                true, false));
         }
 
         long startTime = System.nanoTime();
 
-        // Extract for every individual partition range (simulates Spark planning)
-        for (int i = 0; i < tokenCount; i++) {
-            List<CompositeContinuationToken> tokens =
-                state.extractForEffectiveRange(new Range<>(mins[i], maxs[i], true, false))
-                    .extractContinuationTokens();
+        // Extract for all individual partition ranges at once (simulates Spark planning)
+        List<ChangeFeedState> results = state.extractForEffectiveRanges(ranges);
 
+        assertThat(results).hasSize(tokenCount);
+        for (int i = 0; i < tokenCount; i++) {
+            List<CompositeContinuationToken> tokens = results.get(i).extractContinuationTokens();
             assertThat(tokens).hasSize(1);
             assertThat(tokens.get(0).getToken()).isEqualTo("token_" + i);
         }
@@ -484,9 +488,7 @@ public class ChangeFeedStateTest {
         long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
 
         // Sanity check only: the optimized O(T log T + P log T) approach should
-        // complete in well under 60 seconds. The quadratic version would take
-        // minutes and effectively hang. This is not a strict perf benchmark —
-        // it simply guards against accidental regressions to O(P * T log T).
+        // complete in well under 60 seconds.
         assertThat(elapsedMs)
             .as("5,000 extractions took %d ms, should be < 60,000 ms", elapsedMs)
             .isLessThan(60_000);
@@ -697,64 +699,24 @@ public class ChangeFeedStateTest {
     }
 
     @Test(groups = "unit")
-    public void changeFeedState_extractForEffectiveRange_cacheInvalidatedAfterSetContinuation() {
-        // Verify that replacing the continuation via setContinuation() invalidates
-        // the cached sorted snapshot, ensuring subsequent extractions use the new tokens.
-        String containerRid = "/cols/" + UUID.randomUUID();
-        String pkRangeId = UUID.randomUUID().toString();
-        FeedRangePartitionKeyRangeImpl feedRange = new FeedRangePartitionKeyRangeImpl(pkRangeId);
+    public void changeFeedState_extractForEffectiveRanges_singleBatchAndSingleCallParity() {
+        // Verifies that extractForEffectiveRange (single) and extractForEffectiveRanges (batch)
+        // produce identical results for the same input ranges.
+        ChangeFeedState state = createStateWithManyTokens(20);
 
-        // Create state with 10 tokens
-        ChangeFeedState state = createStateWithFixedRid(containerRid, pkRangeId, feedRange, 10);
+        List<Range<String>> ranges = new ArrayList<>();
+        ranges.add(new Range<>(String.format("%06X", 0), String.format("%06X", 5), true, false));
+        ranges.add(new Range<>(String.format("%06X", 10), String.format("%06X", 15), true, false));
+        ranges.add(new Range<>(String.format("%06X", 18), String.format("%06X", 20), true, false));
 
-        // Prime the cache by extracting a range
-        List<CompositeContinuationToken> tokensBefore =
-            state.extractForEffectiveRange(new Range<>(
-                String.format("%06X", 0), String.format("%06X", 5), true, false))
-                .extractContinuationTokens();
-        assertThat(tokensBefore).hasSize(5);
+        List<ChangeFeedState> batchResults = state.extractForEffectiveRanges(ranges);
 
-        // Build a replacement continuation with only 3 tokens but same containerRid
-        ChangeFeedState newState = createStateWithFixedRid(containerRid, pkRangeId, feedRange, 3);
-        state.setContinuation(newState.getContinuation());
-
-        // Extract all tokens - should reflect the new 3-token continuation, not the stale 10-token cache
-        List<CompositeContinuationToken> tokensAfter = state.extractContinuationTokens();
-        assertThat(tokensAfter).hasSize(3);
-        for (int i = 0; i < 3; i++) {
-            assertThat(tokensAfter.get(i).getToken()).isEqualTo("token_" + i);
+        for (int i = 0; i < ranges.size(); i++) {
+            ChangeFeedState singleResult = state.extractForEffectiveRange(ranges.get(i));
+            assertThat(batchResults.get(i).toString())
+                .as("Batch result at index %d should match single-range result", i)
+                .isEqualTo(singleResult.toString());
         }
-    }
-
-    private ChangeFeedState createStateWithFixedRid(
-        String containerRid,
-        String pkRangeId,
-        FeedRangePartitionKeyRangeImpl feedRange,
-        int tokenCount) {
-
-        StringBuilder continuationEntries = new StringBuilder();
-        for (int i = 0; i < tokenCount; i++) {
-            if (i > 0) {
-                continuationEntries.append(",");
-            }
-            String min = String.format("%06X", i);
-            String max = String.format("%06X", i + 1);
-            String token = "token_" + i;
-            continuationEntries.append(
-                String.format("{\"token\":\"%s\",\"range\":{\"min\":\"%s\",\"max\":\"%s\"}}", token, min, max));
-        }
-
-        String continuationJson = String.format(
-            "{\"V\":1,\"Rid\":\"%s\",\"Continuation\":[%s],\"PKRangeId\":\"%s\"}",
-            containerRid, continuationEntries, pkRangeId);
-
-        FeedRangeContinuation continuation = FeedRangeContinuation.convert(continuationJson);
-        return new ChangeFeedStateV1(
-            containerRid,
-            feedRange,
-            ChangeFeedMode.INCREMENTAL,
-            ChangeFeedStartFromInternal.createFromNow(),
-            continuation);
     }
 
     private ChangeFeedState createStateWithTokenRanges(String[][] tokenRanges) {

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ChangeFeedStateTest.java
@@ -483,12 +483,12 @@ public class ChangeFeedStateTest {
         // The generous margin prevents flakiness on overloaded agents or GC pauses;
         // the quadratic version would hang the test runner entirely.
         assertThat(elapsedMs)
-            .as("Total time for 10,000 extractions should be < 30 seconds")
+            .as("10,000 extractions took %d ms, should be < 30,000 ms", elapsedMs)
             .isLessThan(30_000);
     }
 
     @Test(groups = "unit")
-    public void changeFeedState_extractForEffectiveRange_nullContinuation() {
+    public void changeFeedState_extractContinuationTokens_nullContinuation() {
         String containerRid = "/cols/" + UUID.randomUUID();
         String pkRangeId = UUID.randomUUID().toString();
         FeedRangePartitionKeyRangeImpl feedRange = new FeedRangePartitionKeyRangeImpl(pkRangeId);
@@ -503,6 +503,24 @@ public class ChangeFeedStateTest {
         // With null continuation, extractContinuationTokens returns empty
         List<CompositeContinuationToken> tokens = state.extractContinuationTokens();
         assertThat(tokens).isEmpty();
+    }
+
+    @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
+    public void changeFeedState_extractForEffectiveRange_nullContinuation_throws() {
+        String containerRid = "/cols/" + UUID.randomUUID();
+        String pkRangeId = UUID.randomUUID().toString();
+        FeedRangePartitionKeyRangeImpl feedRange = new FeedRangePartitionKeyRangeImpl(pkRangeId);
+
+        ChangeFeedState state = new ChangeFeedStateV1(
+            containerRid,
+            feedRange,
+            ChangeFeedMode.INCREMENTAL,
+            ChangeFeedStartFromInternal.createFromNow(),
+            null);
+
+        // With null continuation, extractForEffectiveRange passes an empty token list to
+        // FeedRangeContinuation.create(), which throws IllegalArgumentException.
+        state.extractForEffectiveRange(new Range<>("AA", "BB", true, false));
     }
 
     @Test(groups = "unit")

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
+* Fixed quadratic O(P × T log T) performance in `ChangeFeedState.extractForEffectiveRange` that caused excessive driver-side microbatch planning time in the Spark change feed connector for containers with many feed ranges / continuation tokens. The method now sorts continuation tokens once per planning pass and uses binary search for overlap detection, reducing complexity to O(T log T + P log T). - See [PR 49084](https://github.com/Azure/azure-sdk-for-java/pull/49084)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
-* Fixed quadratic O(P × T log T) performance in `ChangeFeedState.extractForEffectiveRange` that caused excessive driver-side microbatch planning time in the Spark change feed connector for containers with many feed ranges / continuation tokens. The method now sorts continuation tokens once per planning pass and uses binary search for overlap detection, reducing complexity to O(T log T + P log T). - See [PR 49084](https://github.com/Azure/azure-sdk-for-java/pull/49084)
+* Fixed quadratic O(P × T log T) performance in `ChangeFeedState.extractForEffectiveRange` that caused excessive driver-side microbatch planning time in the Spark change feed connector for containers with many feed ranges / continuation tokens. Added batch API `extractForEffectiveRanges(List)` that sorts continuation tokens once and uses binary search for overlap detection (matching the `InMemoryCollectionRoutingMap` pattern), reducing complexity to O(T log T + P log T). - See [PR 49084](https://github.com/Azure/azure-sdk-for-java/pull/49084)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
@@ -107,6 +107,10 @@ public abstract class ChangeFeedState extends JsonSerializable {
         }
 
         SortedTokensSnapshot snapshot = this.cachedSortedTokensSnapshot;
+        // Intentional reference equality (==): setContinuation() replaces the reference,
+        // invalidating the cache. In-place mutations via applyServerResponseContinuation()
+        // do not change the reference and do not affect token range order, so the cache
+        // remains valid.
         if (snapshot != null && snapshot.continuationRef == continuation) {
             return snapshot.sortedTokens;
         }
@@ -115,7 +119,7 @@ public abstract class ChangeFeedState extends JsonSerializable {
         Collections.addAll(sorted, continuation.getCurrentContinuationTokens());
         sorted.sort(ContinuationTokenRangeComparator.SINGLETON_INSTANCE);
 
-        this.cachedSortedTokensSnapshot = new SortedTokensSnapshot(continuation, sorted);
+        this.cachedSortedTokensSnapshot = new SortedTokensSnapshot(continuation, Collections.unmodifiableList(sorted));
         return sorted;
     }
 
@@ -133,48 +137,32 @@ public abstract class ChangeFeedState extends JsonSerializable {
         if (!sortedTokens.isEmpty()) {
             int startIndex = findFirstPotentialOverlapIndex(sortedTokens, effectiveRange);
 
-            for (int i = startIndex; i < sortedTokens.size(); i++) {
-                CompositeContinuationToken compositeContinuationToken = sortedTokens.get(i);
-                if (Range.checkOverlapping(effectiveRange, compositeContinuationToken.getRange())) {
-                    Range<String> overlappingRange =
-                        getOverlappingRange(effectiveRange, compositeContinuationToken.getRange());
+            // Primary scan from binary search starting position
+            String[] primaryMinMax = new String[2];
+            collectOverlapping(sortedTokens, effectiveRange, startIndex, sortedTokens.size(),
+                extractedContinuationTokens, primaryMinMax);
+            min = primaryMinMax[0];
+            max = primaryMinMax[1];
 
-                    extractedContinuationTokens.add(
-                        new CompositeContinuationToken(compositeContinuationToken.getToken(),
-                            overlappingRange));
-
-                    if (min == null) {
-                        min = overlappingRange.getMin();
-                    }
-                    max = overlappingRange.getMax();
-                } else {
-                    if (extractedContinuationTokens.size() > 0) {
-                        break;
-                    }
-                }
-            }
-
-            // Fallback: if binary search found no overlaps but started past index 0,
-            // do a full linear scan to handle non-contiguous or legacy overlapping ranges
-            if (extractedContinuationTokens.isEmpty() && startIndex > 0) {
-                for (int i = 0; i < sortedTokens.size(); i++) {
-                    CompositeContinuationToken compositeContinuationToken = sortedTokens.get(i);
-                    if (Range.checkOverlapping(effectiveRange, compositeContinuationToken.getRange())) {
-                        Range<String> overlappingRange =
-                            getOverlappingRange(effectiveRange, compositeContinuationToken.getRange());
-
-                        extractedContinuationTokens.add(
-                            new CompositeContinuationToken(compositeContinuationToken.getToken(),
-                                overlappingRange));
-
-                        if (min == null) {
-                            min = overlappingRange.getMin();
-                        }
-                        max = overlappingRange.getMax();
-                    } else {
-                        if (extractedContinuationTokens.size() > 0) {
-                            break;
-                        }
+            // Fallback: if binary search started past index 0, scan earlier indices for any
+            // overlapping tokens that the binary search may have skipped. This handles both
+            // complete misses (no overlaps found in primary scan) and partial misses (some
+            // overlaps missed due to non-contiguous or legacy overlapping ranges).
+            if (startIndex > 0) {
+                List<CompositeContinuationToken> missedTokens = new ArrayList<>();
+                String[] fallbackMinMax = new String[2];
+                collectOverlapping(sortedTokens, effectiveRange, 0, startIndex,
+                    missedTokens, fallbackMinMax);
+                if (!missedTokens.isEmpty()) {
+                    // Prepend missed tokens (they precede startIndex in sorted order)
+                    missedTokens.addAll(extractedContinuationTokens);
+                    extractedContinuationTokens = missedTokens;
+                    // Missed tokens come first in sorted order, so their min is the overall min
+                    min = fallbackMinMax[0];
+                    // Take the larger max between fallback and primary results
+                    if (max == null || (fallbackMinMax[1] != null
+                        && fallbackMinMax[1].compareTo(max) > 0)) {
+                        max = fallbackMinMax[1];
                     }
                 }
             }
@@ -187,6 +175,47 @@ public abstract class ChangeFeedState extends JsonSerializable {
             false);
 
         return Pair.of(extractedContinuationTokens, totalRange);
+    }
+
+    /**
+     * Collects continuation tokens from sortedTokens[fromIndex..toIndex) that overlap
+     * with effectiveRange. Each collected token's range is trimmed to the overlapping
+     * region. Applies an early-break optimization: stops scanning when a non-overlapping
+     * token is encountered after at least one overlapping token has been found.
+     *
+     * @param sortedTokens the sorted continuation token list
+     * @param effectiveRange the range to check for overlaps
+     * @param fromIndex start index (inclusive)
+     * @param toIndex end index (exclusive)
+     * @param out list to append matching tokens to
+     * @param minMax two-element array for tracking [min, max] of overlapping ranges;
+     *               minMax[0] is set to the first overlap's min, minMax[1] to the last overlap's max
+     */
+    private void collectOverlapping(
+        List<CompositeContinuationToken> sortedTokens,
+        Range<String> effectiveRange,
+        int fromIndex,
+        int toIndex,
+        List<CompositeContinuationToken> out,
+        String[] minMax) {
+
+        for (int i = fromIndex; i < toIndex; i++) {
+            CompositeContinuationToken compositeContinuationToken = sortedTokens.get(i);
+            if (Range.checkOverlapping(effectiveRange, compositeContinuationToken.getRange())) {
+                Range<String> overlappingRange =
+                    getOverlappingRange(effectiveRange, compositeContinuationToken.getRange());
+                out.add(new CompositeContinuationToken(
+                    compositeContinuationToken.getToken(), overlappingRange));
+                if (minMax[0] == null) {
+                    minMax[0] = overlappingRange.getMin();
+                }
+                minMax[1] = overlappingRange.getMax();
+            } else {
+                if (!out.isEmpty()) {
+                    break;
+                }
+            }
+        }
     }
 
     /**

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
@@ -38,7 +38,9 @@ public abstract class ChangeFeedState extends JsonSerializable {
     // Reused across multiple extractForEffectiveRange calls on the same instance to
     // avoid redundant O(T log T) copy+sort per partition during Spark planning.
     // Benign race by design: concurrent callers may both create a snapshot,
-    // but the snapshot is immutable and volatile ensures safe publication.
+    // but the list wrapper is unmodifiable and volatile ensures safe publication.
+    // Note: the contained CompositeContinuationToken instances are themselves mutable;
+    // this cache only guarantees a stable sorted order, not deep immutability.
     // This class is NOT thread-safe for concurrent setContinuation() calls.
     private transient volatile SortedTokensSnapshot cachedSortedTokensSnapshot;
 
@@ -133,8 +135,9 @@ public abstract class ChangeFeedState extends JsonSerializable {
         Collections.addAll(sorted, continuation.getCurrentContinuationTokens());
         sorted.sort(ContinuationTokenRangeComparator.SINGLETON_INSTANCE);
 
-        this.cachedSortedTokensSnapshot = new SortedTokensSnapshot(continuation, Collections.unmodifiableList(sorted));
-        return sorted;
+        SortedTokensSnapshot newSnapshot = new SortedTokensSnapshot(continuation, Collections.unmodifiableList(sorted));
+        this.cachedSortedTokensSnapshot = newSnapshot;
+        return newSnapshot.sortedTokens;
     }
 
     private Pair<List<CompositeContinuationToken>, Range<String>> extractContinuationTokens(

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
@@ -47,6 +47,17 @@ public abstract class ChangeFeedState extends JsonSerializable {
 
     public abstract FeedRangeContinuation getContinuation();
 
+    /**
+     * Sets the continuation for this change feed state.
+     * <p>
+     * Implementations must assign a new {@link FeedRangeContinuation} reference rather than
+     * mutating the existing one in-place. The base class uses reference-equality detection
+     * to invalidate a lazily-cached sorted-token snapshot. If the same reference is reused
+     * with modified contents, the cache will serve stale data.
+     *
+     * @param continuation the new continuation to set
+     * @return this {@link ChangeFeedState} instance
+     */
     public abstract ChangeFeedState setContinuation(FeedRangeContinuation continuation);
 
     public abstract FeedRangeInternal getFeedRange();
@@ -141,19 +152,22 @@ public abstract class ChangeFeedState extends JsonSerializable {
             int startIndex = findFirstPotentialOverlapIndex(sortedTokens, effectiveRange);
 
             // Primary scan from binary search starting position
-            String[] primaryMinMax = new String[2];
+            MinMaxAccumulator primaryMinMax = new MinMaxAccumulator();
             collectOverlapping(sortedTokens, effectiveRange, startIndex, sortedTokens.size(),
                 extractedContinuationTokens, primaryMinMax);
-            min = primaryMinMax[0];
-            max = primaryMinMax[1];
+            min = primaryMinMax.min;
+            max = primaryMinMax.max;
 
             // Fallback: if binary search started past index 0, scan earlier indices for any
             // overlapping tokens that the binary search may have skipped. This handles both
             // complete misses (no overlaps found in primary scan) and partial misses (some
-            // overlaps missed due to non-contiguous or legacy overlapping ranges).
+            // overlaps missed due to non-contiguous token ranges). Note: the early-break
+            // optimization in collectOverlapping still applies, so this does not handle
+            // arbitrary non-contiguous overlapping ranges — it preserves the original
+            // linear scan behavior which assumes contiguous overlaps (Cosmos DB contract).
             if (startIndex > 0) {
                 List<CompositeContinuationToken> missedTokens = new ArrayList<>();
-                String[] fallbackMinMax = new String[2];
+                MinMaxAccumulator fallbackMinMax = new MinMaxAccumulator();
                 collectOverlapping(sortedTokens, effectiveRange, 0, startIndex,
                     missedTokens, fallbackMinMax);
                 if (!missedTokens.isEmpty()) {
@@ -161,11 +175,11 @@ public abstract class ChangeFeedState extends JsonSerializable {
                     missedTokens.addAll(extractedContinuationTokens);
                     extractedContinuationTokens = missedTokens;
                     // Missed tokens come first in sorted order, so their min is the overall min
-                    min = fallbackMinMax[0];
+                    min = fallbackMinMax.min;
                     // Take the larger max between fallback and primary results
-                    if (max == null || (fallbackMinMax[1] != null
-                        && fallbackMinMax[1].compareTo(max) > 0)) {
-                        max = fallbackMinMax[1];
+                    if (max == null || (fallbackMinMax.max != null
+                        && fallbackMinMax.max.compareTo(max) > 0)) {
+                        max = fallbackMinMax.max;
                     }
                 }
             }
@@ -191,8 +205,8 @@ public abstract class ChangeFeedState extends JsonSerializable {
      * @param fromIndex start index (inclusive)
      * @param toIndex end index (exclusive)
      * @param out list to append matching tokens to
-     * @param minMax two-element array for tracking [min, max] of overlapping ranges;
-     *               minMax[0] is set to the first overlap's min, minMax[1] to the last overlap's max
+     * @param minMax accumulator for tracking min/max of overlapping ranges;
+     *               min is set to the first overlap's min, max to the last overlap's max
      */
     private void collectOverlapping(
         List<CompositeContinuationToken> sortedTokens,
@@ -200,7 +214,7 @@ public abstract class ChangeFeedState extends JsonSerializable {
         int fromIndex,
         int toIndex,
         List<CompositeContinuationToken> out,
-        String[] minMax) {
+        MinMaxAccumulator minMax) {
 
         for (int i = fromIndex; i < toIndex; i++) {
             CompositeContinuationToken compositeContinuationToken = sortedTokens.get(i);
@@ -209,10 +223,10 @@ public abstract class ChangeFeedState extends JsonSerializable {
                     getOverlappingRange(effectiveRange, compositeContinuationToken.getRange());
                 out.add(new CompositeContinuationToken(
                     compositeContinuationToken.getToken(), overlappingRange));
-                if (minMax[0] == null) {
-                    minMax[0] = overlappingRange.getMin();
+                if (minMax.min == null) {
+                    minMax.min = overlappingRange.getMin();
                 }
-                minMax[1] = overlappingRange.getMax();
+                minMax.max = overlappingRange.getMax();
             } else {
                 // Early-break: assumes overlapping tokens are contiguous after sorting.
                 // Safe for non-overlapping partition ranges (Cosmos DB contract).
@@ -395,6 +409,14 @@ public abstract class ChangeFeedState extends JsonSerializable {
 
             return MIN_RANGE_COMPARATOR.compare(left.getRange(), right.getRange());
         }
+    }
+
+    /**
+     * Tracks the min and max range values while collecting overlapping tokens.
+     */
+    private static final class MinMaxAccumulator {
+        String min;
+        String max;
     }
 
     /**

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
@@ -34,32 +34,11 @@ public abstract class ChangeFeedState extends JsonSerializable {
     private static final Comparator<Range<String>> MIN_RANGE_COMPARATOR = new Range.MinComparator<>();
     private static final Comparator<Range<String>> MAX_RANGE_COMPARATOR = new Range.MaxComparator<>();
 
-    // Lazily-initialized cache holding a pre-sorted snapshot of continuation tokens.
-    // Reused across multiple extractForEffectiveRange calls on the same instance to
-    // avoid redundant O(T log T) copy+sort per partition during Spark planning.
-    // Benign race by design: concurrent callers may both create a snapshot,
-    // but the list wrapper is unmodifiable and volatile ensures safe publication.
-    // Note: the contained CompositeContinuationToken instances are themselves mutable;
-    // this cache only guarantees a stable sorted order, not deep immutability.
-    // This class is NOT thread-safe for concurrent setContinuation() calls.
-    private transient volatile SortedTokensSnapshot cachedSortedTokensSnapshot;
-
     ChangeFeedState() {
     }
 
     public abstract FeedRangeContinuation getContinuation();
 
-    /**
-     * Sets the continuation for this change feed state.
-     * <p>
-     * Implementations must assign a new {@link FeedRangeContinuation} reference rather than
-     * mutating the existing one in-place. The base class uses reference-equality detection
-     * to invalidate a lazily-cached sorted-token snapshot. If the same reference is reused
-     * with modified contents, the cache will serve stale data.
-     *
-     * @param continuation the new continuation to set
-     * @return this {@link ChangeFeedState} instance
-     */
     public abstract ChangeFeedState setContinuation(FeedRangeContinuation continuation);
 
     public abstract FeedRangeInternal getFeedRange();
@@ -113,77 +92,133 @@ public abstract class ChangeFeedState extends JsonSerializable {
     public abstract void populateRequest(RxDocumentServiceRequest request, int maxItemCount);
 
     public List<CompositeContinuationToken> extractContinuationTokens() {
-        return extractContinuationTokens(PartitionKeyInternalHelper.FullRange).getLeft();
+        return extractContinuationTokensForRange(
+            PartitionKeyInternalHelper.FullRange,
+            getSortedTokensAndRanges()).getLeft();
     }
 
-    private List<CompositeContinuationToken> getOrCreateSortedContinuationTokens() {
+    /**
+     * Extracts a {@link ChangeFeedState} for a single effective range.
+     * <p>
+     * For callers that need to extract states for multiple ranges from the same
+     * continuation, prefer {@link #extractForEffectiveRanges(List)} which sorts
+     * the continuation tokens once and reuses the sorted list across all ranges.
+     *
+     * @param effectiveRange the partition range to extract for
+     * @return a new {@link ChangeFeedState} scoped to the given range
+     */
+    public ChangeFeedState extractForEffectiveRange(Range<String> effectiveRange) {
+        checkNotNull(effectiveRange);
+        return extractForEffectiveRanges(Collections.singletonList(effectiveRange)).get(0);
+    }
+
+    /**
+     * Extracts a list of {@link ChangeFeedState} instances, one per input effective range.
+     * <p>
+     * Continuation tokens are sorted once (O(T log T)) and then each range lookup uses
+     * binary search (O(log T)), following the same pattern as
+     * {@link com.azure.cosmos.implementation.routing.InMemoryCollectionRoutingMap#getOverlappingRanges}.
+     * This avoids the O(P × T log T) cost of sorting per range when called in a loop.
+     * <p>
+     * The returned list preserves the input order: result.get(i) corresponds to
+     * effectiveRanges.get(i).
+     *
+     * @param effectiveRanges the list of partition ranges to extract for
+     * @return a list of {@link ChangeFeedState}, one per input range, in the same order
+     */
+    public List<ChangeFeedState> extractForEffectiveRanges(List<Range<String>> effectiveRanges) {
+        checkNotNull(effectiveRanges, "Argument 'effectiveRanges' must not be null.");
+        checkArgument(!effectiveRanges.isEmpty(), "Argument 'effectiveRanges' must not be empty.");
+
+        SortedTokensAndRanges sorted = getSortedTokensAndRanges();
+
+        List<ChangeFeedState> results = new ArrayList<>(effectiveRanges.size());
+        for (Range<String> effectiveRange : effectiveRanges) {
+            checkNotNull(effectiveRange, "Effective range must not be null.");
+
+            Pair<List<CompositeContinuationToken>, Range<String>> extracted =
+                extractContinuationTokensForRange(effectiveRange, sorted);
+
+            List<CompositeContinuationToken> tokens = extracted.getLeft();
+            Range<String> totalRange = extracted.getRight();
+
+            FeedRangeEpkImpl feedRange = new FeedRangeEpkImpl(totalRange);
+
+            results.add(new ChangeFeedStateV1(
+                this.getContainerRid(),
+                feedRange,
+                this.getMode(),
+                this.getStartFromSettings(),
+                FeedRangeContinuation.create(
+                    this.getContainerRid(),
+                    feedRange,
+                    tokens
+                )
+            ));
+        }
+
+        return results;
+    }
+
+    /**
+     * Sorts continuation tokens once and builds a parallel list of their ranges
+     * for use with {@link Collections#binarySearch}.
+     */
+    private SortedTokensAndRanges getSortedTokensAndRanges() {
         FeedRangeContinuation continuation = this.getContinuation();
         if (continuation == null) {
-            return Collections.emptyList();
+            return new SortedTokensAndRanges(Collections.emptyList(), Collections.emptyList());
         }
 
-        SortedTokensSnapshot snapshot = this.cachedSortedTokensSnapshot;
-        // Intentional reference equality (==): setContinuation() replaces the reference,
-        // invalidating the cache. In-place mutations via applyServerResponseContinuation()
-        // do not change the reference and do not affect token range order, so the cache
-        // remains valid.
-        if (snapshot != null && snapshot.continuationRef == continuation) {
-            return snapshot.sortedTokens;
+        List<CompositeContinuationToken> sortedTokens = new ArrayList<>();
+        Collections.addAll(sortedTokens, continuation.getCurrentContinuationTokens());
+        sortedTokens.sort(ContinuationTokenRangeComparator.SINGLETON_INSTANCE);
+
+        List<Range<String>> sortedRanges = new ArrayList<>(sortedTokens.size());
+        for (CompositeContinuationToken token : sortedTokens) {
+            sortedRanges.add(token.getRange());
         }
 
-        List<CompositeContinuationToken> sorted = new ArrayList<>();
-        Collections.addAll(sorted, continuation.getCurrentContinuationTokens());
-        sorted.sort(ContinuationTokenRangeComparator.SINGLETON_INSTANCE);
-
-        SortedTokensSnapshot newSnapshot = new SortedTokensSnapshot(continuation, Collections.unmodifiableList(sorted));
-        this.cachedSortedTokensSnapshot = newSnapshot;
-        return newSnapshot.sortedTokens;
+        return new SortedTokensAndRanges(sortedTokens, sortedRanges);
     }
 
-    private Pair<List<CompositeContinuationToken>, Range<String>> extractContinuationTokens(
-        Range<String> effectiveRange) {
+    /**
+     * Finds overlapping continuation tokens for an effective range using binary search,
+     * following the same pattern as
+     * {@link com.azure.cosmos.implementation.routing.InMemoryCollectionRoutingMap#getOverlappingRanges}.
+     */
+    private Pair<List<CompositeContinuationToken>, Range<String>> extractContinuationTokensForRange(
+        Range<String> effectiveRange,
+        SortedTokensAndRanges sorted) {
 
         checkNotNull(effectiveRange);
 
-        List<CompositeContinuationToken> extractedContinuationTokens = new ArrayList<>();
+        List<CompositeContinuationToken> extractedTokens = new ArrayList<>();
         String min = null;
         String max = null;
 
-        List<CompositeContinuationToken> sortedTokens = getOrCreateSortedContinuationTokens();
+        if (!sorted.sortedTokens.isEmpty()) {
+            // Binary search for the scan window, matching InMemoryCollectionRoutingMap pattern
+            int minIndex = Collections.binarySearch(sorted.sortedRanges, effectiveRange, MIN_RANGE_COMPARATOR);
+            if (minIndex < 0) {
+                minIndex = Math.max(0, -minIndex - 2);
+            }
 
-        if (!sortedTokens.isEmpty()) {
-            int startIndex = findFirstPotentialOverlapIndex(sortedTokens, effectiveRange);
+            int maxIndex = Collections.binarySearch(sorted.sortedRanges, effectiveRange, MAX_RANGE_COMPARATOR);
+            if (maxIndex < 0) {
+                maxIndex = Math.min(sorted.sortedRanges.size() - 1, -maxIndex - 1);
+            }
 
-            // Primary scan from binary search starting position
-            MinMaxAccumulator primaryMinMax = new MinMaxAccumulator();
-            collectOverlapping(sortedTokens, effectiveRange, startIndex, sortedTokens.size(),
-                extractedContinuationTokens, primaryMinMax);
-            min = primaryMinMax.min;
-            max = primaryMinMax.max;
-
-            // Fallback: if binary search started past index 0, scan earlier indices for any
-            // overlapping tokens that the binary search may have skipped. This handles both
-            // complete misses (no overlaps found in primary scan) and partial misses (some
-            // overlaps missed due to non-contiguous token ranges). Note: the early-break
-            // optimization in collectOverlapping still applies, so this does not handle
-            // arbitrary non-contiguous overlapping ranges — it preserves the original
-            // linear scan behavior which assumes contiguous overlaps (Cosmos DB contract).
-            if (startIndex > 0) {
-                List<CompositeContinuationToken> missedTokens = new ArrayList<>();
-                MinMaxAccumulator fallbackMinMax = new MinMaxAccumulator();
-                collectOverlapping(sortedTokens, effectiveRange, 0, startIndex,
-                    missedTokens, fallbackMinMax);
-                if (!missedTokens.isEmpty()) {
-                    // Prepend missed tokens (they precede startIndex in sorted order)
-                    missedTokens.addAll(extractedContinuationTokens);
-                    extractedContinuationTokens = missedTokens;
-                    // Missed tokens come first in sorted order, so their min is the overall min
-                    min = fallbackMinMax.min;
-                    // Take the larger max between fallback and primary results
-                    if (max == null || (fallbackMinMax.max != null
-                        && fallbackMinMax.max.compareTo(max) > 0)) {
-                        max = fallbackMinMax.max;
+            for (int i = minIndex; i <= maxIndex; i++) {
+                CompositeContinuationToken token = sorted.sortedTokens.get(i);
+                if (Range.checkOverlapping(effectiveRange, token.getRange())) {
+                    Range<String> overlappingRange = getOverlappingRange(effectiveRange, token.getRange());
+                    extractedTokens.add(new CompositeContinuationToken(
+                        token.getToken(), overlappingRange));
+                    if (min == null) {
+                        min = overlappingRange.getMin();
                     }
+                    max = overlappingRange.getMax();
                 }
             }
         }
@@ -194,104 +229,7 @@ public abstract class ChangeFeedState extends JsonSerializable {
             true,
             false);
 
-        return Pair.of(extractedContinuationTokens, totalRange);
-    }
-
-    /**
-     * Collects continuation tokens from sortedTokens[fromIndex..toIndex) that overlap
-     * with effectiveRange. Each collected token's range is trimmed to the overlapping
-     * region. Applies an early-break optimization: stops scanning when a non-overlapping
-     * token is encountered after at least one overlapping token has been found.
-     *
-     * @param sortedTokens the sorted continuation token list
-     * @param effectiveRange the range to check for overlaps
-     * @param fromIndex start index (inclusive)
-     * @param toIndex end index (exclusive)
-     * @param out list to append matching tokens to
-     * @param minMax accumulator for tracking min/max of overlapping ranges;
-     *               min is set to the first overlap's min, max to the last overlap's max
-     */
-    private void collectOverlapping(
-        List<CompositeContinuationToken> sortedTokens,
-        Range<String> effectiveRange,
-        int fromIndex,
-        int toIndex,
-        List<CompositeContinuationToken> out,
-        MinMaxAccumulator minMax) {
-
-        for (int i = fromIndex; i < toIndex; i++) {
-            CompositeContinuationToken compositeContinuationToken = sortedTokens.get(i);
-            if (Range.checkOverlapping(effectiveRange, compositeContinuationToken.getRange())) {
-                Range<String> overlappingRange =
-                    getOverlappingRange(effectiveRange, compositeContinuationToken.getRange());
-                out.add(new CompositeContinuationToken(
-                    compositeContinuationToken.getToken(), overlappingRange));
-                if (minMax.min == null) {
-                    minMax.min = overlappingRange.getMin();
-                }
-                minMax.max = overlappingRange.getMax();
-            } else {
-                // Early-break: assumes overlapping tokens are contiguous after sorting.
-                // Safe for non-overlapping partition ranges (Cosmos DB contract).
-                // Inherited from original linear scan behavior.
-                if (!out.isEmpty()) {
-                    break;
-                }
-            }
-        }
-    }
-
-    /**
-     * Binary search to find the first index in the sorted token list where
-     * overlapping tokens may start for the given effective range.
-     * Uses the same comparator as the sort to ensure consistency.
-     */
-    private static int findFirstPotentialOverlapIndex(
-        List<CompositeContinuationToken> sortedTokens,
-        Range<String> effectiveRange) {
-
-        int low = 0;
-        int high = sortedTokens.size() - 1;
-        int insertionPoint = sortedTokens.size();
-
-        while (low <= high) {
-            int mid = low + (high - low) / 2;
-            int cmp = MIN_RANGE_COMPARATOR.compare(sortedTokens.get(mid).getRange(), effectiveRange);
-            if (cmp > 0) {
-                insertionPoint = mid;
-                high = mid - 1;
-            } else {
-                low = mid + 1;
-            }
-        }
-
-        // Back up by 1 to catch a token whose range.min <= effectiveRange.min
-        // but whose range.max extends past effectiveRange.min
-        return Math.max(0, insertionPoint - 1);
-    }
-
-    public ChangeFeedState extractForEffectiveRange(Range<String> effectiveRange) {
-        checkNotNull(effectiveRange);
-
-        Pair<List<CompositeContinuationToken>, Range<String>> effectiveTokensAndMinMax =
-            this.extractContinuationTokens(effectiveRange);
-
-        List<CompositeContinuationToken> extractedContinuationTokens = effectiveTokensAndMinMax.getLeft();
-        Range<String> totalRange = effectiveTokensAndMinMax.getRight();
-
-        FeedRangeEpkImpl feedRange = new FeedRangeEpkImpl(totalRange);
-
-        return new ChangeFeedStateV1(
-            this.getContainerRid(),
-            feedRange,
-            this.getMode(),
-            this.getStartFromSettings(),
-            FeedRangeContinuation.create(
-                this.getContainerRid(),
-                feedRange,
-                extractedContinuationTokens
-            )
-        );
+        return Pair.of(extractedTokens, totalRange);
     }
 
     private Range<String> getOverlappingRange(Range<String> left, Range<String> right) {
@@ -415,26 +353,18 @@ public abstract class ChangeFeedState extends JsonSerializable {
     }
 
     /**
-     * Tracks the min and max range values while collecting overlapping tokens.
+     * Holds a pre-sorted list of continuation tokens alongside a parallel list of
+     * their ranges, enabling {@link Collections#binarySearch} on the ranges.
      */
-    private static final class MinMaxAccumulator {
-        String min;
-        String max;
-    }
-
-    /**
-     * Holds a pre-sorted snapshot of continuation tokens along with the
-     * continuation reference it was built from for cache invalidation.
-     */
-    private static final class SortedTokensSnapshot {
-        final FeedRangeContinuation continuationRef;
+    private static final class SortedTokensAndRanges {
         final List<CompositeContinuationToken> sortedTokens;
+        final List<Range<String>> sortedRanges;
 
-        SortedTokensSnapshot(
-            FeedRangeContinuation continuationRef,
-            List<CompositeContinuationToken> sortedTokens) {
-            this.continuationRef = continuationRef;
+        SortedTokensAndRanges(
+            List<CompositeContinuationToken> sortedTokens,
+            List<Range<String>> sortedRanges) {
             this.sortedTokens = sortedTokens;
+            this.sortedRanges = sortedRanges;
         }
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
@@ -37,7 +37,10 @@ public abstract class ChangeFeedState extends JsonSerializable {
     // Lazily-initialized cache holding a pre-sorted snapshot of continuation tokens.
     // Reused across multiple extractForEffectiveRange calls on the same instance to
     // avoid redundant O(T log T) copy+sort per partition during Spark planning.
-    private volatile SortedTokensSnapshot cachedSortedTokensSnapshot;
+    // Benign race by design: concurrent callers may both create a snapshot,
+    // but the snapshot is immutable and volatile ensures safe publication.
+    // This class is NOT thread-safe for concurrent setContinuation() calls.
+    private transient volatile SortedTokensSnapshot cachedSortedTokensSnapshot;
 
     ChangeFeedState() {
     }
@@ -211,6 +214,9 @@ public abstract class ChangeFeedState extends JsonSerializable {
                 }
                 minMax[1] = overlappingRange.getMax();
             } else {
+                // Early-break: assumes overlapping tokens are contiguous after sorting.
+                // Safe for non-overlapping partition ranges (Cosmos DB contract).
+                // Inherited from original linear scan behavior.
                 if (!out.isEmpty()) {
                     break;
                 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
@@ -33,6 +33,12 @@ import static com.azure.cosmos.implementation.guava25.base.Preconditions.checkNo
 public abstract class ChangeFeedState extends JsonSerializable {
     private static final Comparator<Range<String>> MIN_RANGE_COMPARATOR = new Range.MinComparator<>();
     private static final Comparator<Range<String>> MAX_RANGE_COMPARATOR = new Range.MaxComparator<>();
+
+    // Lazily-initialized cache holding a pre-sorted snapshot of continuation tokens.
+    // Reused across multiple extractForEffectiveRange calls on the same instance to
+    // avoid redundant O(T log T) copy+sort per partition during Spark planning.
+    private volatile SortedTokensSnapshot cachedSortedTokensSnapshot;
+
     ChangeFeedState() {
     }
 
@@ -94,21 +100,41 @@ public abstract class ChangeFeedState extends JsonSerializable {
         return extractContinuationTokens(PartitionKeyInternalHelper.FullRange).getLeft();
     }
 
+    private List<CompositeContinuationToken> getOrCreateSortedContinuationTokens() {
+        FeedRangeContinuation continuation = this.getContinuation();
+        if (continuation == null) {
+            return Collections.emptyList();
+        }
+
+        SortedTokensSnapshot snapshot = this.cachedSortedTokensSnapshot;
+        if (snapshot != null && snapshot.continuationRef == continuation) {
+            return snapshot.sortedTokens;
+        }
+
+        List<CompositeContinuationToken> sorted = new ArrayList<>();
+        Collections.addAll(sorted, continuation.getCurrentContinuationTokens());
+        sorted.sort(ContinuationTokenRangeComparator.SINGLETON_INSTANCE);
+
+        this.cachedSortedTokensSnapshot = new SortedTokensSnapshot(continuation, sorted);
+        return sorted;
+    }
+
     private Pair<List<CompositeContinuationToken>, Range<String>> extractContinuationTokens(
         Range<String> effectiveRange) {
 
         checkNotNull(effectiveRange);
 
         List<CompositeContinuationToken> extractedContinuationTokens = new ArrayList<>();
-        FeedRangeContinuation continuation = this.getContinuation();
         String min = null;
         String max = null;
-        if (continuation != null) {
-            List<CompositeContinuationToken> continuationTokensSnapshot = new ArrayList<>();
-            Collections.addAll(continuationTokensSnapshot, continuation.getCurrentContinuationTokens());
-            continuationTokensSnapshot.sort(ContinuationTokenRangeComparator.SINGLETON_INSTANCE);
 
-            for (CompositeContinuationToken compositeContinuationToken : continuationTokensSnapshot) {
+        List<CompositeContinuationToken> sortedTokens = getOrCreateSortedContinuationTokens();
+
+        if (!sortedTokens.isEmpty()) {
+            int startIndex = findFirstPotentialOverlapIndex(sortedTokens, effectiveRange);
+
+            for (int i = startIndex; i < sortedTokens.size(); i++) {
+                CompositeContinuationToken compositeContinuationToken = sortedTokens.get(i);
                 if (Range.checkOverlapping(effectiveRange, compositeContinuationToken.getRange())) {
                     Range<String> overlappingRange =
                         getOverlappingRange(effectiveRange, compositeContinuationToken.getRange());
@@ -127,6 +153,31 @@ public abstract class ChangeFeedState extends JsonSerializable {
                     }
                 }
             }
+
+            // Fallback: if binary search found no overlaps but started past index 0,
+            // do a full linear scan to handle non-contiguous or legacy overlapping ranges
+            if (extractedContinuationTokens.isEmpty() && startIndex > 0) {
+                for (int i = 0; i < sortedTokens.size(); i++) {
+                    CompositeContinuationToken compositeContinuationToken = sortedTokens.get(i);
+                    if (Range.checkOverlapping(effectiveRange, compositeContinuationToken.getRange())) {
+                        Range<String> overlappingRange =
+                            getOverlappingRange(effectiveRange, compositeContinuationToken.getRange());
+
+                        extractedContinuationTokens.add(
+                            new CompositeContinuationToken(compositeContinuationToken.getToken(),
+                                overlappingRange));
+
+                        if (min == null) {
+                            min = overlappingRange.getMin();
+                        }
+                        max = overlappingRange.getMax();
+                    } else {
+                        if (extractedContinuationTokens.size() > 0) {
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         Range<String> totalRange = new Range<>(
@@ -136,6 +187,35 @@ public abstract class ChangeFeedState extends JsonSerializable {
             false);
 
         return Pair.of(extractedContinuationTokens, totalRange);
+    }
+
+    /**
+     * Binary search to find the first index in the sorted token list where
+     * overlapping tokens may start for the given effective range.
+     * Uses the same comparator as the sort to ensure consistency.
+     */
+    private static int findFirstPotentialOverlapIndex(
+        List<CompositeContinuationToken> sortedTokens,
+        Range<String> effectiveRange) {
+
+        int low = 0;
+        int high = sortedTokens.size() - 1;
+        int insertionPoint = sortedTokens.size();
+
+        while (low <= high) {
+            int mid = low + (high - low) / 2;
+            int cmp = MIN_RANGE_COMPARATOR.compare(sortedTokens.get(mid).getRange(), effectiveRange);
+            if (cmp > 0) {
+                insertionPoint = mid;
+                high = mid - 1;
+            } else {
+                low = mid + 1;
+            }
+        }
+
+        // Back up by 1 to catch a token whose range.min <= effectiveRange.min
+        // but whose range.max extends past effectiveRange.min
+        return Math.max(0, insertionPoint - 1);
     }
 
     public ChangeFeedState extractForEffectiveRange(Range<String> effectiveRange) {
@@ -279,6 +359,22 @@ public abstract class ChangeFeedState extends JsonSerializable {
             checkNotNull(right, "Argument 'right' must not be null.");
 
             return MIN_RANGE_COMPARATOR.compare(left.getRange(), right.getRange());
+        }
+    }
+
+    /**
+     * Holds a pre-sorted snapshot of continuation tokens along with the
+     * continuation reference it was built from for cache invalidation.
+     */
+    private static final class SortedTokensSnapshot {
+        final FeedRangeContinuation continuationRef;
+        final List<CompositeContinuationToken> sortedTokens;
+
+        SortedTokensSnapshot(
+            FeedRangeContinuation continuationRef,
+            List<CompositeContinuationToken> sortedTokens) {
+            this.continuationRef = continuationRef;
+            this.sortedTokens = sortedTokens;
         }
     }
 }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/common/ChangeFeedState.java
@@ -94,7 +94,7 @@ public abstract class ChangeFeedState extends JsonSerializable {
     public List<CompositeContinuationToken> extractContinuationTokens() {
         return extractContinuationTokensForRange(
             PartitionKeyInternalHelper.FullRange,
-            getSortedTokensAndRanges()).getLeft();
+            getSortedContinuationTokens()).getLeft();
     }
 
     /**
@@ -116,9 +116,9 @@ public abstract class ChangeFeedState extends JsonSerializable {
      * Extracts a list of {@link ChangeFeedState} instances, one per input effective range.
      * <p>
      * Continuation tokens are sorted once (O(T log T)) and then each range lookup uses
-     * binary search (O(log T)), following the same pattern as
+     * binary search (O(log T)) to find the starting position, followed by a forward scan
+     * through contiguous overlapping tokens. This follows the same binary search pattern as
      * {@link com.azure.cosmos.implementation.routing.InMemoryCollectionRoutingMap#getOverlappingRanges}.
-     * This avoids the O(P × T log T) cost of sorting per range when called in a loop.
      * <p>
      * The returned list preserves the input order: result.get(i) corresponds to
      * effectiveRanges.get(i).
@@ -130,14 +130,14 @@ public abstract class ChangeFeedState extends JsonSerializable {
         checkNotNull(effectiveRanges, "Argument 'effectiveRanges' must not be null.");
         checkArgument(!effectiveRanges.isEmpty(), "Argument 'effectiveRanges' must not be empty.");
 
-        SortedTokensAndRanges sorted = getSortedTokensAndRanges();
+        List<CompositeContinuationToken> sortedTokens = getSortedContinuationTokens();
 
         List<ChangeFeedState> results = new ArrayList<>(effectiveRanges.size());
         for (Range<String> effectiveRange : effectiveRanges) {
             checkNotNull(effectiveRange, "Effective range must not be null.");
 
             Pair<List<CompositeContinuationToken>, Range<String>> extracted =
-                extractContinuationTokensForRange(effectiveRange, sorted);
+                extractContinuationTokensForRange(effectiveRange, sortedTokens);
 
             List<CompositeContinuationToken> tokens = extracted.getLeft();
             Range<String> totalRange = extracted.getRight();
@@ -160,36 +160,28 @@ public abstract class ChangeFeedState extends JsonSerializable {
         return results;
     }
 
-    /**
-     * Sorts continuation tokens once and builds a parallel list of their ranges
-     * for use with {@link Collections#binarySearch}.
-     */
-    private SortedTokensAndRanges getSortedTokensAndRanges() {
+    private List<CompositeContinuationToken> getSortedContinuationTokens() {
         FeedRangeContinuation continuation = this.getContinuation();
         if (continuation == null) {
-            return new SortedTokensAndRanges(Collections.emptyList(), Collections.emptyList());
+            return Collections.emptyList();
         }
 
         List<CompositeContinuationToken> sortedTokens = new ArrayList<>();
         Collections.addAll(sortedTokens, continuation.getCurrentContinuationTokens());
         sortedTokens.sort(ContinuationTokenRangeComparator.SINGLETON_INSTANCE);
-
-        List<Range<String>> sortedRanges = new ArrayList<>(sortedTokens.size());
-        for (CompositeContinuationToken token : sortedTokens) {
-            sortedRanges.add(token.getRange());
-        }
-
-        return new SortedTokensAndRanges(sortedTokens, sortedRanges);
+        return sortedTokens;
     }
 
     /**
-     * Finds overlapping continuation tokens for an effective range using binary search,
-     * following the same pattern as
-     * {@link com.azure.cosmos.implementation.routing.InMemoryCollectionRoutingMap#getOverlappingRanges}.
+     * Finds overlapping continuation tokens for an effective range using binary search
+     * to locate the starting position, then scanning forward through contiguous overlapping
+     * tokens. This follows the same pattern as
+     * {@link com.azure.cosmos.implementation.routing.InMemoryCollectionRoutingMap#getOverlappingRanges}
+     * and assumes non-overlapping, contiguous partition ranges (Cosmos DB contract).
      */
     private Pair<List<CompositeContinuationToken>, Range<String>> extractContinuationTokensForRange(
         Range<String> effectiveRange,
-        SortedTokensAndRanges sorted) {
+        List<CompositeContinuationToken> sortedTokens) {
 
         checkNotNull(effectiveRange);
 
@@ -197,20 +189,21 @@ public abstract class ChangeFeedState extends JsonSerializable {
         String min = null;
         String max = null;
 
-        if (!sorted.sortedTokens.isEmpty()) {
-            // Binary search for the scan window, matching InMemoryCollectionRoutingMap pattern
-            int minIndex = Collections.binarySearch(sorted.sortedRanges, effectiveRange, MIN_RANGE_COMPARATOR);
-            if (minIndex < 0) {
-                minIndex = Math.max(0, -minIndex - 2);
+        if (!sortedTokens.isEmpty()) {
+            // Binary search for the first potential overlap position,
+            // matching InMemoryCollectionRoutingMap.getOverlappingRanges pattern
+            int startIndex = Collections.binarySearch(
+                sortedTokens, new CompositeContinuationToken(null, effectiveRange),
+                ContinuationTokenRangeComparator.SINGLETON_INSTANCE);
+            if (startIndex < 0) {
+                // Insertion point - 1: back up to catch a token whose range.min <= effectiveRange.min
+                // but whose range.max extends past effectiveRange.min
+                startIndex = Math.max(0, -startIndex - 2);
             }
 
-            int maxIndex = Collections.binarySearch(sorted.sortedRanges, effectiveRange, MAX_RANGE_COMPARATOR);
-            if (maxIndex < 0) {
-                maxIndex = Math.min(sorted.sortedRanges.size() - 1, -maxIndex - 1);
-            }
-
-            for (int i = minIndex; i <= maxIndex; i++) {
-                CompositeContinuationToken token = sorted.sortedTokens.get(i);
+            // Scan forward from startIndex through contiguous overlapping tokens
+            for (int i = startIndex; i < sortedTokens.size(); i++) {
+                CompositeContinuationToken token = sortedTokens.get(i);
                 if (Range.checkOverlapping(effectiveRange, token.getRange())) {
                     Range<String> overlappingRange = getOverlappingRange(effectiveRange, token.getRange());
                     extractedTokens.add(new CompositeContinuationToken(
@@ -219,6 +212,9 @@ public abstract class ChangeFeedState extends JsonSerializable {
                         min = overlappingRange.getMin();
                     }
                     max = overlappingRange.getMax();
+                } else if (!extractedTokens.isEmpty()) {
+                    // Non-overlapping after finding overlaps — contiguous ranges are exhausted
+                    break;
                 }
             }
         }
@@ -349,22 +345,6 @@ public abstract class ChangeFeedState extends JsonSerializable {
             checkNotNull(right, "Argument 'right' must not be null.");
 
             return MIN_RANGE_COMPARATOR.compare(left.getRange(), right.getRange());
-        }
-    }
-
-    /**
-     * Holds a pre-sorted list of continuation tokens alongside a parallel list of
-     * their ranges, enabling {@link Collections#binarySearch} on the ranges.
-     */
-    private static final class SortedTokensAndRanges {
-        final List<CompositeContinuationToken> sortedTokens;
-        final List<Range<String>> sortedRanges;
-
-        SortedTokensAndRanges(
-            List<CompositeContinuationToken> sortedTokens,
-            List<Range<String>> sortedRanges) {
-            this.sortedTokens = sortedTokens;
-            this.sortedRanges = sortedRanges;
         }
     }
 }


### PR DESCRIPTION
Closes Azure/azure-sdk-for-java#49023

## Summary
Eliminate the quadratic O(P  T log T) complexity in `ChangeFeedState.extractForEffectiveRange` by introducing a batch API `extractForEffectiveRanges(List<Range>)` that sorts continuation tokens once and uses binary search for overlap detection, reducing the total complexity to O(T log T + P log T).

## Problem
The Cosmos Spark change feed connector spent excessive driver time planning microbatches when reading containers with many feed ranges / continuation tokens (>30k). The hot path `ChangeFeedMicroBatchStream.planInputPartitions` repeatedly copied and sorted the full continuation-token list for each planned partition, resulting in O(P  T log T) behavior that could stall planning for >15 minutes.

## Solution
- **Batch API**: New `extractForEffectiveRanges(List<Range<String>>)` method sorts tokens once (O(T log T)), then uses binary search per range (O(log T)) following the established `InMemoryCollectionRoutingMap.getOverlappingRanges` pattern.
- **No internal mutable state**: Removed the volatile `cachedSortedTokensSnapshot` field and all cache invalidation machinery. The sorted token list is local to each batch call  no cache, no invalidation risks, no race conditions.
- **Single-range delegates to batch**: `extractForEffectiveRange(range)` now delegates to `extractForEffectiveRanges(singletonList(range))`, maintaining backward compatibility with a single code path.
- **Spark hot loop optimized**: `ChangeFeedBatch.planInputPartitions` now calls the batch API once instead of calling `extractForEffectiveRange` per partition.

## Files Changed
- `ChangeFeedState.java`  Added `extractForEffectiveRanges`, removed cache machinery (`SortedTokensSnapshot`, `MinMaxAccumulator`, `collectOverlapping`, `findFirstPotentialOverlapIndex`)
- `SparkBridgeImplementationInternal.scala`  Added `extractChangeFeedStateForRanges` batch bridge method
- `ChangeFeedBatch.scala`  Hot loop uses batch API
- `ChangeFeedStateTest.java`  Updated tests for batch API, added single/batch parity test
- `CHANGELOG.md`  Updated entry

---
*Generated by coding-agent-harness*