### PR TITLE
release automation, treat lib 404 as no previous version

### DIFF
--- a/eng/automation/generate_utils.py
+++ b/eng/automation/generate_utils.py
@@ -244,6 +244,11 @@ def compare_with_maven_package(
                 version=previous_version,
             )
         )
+        if r.status_code == 404:
+            logging.warning(
+                "[Changelog][Skip] previous version {0} not found on Maven (404)".format(previous_version)
+            )
+            return breaking, changelog, breaking_changes
         r.raise_for_status()
         old_jar_fd, old_jar = tempfile.mkstemp(".jar")
         try:


### PR DESCRIPTION
# Description

Bug is an edge case when previous initial SDK PR got merged but not released, and a second release comes. Previous version 1.0.0-beta.1 then could not be found.
https://github.com/Azure/azure-rest-api-specs/pull/42962
Treat 404 as no previous version when doing changelog generation.

Tested locally.

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
