### PR TITLE
Add fabric-cosmos-spark-auth_4-0_2-13 for Spark 4.0 / Fabric Runtime 2.0

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -111,6 +111,7 @@
     "sdk/cosmos/azure-cosmos-spark_4-1_2-13/**",
     "sdk/cosmos/azure-cosmos-spark-account-data-resolver-sample/**",
     "sdk/cosmos/fabric-cosmos-spark-auth_3/**",
+    "sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/**",
     "sdk/cosmos/azure-cosmos-encryption/**",
     "sdk/cosmos/azure-cosmos-spark_3_2-12/**",
     "sdk/spring/azure-spring-data-cosmos/**",

--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -83,6 +83,7 @@ known_content_issues:
   - ['sdk/cosmos/azure-cosmos-spark_4-1_2-13/README.md', '#3113']
   - ['sdk/cosmos/azure-cosmos-spark-account-data-resolver-sample/README.md', '#3113']
   - ['sdk/cosmos/fabric-cosmos-spark-auth_3/README.md', '#3113']
+  - ['sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/README.md', '#3113']
   - ['sdk/cosmos/azure-cosmos-spark_3_2-12/dev/README.md', '#3113']
   - ['sdk/cosmos/azure-cosmos-spark_3_2-12/docs/catalog-api.md', '#3113']
   - ['sdk/cosmos/azure-cosmos-spark_3_2-12/docs/configuration-reference.md', '#3113']

--- a/eng/versioning/external_dependencies.txt
+++ b/eng/versioning/external_dependencies.txt
@@ -229,6 +229,7 @@ cosmos_com.google.guava:guava;33.0.0-jre
 cosmos_io.dropwizard.metrics:metrics-core;4.1.0
 cosmos_org.hdrhistogram:HdrHistogram;2.1.12
 cosmos_com.microsoft.azure.synapse:synapseutils_2.12;1.5.4
+cosmos_com.microsoft.azure.synapse:synapseutils_2.13;1.5.4
 
 ## Cosmos Spark connector under sdk\cosmos\azure-cosmos-spark_3-<version>_2-12\pom.xml
 # Cosmos Spark connector runtime dependencies - provided by Spark runtime/host

--- a/eng/versioning/external_dependencies.txt
+++ b/eng/versioning/external_dependencies.txt
@@ -229,7 +229,7 @@ cosmos_com.google.guava:guava;33.0.0-jre
 cosmos_io.dropwizard.metrics:metrics-core;4.1.0
 cosmos_org.hdrhistogram:HdrHistogram;2.1.12
 cosmos_com.microsoft.azure.synapse:synapseutils_2.12;1.5.4
-cosmos_com.microsoft.azure.synapse:synapseutils_2.13;1.5.4
+cosmos_com.microsoft.azure.synapse:synapseutils_2.13;1.6.2
 
 ## Cosmos Spark connector under sdk\cosmos\azure-cosmos-spark_3-<version>_2-12\pom.xml
 # Cosmos Spark connector runtime dependencies - provided by Spark runtime/host

--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -121,6 +121,7 @@ com.azure.cosmos.spark:azure-cosmos-spark_4;0.0.1-beta.1;0.0.1-beta.1
 com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13;4.48.0;4.49.0-beta.1
 com.azure.cosmos.spark:azure-cosmos-spark_4-1_2-13;4.48.0;4.49.0-beta.1
 com.azure.cosmos.spark:fabric-cosmos-spark-auth_3;1.1.0;1.2.0-beta.1
+com.azure.cosmos.spark:fabric-cosmos-spark-auth_4-0_2-13;1.0.0-beta.1;1.0.0-beta.1
 com.azure:azure-cosmos-tests;1.0.0-beta.1;1.0.0-beta.1
 com.azure:azure-data-appconfiguration;1.9.1;1.10.0-beta.1
 com.azure.cosmos.kafka:azure-cosmos-kafka-connect;2.10.0;2.11.0-beta.1

--- a/sdk/cosmos/ci.yml
+++ b/sdk/cosmos/ci.yml
@@ -23,6 +23,7 @@ trigger:
       - sdk/cosmos/azure-cosmos-spark_4/
       - sdk/cosmos/azure-cosmos-spark_4-1_2-13/
       - sdk/cosmos/fabric-cosmos-spark-auth_3/
+      - sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/
       - sdk/cosmos/azure-cosmos-test/
       - sdk/cosmos/azure-cosmos-tests/
       - sdk/cosmos/azure-cosmos-kafka-connect/
@@ -43,6 +44,7 @@ trigger:
       - sdk/cosmos/azure-cosmos-spark_4/pom.xml
       - sdk/cosmos/azure-cosmos-spark_4-1_2-13/pom.xml
       - sdk/cosmos/fabric-cosmos-spark-auth_3/pom.xml
+      - sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/pom.xml
       - sdk/cosmos/azure-cosmos-kafka-connect/pom.xml
 
 pr:
@@ -72,6 +74,7 @@ pr:
       - sdk/cosmos/azure-cosmos-spark_4/
       - sdk/cosmos/azure-cosmos-spark_4-1_2-13/
       - sdk/cosmos/fabric-cosmos-spark-auth_3/
+      - sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/
       - sdk/cosmos/faq/
       - sdk/cosmos/azure-cosmos-kafka-connect/
     exclude:
@@ -89,6 +92,7 @@ pr:
       - sdk/cosmos/azure-cosmos-spark_4/pom.xml
       - sdk/cosmos/azure-cosmos-spark_4-1_2-13/pom.xml
       - sdk/cosmos/fabric-cosmos-spark-auth_3/pom.xml
+      - sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/pom.xml
       - sdk/cosmos/azure-cosmos-test/pom.xml
       - sdk/cosmos/azure-cosmos-tests/pom.xml
       - sdk/cosmos/azure-cosmos-kafka-connect/pom.xml
@@ -127,6 +131,10 @@ parameters:
     default: true
   - name: release_fabriccosmossparkauth3
     displayName: 'fabric-cosmos-spark-auth_3'
+    type: boolean
+    default: true
+  - name: release_fabriccosmossparkauth4
+    displayName: 'fabric-cosmos-spark-auth_4-0_2-13'
     type: boolean
     default: true
   - name: release_azurecosmostest
@@ -201,6 +209,13 @@ extends:
         skipPublishDocGithubIo: true
         skipPublishDocMs: true
         releaseInBatch: ${{ parameters.release_fabriccosmossparkauth3 }}
+      - name: fabric-cosmos-spark-auth_4-0_2-13
+        groupId: com.azure.cosmos.spark
+        safeName: fabriccosmossparkauth4
+        uberJar: true
+        skipPublishDocGithubIo: true
+        skipPublishDocMs: true
+        releaseInBatch: ${{ parameters.release_fabriccosmossparkauth4 }}
       - name: azure-cosmos-test
         groupId: com.azure
         safeName: azurecosmostest

--- a/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/CHANGELOG.md
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/CHANGELOG.md
@@ -1,0 +1,6 @@
+## Release History
+
+### 1.0.0-beta.1 (Unreleased)
+
+#### Features Added
+* Added Spark 4.0 / Scala 2.13 variant of the Fabric account data resolver for Azure Cosmos DB Spark Connector. This allows signed-in users in Fabric Runtime 2.0 to authenticate to CosmosDB using Microsoft Entra ID.

--- a/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/README.md
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/README.md
@@ -1,10 +1,10 @@
 ## Azure Cosmos DB OLTP Spark 4 Connector Fabric Account Data Resolver
 
 This project provides an implementation of the `AccountDataResolver` interface for the Azure Cosmos DB Spark Connector, specifically designed to work with Azure Fabric accounts. 
-It allows signed-in user to authenticate with Microsoft Entra ID within the Azure Fabric environment. To use this implementation, you have to upload the jar file for this project to your fabric environment. It is also necessary to grant the signed-in user's 
+It allows a signed-in user to authenticate with Microsoft Entra ID within the Azure Fabric environment. To use this implementation, you have to upload the jar file for this project to your fabric environment. It is also necessary to grant the signed-in user's 
 identity with the correct permissions to perform data plane operations. Follow the instructions [here](https://learn.microsoft.com/azure/cosmos-db/nosql/how-to-grant-data-plane-access?tabs=built-in-definition%2Ccsharp&pivots=azure-interface-cli) to grant the relevant permissions. 
 To learn more about Microsoft Entra ID (AAD) authentication using the Azure Cosmos DB Spark Connector, see the 
-[AAD Auth Documentation](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_4-0_2-13/docs/AAD-Auth.md). Fabric Native accounts only support gateway mode, so the `spark.cosmos.useGatewayMode` must be set to `true` in the Spark configuration for these accounts.
+[AAD Auth Documentation](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_3/docs/AAD-Auth.md). Fabric Native accounts only support gateway mode, so the `spark.cosmos.useGatewayMode` must be set to `true` in the Spark configuration for these accounts.
 
 ### Configuration options
 
@@ -15,5 +15,5 @@ To learn more about Microsoft Entra ID (AAD) authentication using the Azure Cosm
 
 ### Current Limitations
 
-* There is no support for the [catalog api](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_4-0_2-13/docs/catalog-api.md) operations using this implementation of the `AccountDataResolver` with a CosmosDB Fabric Native Account.
+* There is no support for the [catalog api](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_3/docs/catalog-api.md) operations using this implementation of the `AccountDataResolver` with a CosmosDB Fabric Native Account.
 * Only Spark 4.0 is supported with this implementation of the `AccountDataResolver`.

--- a/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/README.md
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/README.md
@@ -1,0 +1,19 @@
+## Azure Cosmos DB OLTP Spark 4 Connector Fabric Account Data Resolver
+
+This project provides an implementation of the `AccountDataResolver` interface for the Azure Cosmos DB Spark Connector, specifically designed to work with Azure Fabric accounts. 
+It allows signed-in user to authenticate with Microsoft Entra ID within the Azure Fabric environment. To use this implementation, you have to upload the jar file for this project to your fabric environment. It is also necessary to grant the signed-in user's 
+identity with the correct permissions to perform data plane operations. Follow the instructions [here](https://learn.microsoft.com/azure/cosmos-db/nosql/how-to-grant-data-plane-access?tabs=built-in-definition%2Ccsharp&pivots=azure-interface-cli) to grant the relevant permissions. 
+To learn more about Microsoft Entra ID (AAD) authentication using the Azure Cosmos DB Spark Connector, see the 
+[AAD Auth Documentation](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_4-0_2-13/docs/AAD-Auth.md). Fabric Native accounts only support gateway mode, so the `spark.cosmos.useGatewayMode` must be set to `true` in the Spark configuration for these accounts.
+
+### Configuration options
+
+| Config Property Name                          | Default                               | Description                                                                                                                                                |
+|:----------------------------------------------|:--------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `spark.cosmos.accountDataResolverServiceName` | None                                  | Set this value to `com.azure.cosmos.spark.fabric.FabricAccountDataResolver` to use this implementation of the `AccountDataResolver`                        |
+| `spark.cosmos.auth.aad.audience`              | `https://cosmos.azure.com/.default`   | Set this value to change the audience used to obtain the Entra Id token.                                                                                   |
+
+### Current Limitations
+
+* There is no support for the [catalog api](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/azure-cosmos-spark_4-0_2-13/docs/catalog-api.md) operations using this implementation of the `AccountDataResolver` with a CosmosDB Fabric Native Account.
+* Only Spark 4.0 is supported with this implementation of the `AccountDataResolver`.

--- a/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/pom.xml
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/pom.xml
@@ -533,12 +533,16 @@
       </build>
     </profile>
 
-    <!-- Library cannot build for Java 16 and below -->
+    <!-- Skip build and tests for Java < 17 - Spark 4.0 dependencies require Java 17+ -->
     <profile>
       <id>java8</id>
       <activation>
         <jdk>[,17)</jdk>
       </activation>
+      <properties>
+        <cosmos.spark.skip>true</cosmos.spark.skip>
+        <skipTests>true</skipTests>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/pom.xml
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.microsoft.azure.synapse</groupId>
       <artifactId>synapseutils_2.13</artifactId>
-      <version>1.5.4</version> <!-- {x-version-update;cosmos_com.microsoft.azure.synapse:synapseutils_2.13;external_dependency} -->
+      <version>1.6.2</version> <!-- {x-version-update;cosmos_com.microsoft.azure.synapse:synapseutils_2.13;external_dependency} -->
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -184,7 +184,7 @@
                 <include>com.fasterxml.jackson.core:jackson-databind:[2.18.6]</include> <!-- {x-include-update;com.fasterxml.jackson.core:jackson-databind;external_dependency} -->
                 <include>com.fasterxml.jackson.module:jackson-module-scala_2.13:[2.18.6]</include> <!-- {x-include-update;com.fasterxml.jackson.module:jackson-module-scala_2.13;external_dependency} -->
                 <include>com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13:[4.49.0-beta.1]</include> <!-- {x-include-update;com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13;current} -->
-                <include>com.microsoft.azure.synapse:synapseutils_2.13:[1.5.4]</include> <!-- {x-include-update;cosmos_com.microsoft.azure.synapse:synapseutils_2.13;external_dependency} -->
+                <include>com.microsoft.azure.synapse:synapseutils_2.13:[1.6.2]</include> <!-- {x-include-update;cosmos_com.microsoft.azure.synapse:synapseutils_2.13;external_dependency} -->
               </includes>
             </bannedDependencies>
           </rules>

--- a/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/pom.xml
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/pom.xml
@@ -1,0 +1,634 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.azure</groupId>
+    <artifactId>azure-client-sdk-parent</artifactId>
+    <version>1.7.0</version> <!-- {x-version-update;com.azure:azure-client-sdk-parent;current} -->
+    <relativePath>../../parents/azure-client-sdk-parent</relativePath>
+  </parent>
+
+  <groupId>com.azure.cosmos.spark</groupId>
+  <artifactId>fabric-cosmos-spark-auth_4-0_2-13</artifactId>
+  <version>1.0.0-beta.1</version>  <!-- {x-version-update;com.azure.cosmos.spark:fabric-cosmos-spark-auth_4-0_2-13;current} -->
+  <packaging>jar</packaging>
+  <url>https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13</url>
+  <name>OLTP Spark 4.0 Connector for Azure Cosmos DB SQL API Account Data Resolver for Fabric</name>
+  <description>OLTP Spark 4.0 Connector for Azure Cosmos DB SQL API Account Data Resolver for Fabric</description>
+  <scm>
+    <connection>scm:git:https://github.com/Azure/azure-sdk-for-java.git/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13</connection>
+    <developerConnection></developerConnection>
+    <url>https://github.com/Azure/azure-sdk-for-java/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13</url>
+  </scm>
+  <organization>
+    <name>Microsoft Corporation</name>
+    <url>http://microsoft.com</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>The MIT License (MIT)</name>
+      <url>http://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>microsoft</id>
+      <name>Microsoft Corporation</name>
+    </developer>
+  </developers>
+  <properties>
+    <maven.build.timestamp.format>MM-dd-HH-mm-ss</maven.build.timestamp.format>
+    <jacoco.min.branchcoverage>0.17</jacoco.min.branchcoverage>
+    <jacoco.min.linecoverage>0.18</jacoco.min.linecoverage>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <jacoco.skip>true</jacoco.skip>
+    <shadingPrefix>fabric_cosmos_spark</shadingPrefix>
+    <legal>
+      <![CDATA[[INFO] Any downloads listed may be third party software.  Microsoft grants you no rights for third party software.]]>
+    </legal>
+    <codesnippet.skip>true</codesnippet.skip>
+    <revapi.skip>true</revapi.skip>
+    <checkstyle.skip>true</checkstyle.skip>
+    <spotbugs.skip>true</spotbugs.skip>
+    <spotless.skip>true</spotless.skip>
+
+    <cosmos.spark.skip>false</cosmos.spark.skip>
+    <cosmos-spark-version>4.0</cosmos-spark-version>
+    <maven.main.skip>${cosmos.spark.skip}</maven.main.skip>
+    <maven.test.skip>${cosmos.spark.skip}</maven.test.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.18.6</version> <!-- {x-version-update;com.fasterxml.jackson.core:jackson-databind;external_dependency} -->
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_2.13</artifactId>
+      <version>2.18.6</version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.13;external_dependency} -->
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.13.17</version> <!-- {x-version-update;cosmos-scala213_org.scala-lang:scala-library;external_dependency} -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_2.13</artifactId>
+      <version>3.2.2</version> <!-- {x-version-update;cosmos-scala213_org.scalatest:scalatest_2.13;external_dependency} -->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest-flatspec_2.13</artifactId>
+      <version>3.2.3</version> <!-- {x-version-update;cosmos-scala213_org.scalatest:scalatest-flatspec_2.13;external_dependency} -->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure.synapse</groupId>
+      <artifactId>synapseutils_2.13</artifactId>
+      <version>1.5.4</version> <!-- {x-version-update;cosmos_com.microsoft.azure.synapse:synapseutils_2.13;external_dependency} -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.azure.cosmos.spark</groupId>
+      <artifactId>azure-cosmos-spark_4-0_2-13</artifactId>
+      <version>4.49.0-beta.1</version> <!-- {x-version-update;com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13;current} -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version> <!-- {x-version-update;org.slf4j:slf4j-api;external_dependency} -->
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>META-INF/services/com.azure.cosmos.spark.AccountDataResolver</include>
+          <include>fabric-cosmos-spark-auth_4-0_2-13.properties</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.1</version> <!-- {x-version-update;org.codehaus.mojo:build-helper-maven-plugin;external_dependency} -->
+        <executions>
+          <execution>
+            <id>add-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${basedir}/src/main/scala</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${basedir}/src/test/scala</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-resources</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>add-resource</goal>
+            </goals>
+            <configuration>
+              <resources>
+                <resource><directory>${basedir}/src/main/resources</directory></resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.1</version> <!-- {x-version-update;org.apache.maven.plugins:maven-enforcer-plugin;external_dependency} -->
+        <configuration>
+          <rules>
+            <bannedDependencies>
+              <includes combine.children="append">
+                <include>org.slf4j:slf4j-api:[1.7.36]</include> <!-- {x-include-update;org.slf4j:slf4j-api;external_dependency} -->
+                <include>org.scala-lang:scala-library:[2.13.17]</include> <!-- {x-include-update;cosmos-scala213_org.scala-lang:scala-library;external_dependency} -->
+                <include>org.scala-lang.modules:scala-java8-compat_2.13:[0.9.1]</include> <!-- {x-include-update;cosmos-scala213_org.scala-lang.modules:scala-java8-compat_2.13;external_dependency} -->
+                <include>org.scalatest:scalatest_2.13:[3.2.2]</include> <!-- {x-include-update;cosmos-scala213_org.scalatest:scalatest_2.13;external_dependency} -->
+                <include>org.apache.maven.plugins:maven-antrun-plugin:[3.1.0]</include> <!-- {x-include-update;org.apache.maven.plugins:maven-antrun-plugin;external_dependency} -->
+                <include>org.scalastyle:scalastyle-maven-plugin:[1.0.0]</include> <!-- {x-include-update;cosmos_org.scalastyle:scalastyle-maven-plugin;external_dependency} -->
+                <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310:[2.18.6]</include> <!-- {x-include-update;com.fasterxml.jackson.datatype:jackson-datatype-jsr310;external_dependency} -->
+                <include>com.fasterxml.jackson.core:jackson-databind:[2.18.6]</include> <!-- {x-include-update;com.fasterxml.jackson.core:jackson-databind;external_dependency} -->
+                <include>com.fasterxml.jackson.module:jackson-module-scala_2.13:[2.18.6]</include> <!-- {x-include-update;com.fasterxml.jackson.module:jackson-module-scala_2.13;external_dependency} -->
+                <include>com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13:[4.49.0-beta.1]</include> <!-- {x-include-update;com.azure.cosmos.spark:azure-cosmos-spark_4-0_2-13;current} -->
+                <include>com.microsoft.azure.synapse:synapseutils_2.13:[1.5.4]</include> <!-- {x-include-update;cosmos_com.microsoft.azure.synapse:synapseutils_2.13;external_dependency} -->
+              </includes>
+            </bannedDependencies>
+          </rules>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>build-scala</id>
+      <activation>
+        <file>
+          <exists>${basedir}/scalastyle_config.xml</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.14.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-compiler-plugin;external_dependency} -->
+            <configuration>
+              <failOnWarning>false</failOnWarning>
+            </configuration>
+          </plugin>
+          <!-- START: Empty Java Doc -->
+          <!-- The following code will generate an empty javadoc with just a README.md. This is necessary
+              to pass the required checks on Maven. The way this works is by setting the classesDirectory
+              to a directory that only contains the README.md, which we need to copy. If the classesDirectory
+              is set to the root, where the README.md lives, it still won't have javadocs but the jar file
+              will contain a bunch of files that shouldn't be there. The faux sources directory is deleted
+              and recreated with the README.md being copied every time to guarantee that, when building locally,
+              it'll have the latest copy of the README.md file.
+          -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.11.3</version> <!-- {x-version-update;org.apache.maven.plugins:maven-javadoc-plugin;external_dependency} -->
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <skip>true</skip>
+                  <additionalDependencies>
+                    <additionalDependency>
+                      <groupId>org.projectlombok</groupId>
+                      <artifactId>lombok</artifactId>
+                      <version>1.18.6</version>
+                    </additionalDependency>
+                  </additionalDependencies>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.4.2</version> <!-- {x-version-update;org.apache.maven.plugins:maven-jar-plugin;external_dependency} -->
+            <executions>
+              <execution>
+                <id>01-empty-javadoc-jar-with-readme</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <classifier>javadoc</classifier>
+                  <classesDirectory>${project.basedir}/javadocTemp</classesDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <version>4.8.1</version> <!-- {x-version-update;cosmos_net.alchim31.maven:scala-maven-plugin;external_dependency} -->
+            <configuration>
+              <source>17</source>
+              <target>17</target>
+              <scalaVersion>2.13.17</scalaVersion>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>compile</goal>
+                  <goal>testCompile</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.scalastyle</groupId>
+            <artifactId>scalastyle-maven-plugin</artifactId>
+            <version>1.0.0</version> <!-- {x-version-update;cosmos_org.scalastyle:scalastyle-maven-plugin;external_dependency} -->
+            <configuration>
+              <verbose>false</verbose>
+              <failOnViolation>true</failOnViolation>
+              <includeTestSourceDirectory>true</includeTestSourceDirectory>
+              <failOnWarning>true</failOnWarning>
+              <sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>
+              <testSourceDirectory>${project.basedir}/src/test/scala</testSourceDirectory>
+              <configLocation>${project.basedir}/scalastyle_config.xml</configLocation>
+              <outputFile>${project.build.outputDirectory}/scalastyle-output.xml</outputFile>
+              <outputEncoding>UTF-8</outputEncoding>
+            </configuration>
+            <executions>
+              <execution>
+                <id>validate-style</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>verify-style</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- Shading has been moved to a separate profile since there is a bug which may result in it deadlocking during a parallel build. -->
+          <!-- See https://issues.apache.org/jira/projects/MSHADE/issues/MSHADE-384 -->
+          <!-- Once this issue is resolved this can be moved back into the build-scala profile. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.6.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-shade-plugin;external_dependency} -->
+            <executions>
+              <execution>
+                <id>02-shade</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <relocations>
+                    <relocation>
+                      <pattern>com.azure</pattern>
+                      <shadedPattern>${shadingPrefix}.com.azure</shadedPattern>
+                      <excludes>
+                        <exclude>com.azure.cosmos.spark.*</exclude>
+                        <exclude>com.azure.cosmos.spark.fabric.*</exclude>
+                        <exclude>com.azure.cosmos.spark.diagnostics.*</exclude>
+                        <exclude>com.azure.cosmos.spark.udf.*</exclude>
+                        <exclude>com.azure.cosmos.implementation.SparkBridgeInternal</exclude>
+                        <exclude>com.azure.cosmos.models.CosmosParameterizedQuery</exclude>
+                      </excludes>
+                    </relocation>
+                    <relocation>
+                      <pattern>scala.concurrent.java8</pattern>
+                      <shadedPattern>${shadingPrefix}.scala.concurrent.java8</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.fasterxml</pattern>
+                      <shadedPattern>${shadingPrefix}.com.fasterxml</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.thoughtworks.paranamer</pattern>
+                      <shadedPattern>${shadingPrefix}.com.thoughtworks.paranamer</shadedPattern>
+                    </relocation>
+                  </relocations>
+                  <filters>
+                    <filter>
+                      <artifact>com.azure.cosmos.spark:fabric-cosmos-spark-auth_4-0_2-13</artifact>
+                      <includes>
+                        <include>**</include>
+                      </includes>
+                    </filter>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <!-- suppress warning: Discovered module-info.class. Shading will break its strong encapsulation. -->
+                        <!-- https://stackoverflow.com/questions/56063566/maven-how-to-remove-module-info-class-warning-for-shaded-jar -->
+                        <exclude>module-info.class</exclude>
+                        <!-- remove the dependencies signature as not relevant-->
+                        <exclude>META-INF/*.MF</exclude>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                  <artifactSet>
+                    <excludes>
+                      <exclude>org.slf4j</exclude>
+                      <exclude>org.apache.hadoop:*</exclude>
+                      <exclude>org.apache.spark:*</exclude>
+                      <exclude>org.scala-lang:*</exclude>
+                    </excludes>
+                  </artifactSet>
+                  <minimizeJar>true</minimizeJar>
+                  <transformers>
+                    <!-- prevents apache license duplication -->
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                    </transformer>
+
+                    <!-- Some licenses (including the Apache License, Version 2)
+                     require that notices are preserved by downstream distributors.
+                      ApacheNoticeResourceTransformer automates the assembly of an appropriate NOTICE. -->
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                      <addHeader>false</addHeader>
+                    </transformer>
+
+                    <!-- The PropertiesTransformer allows a set of properties files to be merged
+                     and to resolve conflicts based on an ordinal giving the priority of each file.
+                     An optional alreadyMergedKey enables to have a boolean flag in the file which,
+                     if set to true, request to use the file as it as the result of the merge.
+                     If two files are considered complete in the merge process then the shade will fail.-->
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
+                      <!-- required configuration -->
+                      <!-- merges all netty lib version files into one file -->
+                      <resource>META-INF/io.netty.versions.properties</resource>
+                      <ordinalKey>ordinal</ordinalKey>
+                      <!-- optional configuration -->
+
+                      <alreadyMergedKey>already_merged</alreadyMergedKey>
+                      <defaultOrdinal>0</defaultOrdinal>
+                      <reverseOrder>false</reverseOrder>
+                    </transformer>
+
+                    <!-- this handles and properly merges the content of META-INF/services in the dependencies -->
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                      <!-- once 3.3.0 shade plugin is release upgrade the maven plugin and remove AppendingTransformer
+                        https://issues.apache.org/jira/browse/MSHADE-371 -->
+                      <resource>META-INF/NOTICE.md</resource>
+                    </transformer>
+
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                      <!-- once 3.3.0 shade plugin is release upgrade the maven plugin and remove AppendingTransformer
+                        https://issues.apache.org/jira/browse/MSHADE-371 -->
+                      <resource>META-INF/LICENSE.md</resource>
+                    </transformer>
+                  </transformers>
+
+                  <!-- When true, it will attempt to shade the contents of the java source files when creating the sources jar. -->
+                  <shadeSourcesContent>true</shadeSourcesContent>
+                  <createDependencyReducedPom>true</createDependencyReducedPom>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-antrun-plugin;external_dependency} -->
+            <executions>
+              <execution>
+                <id>01-copy-readme-to-javadocTemp</id>
+                <phase>prepare-package</phase>
+                <configuration>
+                  <target>
+                    <echo>Deleting existing ${project.basedir}/javadocTemp</echo>
+                    <delete includeEmptyDirs="true" quiet="true">
+                      <fileset dir="${project.basedir}/javadocTemp"/>
+                    </delete>
+                    <echo>Copying ${project.basedir}/README.md to
+                      ${project.basedir}/javadocTemp/README.md
+                    </echo>
+                    <copy file="${project.basedir}/README.md" tofile="${project.basedir}/javadocTemp/README.md"/>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>xml-maven-plugin</artifactId>
+            <version>1.1.0</version> <!-- {x-version-update;org.codehaus.mojo:xml-maven-plugin;external_dependency} -->
+            <executions>
+              <execution>
+                <id>stripDependencyReducedPom</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>transform</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <transformationSets>
+                <transformationSet>
+                  <dir>${project.basedir}</dir>
+                  <includes>dependency-reduced-pom.xml</includes>
+                  <stylesheet>${project.basedir}/../azure-cosmos-spark_3/stripDependencyReducedPom.xsl</stylesheet>
+                  <outputDir>${project.basedir}</outputDir>
+                  <skipDefaultExcludes>true</skipDefaultExcludes>
+                  <addedToClasspath>false</addedToClasspath>
+                </transformationSet>
+              </transformationSets>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>unit</id>
+      <activation>
+        <file>
+          <exists>${basedir}/scalastyle_config.xml</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.5.3</version> <!-- {x-version-update;org.apache.maven.plugins:maven-surefire-plugin;external_dependency} -->
+            <configuration>
+              <systemPropertyVariables>
+                <COSMOS.CLIENT_LEAK_DETECTION_ENABLED>true</COSMOS.CLIENT_LEAK_DETECTION_ENABLED>
+                <io.netty.leakDetection.samplingInterval>1</io.netty.leakDetection.samplingInterval>
+                <io.netty.leakDetection.targetRecords>256</io.netty.leakDetection.targetRecords>
+                <io.netty.leakDetection.level>paranoid</io.netty.leakDetection.level>
+              </systemPropertyVariables>
+              <includes>
+                <include>**/*.*</include>
+                <include>**/*Test.*</include>
+                <include>**/*Suite.*</include>
+                <include>**/*Spec.*</include>
+              </includes>
+              <skipTests>true</skipTests>
+              <properties>
+                <property>
+                  <name>surefire.testng.verbose</name>
+                  <value>2</value>
+                </property>
+                <property>
+                  <name>listener</name>
+                  <value>com.azure.cosmos.CosmosNettyLeakDetectorFactory</value>
+                </property>
+              </properties>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Library cannot build for Java 16 and below -->
+    <profile>
+      <id>java8</id>
+      <activation>
+        <jdk>[,17)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.14.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-compiler-plugin;external_dependency} -->
+            <configuration>
+              <skipMain>true</skipMain>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.11.3</version> <!-- {x-version-update;org.apache.maven.plugins:maven-javadoc-plugin;external_dependency} -->
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.4.2</version> <!-- {x-version-update;org.apache.maven.plugins:maven-jar-plugin;external_dependency} -->
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Override the parent client.pom.xml's java11+ profile to override target of base-compile execution from 1.8 to 17-->
+    <profile>
+      <id>java-lts</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.14.0</version> <!-- {x-version-update;org.apache.maven.plugins:maven-compiler-plugin;external_dependency} -->
+            <executions>
+              <execution>
+                <id>default-compile</id>
+                <configuration>
+                  <release>17</release>
+                </configuration>
+              </execution>
+              <!-- Here the 'base-compile' execution section of java-lts profile defined in parent pom.client.xml is
+              overridden. In parent pom, this execution entry enforces java8 release compatibility. The Spark
+              connectors for Spark 4.0 and above are available in Java17, hence here in this pom we override that
+              release compact to 17.
+              -->
+              <execution>
+                <id>base-compile</id>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <release>17</release>
+                </configuration>
+              </execution>
+              <execution>
+                <id>default-testCompile</id>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <release>17</release>
+                  <testRelease>17</testRelease>
+                </configuration>
+              </execution>
+              <execution>
+                <id>base-testCompile</id>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <testRelease>17</testRelease>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+    </profile>
+  </profiles>
+
+</project>

--- a/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/scalastyle_config.xml
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/scalastyle_config.xml
@@ -1,0 +1,130 @@
+<scalastyle commentFilter="enabled">
+  <name>Scalastyle standard configuration</name>
+  <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+    <parameters>
+      <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+    <parameters>
+      <parameter name="header"><![CDATA[// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+    <parameters>
+      <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+      <parameter name="tabSize"><![CDATA[4]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+    <parameters>
+      <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+    <parameters>
+      <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+    <parameters>
+      <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+    <parameters>
+      <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+    <parameters>
+      <parameter name="maxParameters"><![CDATA[8]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+    <parameters>
+      <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters>
+      <parameter name="regex"><![CDATA[println]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+    <parameters>
+      <parameter name="maxTypes"><![CDATA[30]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+    <parameters>
+      <parameter name="maximum"><![CDATA[10]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+    <parameters>
+      <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+      <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+    <parameters>
+      <parameter name="maxLength"><![CDATA[50]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+    <parameters>
+      <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+    <parameters>
+      <parameter name="maxMethods"><![CDATA[30]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+  <check level="warning" class="org.scalastyle.scalariform.WhileChecker" enabled="false"></check>
+  <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"></check>
+  <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"></check>
+  <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="false"></check>
+  <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
+    <parameters>
+      <parameter name="regex"><![CDATA[println]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+    <parameters>
+      <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true"></check>
+  <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
+    <parameters>
+      <parameter name="allowed"><![CDATA[2]]></parameter>
+      <parameter name="ignoreRegex"><![CDATA[^""$]]></parameter>
+    </parameters>
+  </check>
+  <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"></check>
+</scalastyle>

--- a/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/src/main/resources/META-INF/services/com.azure.cosmos.spark.AccountDataResolver
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/src/main/resources/META-INF/services/com.azure.cosmos.spark.AccountDataResolver
@@ -1,0 +1,1 @@
+com.azure.cosmos.spark.fabric.FabricAccountDataResolver

--- a/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/src/main/resources/fabric-cosmos-spark-auth_4-0_2-13.properties
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/src/main/resources/fabric-cosmos-spark-auth_4-0_2-13.properties
@@ -1,0 +1,2 @@
+name=${project.artifactId}
+version=${project.version}

--- a/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/src/main/scala/com/azure/cosmos/spark/fabric/BasicLoggingTrait.scala
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/src/main/scala/com/azure/cosmos/spark/fabric/BasicLoggingTrait.scala
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.azure.cosmos.spark.fabric
+
+import org.slf4j.{Logger, LoggerFactory}
+
+trait BasicLoggingTrait {
+  // Make the log field transient so that objects with Logging can
+  // be serialized and used on another machine
+  @transient private lazy val log : Logger = LoggerFactory.getLogger(logName)
+
+  // Method to get the logger name for this object
+  protected def logName: String = {
+    // Ignore trailing $'s in the class names for Scala objects
+    this.getClass.getName.stripSuffix("$")
+  }
+
+  // Log methods that take only a String
+  protected def logInfo(msg: => String) {
+    if (log.isInfoEnabled) log.info(msg)
+  }
+
+  protected def logDebug(msg: => String) {
+    if (log.isDebugEnabled) log.debug(msg)
+  }
+
+  protected def logTrace(msg: => String) {
+    if (log.isTraceEnabled) log.trace(msg)
+  }
+
+  protected def logWarning(msg: => String) {
+    if (log.isWarnEnabled) log.warn(msg)
+  }
+
+  protected def logError(msg: => String) {
+    if (log.isErrorEnabled) log.error(msg)
+  }
+
+  // Log methods that take Throwables (Exceptions/Errors) too
+  protected def logInfo(msg: => String, throwable: Throwable) {
+    if (log.isInfoEnabled) log.info(msg, throwable)
+  }
+
+  protected def isDebugLogEnabled: Boolean = {
+    log.isDebugEnabled()
+  }
+
+  protected def logDebug(msg: => String, throwable: Throwable) {
+    if (log.isDebugEnabled) log.debug(msg, throwable)
+  }
+
+  protected def logTrace(msg: => String, throwable: Throwable) {
+    if (log.isTraceEnabled) log.trace(msg, throwable)
+  }
+
+  protected def logWarning(msg: => String, throwable: Throwable) {
+    if (log.isWarnEnabled) log.warn(msg, throwable)
+  }
+
+  protected def logError(msg: => String, throwable: Throwable) {
+    if (log.isErrorEnabled) log.error(msg, throwable)
+  }
+}

--- a/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/src/main/scala/com/azure/cosmos/spark/fabric/FabricAccountDataResolver.scala
+++ b/sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/src/main/scala/com/azure/cosmos/spark/fabric/FabricAccountDataResolver.scala
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.azure.cosmos.spark.fabric
+
+import com.azure.cosmos.spark.AccountDataResolver
+import com.azure.cosmos.spark.CosmosAccessToken
+import com.azure.cosmos.spark.CosmosConfigNames.AccountDataResolverServiceName
+import com.fasterxml.jackson.databind.ObjectMapper
+
+import java.time.{Instant, OffsetDateTime, ZoneOffset}
+import scala.collection.concurrent.TrieMap
+
+class FabricAccountDataResolver extends AccountDataResolver with BasicLoggingTrait {
+
+  override def getAccountDataConfig(configs: Map[String, String]): Map[String, String] = {
+    val configParameters = ConfigParameters.apply(configs)
+    if (isEnabled(configParameters)) {
+      configs + ("spark.cosmos.auth.type" -> "AccessToken")
+    } else {
+      configs
+    }
+  }
+
+  private def isEnabled(configs: ConfigParameters): Boolean = {
+    configs.accountDataResolverServiceName.isDefined && configs.accountDataResolverServiceName.get
+      .equalsIgnoreCase(FabricAccountDataResolver.ACCOUNT_DATA_RESOLVER_SERVICE_NAME)
+  }
+
+  override def getAccessTokenProvider(configs: Map[String, String]): Option[List[String] => CosmosAccessToken] = {
+    val configParameters = ConfigParameters.apply(configs)
+    FabricAccountDataResolver.tokenProviders.getOrElseUpdate(
+      configParameters,
+      getAccessTokenProviderImpl(configParameters)
+    )
+  }
+
+  private def getAccessTokenProviderImpl(configs: ConfigParameters): Option[List[String] => CosmosAccessToken] = {
+    if (isEnabled(configs)) {
+      logInfo(s"FabricAccountDataResolver is enabled")
+      Some((_: List[String]) => {
+        // obtains the access token from fabric environment
+        val accessToken = mssparkutils.credentials.getToken(configs.audience.getOrElse(FabricAccountDataResolver.AUDIENCE))
+        // Extract the expiration time from the JWT payload
+        val parts = accessToken.split("\\.")
+        val payloadJson = new String(java.util.Base64.getUrlDecoder.decode(parts(1)))
+        val node = FabricAccountDataResolver.objectMapper.readTree(payloadJson)
+        val expirationEpoch = node.get("exp").asLong()
+        val expirationTime = OffsetDateTime.ofInstant(
+          Instant.ofEpochSecond(expirationEpoch),
+          ZoneOffset.UTC
+        )
+        CosmosAccessToken(accessToken, expirationTime)
+      })
+    } else {
+      logInfo(s"FabricAccountDataResolver is disabled")
+      None
+    }
+  }
+
+}
+
+private object FabricConfigNames {
+  val Audience = "spark.cosmos.auth.aad.audience"
+}
+
+private case class ConfigParameters(audience: Option[String], accountDataResolverServiceName: Option[String])
+private object ConfigParameters {
+  def apply(configs: Map[String, String]): ConfigParameters = {
+    // lookup keys case-insensitively to accept lowercase variations
+    def getIgnoreCase(key: String): Option[String] =
+      configs.collectFirst { case (k, v) if k.equalsIgnoreCase(key) => v }
+    new ConfigParameters(
+      getIgnoreCase(FabricConfigNames.Audience),
+      getIgnoreCase(AccountDataResolverServiceName)
+    )
+  }
+}
+
+private object FabricAccountDataResolver {
+  private val tokenProviders : TrieMap[ConfigParameters, Option[List[String] => CosmosAccessToken]] =
+    new TrieMap[ConfigParameters, Option[List[String] => CosmosAccessToken]]()
+  private final val AUDIENCE = "https://cosmos.azure.com/.default"
+  private final val ACCOUNT_DATA_RESOLVER_SERVICE_NAME = "com.azure.cosmos.spark.fabric.FabricAccountDataResolver"
+  private final val objectMapper = new ObjectMapper()
+}

--- a/sdk/cosmos/pom.xml
+++ b/sdk/cosmos/pom.xml
@@ -27,6 +27,7 @@
     <module>azure-cosmos-kafka-connect</module>
     <module>azure-cosmos-spark-account-data-resolver-sample</module>
     <module>fabric-cosmos-spark-auth_3</module>
+    <module>fabric-cosmos-spark-auth_4-0_2-13</module>
     <module>azure-resourcemanager-cosmos</module>
   </modules>
 </project>


### PR DESCRIPTION
Closes Azure/azure-sdk-for-java#48884

## Summary
Add Spark 4.0 / Scala 2.13 variant of the Fabric Cosmos Spark account data resolver (`fabric-cosmos-spark-auth_4-0_2-13`), enabling Microsoft Entra ID authentication for Fabric Runtime 2.0 users.

## What's New
- **New module:** `fabric-cosmos-spark-auth_4-0_2-13`
  - Identical Scala source code to `fabric-cosmos-spark-auth_3`
  - Dependencies updated from Scala 2.12 → 2.13 suffixes
  - Java 17+ required (Spark 4.0 requirement)
  - Depends on `azure-cosmos-spark_4-0_2-13` connector
  - `cosmos-spark-version = 4.0`
  - `scalaVersion = 2.13.17`

## Files Changed
| Category | Files |
|----------|-------|
| New module | `sdk/cosmos/fabric-cosmos-spark-auth_4-0_2-13/` (pom.xml, CHANGELOG.md, README.md, scalastyle_config.xml, Scala sources, resources) |
| CI | `sdk/cosmos/ci.yml` — trigger/pr paths, release parameter, artifact entry |
| Versioning | `eng/versioning/version_client.txt`, `eng/versioning/external_dependencies.txt` |
| Parent POM | `sdk/cosmos/pom.xml` — added module |

## Notes
- `synapseutils_2.13` added to `external_dependencies.txt` — this artifact is provided by the Fabric Runtime 2.0 environment at runtime
- Module naming follows the Spark connector convention: `{name}_{spark-major}-{spark-minor}_{scala-major}-{scala-minor}`

---
*Generated by coding-agent-harness*