### PR TITLE
eng, replace Maven Central with Azure Artifacts feed in automation scripts

### DIFF
--- a/eng/automation/generate_data.py
+++ b/eng/automation/generate_data.py
@@ -453,7 +453,7 @@ def uri_file_exists(file_path: str) -> bool:
 
 def uri_file_read(file_path: str) -> str:
     if file_path.startswith("http://") or file_path.startswith("https://"):
-        return requests.get(file_path).text
+        return requests.get(file_path, timeout=30).text
     else:
         with open(file_path, "r", encoding="utf-8") as f_in:
             return f_in.read()

--- a/eng/automation/generate_utils.py
+++ b/eng/automation/generate_utils.py
@@ -237,12 +237,19 @@ def compare_with_maven_package(
             "[Changelog] Compare stable version {0} with current version {1}".format(previous_version, current_version)
         )
 
+        headers = {}
+        token = os.environ.get("SYSTEM_ACCESSTOKEN")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
         r = requests.get(
             MAVEN_URL.format(
                 group_id=group_id.replace(".", "/"),
                 artifact_id=module,
                 version=previous_version,
-            )
+            ),
+            headers=headers,
+            timeout=30,
         )
         if r.status_code == 404:
             logging.warning(

--- a/eng/automation/generation.yml
+++ b/eng/automation/generation.yml
@@ -57,6 +57,8 @@ steps:
       ./eng/automation/generate.py --tsp-config "$(TSP_CONFIG)" --version "$(VERSION)" --auto-commit-external-change --user-name "azure-sdk" --user-email "azuresdk@microsoft.com"
     displayName: Generation from TypeSpec
     condition: ${{ eq(parameters.RELEASE_TYPE, 'TypeSpec') }}
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
   - bash: |
       export PATH=$JAVA_HOME_11_X64/bin:$PATH
@@ -65,6 +67,8 @@ steps:
       ./eng/automation/generate.py --readme "$(README)" --tag "$(TAG)" --autorest-options="$(AUTOREST_OPTIONS)" --service "$(SERVICE)" --version "$(VERSION)" --suffix "$(SUFFIX)" --auto-commit-external-change --user-name "azure-sdk" --user-email "azuresdk@microsoft.com"
     displayName: Generation from Swagger
     condition: ${{ eq(parameters.RELEASE_TYPE, 'Swagger') }}
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
   - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
     parameters:

--- a/eng/automation/parameters.py
+++ b/eng/automation/parameters.py
@@ -12,7 +12,7 @@ ARTIFACT_FORMAT = None
 OUTPUT_FOLDER_FORMAT = None
 
 # Constant parameters
-MAVEN_HOST = "https://repo1.maven.org/maven2"
+MAVEN_HOST = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1"
 MAVEN_URL = MAVEN_HOST + "/{group_id}/{artifact_id}/{version}/{artifact_id}-{version}.jar"
 
 SDK_ROOT = "../../"  # related to file dir

--- a/eng/automation/utils.py
+++ b/eng/automation/utils.py
@@ -405,7 +405,12 @@ def get_latest_ga_version(group_id: str, module: str, previous_version: str) -> 
 
     group_path = group_id.replace(".", "/")
 
-    response = requests.get(f"{MAVEN_HOST}/{group_path}/{module}")
+    headers = {}
+    token = os.environ.get("SYSTEM_ACCESSTOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    response = requests.get(f"{MAVEN_HOST}/{group_path}/{module}", headers=headers, timeout=30)
 
     response.raise_for_status()
 


### PR DESCRIPTION
Similar to PR #48817 (PowerShell scripts), this updates the Python automation scripts under `eng/automation/` to use the Azure Artifacts internal feed instead of Maven Central.

## Key Changes

**Feed URL Update:**
- Replaced `MAVEN_HOST` (`repo1.maven.org`) with Azure Artifacts feed URL (`pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1`)

**Authentication:**
- Added `SYSTEM_ACCESSTOKEN` Bearer auth headers to HTTP requests in `utils.py` and `generate_utils.py` for CI environments
- Auth is optional — when `SYSTEM_ACCESSTOKEN` is unset (local dev), requests proceed without auth

**Timeout:**
- Added `timeout=30` to all `requests.get()` calls that were missing timeouts

**Pipeline:**
- Exposed `SYSTEM_ACCESSTOKEN` env var in `generation.yml` pipeline steps