### PR TITLE
Storage Content Validation - Audit DecodedResponse

### DIFF
--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
@@ -69,7 +69,7 @@ class DecodedResponse extends HttpResponse {
 
     @Override
     public Mono<String> getBodyAsString() {
-        return FluxUtil.collectBytesInByteBufferStream(decodedBody).map(b -> new String(b, StandardCharsets.UTF_8));
+        return getBodyAsString(StandardCharsets.UTF_8);
     }
 
     @Override
@@ -80,10 +80,5 @@ class DecodedResponse extends HttpResponse {
     @Override
     public BinaryData getBodyAsBinaryData() {
         return BinaryData.fromFlux(decodedBody, null, false).block();
-    }
-
-    @Override
-    public void close() {
-        originalResponse.close();
     }
 }

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
@@ -69,12 +69,7 @@ class DecodedResponse extends HttpResponse {
 
     @Override
     public Mono<String> getBodyAsString() {
-        // Match the base HttpResponse contract (and BufferedHttpResponse's idiom): inspect the response for a BOM
-        // and the Content-Type header's charset parameter, falling back to UTF-8 when neither is present. Pinning
-        // UTF-8 unconditionally would drop the auto-detection behavior that callers viewing this as a generic
-        // HttpResponse expect.
-        return getBodyAsByteArray().map(
-            bytes -> CoreUtils.bomAwareToString(bytes, originalResponse.getHeaderValue(HttpHeaderName.CONTENT_TYPE)));
+        return getBodyAsByteArray().map(b -> CoreUtils.bomAwareToString(b, originalResponse.getHeaderValue(HttpHeaderName.CONTENT_TYPE)));
     }
 
     @Override

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
@@ -5,7 +5,6 @@ package com.azure.storage.common.policy;
 
 import com.azure.core.http.HttpHeaders;
 import com.azure.core.http.HttpResponse;
-import com.azure.core.util.BinaryData;
 import com.azure.core.util.FluxUtil;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -75,10 +74,5 @@ class DecodedResponse extends HttpResponse {
     @Override
     public Mono<String> getBodyAsString(Charset charset) {
         return FluxUtil.collectBytesInByteBufferStream(decodedBody).map(b -> new String(b, charset));
-    }
-
-    @Override
-    public BinaryData getBodyAsBinaryData() {
-        return BinaryData.fromFlux(decodedBody, null, false).block();
     }
 }

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
@@ -69,7 +69,8 @@ class DecodedResponse extends HttpResponse {
 
     @Override
     public Mono<String> getBodyAsString() {
-        return getBodyAsByteArray().map(b -> CoreUtils.bomAwareToString(b, originalResponse.getHeaderValue(HttpHeaderName.CONTENT_TYPE)));
+        return getBodyAsByteArray()
+            .map(b -> CoreUtils.bomAwareToString(b, originalResponse.getHeaderValue(HttpHeaderName.CONTENT_TYPE)));
     }
 
     @Override

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
@@ -5,12 +5,14 @@ package com.azure.storage.common.policy;
 
 import com.azure.core.http.HttpHeaders;
 import com.azure.core.http.HttpResponse;
+import com.azure.core.util.BinaryData;
 import com.azure.core.util.FluxUtil;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * {@link HttpResponse} wrapper that exposes a decoded body stream while preserving the request, status code, and
@@ -24,8 +26,6 @@ import java.nio.charset.Charset;
 class DecodedResponse extends HttpResponse {
     private final HttpResponse originalResponse;
     private final Flux<ByteBuffer> decodedBody;
-    private final HttpHeaders httpHeaders;
-    private final int statusCode;
 
     /**
      * Wraps {@code httpResponse} with a body backed by {@code decodedBody}.
@@ -36,28 +36,25 @@ class DecodedResponse extends HttpResponse {
      * pipeline.
      */
     DecodedResponse(HttpResponse httpResponse, Flux<ByteBuffer> decodedBody) {
-        // Preserve the original request so retry policies, response models, and logging keep their reference chain
-        // intact.
         super(httpResponse.getRequest());
         this.originalResponse = httpResponse;
         this.decodedBody = decodedBody;
-        this.statusCode = httpResponse.getStatusCode();
-        this.httpHeaders = httpResponse.getHeaders();
     }
 
     @Override
     public int getStatusCode() {
-        return statusCode;
+        return originalResponse.getStatusCode();
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public String getHeaderValue(String name) {
-        return httpHeaders.getValue(name);
+        return originalResponse.getHeaderValue(name);
     }
 
     @Override
     public HttpHeaders getHeaders() {
-        return httpHeaders;
+        return originalResponse.getHeaders();
     }
 
     @Override
@@ -72,11 +69,21 @@ class DecodedResponse extends HttpResponse {
 
     @Override
     public Mono<String> getBodyAsString() {
-        return FluxUtil.collectBytesInByteBufferStream(decodedBody).map(String::new);
+        return FluxUtil.collectBytesInByteBufferStream(decodedBody).map(b -> new String(b, StandardCharsets.UTF_8));
     }
 
     @Override
     public Mono<String> getBodyAsString(Charset charset) {
         return FluxUtil.collectBytesInByteBufferStream(decodedBody).map(b -> new String(b, charset));
+    }
+
+    @Override
+    public BinaryData getBodyAsBinaryData() {
+        return BinaryData.fromFlux(decodedBody, null, false).block();
+    }
+
+    @Override
+    public void close() {
+        originalResponse.close();
     }
 }

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/DecodedResponse.java
@@ -3,15 +3,16 @@
 
 package com.azure.storage.common.policy;
 
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpHeaders;
 import com.azure.core.http.HttpResponse;
+import com.azure.core.util.CoreUtils;
 import com.azure.core.util.FluxUtil;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 /**
  * {@link HttpResponse} wrapper that exposes a decoded body stream while preserving the request, status code, and
@@ -68,7 +69,12 @@ class DecodedResponse extends HttpResponse {
 
     @Override
     public Mono<String> getBodyAsString() {
-        return getBodyAsString(StandardCharsets.UTF_8);
+        // Match the base HttpResponse contract (and BufferedHttpResponse's idiom): inspect the response for a BOM
+        // and the Content-Type header's charset parameter, falling back to UTF-8 when neither is present. Pinning
+        // UTF-8 unconditionally would drop the auto-detection behavior that callers viewing this as a generic
+        // HttpResponse expect.
+        return getBodyAsByteArray().map(
+            bytes -> CoreUtils.bomAwareToString(bytes, originalResponse.getHeaderValue(HttpHeaderName.CONTENT_TYPE)));
     }
 
     @Override

--- a/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/DecodedResponseTests.java
+++ b/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/DecodedResponseTests.java
@@ -12,7 +12,6 @@ import com.azure.core.test.http.MockHttpResponse;
 import com.azure.core.util.BinaryData;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.io.ByteArrayOutputStream;
@@ -23,10 +22,8 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,14 +59,6 @@ public class DecodedResponseTests {
         return Flux.just(ByteBuffer.wrap(data));
     }
 
-    private static Flux<ByteBuffer> fluxOfChunks(byte[]... chunks) {
-        ByteBuffer[] buffers = new ByteBuffer[chunks.length];
-        for (int i = 0; i < chunks.length; i++) {
-            buffers[i] = ByteBuffer.wrap(chunks[i]);
-        }
-        return Flux.fromArray(buffers);
-    }
-
     @Test
     public void preservesRequestStatusCodeAndHeaders() {
         HttpHeaders h = new HttpHeaders().set(HttpHeaderName.CONTENT_LENGTH, "100").set(CUSTOM_HEADER, "value");
@@ -89,15 +78,6 @@ public class DecodedResponseTests {
 
         assertEquals("value", wrapper.getHeaderValue(CUSTOM_HEADER.getCaseInsensitiveName()));
         assertNull(wrapper.getHeaderValue("nonexistent"));
-    }
-
-    @Test
-    public void getHeaderValueByHttpHeaderNameUsesInheritedDefault() {
-        HttpHeaders h = headers(CUSTOM_HEADER, "value");
-        DecodedResponse wrapper = new DecodedResponse(mockResponse(200, h, new byte[0]), fluxOf(new byte[0]));
-
-        assertEquals("value", wrapper.getHeaderValue(CUSTOM_HEADER));
-        assertNull(wrapper.getHeaderValue(HttpHeaderName.fromString("nonexistent")));
     }
 
     @Test
@@ -122,19 +102,6 @@ public class DecodedResponseTests {
 
         StepVerifier.create(wrapper.getBodyAsByteArray())
             .expectNextMatches(b -> Arrays.equals(decoded, b))
-            .verifyComplete();
-    }
-
-    @Test
-    public void getBodyAsByteArrayConcatenatesMultipleChunks() {
-        byte[] chunkA = bytes("hello ");
-        byte[] chunkB = bytes("world");
-        byte[] expected = bytes("hello world");
-        DecodedResponse wrapper
-            = new DecodedResponse(mockResponse(200, new HttpHeaders(), new byte[0]), fluxOfChunks(chunkA, chunkB));
-
-        StepVerifier.create(wrapper.getBodyAsByteArray())
-            .expectNextMatches(b -> Arrays.equals(expected, b))
             .verifyComplete();
     }
 
@@ -168,16 +135,7 @@ public class DecodedResponseTests {
         BinaryData data = wrapper.getBodyAsBinaryData();
         assertNotNull(data);
         assertArrayEquals(decoded, data.toBytes());
-    }
-
-    @Test
-    public void getBodyAsBinaryDataWorksWhenContentLengthHeaderMissing() {
-        byte[] decoded = bytes("payload");
-        DecodedResponse wrapper
-            = new DecodedResponse(mockResponse(200, new HttpHeaders(), bytes("ignored")), fluxOf(decoded));
-
-        BinaryData data = wrapper.getBodyAsBinaryData();
-        assertArrayEquals(decoded, data.toBytes());
+        assertEquals((long) decoded.length, (long) data.getLength());
     }
 
     @Test
@@ -194,31 +152,16 @@ public class DecodedResponseTests {
     }
 
     @Test
-    public void inheritedWriteBodyToWritesDecodedBytesAndClosesOriginal() throws IOException {
+    public void inheritedWriteBodyToWritesDecodedBytes() throws IOException {
         byte[] decoded = bytes("write me");
-        AtomicInteger closeCount = new AtomicInteger();
-        HttpResponse original = trackingResponse(closeCount, new HttpHeaders(), bytes("encoded"));
-        DecodedResponse wrapper = new DecodedResponse(original, fluxOf(decoded));
+        DecodedResponse wrapper
+            = new DecodedResponse(mockResponse(200, new HttpHeaders(), bytes("encoded")), fluxOf(decoded));
 
         ByteArrayOutputStream sink = new ByteArrayOutputStream();
         try (WritableByteChannel channel = Channels.newChannel(sink)) {
             wrapper.writeBodyTo(channel);
         }
 
-        assertArrayEquals(decoded, sink.toByteArray());
-        assertEquals(1, closeCount.get());
-    }
-
-    @Test
-    public void inheritedWriteBodyToAsyncWritesDecodedBytes() {
-        byte[] decoded = bytes("async write");
-        DecodedResponse wrapper
-            = new DecodedResponse(mockResponse(200, new HttpHeaders(), new byte[0]), fluxOf(decoded));
-
-        ByteArrayOutputStream sink = new ByteArrayOutputStream();
-        ByteArrayAsynchronousChannel asyncChannel = new ByteArrayAsynchronousChannel(sink);
-
-        StepVerifier.create(wrapper.writeBodyToAsync(asyncChannel)).verifyComplete();
         assertArrayEquals(decoded, sink.toByteArray());
     }
 
@@ -235,76 +178,6 @@ public class DecodedResponseTests {
             .verifyComplete();
     }
 
-    @Test
-    public void closeDelegatesToWrappedResponse() {
-        AtomicInteger closeCount = new AtomicInteger();
-        HttpResponse original = trackingResponse(closeCount, new HttpHeaders(), new byte[0]);
-        DecodedResponse wrapper = new DecodedResponse(original, fluxOf(new byte[0]));
-
-        wrapper.close();
-        assertEquals(1, closeCount.get());
-        wrapper.close();
-        assertEquals(2, closeCount.get());
-    }
-
-    @Test
-    public void closeDoesNotSubscribeToDecodedBody() {
-        AtomicInteger subscribeCount = new AtomicInteger();
-        Flux<ByteBuffer> decoded = fluxOf(bytes("decoded")).doOnSubscribe(s -> subscribeCount.incrementAndGet());
-
-        DecodedResponse wrapper = new DecodedResponse(mockResponse(200, new HttpHeaders(), new byte[0]), decoded);
-        wrapper.close();
-
-        assertEquals(0, subscribeCount.get());
-    }
-
-    private static HttpResponse trackingResponse(AtomicInteger closeCount, HttpHeaders headers, byte[] body) {
-        MockHttpResponse delegate = new MockHttpResponse(newRequest(), 200, headers, body);
-        return new HttpResponse(delegate.getRequest()) {
-            @Override
-            public int getStatusCode() {
-                return delegate.getStatusCode();
-            }
-
-            @Override
-            @SuppressWarnings("deprecation")
-            public String getHeaderValue(String name) {
-                return delegate.getHeaderValue(name);
-            }
-
-            @Override
-            public HttpHeaders getHeaders() {
-                return delegate.getHeaders();
-            }
-
-            @Override
-            public Flux<ByteBuffer> getBody() {
-                return delegate.getBody();
-            }
-
-            @Override
-            public Mono<byte[]> getBodyAsByteArray() {
-                return delegate.getBodyAsByteArray();
-            }
-
-            @Override
-            public Mono<String> getBodyAsString() {
-                return delegate.getBodyAsString();
-            }
-
-            @Override
-            public Mono<String> getBodyAsString(Charset charset) {
-                return delegate.getBodyAsString(charset);
-            }
-
-            @Override
-            public void close() {
-                closeCount.incrementAndGet();
-                delegate.close();
-            }
-        };
-    }
-
     private static byte[] readAll(InputStream stream) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         byte[] buf = new byte[1024];
@@ -313,56 +186,5 @@ public class DecodedResponseTests {
             out.write(buf, 0, n);
         }
         return out.toByteArray();
-    }
-
-    private static final class ByteArrayAsynchronousChannel implements java.nio.channels.AsynchronousByteChannel {
-        private final ByteArrayOutputStream sink;
-        private volatile boolean open = true;
-
-        ByteArrayAsynchronousChannel(ByteArrayOutputStream sink) {
-            this.sink = sink;
-        }
-
-        @Override
-        public <A> void read(ByteBuffer dst, A attachment,
-            java.nio.channels.CompletionHandler<Integer, ? super A> handler) {
-            handler.failed(new UnsupportedOperationException("read not supported"), attachment);
-        }
-
-        @Override
-        public java.util.concurrent.Future<Integer> read(ByteBuffer dst) {
-            java.util.concurrent.CompletableFuture<Integer> future = new java.util.concurrent.CompletableFuture<>();
-            future.completeExceptionally(new UnsupportedOperationException("read not supported"));
-            return future;
-        }
-
-        @Override
-        public <A> void write(ByteBuffer src, A attachment,
-            java.nio.channels.CompletionHandler<Integer, ? super A> handler) {
-            int written = src.remaining();
-            byte[] data = new byte[written];
-            src.get(data);
-            sink.write(data, 0, data.length);
-            handler.completed(written, attachment);
-        }
-
-        @Override
-        public java.util.concurrent.Future<Integer> write(ByteBuffer src) {
-            int written = src.remaining();
-            byte[] data = new byte[written];
-            src.get(data);
-            sink.write(data, 0, data.length);
-            return java.util.concurrent.CompletableFuture.completedFuture(written);
-        }
-
-        @Override
-        public boolean isOpen() {
-            return open;
-        }
-
-        @Override
-        public void close() {
-            open = false;
-        }
     }
 }

--- a/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/DecodedResponseTests.java
+++ b/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/DecodedResponseTests.java
@@ -9,7 +9,6 @@ import com.azure.core.http.HttpMethod;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.test.http.MockHttpResponse;
-import com.azure.core.util.BinaryData;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -124,18 +123,6 @@ public class DecodedResponseTests {
             = new DecodedResponse(mockResponse(200, new HttpHeaders(), new byte[0]), fluxOf(latin1));
 
         StepVerifier.create(wrapper.getBodyAsString(StandardCharsets.ISO_8859_1)).expectNext(text).verifyComplete();
-    }
-
-    @Test
-    public void getBodyAsBinaryDataReportsDecodedSizeNotContentLength() {
-        byte[] decoded = bytes("decoded");
-        HttpHeaders h = new HttpHeaders().set(HttpHeaderName.CONTENT_LENGTH, String.valueOf(decoded.length + 64));
-        DecodedResponse wrapper = new DecodedResponse(mockResponse(200, h, bytes("ignored")), fluxOf(decoded));
-
-        BinaryData data = wrapper.getBodyAsBinaryData();
-        assertNotNull(data);
-        assertArrayEquals(decoded, data.toBytes());
-        assertEquals((long) decoded.length, (long) data.getLength());
     }
 
     @Test

--- a/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/DecodedResponseTests.java
+++ b/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/DecodedResponseTests.java
@@ -1,0 +1,368 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.storage.common.policy;
+
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.test.http.MockHttpResponse;
+import com.azure.core.util.BinaryData;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class DecodedResponseTests {
+
+    private static final HttpHeaderName CUSTOM_HEADER = HttpHeaderName.fromString("x-ms-custom");
+
+    private static HttpRequest newRequest() {
+        try {
+            return new HttpRequest(HttpMethod.GET, new URL("http://example.com/"));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static HttpHeaders headers(HttpHeaderName name, String value) {
+        return new HttpHeaders().set(name, value);
+    }
+
+    private static MockHttpResponse mockResponse(int status, HttpHeaders headers, byte[] body) {
+        return new MockHttpResponse(newRequest(), status, headers, body);
+    }
+
+    private static byte[] bytes(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static Flux<ByteBuffer> fluxOf(byte[] data) {
+        return Flux.just(ByteBuffer.wrap(data));
+    }
+
+    private static Flux<ByteBuffer> fluxOfChunks(byte[]... chunks) {
+        ByteBuffer[] buffers = new ByteBuffer[chunks.length];
+        for (int i = 0; i < chunks.length; i++) {
+            buffers[i] = ByteBuffer.wrap(chunks[i]);
+        }
+        return Flux.fromArray(buffers);
+    }
+
+    @Test
+    public void preservesRequestStatusCodeAndHeaders() {
+        HttpHeaders h = new HttpHeaders().set(HttpHeaderName.CONTENT_LENGTH, "100").set(CUSTOM_HEADER, "value");
+        MockHttpResponse original = mockResponse(206, h, bytes("encoded"));
+
+        DecodedResponse wrapper = new DecodedResponse(original, fluxOf(bytes("decoded")));
+
+        assertSame(original.getRequest(), wrapper.getRequest());
+        assertEquals(206, wrapper.getStatusCode());
+        assertSame(h, wrapper.getHeaders());
+    }
+
+    @Test
+    public void getHeaderValueByStringReturnsHeaderValue() {
+        HttpHeaders h = headers(CUSTOM_HEADER, "value");
+        DecodedResponse wrapper = new DecodedResponse(mockResponse(200, h, new byte[0]), fluxOf(new byte[0]));
+
+        assertEquals("value", wrapper.getHeaderValue(CUSTOM_HEADER.getCaseInsensitiveName()));
+        assertNull(wrapper.getHeaderValue("nonexistent"));
+    }
+
+    @Test
+    public void getHeaderValueByHttpHeaderNameUsesInheritedDefault() {
+        HttpHeaders h = headers(CUSTOM_HEADER, "value");
+        DecodedResponse wrapper = new DecodedResponse(mockResponse(200, h, new byte[0]), fluxOf(new byte[0]));
+
+        assertEquals("value", wrapper.getHeaderValue(CUSTOM_HEADER));
+        assertNull(wrapper.getHeaderValue(HttpHeaderName.fromString("nonexistent")));
+    }
+
+    @Test
+    public void getBodyReturnsDecodedFlux() {
+        byte[] decoded = bytes("decoded body");
+        DecodedResponse wrapper
+            = new DecodedResponse(mockResponse(200, new HttpHeaders(), bytes("encoded")), fluxOf(decoded));
+
+        StepVerifier.create(wrapper.getBody().reduce(new ByteArrayOutputStream(), (sink, buf) -> {
+            byte[] copy = new byte[buf.remaining()];
+            buf.get(copy);
+            sink.write(copy, 0, copy.length);
+            return sink;
+        })).expectNextMatches(sink -> Arrays.equals(decoded, sink.toByteArray())).verifyComplete();
+    }
+
+    @Test
+    public void getBodyAsByteArrayReturnsDecodedBytes() {
+        byte[] decoded = bytes("decoded body");
+        DecodedResponse wrapper
+            = new DecodedResponse(mockResponse(200, new HttpHeaders(), bytes("encoded")), fluxOf(decoded));
+
+        StepVerifier.create(wrapper.getBodyAsByteArray())
+            .expectNextMatches(b -> Arrays.equals(decoded, b))
+            .verifyComplete();
+    }
+
+    @Test
+    public void getBodyAsByteArrayConcatenatesMultipleChunks() {
+        byte[] chunkA = bytes("hello ");
+        byte[] chunkB = bytes("world");
+        byte[] expected = bytes("hello world");
+        DecodedResponse wrapper
+            = new DecodedResponse(mockResponse(200, new HttpHeaders(), new byte[0]), fluxOfChunks(chunkA, chunkB));
+
+        StepVerifier.create(wrapper.getBodyAsByteArray())
+            .expectNextMatches(b -> Arrays.equals(expected, b))
+            .verifyComplete();
+    }
+
+    @Test
+    public void getBodyAsStringDecodesDecodedBytesAsUtf8() {
+        // The no-arg overload pins the charset to UTF-8 (storage convention) regardless of platform default. The
+        // override does no Content-Type / BOM auto-detection; it always treats the decoded bytes as UTF-8.
+        String text = "héllo wörld – ✓";
+        DecodedResponse wrapper = new DecodedResponse(mockResponse(200, new HttpHeaders(), new byte[0]),
+            fluxOf(text.getBytes(StandardCharsets.UTF_8)));
+
+        StepVerifier.create(wrapper.getBodyAsString()).expectNext(text).verifyComplete();
+    }
+
+    @Test
+    public void getBodyAsStringWithCharsetUsesProvidedCharset() {
+        String text = "ümlaut";
+        byte[] latin1 = text.getBytes(StandardCharsets.ISO_8859_1);
+        DecodedResponse wrapper
+            = new DecodedResponse(mockResponse(200, new HttpHeaders(), new byte[0]), fluxOf(latin1));
+
+        StepVerifier.create(wrapper.getBodyAsString(StandardCharsets.ISO_8859_1)).expectNext(text).verifyComplete();
+    }
+
+    @Test
+    public void getBodyAsBinaryDataReportsDecodedSizeNotContentLength() {
+        byte[] decoded = bytes("decoded");
+        HttpHeaders h = new HttpHeaders().set(HttpHeaderName.CONTENT_LENGTH, String.valueOf(decoded.length + 64));
+        DecodedResponse wrapper = new DecodedResponse(mockResponse(200, h, bytes("ignored")), fluxOf(decoded));
+
+        BinaryData data = wrapper.getBodyAsBinaryData();
+        assertNotNull(data);
+        assertArrayEquals(decoded, data.toBytes());
+    }
+
+    @Test
+    public void getBodyAsBinaryDataWorksWhenContentLengthHeaderMissing() {
+        byte[] decoded = bytes("payload");
+        DecodedResponse wrapper
+            = new DecodedResponse(mockResponse(200, new HttpHeaders(), bytes("ignored")), fluxOf(decoded));
+
+        BinaryData data = wrapper.getBodyAsBinaryData();
+        assertArrayEquals(decoded, data.toBytes());
+    }
+
+    @Test
+    public void inheritedGetBodyAsInputStreamUsesDecodedBytes() throws IOException {
+        // Base getBodyAsInputStream() routes through getBodyAsByteArray(), so the override is exercised end-to-end.
+        byte[] decoded = bytes("decoded stream");
+        DecodedResponse wrapper
+            = new DecodedResponse(mockResponse(200, new HttpHeaders(), bytes("encoded")), fluxOf(decoded));
+
+        try (InputStream stream = wrapper.getBodyAsInputStream().block()) {
+            assertNotNull(stream);
+            assertArrayEquals(decoded, readAll(stream));
+        }
+    }
+
+    @Test
+    public void inheritedWriteBodyToWritesDecodedBytesAndClosesOriginal() throws IOException {
+        byte[] decoded = bytes("write me");
+        AtomicInteger closeCount = new AtomicInteger();
+        HttpResponse original = trackingResponse(closeCount, new HttpHeaders(), bytes("encoded"));
+        DecodedResponse wrapper = new DecodedResponse(original, fluxOf(decoded));
+
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        try (WritableByteChannel channel = Channels.newChannel(sink)) {
+            wrapper.writeBodyTo(channel);
+        }
+
+        assertArrayEquals(decoded, sink.toByteArray());
+        assertEquals(1, closeCount.get());
+    }
+
+    @Test
+    public void inheritedWriteBodyToAsyncWritesDecodedBytes() {
+        byte[] decoded = bytes("async write");
+        DecodedResponse wrapper
+            = new DecodedResponse(mockResponse(200, new HttpHeaders(), new byte[0]), fluxOf(decoded));
+
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        ByteArrayAsynchronousChannel asyncChannel = new ByteArrayAsynchronousChannel(sink);
+
+        StepVerifier.create(wrapper.writeBodyToAsync(asyncChannel)).verifyComplete();
+        assertArrayEquals(decoded, sink.toByteArray());
+    }
+
+    @Test
+    public void inheritedBufferReturnsResponseBackedByDecodedBody() {
+        byte[] decoded = bytes("buffered");
+        DecodedResponse wrapper
+            = new DecodedResponse(mockResponse(200, new HttpHeaders(), bytes("encoded")), fluxOf(decoded));
+
+        HttpResponse buffered = wrapper.buffer();
+        assertNotNull(buffered);
+        StepVerifier.create(buffered.getBodyAsByteArray())
+            .expectNextMatches(b -> Arrays.equals(decoded, b))
+            .verifyComplete();
+    }
+
+    @Test
+    public void closeDelegatesToWrappedResponse() {
+        AtomicInteger closeCount = new AtomicInteger();
+        HttpResponse original = trackingResponse(closeCount, new HttpHeaders(), new byte[0]);
+        DecodedResponse wrapper = new DecodedResponse(original, fluxOf(new byte[0]));
+
+        wrapper.close();
+        assertEquals(1, closeCount.get());
+        wrapper.close();
+        assertEquals(2, closeCount.get());
+    }
+
+    @Test
+    public void closeDoesNotSubscribeToDecodedBody() {
+        AtomicInteger subscribeCount = new AtomicInteger();
+        Flux<ByteBuffer> decoded = fluxOf(bytes("decoded")).doOnSubscribe(s -> subscribeCount.incrementAndGet());
+
+        DecodedResponse wrapper = new DecodedResponse(mockResponse(200, new HttpHeaders(), new byte[0]), decoded);
+        wrapper.close();
+
+        assertEquals(0, subscribeCount.get());
+    }
+
+    private static HttpResponse trackingResponse(AtomicInteger closeCount, HttpHeaders headers, byte[] body) {
+        MockHttpResponse delegate = new MockHttpResponse(newRequest(), 200, headers, body);
+        return new HttpResponse(delegate.getRequest()) {
+            @Override
+            public int getStatusCode() {
+                return delegate.getStatusCode();
+            }
+
+            @Override
+            @SuppressWarnings("deprecation")
+            public String getHeaderValue(String name) {
+                return delegate.getHeaderValue(name);
+            }
+
+            @Override
+            public HttpHeaders getHeaders() {
+                return delegate.getHeaders();
+            }
+
+            @Override
+            public Flux<ByteBuffer> getBody() {
+                return delegate.getBody();
+            }
+
+            @Override
+            public Mono<byte[]> getBodyAsByteArray() {
+                return delegate.getBodyAsByteArray();
+            }
+
+            @Override
+            public Mono<String> getBodyAsString() {
+                return delegate.getBodyAsString();
+            }
+
+            @Override
+            public Mono<String> getBodyAsString(Charset charset) {
+                return delegate.getBodyAsString(charset);
+            }
+
+            @Override
+            public void close() {
+                closeCount.incrementAndGet();
+                delegate.close();
+            }
+        };
+    }
+
+    private static byte[] readAll(InputStream stream) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buf = new byte[1024];
+        int n;
+        while ((n = stream.read(buf)) != -1) {
+            out.write(buf, 0, n);
+        }
+        return out.toByteArray();
+    }
+
+    private static final class ByteArrayAsynchronousChannel implements java.nio.channels.AsynchronousByteChannel {
+        private final ByteArrayOutputStream sink;
+        private volatile boolean open = true;
+
+        ByteArrayAsynchronousChannel(ByteArrayOutputStream sink) {
+            this.sink = sink;
+        }
+
+        @Override
+        public <A> void read(ByteBuffer dst, A attachment,
+            java.nio.channels.CompletionHandler<Integer, ? super A> handler) {
+            handler.failed(new UnsupportedOperationException("read not supported"), attachment);
+        }
+
+        @Override
+        public java.util.concurrent.Future<Integer> read(ByteBuffer dst) {
+            java.util.concurrent.CompletableFuture<Integer> future = new java.util.concurrent.CompletableFuture<>();
+            future.completeExceptionally(new UnsupportedOperationException("read not supported"));
+            return future;
+        }
+
+        @Override
+        public <A> void write(ByteBuffer src, A attachment,
+            java.nio.channels.CompletionHandler<Integer, ? super A> handler) {
+            int written = src.remaining();
+            byte[] data = new byte[written];
+            src.get(data);
+            sink.write(data, 0, data.length);
+            handler.completed(written, attachment);
+        }
+
+        @Override
+        public java.util.concurrent.Future<Integer> write(ByteBuffer src) {
+            int written = src.remaining();
+            byte[] data = new byte[written];
+            src.get(data);
+            sink.write(data, 0, data.length);
+            return java.util.concurrent.CompletableFuture.completedFuture(written);
+        }
+
+        @Override
+        public boolean isOpen() {
+            return open;
+        }
+
+        @Override
+        public void close() {
+            open = false;
+        }
+    }
+}

--- a/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/DecodedResponseTests.java
+++ b/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/DecodedResponseTests.java
@@ -9,6 +9,7 @@ import com.azure.core.http.HttpMethod;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.test.http.MockHttpResponse;
+import com.azure.core.util.BinaryData;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
@@ -105,9 +106,9 @@ public class DecodedResponseTests {
     }
 
     @Test
-    public void getBodyAsStringDecodesDecodedBytesAsUtf8() {
-        // The no-arg overload pins the charset to UTF-8 (storage convention) regardless of platform default. The
-        // override does no Content-Type / BOM auto-detection; it always treats the decoded bytes as UTF-8.
+    public void getBodyAsStringDefaultsToUtf8WhenNoCharsetSpecified() {
+        // The no-arg overload routes through CoreUtils.bomAwareToString, which falls back to UTF-8 when neither a
+        // BOM nor a Content-Type charset parameter is present. This test pins the "no headers, no BOM" path.
         String text = "héllo wörld – ✓";
         DecodedResponse wrapper = new DecodedResponse(mockResponse(200, new HttpHeaders(), new byte[0]),
             fluxOf(text.getBytes(StandardCharsets.UTF_8)));
@@ -116,7 +117,36 @@ public class DecodedResponseTests {
     }
 
     @Test
-    public void getBodyAsStringWithCharsetUsesProvidedCharset() {
+    public void getBodyAsStringHonorsCharsetFromContentTypeHeader() {
+        // Per the base HttpResponse contract, the no-arg getBodyAsString() must honor a charset declared in the
+        // response's Content-Type header. Without the bom-aware decoding the bytes would be (mis)interpreted as
+        // UTF-8 and the assertion below would fail.
+        String text = "ümlaut";
+        byte[] iso = text.getBytes(StandardCharsets.ISO_8859_1);
+        HttpHeaders h = new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, "text/plain; charset=ISO-8859-1");
+        DecodedResponse wrapper = new DecodedResponse(mockResponse(200, h, new byte[0]), fluxOf(iso));
+
+        StepVerifier.create(wrapper.getBodyAsString()).expectNext(text).verifyComplete();
+    }
+
+    @Test
+    public void getBodyAsStringDetectsUtf8BomAndStripsIt() {
+        // A leading UTF-8 BOM (EF BB BF) must be detected and stripped from the decoded string, matching the base
+        // HttpResponse contract that CoreUtils.bomAwareToString implements.
+        String text = "with bom";
+        byte[] bom = new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+        byte[] payload = text.getBytes(StandardCharsets.UTF_8);
+        byte[] withBom = new byte[bom.length + payload.length];
+        System.arraycopy(bom, 0, withBom, 0, bom.length);
+        System.arraycopy(payload, 0, withBom, bom.length, payload.length);
+        DecodedResponse wrapper
+            = new DecodedResponse(mockResponse(200, new HttpHeaders(), new byte[0]), fluxOf(withBom));
+
+        StepVerifier.create(wrapper.getBodyAsString()).expectNext(text).verifyComplete();
+    }
+
+    @Test
+    public void getBodyAsStringDecodesUsingProvidedCharset() {
         String text = "ümlaut";
         byte[] latin1 = text.getBytes(StandardCharsets.ISO_8859_1);
         DecodedResponse wrapper
@@ -153,7 +183,7 @@ public class DecodedResponseTests {
     }
 
     @Test
-    public void inheritedBufferReturnsResponseBackedByDecodedBody() {
+    public void inheritedBufferReturnsResponseBackedByDecodedBytes() {
         byte[] decoded = bytes("buffered");
         DecodedResponse wrapper
             = new DecodedResponse(mockResponse(200, new HttpHeaders(), bytes("encoded")), fluxOf(decoded));
@@ -163,6 +193,21 @@ public class DecodedResponseTests {
         StepVerifier.create(buffered.getBodyAsByteArray())
             .expectNextMatches(b -> Arrays.equals(decoded, b))
             .verifyComplete();
+    }
+
+    @Test
+    public void inheritedGetBodyAsBinaryDataReturnsDecodedBytes() {
+        // Base HttpResponse#getBodyAsBinaryData() pulls from getBody() (our override), so the resulting BinaryData
+        // must contain the decoded payload, not the original wire body. A divergent Content-Length header is set
+        // to make the wire vs decoded distinction explicit and guard against regressions in header forwarding.
+        byte[] decoded = bytes("decoded payload");
+        HttpHeaders h = new HttpHeaders().set(HttpHeaderName.CONTENT_LENGTH, String.valueOf(decoded.length + 32));
+        DecodedResponse wrapper
+            = new DecodedResponse(mockResponse(200, h, bytes("encoded wire body")), fluxOf(decoded));
+
+        BinaryData data = wrapper.getBodyAsBinaryData();
+        assertNotNull(data);
+        assertArrayEquals(decoded, data.toBytes());
     }
 
     private static byte[] readAll(InputStream stream) throws IOException {


### PR DESCRIPTION
From HttpResponse, the constructor only stores the HttpRequest; getRequest() is final and returns that. Everything else is either abstract (must implement) or has a default on the base class. So for a body-swapping wrapper, we must implement the seven abstract members.