### PR TITLE
Add ServiceClientBuilder annotation to attributeValueChanged revapi linting config

### DIFF
--- a/eng/lintingconfigs/revapi/track2/revapi.json
+++ b/eng/lintingconfigs/revapi/track2/revapi.json
@@ -302,7 +302,7 @@
           "regex": true,
           "code": "java\\.annotation\\.(added|attributeValueChanged)",
           "old": ".*",
-          "annotationType": "com\\.azure\\.core\\.annotation\\.Service(Method|Client)",
+          "annotationType": "com\\.azure\\.core\\.annotation\\.Service(Method|Client|ClientBuilder)",
           "justification": "These are SDK metadata annotations and don't affect runtime behavior."
         },
         {


### PR DESCRIPTION
This pull request makes a minor update to the RevAPI linting configuration. The change expands the annotation types covered by a specific rule to include `ServiceClientBuilder` annotations, in addition to the existing `ServiceMethod` and `ServiceClient` annotations.

* Linting configuration update:
  * [`eng/lintingconfigs/revapi/track2/revapi.json`](diffhunk://#diff-315ac037a214b2389f14a2d036b45c52d8fe63af09860ad19270d7a912a609c5L305-R305): Updated the `annotationType` regex to include `ClientBuilder`, ensuring that rules apply to `ServiceClientBuilder` annotations as well.