### PR TITLE
[Cosmos][Kafka] Address log4j CVEs in azure-cosmos-kafka-connect

### DIFF
--- a/eng/versioning/external_dependencies.txt
+++ b/eng/versioning/external_dependencies.txt
@@ -280,6 +280,9 @@ cosmos_org.testcontainers:kafka;1.21.4
 cosmos_org.sourcelab:kafka-connect-client;4.0.4
 cosmos_io.confluent:kafka-avro-serializer;7.6.0
 cosmos_org.apache.avro:avro;1.11.4
+cosmos_org.apache.logging.log4j:log4j-api;2.25.3
+cosmos_org.apache.logging.log4j:log4j-core;2.25.3
+cosmos_org.apache.logging.log4j:log4j-slf4j-impl;2.25.3
 # Maven Tools for Cosmos Kafka connector only
 
 # sdk\resourcemanager\azure-resourcemanager\pom.xml

--- a/sdk/cosmos/azure-cosmos-kafka-connect/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/CHANGELOG.md
@@ -9,6 +9,8 @@
 #### Bugs Fixed
 
 #### Other Changes
+* Updated `log4j-api`, `log4j-core` and `log4j-slf4j-impl` test dependencies to `2.25.3` to address [CVE-2025-68161](https://github.com/advisories/GHSA-pgxp-9w8h-vfh4) (Apache Log4j: information disclosure via missing TLS hostname verification).
+* Picked up patched versions of `jackson-core` (`2.18.6`) and `netty-codec-http`/`netty-codec-http2` (`4.1.132.Final`) transitively via `azure-cosmos` `4.81.0-beta.1`, addressing [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq), [CVE-2026-33870](https://nvd.nist.gov/vuln/detail/CVE-2026-33870), [CVE-2025-67735](https://nvd.nist.gov/vuln/detail/CVE-2025-67735) and [CVE-2026-33871](https://nvd.nist.gov/vuln/detail/CVE-2026-33871).
 
 ### 2.10.0 (2026-05-01)
 

--- a/sdk/cosmos/azure-cosmos-kafka-connect/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/CHANGELOG.md
@@ -9,7 +9,6 @@
 #### Bugs Fixed
 
 #### Other Changes
-* Updated `log4j-api`, `log4j-core` and `log4j-slf4j-impl` test dependencies to `2.25.3` to address [CVE-2025-68161](https://logging.apache.org/security.html#CVE-2025-68161) (Apache Log4j: information disclosure via missing TLS hostname verification).
 
 ### 2.10.0 (2026-05-01)
 

--- a/sdk/cosmos/azure-cosmos-kafka-connect/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 #### Other Changes
 * Updated `log4j-api`, `log4j-core` and `log4j-slf4j-impl` test dependencies to `2.25.3` to address [CVE-2025-68161](https://github.com/advisories/GHSA-pgxp-9w8h-vfh4) (Apache Log4j: information disclosure via missing TLS hostname verification).
-* Picked up patched versions of `jackson-core` (`2.18.6`) and `netty-codec-http`/`netty-codec-http2` (`4.1.132.Final`) transitively via `azure-cosmos` `4.81.0-beta.1`, addressing [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq), [CVE-2026-33870](https://nvd.nist.gov/vuln/detail/CVE-2026-33870), [CVE-2025-67735](https://nvd.nist.gov/vuln/detail/CVE-2025-67735) and [CVE-2026-33871](https://nvd.nist.gov/vuln/detail/CVE-2026-33871).
 
 ### 2.10.0 (2026-05-01)
 

--- a/sdk/cosmos/azure-cosmos-kafka-connect/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/CHANGELOG.md
@@ -9,7 +9,7 @@
 #### Bugs Fixed
 
 #### Other Changes
-* Updated `log4j-api`, `log4j-core` and `log4j-slf4j-impl` test dependencies to `2.25.3` to address [CVE-2025-68161](https://github.com/advisories/GHSA-pgxp-9w8h-vfh4) (Apache Log4j: information disclosure via missing TLS hostname verification).
+* Updated `log4j-api`, `log4j-core` and `log4j-slf4j-impl` test dependencies to `2.25.3` to address [CVE-2025-68161](https://logging.apache.org/security.html#CVE-2025-68161) (Apache Log4j: information disclosure via missing TLS hostname verification).
 
 ### 2.10.0 (2026-05-01)
 

--- a/sdk/cosmos/azure-cosmos-kafka-connect/pom.xml
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/pom.xml
@@ -307,6 +307,9 @@ Licensed under the MIT License.
                 <include>com.jayway.jsonpath:json-path:[2.9.0]</include> <!-- {x-include-update;cosmos_com.jayway.jsonpath:json-path;external_dependency} -->
                 <include>org.sourcelab:kafka-connect-client:[4.0.4]</include> <!-- {x-include-update;cosmos_org.sourcelab:kafka-connect-client;external_dependency} -->
                 <include>org.apache.maven.plugins:maven-antrun-plugin:[3.1.0]</include> <!-- {x-include-update;org.apache.maven.plugins:maven-antrun-plugin;external_dependency} -->
+                <include>org.apache.logging.log4j:log4j-api:[2.25.3]</include> <!-- {x-include-update;cosmos_org.apache.logging.log4j:log4j-api;external_dependency} -->
+                <include>org.apache.logging.log4j:log4j-core:[2.25.3]</include> <!-- {x-include-update;cosmos_org.apache.logging.log4j:log4j-core;external_dependency} -->
+                <include>org.apache.logging.log4j:log4j-slf4j-impl:[2.25.3]</include> <!-- {x-include-update;cosmos_org.apache.logging.log4j:log4j-slf4j-impl;external_dependency} -->
               </includes>
             </bannedDependencies>
           </rules>

--- a/sdk/cosmos/azure-cosmos-kafka-connect/pom.xml
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/pom.xml
@@ -181,21 +181,21 @@ Licensed under the MIT License.
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.2</version> <!-- {x-version-update;org.apache.logging.log4j:log4j-slf4j-impl;external_dependency} -->
+      <version>2.25.3</version> <!-- {x-version-update;cosmos_org.apache.logging.log4j:log4j-slf4j-impl;external_dependency} -->
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.17.2</version> <!-- {x-version-update;org.apache.logging.log4j:log4j-api;external_dependency} -->
+      <version>2.25.3</version> <!-- {x-version-update;cosmos_org.apache.logging.log4j:log4j-api;external_dependency} -->
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.2</version> <!-- {x-version-update;org.apache.logging.log4j:log4j-core;external_dependency} -->
+      <version>2.25.3</version> <!-- {x-version-update;cosmos_org.apache.logging.log4j:log4j-core;external_dependency} -->
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
## Description

Addresses the following CVEs reported against the published `microsoftcorporation-kafka-connect-cosmos` v1.18.0 connector for the `azure-cosmos-kafka-connect` module.

| CVE / Advisory | Package | Installed | Fixed | Severity | How it's fixed |
| [CVE-2025-68161](https://github.com/advisories/GHSA-pgxp-9w8h-vfh4) | `org.apache.logging.log4j:log4j-core` | 2.17.1 | **2.25.3** | MEDIUM | Explicitly bumped (test scope) via new `cosmos_*`-prefixed tokens in this PR |

## Changes

- `eng/versioning/external_dependencies.txt` — add three `cosmos_org.apache.logging.log4j:*` tokens at `2.25.3` so the kafka connector can advance independently of the global `2.17.2` pin used elsewhere (this mirrors the existing pattern for `cosmos_org.apache.kafka:*`, `cosmos_io.confluent:*`, etc.).
- `sdk/cosmos/azure-cosmos-kafka-connect/pom.xml` — switch the three `log4j-*` test-scope dependencies to the new tokens at `2.25.3`. No other cosmos modules are affected.
- `sdk/cosmos/azure-cosmos-kafka-connect/CHANGELOG.md` — document the CVE fixes under the existing `2.11.0-beta.1` entry.

## Scope notes

- `log4j-api`, `log4j-core`, and `log4j-slf4j-impl` are `<scope>test</scope>` in `pom.xml`. They are **not** shaded into the published uber jar (`maven-shade-plugin` does not include test scope by default). The bump is purely to satisfy SBOM scanners that read the dependency-reduced POM published by the shade plugin.
- The stale `azure-cosmos-kafka-connect-1.0.0-beta.5.jar` files that may appear locally under `src/docker/connectors/` and `src/test/connectorPlugins/connectors/` are **gitignored** and never published — `build.sh` deletes and rebuilds them before integration tests run. No action needed.

## Validation

- `eng/versioning/pom_file_version_scanner.ps1` — passes (version comments match `external_dependencies.txt`).
- Local maven `package` build was attempted but could not complete due to ADO feed auth in this dev environment (`com.azure:azure-cosmos:pom:4.81.0-beta.1` returns 401). The repo pipeline will exercise the full build.

## Related

Equivalent fixes may be needed in the standalone Confluent Hub v1 connector repo (out of scope for this PR).
