### PR TITLE
infra: tolerate nested TempTypeSpecFiles cleanup race in Compare-CurrentToCodegeneration.ps1

### DIFF
--- a/eng/scripts/Compare-CurrentToCodegeneration.ps1
+++ b/eng/scripts/Compare-CurrentToCodegeneration.ps1
@@ -176,9 +176,17 @@ $generateScript = {
           throw
         }
       } finally {
-        Get-ChildItem -Path $directory -Filter TempTypeSpecFiles -Recurse -Directory | ForEach-Object {
-          Remove-Item -Path $_.FullName -Recurse -Force | Out-Null
-        }
+        # Sort by descending path length so deepest TempTypeSpecFiles copies are
+        # removed first. An outer TempTypeSpecFiles can contain nested copies inside
+        # node_modules/@azure-tools/<emitter>/TempTypeSpecFiles; without sorting,
+        # the recursive removal of an outer match can wipe a path that a later
+        # iteration still expects to exist. SilentlyContinue covers the residual
+        # cross-root race where deletion order alone is not enough.
+        Get-ChildItem -Path $directory -Filter TempTypeSpecFiles -Recurse -Directory |
+          Sort-Object -Property { $_.FullName.Length } -Descending |
+          ForEach-Object {
+            Remove-Item -Path $_.FullName -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
+          }
       }
 
       # Update code snippets before comparing the diff


### PR DESCRIPTION
## Problem

`eng/scripts/Compare-CurrentToCodegeneration.ps1` (introduced by #45941) cleans up `TempTypeSpecFiles` after `tsp-client update`. When an outer `TempTypeSpecFiles` contains nested copies inside `node_modules/@azure-tools/<emitter>/TempTypeSpecFiles`, `Get-ChildItem -Recurse -Directory` enumerates BOTH directories. The outer one is removed first by `Remove-Item -Recurse`, which also wipes the nested one. The next iteration then tries to delete a path that no longer exists and the script throws:

```
Remove-Item: Cannot remove item .../TempTypeSpecFiles/node_modules/@azure-tools/openai-typespec/src:
Could not find a part of the path
```

The verification step itself succeeds (the log clearly shows `Successfully ran TypeSpec update in directory ... with no diff` immediately before the failure). Only the post-step cleanup fails, but it marks the `Verify Swagger and TypeSpec Code Generation` task as failed and turns `java - pullrequest (Build Analyze)` red on every PR that hits the race.

## Fix

Make the cleanup tolerant to the nested-deletion race:

1. Sort matched directories by descending path length so deepest `TempTypeSpecFiles` copies are removed first. This makes the common nested-within-nested case work without relying on the fallback.
2. Add `-ErrorAction SilentlyContinue` to `Remove-Item` to cover the residual cross-root race (separate root directories whose children get wiped by an unrelated outer deletion).

Both pieces matter: sorting handles the common case cleanly, and `SilentlyContinue` is the safety net for any remaining ordering surprises across distinct roots.

## Scope

Single file, ~5 lines of code (plus comment explaining the rationale). No tests added: the script has no unit tests today and adding mock-filesystem coverage is out of scope for a build-unblock fix.

## Why this is not a regression

This race has existed since #45941 introduced the cleanup loop. It surfaces only when the directory graph contains an outer `TempTypeSpecFiles` with nested `TempTypeSpecFiles` under `node_modules`, which is becoming more common as more emitters land in `tsp-client`. The verification logic itself is untouched.

## Affected PRs

Recent CI failures with this exact signature:

- #48460: builds 6266473, 6288751, 6289049
- #49159: concurrent runs

After this lands, those PRs (and any future PR hitting the same race) will see `Verify Swagger and TypeSpec Code Generation` succeed.

## Verification

Script parses cleanly. Functional verification of the cleanup race is hard to reproduce deterministically in CI without setting up the exact nested directory layout, but the change is a strict superset of safe deletion behavior:

- Sort order does not change which paths are matched, only the order they are removed in.
- `-ErrorAction SilentlyContinue` only suppresses errors on `Remove-Item` itself; the surrounding `try`/`finally` and exit-code handling are unchanged.
