### PR TITLE
mgmt, deprecate Azure Resource Manager Deployment Manager SDK

### DIFF
--- a/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/CHANGELOG.md
+++ b/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Other Changes
 
-- Please note, this package has been deprecated and will no longer be maintained after 2026-05-18. The Azure Deployment Manager service has been permanently retired. Refer to our deprecation policy (https://aka.ms/azsdk/support-policies) for more details.
+- Please note, this package has been deprecated and will no longer be maintained after 2026-01-27. The Azure Deployment Manager service has been permanently retired. Refer to our deprecation policy (https://aka.ms/azsdk/support-policies) for more details.
 
 ## 1.0.0-beta.2 (2023-01-16)
 

--- a/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/CHANGELOG.md
+++ b/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.3 (2026-05-18)
 
 ### Other Changes
+
+- Please note, this package has been deprecated and will no longer be maintained after 2026-05-18. The Azure Deployment Manager service has been permanently retired. Refer to our deprecation policy (https://aka.ms/azsdk/support-policies) for more details.
 
 ## 1.0.0-beta.2 (2023-01-16)
 

--- a/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/CHANGELOG.md
+++ b/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.3 (2026-05-18)
+## 1.0.0-beta.3 (2026-06-04)
 
 ### Other Changes
 

--- a/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/README.md
+++ b/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/README.md
@@ -1,5 +1,7 @@
 # Azure Resource Manager Deployment client library for Java
 
+Please note, this package has been deprecated and will no longer be maintained after 2026-05-18. The Azure Deployment Manager service has been permanently retired. Refer to our deprecation policy (https://aka.ms/azsdk/support-policies) for more details.
+
 Azure Resource Manager Deployment client library for Java.
 
 This package contains Microsoft Azure SDK for Deployment Management SDK. REST APIs for orchestrating deployments using the Azure Deployment Manager (ADM). Package tag package-2019-11-01-preview. For documentation on how to use this package, please see [Azure Management Libraries for Java](https://aka.ms/azsdk/java/mgmt).

--- a/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/README.md
+++ b/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/README.md
@@ -1,6 +1,8 @@
 # Azure Resource Manager Deployment client library for Java
 
-Please note, this package has been deprecated and will no longer be maintained after 2026-01-27. The Azure Deployment Manager service has been permanently retired. Refer to our deprecation policy (https://aka.ms/azsdk/support-policies) for more details.
+> Please note, this package has been deprecated and will no longer be maintained after 2026-01-27.
+> The Azure Deployment Manager service has been permanently retired. Refer to our
+> [deprecation policy](https://aka.ms/azsdk/support-policies) for more details.
 
 Azure Resource Manager Deployment client library for Java.
 

--- a/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/README.md
+++ b/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/README.md
@@ -1,6 +1,6 @@
 # Azure Resource Manager Deployment client library for Java
 
-Please note, this package has been deprecated and will no longer be maintained after 2026-05-18. The Azure Deployment Manager service has been permanently retired. Refer to our deprecation policy (https://aka.ms/azsdk/support-policies) for more details.
+Please note, this package has been deprecated and will no longer be maintained after 2026-01-27. The Azure Deployment Manager service has been permanently retired. Refer to our deprecation policy (https://aka.ms/azsdk/support-policies) for more details.
 
 Azure Resource Manager Deployment client library for Java.
 

--- a/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/pom.xml
+++ b/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/pom.xml
@@ -13,7 +13,7 @@
   <packaging>jar</packaging>
 
   <name>Microsoft Azure SDK for Deployment Management</name>
-  <description>Please note, this package has been deprecated and will no longer be maintained after 2026-05-18. The Azure Deployment Manager service has been permanently retired. Refer to our deprecation policy (https://aka.ms/azsdk/support-policies) for more details. This package contains Microsoft Azure SDK for Deployment Management SDK. For documentation on how to use this package, please see https://aka.ms/azsdk/java/mgmt. REST APIs for orchestrating deployments using the Azure Deployment Manager (ADM). See https://docs.microsoft.com/en-us/azure-resource-manager/deployment-manager-overview for more information. Package tag package-2019-11-01-preview.</description>
+  <description>Please note, this package has been deprecated and will no longer be maintained after 2026-01-27. The Azure Deployment Manager service has been permanently retired. Refer to our deprecation policy (https://aka.ms/azsdk/support-policies) for more details. This package contains Microsoft Azure SDK for Deployment Management SDK. For documentation on how to use this package, please see https://aka.ms/azsdk/java/mgmt. REST APIs for orchestrating deployments using the Azure Deployment Manager (ADM). See https://docs.microsoft.com/en-us/azure-resource-manager/deployment-manager-overview for more information. Package tag package-2019-11-01-preview.</description>
   <url>https://github.com/Azure/azure-sdk-for-java</url>
 
   <licenses>

--- a/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/pom.xml
+++ b/sdk/deploymentmanager/azure-resourcemanager-deploymentmanager/pom.xml
@@ -13,7 +13,7 @@
   <packaging>jar</packaging>
 
   <name>Microsoft Azure SDK for Deployment Management</name>
-  <description>This package contains Microsoft Azure SDK for Deployment Management SDK. For documentation on how to use this package, please see https://aka.ms/azsdk/java/mgmt. REST APIs for orchestrating deployments using the Azure Deployment Manager (ADM). See https://docs.microsoft.com/en-us/azure-resource-manager/deployment-manager-overview for more information. Package tag package-2019-11-01-preview.</description>
+  <description>Please note, this package has been deprecated and will no longer be maintained after 2026-05-18. The Azure Deployment Manager service has been permanently retired. Refer to our deprecation policy (https://aka.ms/azsdk/support-policies) for more details. This package contains Microsoft Azure SDK for Deployment Management SDK. For documentation on how to use this package, please see https://aka.ms/azsdk/java/mgmt. REST APIs for orchestrating deployments using the Azure Deployment Manager (ADM). See https://docs.microsoft.com/en-us/azure-resource-manager/deployment-manager-overview for more information. Package tag package-2019-11-01-preview.</description>
   <url>https://github.com/Azure/azure-sdk-for-java</url>
 
   <licenses>


### PR DESCRIPTION
### Summary
Add deprecation notice for Azure Resource Manager Deployment Manager SDK to signal service retirement.

### Details
- Add/update deprecation message using existing beta version
- No API or behavior changes
- Version is unchanged

### Motivation
Deployment Manager is being retired. This change ensures users can see the deprecation notice both in code and on Maven.

### Related PR
- Follow the same pattern as #48358

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
