### PR TITLE
Address remaining APIView feedback for transcription SDK

### DIFF
--- a/sdk/transcription/azure-ai-speech-transcription/CHANGELOG.md
+++ b/sdk/transcription/azure-ai-speech-transcription/CHANGELOG.md
@@ -4,12 +4,9 @@
 
 First stable release of the Azure AI Speech Transcription client library for Java.
 
-### Features Added
-
-- Added `RequestOptions` parameter to the `transcribeWithResponse(TranscriptionOptions, RequestOptions)` convenience overload on both `TranscriptionClient` and `TranscriptionAsyncClient`, aligning with the Azure SDK for Java guideline that the maximal `*WithResponse` overload must accept `RequestOptions`. Callers can pass `null` to use defaults.
-
 ### Breaking Changes
 
+- Replaced the single-argument `transcribeWithResponse(TranscriptionOptions)` convenience overload on `TranscriptionClient` and `TranscriptionAsyncClient` with `transcribeWithResponse(TranscriptionOptions, RequestOptions)`, aligning with the Azure SDK for Java guideline that the maximal `*WithResponse` overload must accept `RequestOptions`. Callers can pass `null` to use defaults.
 - `TranscriptionDiarizationOptions` no longer has a no-arg constructor. Callers must now explicitly pass an `enabled` flag via the new `TranscriptionDiarizationOptions(boolean enabled)` constructor, allowing diarization to be set to either `true` or `false`. The `isEnabled()` getter is retained.
 - Removed `TranscriptionContent` from the public API. It was an internal multipart-request-body wrapper that was never accepted or returned by any public method; the public `transcribe` / `transcribeWithResponse` overloads now build the multipart body internally.
 - Renamed `TranscribedPhrase.getOffset()` and `TranscribedWord.getOffset()` to `getOffsetInMs()` and changed the return type from `int` to `java.time.Duration` to make the unit of measure explicit in the API name and align with the idiomatic Java type already used by `getDuration()`.

--- a/sdk/transcription/azure-ai-speech-transcription/customization/src/main/java/SpeechTranscriptionCustomization.java
+++ b/sdk/transcription/azure-ai-speech-transcription/customization/src/main/java/SpeechTranscriptionCustomization.java
@@ -58,9 +58,9 @@ public class SpeechTranscriptionCustomization extends Customization {
             // Rename getOffset() to getOffsetInMs() on TranscribedPhrase and TranscribedWord for clarity
             // (the underlying int value is in milliseconds).
             logger.info("Renaming TranscribedPhrase.getOffset() to getOffsetInMs()");
-            renameOffsetGetter(models, "TranscribedPhrase");
+            renameOffsetGetter(models, "TranscribedPhrase", "phrase");
             logger.info("Renaming TranscribedWord.getOffset() to getOffsetInMs()");
-            renameOffsetGetter(models, "TranscribedWord");
+            renameOffsetGetter(models, "TranscribedWord", "word");
 
             // Customize TranscriptionDiarizationOptions to properly serialize enabled field
             logger.info("Customizing TranscriptionDiarizationOptions.toJson()");
@@ -99,6 +99,38 @@ public class SpeechTranscriptionCustomization extends Customization {
         logger.info("Removing TranscriptionContent.java from the public models package");
         customization.getRawEditor()
             .removeFile("src/main/java/com/azure/ai/speech/transcription/models/TranscriptionContent.java");
+
+        // Keep the package metadata JSON consistent with the actual published surface area: strip the
+        // TranscriptionContent crossLanguageDefinitions entry and the generatedFiles entry that point to
+        // the now-removed model. Without this, downstream tooling that reads the metadata sees a class
+        // that does not exist in the JAR.
+        logger.info("Removing TranscriptionContent entries from package metadata JSON");
+        String metadataPath = "src/main/resources/META-INF/azure-ai-speech-transcription_metadata.json";
+        try {
+            String metadata = customization.getRawEditor().getFileContent(metadataPath);
+            if (metadata != null) {
+                String updated = metadata
+                    // crossLanguageDefinitions entry (with optional trailing comma on either side).
+                    .replaceAll(
+                        ",\\s*\"com\\.azure\\.ai\\.speech\\.transcription\\.models\\.TranscriptionContent\"\\s*:\\s*\"[^\"]*\"",
+                        "")
+                    .replaceAll(
+                        "\"com\\.azure\\.ai\\.speech\\.transcription\\.models\\.TranscriptionContent\"\\s*:\\s*\"[^\"]*\"\\s*,",
+                        "")
+                    // generatedFiles entry.
+                    .replaceAll(
+                        ",\\s*\"src/main/java/com/azure/ai/speech/transcription/models/TranscriptionContent\\.java\"",
+                        "")
+                    .replaceAll(
+                        "\"src/main/java/com/azure/ai/speech/transcription/models/TranscriptionContent\\.java\"\\s*,",
+                        "");
+                if (!updated.equals(metadata)) {
+                    customization.getRawEditor().replaceFile(metadataPath, updated);
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to update package metadata JSON: " + e.getMessage());
+        }
     }
 
     /**
@@ -150,8 +182,9 @@ public class SpeechTranscriptionCustomization extends Customization {
      *
      * @param packageCustomization the package customization
      * @param className the name of the class to customize
+     * @param subjectNoun the noun describing what the offset refers to (e.g. "phrase" or "word"), used in the JavaDoc.
      */
-    private void renameOffsetGetter(PackageCustomization packageCustomization, String className) {
+    private void renameOffsetGetter(PackageCustomization packageCustomization, String className, String subjectNoun) {
         packageCustomization.getClass(className).customizeAst(ast -> {
             ast.addImport("java.time.Duration");
             ast.getClassByName(className).ifPresent(clazz -> clazz.getMethodsByName("getOffset").forEach(method -> {
@@ -159,7 +192,7 @@ public class SpeechTranscriptionCustomization extends Customization {
                 method.setType("Duration");
                 method.setBody(parseBlock("{ return Duration.ofMillis(this.offset); }"));
                 method.setJavadocComment(
-                    new Javadoc(parseText("Get the offset property: The start offset of the phrase in milliseconds."))
+                    new Javadoc(parseText("Get the offset property: The start offset of the " + subjectNoun + " in milliseconds."))
                         .addBlockTag("return", "the offset value as Duration."));
             }));
         });
@@ -196,6 +229,18 @@ public class SpeechTranscriptionCustomization extends Customization {
                         + "if (this.enabled != null) { jsonWriter.writeBooleanField(\"enabled\", this.enabled); } "
                         + "if (this.maxSpeakers != null) { jsonWriter.writeNumberField(\"maxSpeakers\", this.maxSpeakers); } "
                         + "return jsonWriter.writeEndObject(); }")));
+
+                // Update the JavaDoc on the 'enabled' field and isEnabled() getter to reflect that the
+                // client no longer auto-enables diarization when maxSpeakers is set; callers must opt in
+                // explicitly via the new constructor.
+                clazz.getFieldByName("enabled").ifPresent(field -> field.setJavadocComment(
+                    new Javadoc(parseText("Whether speaker diarization is enabled for this transcription request. "
+                        + "Set via the constructor; callers must opt in explicitly even when maxSpeakers is specified."))));
+                clazz.getMethodsByName("isEnabled").forEach(method -> method.setJavadocComment(
+                    new Javadoc(parseText("Get the enabled property: whether speaker diarization is enabled for this "
+                        + "transcription request. The value is supplied via the constructor; the client does not "
+                        + "auto-enable diarization when maxSpeakers is specified."))
+                        .addBlockTag("return", "the enabled value.")));
 
                 // Rewrite fromJson() to construct via the new constructor (default to false; overwrite below).
                 clazz.getMethodsByName("fromJson")

--- a/sdk/transcription/azure-ai-speech-transcription/customization/src/main/java/SpeechTranscriptionCustomization.java
+++ b/sdk/transcription/azure-ai-speech-transcription/customization/src/main/java/SpeechTranscriptionCustomization.java
@@ -99,38 +99,6 @@ public class SpeechTranscriptionCustomization extends Customization {
         logger.info("Removing TranscriptionContent.java from the public models package");
         customization.getRawEditor()
             .removeFile("src/main/java/com/azure/ai/speech/transcription/models/TranscriptionContent.java");
-
-        // Keep the package metadata JSON consistent with the actual published surface area: strip the
-        // TranscriptionContent crossLanguageDefinitions entry and the generatedFiles entry that point to
-        // the now-removed model. Without this, downstream tooling that reads the metadata sees a class
-        // that does not exist in the JAR.
-        logger.info("Removing TranscriptionContent entries from package metadata JSON");
-        String metadataPath = "src/main/resources/META-INF/azure-ai-speech-transcription_metadata.json";
-        try {
-            String metadata = customization.getRawEditor().getFileContent(metadataPath);
-            if (metadata != null) {
-                String updated = metadata
-                    // crossLanguageDefinitions entry (with optional trailing comma on either side).
-                    .replaceAll(
-                        ",\\s*\"com\\.azure\\.ai\\.speech\\.transcription\\.models\\.TranscriptionContent\"\\s*:\\s*\"[^\"]*\"",
-                        "")
-                    .replaceAll(
-                        "\"com\\.azure\\.ai\\.speech\\.transcription\\.models\\.TranscriptionContent\"\\s*:\\s*\"[^\"]*\"\\s*,",
-                        "")
-                    // generatedFiles entry.
-                    .replaceAll(
-                        ",\\s*\"src/main/java/com/azure/ai/speech/transcription/models/TranscriptionContent\\.java\"",
-                        "")
-                    .replaceAll(
-                        "\"src/main/java/com/azure/ai/speech/transcription/models/TranscriptionContent\\.java\"\\s*,",
-                        "");
-                if (!updated.equals(metadata)) {
-                    customization.getRawEditor().replaceFile(metadataPath, updated);
-                }
-            }
-        } catch (Exception e) {
-            logger.warn("Failed to update package metadata JSON: " + e.getMessage());
-        }
     }
 
     /**

--- a/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/models/TranscribedWord.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/models/TranscribedWord.java
@@ -61,7 +61,7 @@ public final class TranscribedWord implements JsonSerializable<TranscribedWord> 
     }
 
     /**
-     * Get the offset property: The start offset of the phrase in milliseconds.
+     * Get the offset property: The start offset of the word in milliseconds.
      *
      * @return the offset value as Duration.
      */

--- a/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/models/TranscriptionDiarizationOptions.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/models/TranscriptionDiarizationOptions.java
@@ -17,8 +17,9 @@ import java.io.IOException;
 @Fluent
 public final class TranscriptionDiarizationOptions implements JsonSerializable<TranscriptionDiarizationOptions> {
 
-    /*
-     * Enable speaker diarization. This is automatically set to true when maxSpeakers is specified.
+    /**
+     * Whether speaker diarization is enabled for this transcription request. Set via the constructor; callers must opt
+     * in explicitly even when maxSpeakers is specified.
      */
     @Generated
     private Boolean enabled;
@@ -30,8 +31,8 @@ public final class TranscriptionDiarizationOptions implements JsonSerializable<T
     private Integer maxSpeakers;
 
     /**
-     * Get the enabled property: Enable speaker diarization. This is automatically set to true when maxSpeakers is
-     * specified.
+     * Get the enabled property: whether speaker diarization is enabled for this transcription request. The value is
+     * supplied via the constructor; the client does not auto-enable diarization when maxSpeakers is specified.
      *
      * @return the enabled value.
      */


### PR DESCRIPTION
- Fix TranscribedWord.getOffsetInMs() JavaDoc to refer to 'word' instead of 'phrase'

- Parameterize renameOffsetGetter customization with subject noun

- Update TranscriptionDiarizationOptions.enabled JavaDoc: callers must opt in explicitly via the constructor; the client does not auto-enable when maxSpeakers is set

- Move 'RequestOptions on transcribeWithResponse' entry under Breaking Changes in CHANGELOG (it replaces the prior single-arg overload)


# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
