### PR TITLE
Address APIView feedback: rename Duration getOffsetInMs()

### DIFF
--- a/sdk/transcription/azure-ai-speech-transcription/CHANGELOG.md
+++ b/sdk/transcription/azure-ai-speech-transcription/CHANGELOG.md
@@ -9,7 +9,7 @@ First stable release of the Azure AI Speech Transcription client library for Jav
 - Replaced the single-argument `transcribeWithResponse(TranscriptionOptions)` convenience overload on `TranscriptionClient` and `TranscriptionAsyncClient` with `transcribeWithResponse(TranscriptionOptions, RequestOptions)`, aligning with the Azure SDK for Java guideline that the maximal `*WithResponse` overload must accept `RequestOptions`. Callers can pass `null` to use defaults.
 - `TranscriptionDiarizationOptions` no longer has a no-arg constructor. Callers must now explicitly pass an `enabled` flag via the new `TranscriptionDiarizationOptions(boolean enabled)` constructor, allowing diarization to be set to either `true` or `false`. The `isEnabled()` getter is retained.
 - Removed `TranscriptionContent` from the public API. It was an internal multipart-request-body wrapper that was never accepted or returned by any public method; the public `transcribe` / `transcribeWithResponse` overloads now build the multipart body internally.
-- Renamed `TranscribedPhrase.getOffset()` and `TranscribedWord.getOffset()` to `getOffsetInMs()` and changed the return type from `int` to `java.time.Duration` to make the unit of measure explicit in the API name and align with the idiomatic Java type already used by `getDuration()`.
+- Changed the return type of `TranscribedPhrase.getOffset()` and `TranscribedWord.getOffset()` from `int` (milliseconds) to `java.time.Duration` to align with the idiomatic Java type already used by `getDuration()` and to let callers easily convert/compare across units.
 
 ## 1.0.0-beta.3 (2026-04-22)
 

--- a/sdk/transcription/azure-ai-speech-transcription/README.md
+++ b/sdk/transcription/azure-ai-speech-transcription/README.md
@@ -145,7 +145,7 @@ try {
     TranscriptionResult result = client.transcribe(options);
 
     // Process results
-    System.out.println("Duration: " + result.getDuration() + " ms");
+    System.out.println("Duration: " + result.getDuration().toMillis() + " ms");
     result.getCombinedPhrases().forEach(phrase -> {
         System.out.println("Channel " + phrase.getChannel() + ": " + phrase.getText());
     });

--- a/sdk/transcription/azure-ai-speech-transcription/customization/src/main/java/SpeechTranscriptionCustomization.java
+++ b/sdk/transcription/azure-ai-speech-transcription/customization/src/main/java/SpeechTranscriptionCustomization.java
@@ -55,12 +55,14 @@ public class SpeechTranscriptionCustomization extends Customization {
             logger.info("Customizing TranscribedWord.getDuration()");
             customizeDurationGetter(models, "TranscribedWord");
 
-            // Rename getOffset() to getOffsetInMs() on TranscribedPhrase and TranscribedWord for clarity
-            // (the underlying int value is in milliseconds).
-            logger.info("Renaming TranscribedPhrase.getOffset() to getOffsetInMs()");
-            renameOffsetGetter(models, "TranscribedPhrase", "phrase");
-            logger.info("Renaming TranscribedWord.getOffset() to getOffsetInMs()");
-            renameOffsetGetter(models, "TranscribedWord", "word");
+            // Change the return type of getOffset() from int (milliseconds) to Duration on
+            // TranscribedPhrase and TranscribedWord. The Duration type makes the unit explicit and
+            // allows callers to easily convert/compare across units, so the method name does not
+            // need a "InMs" suffix.
+            logger.info("Customizing TranscribedPhrase.getOffset() to return Duration");
+            customizeOffsetGetter(models, "TranscribedPhrase", "phrase");
+            logger.info("Customizing TranscribedWord.getOffset() to return Duration");
+            customizeOffsetGetter(models, "TranscribedWord", "word");
 
             // Customize TranscriptionDiarizationOptions to properly serialize enabled field
             logger.info("Customizing TranscriptionDiarizationOptions.toJson()");
@@ -144,23 +146,23 @@ public class SpeechTranscriptionCustomization extends Customization {
     }
 
     /**
-     * Rename the generated {@code getOffset()} getter to {@code getOffsetInMs()} and change its return type
-     * from {@code int} (milliseconds) to {@link java.time.Duration} so it matches the idiomatic Java type used
-     * by {@code getDuration()}. The backing field and JSON wire name remain unchanged.
+     * Change the return type of the generated {@code getOffset()} getter from {@code int} (milliseconds)
+     * to {@link java.time.Duration} so it matches the idiomatic Java type used by {@code getDuration()}.
+     * The method name is preserved (the {@code Duration} type itself conveys the unit). The backing field
+     * and JSON wire name remain unchanged.
      *
      * @param packageCustomization the package customization
      * @param className the name of the class to customize
      * @param subjectNoun the noun describing what the offset refers to (e.g. "phrase" or "word"), used in the JavaDoc.
      */
-    private void renameOffsetGetter(PackageCustomization packageCustomization, String className, String subjectNoun) {
+    private void customizeOffsetGetter(PackageCustomization packageCustomization, String className, String subjectNoun) {
         packageCustomization.getClass(className).customizeAst(ast -> {
             ast.addImport("java.time.Duration");
             ast.getClassByName(className).ifPresent(clazz -> clazz.getMethodsByName("getOffset").forEach(method -> {
-                method.setName("getOffsetInMs");
                 method.setType("Duration");
                 method.setBody(parseBlock("{ return Duration.ofMillis(this.offset); }"));
                 method.setJavadocComment(
-                    new Javadoc(parseText("Get the offset property: The start offset of the " + subjectNoun + " in milliseconds."))
+                    new Javadoc(parseText("Get the offset property: The start offset of the " + subjectNoun + "."))
                         .addBlockTag("return", "the offset value as Duration."));
             }));
         });

--- a/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/models/TranscribedPhrase.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/models/TranscribedPhrase.java
@@ -106,16 +106,6 @@ public final class TranscribedPhrase implements JsonSerializable<TranscribedPhra
     }
 
     /**
-     * Get the offset property: The start offset of the phrase in milliseconds.
-     *
-     * @return the offset value as Duration.
-     */
-    @Generated
-    public Duration getOffsetInMs() {
-        return Duration.ofMillis(this.offset);
-    }
-
-    /**
      * Get the duration property: The duration in milliseconds.
      *
      * @return the duration value as Duration.
@@ -233,5 +223,15 @@ public final class TranscribedPhrase implements JsonSerializable<TranscribedPhra
             deserializedTranscribedPhrase.locale = locale;
             return deserializedTranscribedPhrase;
         });
+    }
+
+    /**
+     * Get the offset property: The start offset of the phrase.
+     *
+     * @return the offset value as Duration.
+     */
+    @Generated
+    public Duration getOffset() {
+        return Duration.ofMillis(this.offset);
     }
 }

--- a/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/models/TranscribedWord.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/models/TranscribedWord.java
@@ -61,16 +61,6 @@ public final class TranscribedWord implements JsonSerializable<TranscribedWord> 
     }
 
     /**
-     * Get the offset property: The start offset of the word in milliseconds.
-     *
-     * @return the offset value as Duration.
-     */
-    @Generated
-    public Duration getOffsetInMs() {
-        return Duration.ofMillis(this.offset);
-    }
-
-    /**
      * Get the duration property: The duration in milliseconds.
      *
      * @return the duration value as Duration.
@@ -123,5 +113,15 @@ public final class TranscribedWord implements JsonSerializable<TranscribedWord> 
             }
             return new TranscribedWord(text, offset, duration);
         });
+    }
+
+    /**
+     * Get the offset property: The start offset of the word.
+     *
+     * @return the offset value as Duration.
+     */
+    @Generated
+    public Duration getOffset() {
+        return Duration.ofMillis(this.offset);
     }
 }

--- a/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/ReadmeSamples.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/ReadmeSamples.java
@@ -46,7 +46,7 @@ public final class ReadmeSamples {
             TranscriptionResult result = client.transcribe(options);
 
             // Process results
-            System.out.println("Duration: " + result.getDuration() + " ms");
+            System.out.println("Duration: " + result.getDuration().toMillis() + " ms");
             result.getCombinedPhrases().forEach(phrase -> {
                 System.out.println("Channel " + phrase.getChannel() + ": " + phrase.getText());
             });
@@ -158,7 +158,7 @@ public final class ReadmeSamples {
         result.getPhrases().forEach(phrase -> {
             System.out.println("Speaker " + phrase.getSpeaker() + ": " + phrase.getText());
             System.out.println("Confidence: " + phrase.getConfidence());
-            System.out.println("Offset: " + phrase.getOffsetInMs().toMillis() + " ms");
+            System.out.println("Offset: " + phrase.getOffset().toMillis() + " ms");
         });
         // END: com.azure.ai.speech.transcription.transcriptionoptions.advanced
     }
@@ -211,14 +211,14 @@ public final class ReadmeSamples {
             System.out.println("  Speaker: " + phrase.getSpeaker());
             System.out.println("  Locale: " + phrase.getLocale());
             System.out.println("  Confidence: " + phrase.getConfidence());
-            System.out.println("  Timing: " + phrase.getOffsetInMs().toMillis() + " ms - "
-                + (phrase.getOffsetInMs().toMillis() + phrase.getDuration().toMillis()) + " ms");
+            System.out.println("  Timing: " + phrase.getOffset().toMillis() + " ms - "
+                + (phrase.getOffset().toMillis() + phrase.getDuration().toMillis()) + " ms");
 
             // Process individual words with timestamps
             if (phrase.getWords() != null) {
                 phrase.getWords().forEach(word -> {
                     System.out.println("    Word: " + word.getText() + " @ "
-                        + word.getOffsetInMs().toMillis() + " ms");
+                        + word.getOffset().toMillis() + " ms");
                 });
             }
         });

--- a/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/TranscribeMultiLanguageSample.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/TranscribeMultiLanguageSample.java
@@ -79,7 +79,7 @@ public class TranscribeMultiLanguageSample {
 
                 for (int i = 0; i < result.getPhrases().size(); i++) {
                     TranscribedPhrase phrase = result.getPhrases().get(i);
-                    long offsetMs = phrase.getOffsetInMs().toMillis();
+                    long offsetMs = phrase.getOffset().toMillis();
                     long durationMs = phrase.getDuration().toMillis();
 
                     System.out.println("\n[Phrase " + (i + 1) + "] " + offsetMs + "ms - " + (offsetMs + durationMs) + "ms");

--- a/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/TranscribeWithDiarizationSample.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/TranscribeWithDiarizationSample.java
@@ -68,8 +68,8 @@ public class TranscribeWithDiarizationSample {
             if (result.getPhrases() != null && !result.getPhrases().isEmpty()) {
                 for (TranscribedPhrase phrase : result.getPhrases()) {
                     int speakerId = phrase.getSpeaker() != null ? phrase.getSpeaker() : 0;
-                    double startTime = phrase.getOffsetInMs().toMillis() / 1000.0;
-                    double endTime = (phrase.getOffsetInMs().toMillis() + phrase.getDuration().toMillis()) / 1000.0;
+                    double startTime = phrase.getOffset().toMillis() / 1000.0;
+                    double endTime = (phrase.getOffset().toMillis() + phrase.getDuration().toMillis()) / 1000.0;
 
                     System.out.println(String.format("\n[Speaker %d] (%.2fs - %.2fs)",
                         speakerId, startTime, endTime));

--- a/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/TranscribeWithPhraseListSample.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/TranscribeWithPhraseListSample.java
@@ -80,7 +80,7 @@ public class TranscribeWithPhraseListSample {
                 System.out.println("\nDetailed phrases:");
                 result.getPhrases().forEach(phrase ->
                     System.out.println(String.format("  [%dms]: %s",
-                        phrase.getOffsetInMs().toMillis(),
+                        phrase.getOffset().toMillis(),
                         phrase.getText()))
                 );
             }

--- a/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/javadoccodesnippets/TranscriptionAsyncClientJavaDocCodeSnippets.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/javadoccodesnippets/TranscriptionAsyncClientJavaDocCodeSnippets.java
@@ -195,15 +195,15 @@ public class TranscriptionAsyncClientJavaDocCodeSnippets {
                 if (result.getPhrases() != null) {
                     result.getPhrases().forEach(phrase -> {
                         System.out.printf("Phrase (%.2f-%.2fs): %s%n",
-                            phrase.getOffsetInMs().toMillis() / 1000.0,
-                            (phrase.getOffsetInMs().toMillis() + phrase.getDuration().toMillis()) / 1000.0,
+                            phrase.getOffset().toMillis() / 1000.0,
+                            (phrase.getOffset().toMillis() + phrase.getDuration().toMillis()) / 1000.0,
                             phrase.getText());
 
                         if (phrase.getWords() != null) {
                             phrase.getWords().forEach(word ->
                                 System.out.printf("  \"%s\" at %.2fs%n",
                                     word.getText(),
-                                    word.getOffsetInMs().toMillis() / 1000.0)
+                                    word.getOffset().toMillis() / 1000.0)
                             );
                         }
                     });

--- a/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/javadoccodesnippets/TranscriptionClientJavaDocCodeSnippets.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/samples/java/com/azure/ai/speech/transcription/javadoccodesnippets/TranscriptionClientJavaDocCodeSnippets.java
@@ -144,8 +144,8 @@ public class TranscriptionClientJavaDocCodeSnippets {
         if (result.getPhrases() != null) {
             result.getPhrases().forEach(phrase -> {
                 System.out.printf("Phrase (%.2f-%.2fs): %s%n",
-                    phrase.getOffsetInMs().toMillis() / 1000.0,
-                    (phrase.getOffsetInMs().toMillis() + phrase.getDuration().toMillis()) / 1000.0,
+                    phrase.getOffset().toMillis() / 1000.0,
+                    (phrase.getOffset().toMillis() + phrase.getDuration().toMillis()) / 1000.0,
                     phrase.getText());
 
                 // Get word-level timing information
@@ -153,7 +153,7 @@ public class TranscriptionClientJavaDocCodeSnippets {
                     phrase.getWords().forEach(word -> {
                         System.out.printf("  Word: \"%s\" at %.2fs%n",
                             word.getText(),
-                            word.getOffsetInMs().toMillis() / 1000.0);
+                            word.getOffset().toMillis() / 1000.0);
                     });
                 }
             });

--- a/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/TranscriptionClientTestBase.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/TranscriptionClientTestBase.java
@@ -134,7 +134,7 @@ class TranscriptionClientTestBase extends TestProxyTestBase {
     protected void validateTranscriptionResult(String testName, TranscriptionResult result) {
         if (PRINT_RESULTS) {
             System.out.println("\n===== Test: " + testName + " =====");
-            System.out.println("Duration: " + result.getDuration() + "ms");
+            System.out.println("Duration: " + result.getDuration().toMillis() + "ms");
             if (result.getCombinedPhrases() != null) {
                 result.getCombinedPhrases()
                     .forEach(phrase -> System.out.println("Channel " + phrase.getChannel() + ": " + phrase.getText()));
@@ -167,7 +167,7 @@ class TranscriptionClientTestBase extends TestProxyTestBase {
             assertFalse(phrase.getText().isEmpty(), "Phrase text should not be empty");
             assertTrue(phrase.getConfidence() >= 0 && phrase.getConfidence() <= 1,
                 "Confidence should be between 0 and 1");
-            assertTrue(phrase.getOffsetInMs().toMillis() >= 0, "Offset should be non-negative");
+            assertTrue(phrase.getOffset().toMillis() >= 0, "Offset should be non-negative");
             assertTrue(phrase.getDuration().toMillis() > 0, "Phrase duration should be positive");
         });
     }

--- a/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFileTests.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFileTests.java
@@ -24,7 +24,7 @@ public final class TranscribeAudioFileTests extends TranscriptionClientTestBase 
         // response assertion
         Assertions.assertNotNull(response);
         // verify property "duration"
-        Assertions.assertEquals(2000, response.getDuration());
+        Assertions.assertEquals(2000, response.getDuration().toMillis());
         // verify property "combinedPhrases"
         List<ChannelCombinedPhrases> responseCombinedPhrases = response.getCombinedPhrases();
         ChannelCombinedPhrases responseCombinedPhrasesFirstItem = responseCombinedPhrases.iterator().next();
@@ -34,15 +34,15 @@ public final class TranscribeAudioFileTests extends TranscriptionClientTestBase 
         List<TranscribedPhrase> responsePhrases = response.getPhrases();
         TranscribedPhrase responsePhrasesFirstItem = responsePhrases.iterator().next();
         Assertions.assertNotNull(responsePhrasesFirstItem);
-        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffsetInMs().toMillis());
-        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration());
+        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffset().toMillis());
+        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration().toMillis());
         Assertions.assertEquals("Weather", responsePhrasesFirstItem.getText());
         List<TranscribedWord> responsePhrasesFirstItemWords = responsePhrasesFirstItem.getWords();
         TranscribedWord responsePhrasesFirstItemWordsFirstItem = responsePhrasesFirstItemWords.iterator().next();
         Assertions.assertNotNull(responsePhrasesFirstItemWordsFirstItem);
         Assertions.assertEquals("weather", responsePhrasesFirstItemWordsFirstItem.getText());
-        Assertions.assertEquals(40, responsePhrasesFirstItemWordsFirstItem.getOffsetInMs().toMillis());
-        Assertions.assertEquals(320, responsePhrasesFirstItemWordsFirstItem.getDuration());
+        Assertions.assertEquals(40, responsePhrasesFirstItemWordsFirstItem.getOffset().toMillis());
+        Assertions.assertEquals(320, responsePhrasesFirstItemWordsFirstItem.getDuration().toMillis());
         Assertions.assertEquals("en-US", responsePhrasesFirstItem.getLocale());
         Assertions.assertEquals(0.78983736, responsePhrasesFirstItem.getConfidence());
     }

--- a/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFromURLTests.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeAudioFromURLTests.java
@@ -24,7 +24,7 @@ public final class TranscribeAudioFromURLTests extends TranscriptionClientTestBa
         // response assertion
         Assertions.assertNotNull(response);
         // verify property "duration"
-        Assertions.assertEquals(2000, response.getDuration());
+        Assertions.assertEquals(2000, response.getDuration().toMillis());
         // verify property "combinedPhrases"
         List<ChannelCombinedPhrases> responseCombinedPhrases = response.getCombinedPhrases();
         ChannelCombinedPhrases responseCombinedPhrasesFirstItem = responseCombinedPhrases.iterator().next();
@@ -34,15 +34,15 @@ public final class TranscribeAudioFromURLTests extends TranscriptionClientTestBa
         List<TranscribedPhrase> responsePhrases = response.getPhrases();
         TranscribedPhrase responsePhrasesFirstItem = responsePhrases.iterator().next();
         Assertions.assertNotNull(responsePhrasesFirstItem);
-        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffsetInMs().toMillis());
-        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration());
+        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffset().toMillis());
+        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration().toMillis());
         Assertions.assertEquals("Weather", responsePhrasesFirstItem.getText());
         List<TranscribedWord> responsePhrasesFirstItemWords = responsePhrasesFirstItem.getWords();
         TranscribedWord responsePhrasesFirstItemWordsFirstItem = responsePhrasesFirstItemWords.iterator().next();
         Assertions.assertNotNull(responsePhrasesFirstItemWordsFirstItem);
         Assertions.assertEquals("weather", responsePhrasesFirstItemWordsFirstItem.getText());
-        Assertions.assertEquals(40, responsePhrasesFirstItemWordsFirstItem.getOffsetInMs().toMillis());
-        Assertions.assertEquals(320, responsePhrasesFirstItemWordsFirstItem.getDuration());
+        Assertions.assertEquals(40, responsePhrasesFirstItemWordsFirstItem.getOffset().toMillis());
+        Assertions.assertEquals(320, responsePhrasesFirstItemWordsFirstItem.getDuration().toMillis());
         Assertions.assertEquals("en-US", responsePhrasesFirstItem.getLocale());
         Assertions.assertEquals(0.78983736, responsePhrasesFirstItem.getConfidence());
     }

--- a/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeWithEnhancedModeTests.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/test/java/com/azure/ai/speech/transcription/generated/TranscribeWithEnhancedModeTests.java
@@ -24,7 +24,7 @@ public final class TranscribeWithEnhancedModeTests extends TranscriptionClientTe
         // response assertion
         Assertions.assertNotNull(response);
         // verify property "duration"
-        Assertions.assertEquals(2000, response.getDuration());
+        Assertions.assertEquals(2000, response.getDuration().toMillis());
         // verify property "combinedPhrases"
         List<ChannelCombinedPhrases> responseCombinedPhrases = response.getCombinedPhrases();
         ChannelCombinedPhrases responseCombinedPhrasesFirstItem = responseCombinedPhrases.iterator().next();
@@ -34,15 +34,15 @@ public final class TranscribeWithEnhancedModeTests extends TranscriptionClientTe
         List<TranscribedPhrase> responsePhrases = response.getPhrases();
         TranscribedPhrase responsePhrasesFirstItem = responsePhrases.iterator().next();
         Assertions.assertNotNull(responsePhrasesFirstItem);
-        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffsetInMs().toMillis());
-        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration());
+        Assertions.assertEquals(40, responsePhrasesFirstItem.getOffset().toMillis());
+        Assertions.assertEquals(320, responsePhrasesFirstItem.getDuration().toMillis());
         Assertions.assertEquals("天气", responsePhrasesFirstItem.getText());
         List<TranscribedWord> responsePhrasesFirstItemWords = responsePhrasesFirstItem.getWords();
         TranscribedWord responsePhrasesFirstItemWordsFirstItem = responsePhrasesFirstItemWords.iterator().next();
         Assertions.assertNotNull(responsePhrasesFirstItemWordsFirstItem);
         Assertions.assertEquals("天", responsePhrasesFirstItemWordsFirstItem.getText());
-        Assertions.assertEquals(0, responsePhrasesFirstItemWordsFirstItem.getOffsetInMs().toMillis());
-        Assertions.assertEquals(0, responsePhrasesFirstItemWordsFirstItem.getDuration());
+        Assertions.assertEquals(0, responsePhrasesFirstItemWordsFirstItem.getOffset().toMillis());
+        Assertions.assertEquals(0, responsePhrasesFirstItemWordsFirstItem.getDuration().toMillis());
         Assertions.assertEquals("zh-CN", responsePhrasesFirstItem.getLocale());
         Assertions.assertEquals(0.78983736, responsePhrasesFirstItem.getConfidence());
     }


### PR DESCRIPTION
Reverts the rename of TranscribedPhrase.getOffsetInMs() and TranscribedWord.getOffsetInMs() back to getOffset(). The Duration return type already conveys the unit, so the `InMs` suffix is unnecessary and the original method name lets callers easily convert/compare across units.

Also: fix Duration.toString() formatting in README/sample/test println statements (use toMillis()); fix TranscribedWord.getOffset() JavaDoc that incorrectly said 'phrase'; restore .toMillis() patches in regenerated tests.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
