### PR TITLE
Using all the snippet for readme are being used

### DIFF
--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -545,7 +545,7 @@ System.out.println("Type: " + index.getType());
 
 ```java com.azure.ai.projects.IndexesDeleteSample.deleteIndex
 
-String indexName = "test-index"; //Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
+String indexName = Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
 String indexVersion = Configuration.getGlobalConfiguration().get("INDEX_VERSION", "1.0");
 
 // Delete the index version

--- a/sdk/ai/azure-ai-projects/README.md
+++ b/sdk/ai/azure-ai-projects/README.md
@@ -102,9 +102,13 @@ The `FoundryFeaturesOptInKeys` enum defines all known opt-in keys: `EVALUATIONS_
 
 ## Examples
 
+The examples below show common operations for each AI Projects sub-client. For complete runnable samples, see the [package samples][package_samples].
+
 ### Connections operations
 
-The code below shows some Connection operations, which allow you to enumerate the Azure Resources connected to your AI Foundry Projects. These connections can be seen in the "Management Center", in the "Connected resources" tab in your AI Foundry Project. For more samples see the [package samples][package_samples].
+Connection operations allow you to enumerate the Azure resources connected to your AI Foundry Project. These connections can be seen in the "Management Center", in the "Connected resources" tab in your AI Foundry Project.
+
+#### List connections
 
 ```java com.azure.ai.projects.ConnectionsSample.listConnections
 PagedIterable<Connection> connections = connectionsClient.listConnections();
@@ -116,18 +120,368 @@ for (Connection connection : connections) {
 }
 ```
 
-### Indexes
+#### Get a connection without credentials
 
-The code below shows some Indexes operations to list and create indexes. For more samples see the [package samples][package_samples].
+```java com.azure.ai.projects.ConnectionsSample.getConnectionWithoutCredentials
 
-```java com.azure.ai.projects.IndexesListSample.listIndexes
-indexesClient.listLatestIndexVersions().forEach(index -> {
-    System.out.println("Index name: " + index.getName());
-    System.out.println("Index version: " + index.getVersion());
-    System.out.println("Index description: " + index.getDescription());
-    System.out.println("-------------------------------------------------");
-});
+String connectionName = Configuration.getGlobalConfiguration().get("TEST_CONNECTION_NAME", "");
+Connection connection = connectionsClient.getConnection(connectionName);
+
+System.out.printf("Connection name: %s%n", connection.getName());
+
 ```
+
+#### Get a connection with credentials
+
+```java com.azure.ai.projects.ConnectionsSample.getConnectionWithCredentials
+
+String connectionName = Configuration.getGlobalConfiguration().get("TEST_CONNECTION_NAME", "");
+Connection connection = connectionsClient.getConnectionWithCredentials(connectionName);
+
+System.out.printf("Connection name: %s%n", connection.getName());
+System.out.printf("Connection credentials: %s%n", connection.getCredential().getType());
+
+```
+
+#### Asynchronous connection operations
+
+```java com.azure.ai.projects.ConnectionsAsyncSample.listConnections
+
+return connectionsAsyncClient.listConnections()
+    .doOnNext(connection -> System.out.printf("Connection name: %s%n", connection.getName()));
+
+```
+
+```java com.azure.ai.projects.ConnectionsAsyncSample.getConnectionWithoutCredentials
+
+String connectionName = Configuration.getGlobalConfiguration().get("TEST_CONNECTION_NAME", "");
+return connectionsAsyncClient.getConnection(connectionName)
+    .doOnNext(connection -> System.out.printf("Connection name: %s%n", connection.getName()));
+
+```
+
+```java com.azure.ai.projects.ConnectionsAsyncSample.getConnectionWithCredentials
+
+String connectionName = Configuration.getGlobalConfiguration().get("TEST_CONNECTION_NAME", "");
+return connectionsAsyncClient.getConnectionWithCredentials(connectionName)
+    .doOnNext(connection -> {
+        System.out.printf("Connection name: %s%n", connection.getName());
+        System.out.printf("Connection credentials: %s%n", connection.getCredential().getType());
+    });
+
+```
+
+### Deployments operations
+
+Deployment operations allow you to enumerate and inspect the models deployed to your AI Foundry Project.
+
+#### List deployments
+
+```java com.azure.ai.projects.DeploymentsSample.listDeployments
+
+PagedIterable<Deployment> deployments = deploymentsClient.listDeployments();
+for (Deployment deployment : deployments) {
+    System.out.printf("Deployment name: %s%n", deployment.getName());
+}
+
+```
+
+#### Get a deployment
+
+```java com.azure.ai.projects.DeploymentsSample.getDeployment
+
+String deploymentName = Configuration.getGlobalConfiguration().get("FOUNDRY_MODEL_NAME", "");
+Deployment deployment = deploymentsClient.getDeployment(deploymentName);
+
+System.out.printf("Deployment name: %s%n", deployment.getName());
+System.out.printf("Deployment type: %s%n", deployment.getType().getValue());
+
+```
+
+#### Asynchronous deployment operations
+
+```java com.azure.ai.projects.DeploymentsAsyncSample.listDeployments
+
+return deploymentsAsyncClient.listDeployments()
+    .doOnNext(deployment -> System.out.printf("Deployment name: %s%n", deployment.getName()));
+
+```
+
+```java com.azure.ai.projects.DeploymentsAsyncSample.getDeployment
+
+String deploymentName = Configuration.getGlobalConfiguration().get("FOUNDRY_MODEL_NAME", "");
+return deploymentsAsyncClient.getDeployment(deploymentName)
+    .doOnNext(deployment -> {
+        System.out.printf("Deployment name: %s%n", deployment.getName());
+        System.out.printf("Deployment type: %s%n", deployment.getType().getValue());
+    });
+
+```
+
+### Datasets operations
+
+Dataset operations allow you to create, enumerate, retrieve, update, and delete dataset versions in your AI Foundry Project.
+
+#### Create a dataset version from a local file
+
+```java com.azure.ai.projects.DatasetsSample.createDatasetWithFile
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "my-dataset");
+String datasetVersionString = Configuration.getGlobalConfiguration().get("DATASET_VERSION", "1.0");
+
+Path filePath = getPath("product_info.md");
+
+FileDatasetVersion createdDatasetVersion = datasetsClient.createDatasetWithFile(datasetName, datasetVersionString, filePath);
+
+System.out.println("Created dataset version: " + createdDatasetVersion.getId());
+
+```
+
+#### List datasets
+
+```java com.azure.ai.projects.DatasetsSample.listDatasets
+
+System.out.println("Listing all datasets (latest versions):");
+datasetsClient.listLatestDatasetVersions().forEach(dataset -> {
+    System.out.println("\nDataset name: " + dataset.getName());
+    System.out.println("Dataset Id: " + dataset.getId());
+    System.out.println("Dataset version: " + dataset.getVersion());
+    System.out.println("Dataset type: " + dataset.getType());
+    if (dataset.getDescription() != null) {
+        System.out.println("Description: " + dataset.getDescription());
+    }
+});
+
+```
+
+#### List dataset versions
+
+```java com.azure.ai.projects.DatasetsSample.listDatasetVersions
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "test");
+
+System.out.println("Listing all versions of dataset: " + datasetName);
+datasetsClient.listDatasetVersions(datasetName).forEach(version -> {
+    System.out.println("\nDataset name: " + version.getName());
+    System.out.println("Dataset version: " + version.getVersion());
+    System.out.println("Dataset type: " + version.getType());
+    if (version.getDataUrl() != null) {
+        System.out.println("Data URI: " + version.getDataUrl());
+    }
+});
+
+```
+
+#### Get a dataset version
+
+```java com.azure.ai.projects.DatasetsSample.getDataset
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "test");
+String datasetVersion = Configuration.getGlobalConfiguration().get("DATASET_VERSION", "1");
+
+DatasetVersion dataset = datasetsClient.getDatasetVersion(datasetName, datasetVersion);
+
+System.out.println("Retrieved dataset:");
+System.out.println("Name: " + dataset.getName());
+System.out.println("Version: " + dataset.getVersion());
+System.out.println("Type: " + dataset.getType());
+if (dataset.getDataUrl() != null) {
+    System.out.println("Data URI: " + dataset.getDataUrl());
+}
+if (dataset.getDescription() != null) {
+    System.out.println("Description: " + dataset.getDescription());
+}
+
+```
+
+#### Create or update a dataset version
+
+```java com.azure.ai.projects.DatasetsSample.createOrUpdateDataset
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "my-dataset");
+String datasetVersion = Configuration.getGlobalConfiguration().get("DATASET_VERSION", "1.0");
+String dataUri = Configuration.getGlobalConfiguration().get("DATA_URI", "https://example.com/data.txt");
+
+// Create a new FileDatasetVersion with provided dataUri
+FileDatasetVersion fileDataset = new FileDatasetVersion()
+    .setDataUrl(dataUri)
+    .setDescription("Sample dataset created via SDK");
+
+// Create or update the dataset
+FileDatasetVersion createdDataset = (FileDatasetVersion) datasetsClient.createOrUpdateDatasetVersion(
+    datasetName,
+    datasetVersion,
+    fileDataset
+);
+
+System.out.println("Created/Updated dataset:");
+System.out.println("Name: " + createdDataset.getName());
+System.out.println("Version: " + createdDataset.getVersion());
+System.out.println("Data URI: " + createdDataset.getDataUrl());
+
+```
+
+#### Start a pending upload for a dataset version
+
+```java com.azure.ai.projects.DatasetsSample.pendingUploadSample
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "my-dataset");
+String datasetVersion = Configuration.getGlobalConfiguration().get("DATASET_VERSION", "1.0");
+
+// Create a pending upload request for the dataset
+PendingUploadRequest request = new PendingUploadRequest();
+
+// Get the pending upload response with blob reference
+PendingUploadResponse response = datasetsClient.pendingUpload(datasetName, datasetVersion, request);
+
+System.out.println("Pending upload initiated with ID: " + response.getPendingUploadId());
+System.out.println("Blob URI: " + response.getBlobReference().getBlobUrl());
+
+```
+
+#### Delete a dataset version
+
+```java com.azure.ai.projects.DatasetsSample.deleteDataset
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "my-dataset");
+String datasetVersion = Configuration.getGlobalConfiguration().get("DATASET_VERSION", "1.0");
+
+// Delete the specific version of the dataset
+datasetsClient.deleteDatasetVersion(datasetName, datasetVersion);
+
+System.out.println("Deleted dataset: " + datasetName + ", version: " + datasetVersion);
+
+```
+
+#### Asynchronous dataset operations
+
+```java com.azure.ai.projects.DatasetsAsyncSample.createDatasetWithFile
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "my-dataset");
+String datasetVersionString = Configuration.getGlobalConfiguration().get("DATASET_VERSION", "1.0");
+
+Path filePath = getPath("product_info.md");
+
+return datasetsAsyncClient.createDatasetWithFile(datasetName, datasetVersionString, filePath)
+    .doOnNext(createdDatasetVersion ->
+        System.out.println("Created dataset version: " + createdDatasetVersion.getId()));
+
+```
+
+```java com.azure.ai.projects.DatasetsAsyncSample.listDatasets
+
+System.out.println("Listing all datasets (latest versions):");
+return datasetsAsyncClient.listLatestDatasetVersions()
+    .doOnNext(dataset -> {
+        System.out.println("\nDataset name: " + dataset.getName());
+        System.out.println("Dataset Id: " + dataset.getId());
+        System.out.println("Dataset version: " + dataset.getVersion());
+        System.out.println("Dataset type: " + dataset.getType());
+        if (dataset.getDescription() != null) {
+            System.out.println("Description: " + dataset.getDescription());
+        }
+    });
+
+```
+
+```java com.azure.ai.projects.DatasetsAsyncSample.listDatasetVersions
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "test");
+
+System.out.println("Listing all versions of dataset: " + datasetName);
+return datasetsAsyncClient.listDatasetVersions(datasetName)
+    .doOnNext(version -> {
+        System.out.println("\nDataset name: " + version.getName());
+        System.out.println("Dataset version: " + version.getVersion());
+        System.out.println("Dataset type: " + version.getType());
+        if (version.getDataUrl() != null) {
+            System.out.println("Data URI: " + version.getDataUrl());
+        }
+    });
+
+```
+
+```java com.azure.ai.projects.DatasetsAsyncSample.getDataset
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "test");
+String datasetVersion = Configuration.getGlobalConfiguration().get("DATASET_VERSION", "1");
+
+return datasetsAsyncClient.getDatasetVersion(datasetName, datasetVersion)
+    .doOnNext(dataset -> {
+        System.out.println("Retrieved dataset:");
+        System.out.println("Name: " + dataset.getName());
+        System.out.println("Version: " + dataset.getVersion());
+        System.out.println("Type: " + dataset.getType());
+        if (dataset.getDataUrl() != null) {
+            System.out.println("Data URI: " + dataset.getDataUrl());
+        }
+        if (dataset.getDescription() != null) {
+            System.out.println("Description: " + dataset.getDescription());
+        }
+    });
+
+```
+
+```java com.azure.ai.projects.DatasetsAsyncSample.createOrUpdateDataset
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "my-dataset");
+String datasetVersion = Configuration.getGlobalConfiguration().get("DATASET_VERSION", "1.0");
+String dataUri = Configuration.getGlobalConfiguration().get("DATA_URI", "https://example.com/data.txt");
+
+// Create a new FileDatasetVersion with provided dataUri
+FileDatasetVersion fileDataset = new FileDatasetVersion()
+    .setDataUrl(dataUri)
+    .setDescription("Sample dataset created via SDK");
+
+// Create or update the dataset
+return datasetsAsyncClient.createOrUpdateDatasetVersion(
+    datasetName,
+    datasetVersion,
+    fileDataset
+).doOnNext(createdDataset -> {
+    FileDatasetVersion fileDatasetVersion = (FileDatasetVersion) createdDataset;
+    System.out.println("Created/Updated dataset:");
+    System.out.println("Name: " + fileDatasetVersion.getName());
+    System.out.println("Version: " + fileDatasetVersion.getVersion());
+    System.out.println("Data URI: " + fileDatasetVersion.getDataUrl());
+});
+
+```
+
+```java com.azure.ai.projects.DatasetsAsyncSample.pendingUploadSample
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "my-dataset");
+String datasetVersion = Configuration.getGlobalConfiguration().get("DATASET_VERSION", "1.0");
+
+// Create a pending upload request for the dataset
+PendingUploadRequest request = new PendingUploadRequest();
+
+// Get the pending upload response with blob reference
+return datasetsAsyncClient.pendingUpload(datasetName, datasetVersion, request)
+    .doOnNext(response -> {
+        System.out.println("Pending upload initiated with ID: " + response.getPendingUploadId());
+        System.out.println("Blob URI: " + response.getBlobReference().getBlobUrl());
+    });
+
+```
+
+```java com.azure.ai.projects.DatasetsAsyncSample.deleteDataset
+
+String datasetName = Configuration.getGlobalConfiguration().get("DATASET_NAME", "my-dataset");
+String datasetVersion = Configuration.getGlobalConfiguration().get("DATASET_VERSION", "1.0");
+
+// Delete the specific version of the dataset
+return datasetsAsyncClient.deleteDatasetVersion(datasetName, datasetVersion)
+    .doOnSuccess(unused ->
+        System.out.println("Deleted dataset: " + datasetName + ", version: " + datasetVersion));
+
+```
+
+### Indexes operations
+
+Index operations allow you to create and enumerate search indexes used by your AI Foundry Project.
+
+#### Create or update an index version
 
 ```java com.azure.ai.projects.IndexesGetSample.createOrUpdateIndex
 String indexName = Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
@@ -144,6 +498,290 @@ AIProjectIndex index = indexesClient.createOrUpdateIndexVersion(
 );
 
 System.out.println("Index created: " + index.getName());
+```
+
+#### List indexes
+
+```java com.azure.ai.projects.IndexesListSample.listIndexes
+indexesClient.listLatestIndexVersions().forEach(index -> {
+    System.out.println("Index name: " + index.getName());
+    System.out.println("Index version: " + index.getVersion());
+    System.out.println("Index description: " + index.getDescription());
+    System.out.println("-------------------------------------------------");
+});
+```
+
+#### List index versions
+
+```java com.azure.ai.projects.IndexesListVersionsSample.listIndexVersions
+
+String indexName = Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
+
+indexesClient.listIndexVersions(indexName).forEach(index -> {
+    System.out.println("Index name: " + index.getName());
+    System.out.println("Index version: " + index.getVersion());
+    System.out.println("Index type: " + index.getType());
+});
+
+```
+
+#### Get an index version
+
+```java com.azure.ai.projects.IndexesGetSample.getIndex
+
+String indexName = Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
+String indexVersion = Configuration.getGlobalConfiguration().get("INDEX_VERSION", "1.0");
+
+AIProjectIndex index = indexesClient.getIndexVersion(indexName, indexVersion);
+
+System.out.println("Retrieved index:");
+System.out.println("Name: " + index.getName());
+System.out.println("Version: " + index.getVersion());
+System.out.println("Type: " + index.getType());
+
+```
+
+#### Delete an index version
+
+```java com.azure.ai.projects.IndexesDeleteSample.deleteIndex
+
+String indexName = "test-index"; //Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
+String indexVersion = Configuration.getGlobalConfiguration().get("INDEX_VERSION", "1.0");
+
+// Delete the index version
+indexesClient.deleteIndexVersion(indexName, indexVersion);
+
+System.out.println("Deleted index: " + indexName + ", version: " + indexVersion);
+
+```
+
+#### Asynchronous index operations
+
+```java com.azure.ai.projects.IndexesAsyncSample.createOrUpdateIndex
+
+String indexName = Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
+String indexVersion = Configuration.getGlobalConfiguration().get("INDEX_VERSION", "2.0");
+String aiSearchConnectionName = Configuration.getGlobalConfiguration().get("AI_SEARCH_CONNECTION_NAME", "");
+String aiSearchIndexName = Configuration.getGlobalConfiguration().get("AI_SEARCH_INDEX_NAME", "");
+
+return indexesAsyncClient.createOrUpdateIndexVersion(
+    indexName,
+    indexVersion,
+    new AzureAISearchIndex()
+        .setConnectionName(aiSearchConnectionName)
+        .setIndexName(aiSearchIndexName)
+).doOnNext(index -> System.out.println("Index created: " + index.getName()));
+
+```
+
+```java com.azure.ai.projects.IndexesAsyncSample.listIndexes
+
+return indexesAsyncClient.listLatestIndexVersions()
+    .doOnNext(index -> {
+        System.out.println("Index name: " + index.getName());
+        System.out.println("Index version: " + index.getVersion());
+    });
+
+```
+
+```java com.azure.ai.projects.IndexesAsyncSample.listIndexVersions
+
+String indexName = Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
+
+return indexesAsyncClient.listIndexVersions(indexName)
+    .doOnNext(index -> {
+        System.out.println("Index name: " + index.getName());
+        System.out.println("Index version: " + index.getVersion());
+        System.out.println("Index type: " + index.getType());
+    });
+
+```
+
+```java com.azure.ai.projects.IndexesAsyncSample.getIndex
+
+String indexName = Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
+String indexVersion = Configuration.getGlobalConfiguration().get("INDEX_VERSION", "1.0");
+
+return indexesAsyncClient.getIndexVersion(indexName, indexVersion)
+    .doOnNext(index -> {
+        System.out.println("Retrieved index:");
+        System.out.println("Name: " + index.getName());
+        System.out.println("Version: " + index.getVersion());
+        System.out.println("Type: " + index.getType());
+    });
+
+```
+
+```java com.azure.ai.projects.IndexesAsyncSample.deleteIndex
+
+String indexName = Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
+String indexVersion = Configuration.getGlobalConfiguration().get("INDEX_VERSION", "1.0");
+
+// Delete the index version
+return indexesAsyncClient.deleteIndexVersion(indexName, indexVersion)
+    .doOnSuccess(unused ->
+        System.out.println("Deleted index: " + indexName + ", version: " + indexVersion));
+
+```
+
+### Skills operations
+
+Skills are a preview feature. The `SkillsClient` automatically sets the `Skills=V1Preview` opt-in flag on every request.
+
+#### Create a skill
+
+```java com.azure.ai.projects.SkillsSample.createSkill
+
+Map<String, String> metadata = new HashMap<>();
+metadata.put("domain", "support");
+
+SkillDetails skill = skillsClient.createSkill(
+    "product-support-skill",
+    "Answers product support questions using company policy.",
+    "You help answer product support questions using company policy and product guidance.",
+    metadata
+);
+
+System.out.println("Created skill: " + skill.getName());
+System.out.println("Skill ID: " + skill.getSkillId());
+System.out.println("Blob present: " + skill.isBlobPresent());
+
+```
+
+#### Get a skill
+
+```java com.azure.ai.projects.SkillsSample.getSkill
+
+String skillName = "product-support-skill";
+SkillDetails skill = skillsClient.getSkill(skillName);
+
+System.out.println("Skill name: " + skill.getName());
+System.out.println("Skill ID: " + skill.getSkillId());
+System.out.println("Description: " + skill.getDescription());
+
+```
+
+#### Update a skill
+
+```java com.azure.ai.projects.SkillsSample.updateSkill
+
+String skillName = "product-support-skill";
+
+Map<String, String> metadata = new HashMap<>();
+metadata.put("domain", "support");
+metadata.put("status", "updated");
+
+SkillDetails updated = skillsClient.updateSkill(
+    skillName,
+    "Updated description for the sample skill.",
+    null,
+    metadata
+);
+
+System.out.println("Updated skill: " + updated.getName());
+System.out.println("Description: " + updated.getDescription());
+System.out.println("Metadata: " + updated.getMetadata());
+
+```
+
+#### List skills
+
+```java com.azure.ai.projects.SkillsSample.listSkills
+
+PagedIterable<SkillDetails> skills = skillsClient.listSkills();
+for (SkillDetails skill : skills) {
+    System.out.println("Skill name: " + skill.getName());
+    System.out.println("Skill ID: " + skill.getSkillId());
+    System.out.println("Blob present: " + skill.isBlobPresent());
+    System.out.println("-------------------------------------------------");
+}
+
+```
+
+#### Delete a skill
+
+```java com.azure.ai.projects.SkillsSample.deleteSkill
+
+String skillName = "product-support-skill";
+skillsClient.deleteSkill(skillName);
+
+System.out.println("Deleted skill: " + skillName);
+
+```
+
+#### Asynchronous skills operations
+
+```java com.azure.ai.projects.SkillsAsyncSample.createSkill
+
+Map<String, String> metadata = new HashMap<>();
+metadata.put("domain", "support");
+
+return skillsAsyncClient.createSkill(
+    "product-support-skill",
+    "Answers product support questions using company policy.",
+    "You help answer product support questions using company policy and product guidance.",
+    metadata
+).doOnNext(skill -> {
+    System.out.println("Created skill: " + skill.getName());
+    System.out.println("Skill ID: " + skill.getSkillId());
+    System.out.println("Blob present: " + skill.isBlobPresent());
+});
+
+```
+
+```java com.azure.ai.projects.SkillsAsyncSample.getSkill
+
+String skillName = "product-support-skill";
+
+return skillsAsyncClient.getSkill(skillName)
+    .doOnNext(skill -> {
+        System.out.println("Skill name: " + skill.getName());
+        System.out.println("Skill ID: " + skill.getSkillId());
+        System.out.println("Description: " + skill.getDescription());
+    });
+
+```
+
+```java com.azure.ai.projects.SkillsAsyncSample.updateSkill
+
+String skillName = "product-support-skill";
+
+Map<String, String> metadata = new HashMap<>();
+metadata.put("domain", "support");
+metadata.put("status", "updated");
+
+return skillsAsyncClient.updateSkill(
+    skillName,
+    "Updated description for the sample skill.",
+    null,
+    metadata
+).doOnNext(updated -> {
+    System.out.println("Updated skill: " + updated.getName());
+    System.out.println("Description: " + updated.getDescription());
+    System.out.println("Metadata: " + updated.getMetadata());
+});
+
+```
+
+```java com.azure.ai.projects.SkillsAsyncSample.listSkills
+
+return skillsAsyncClient.listSkills()
+    .doOnNext(skill -> {
+        System.out.println("Skill name: " + skill.getName());
+        System.out.println("Skill ID: " + skill.getSkillId());
+        System.out.println("Blob present: " + skill.isBlobPresent());
+        System.out.println("-------------------------------------------------");
+    });
+
+```
+
+```java com.azure.ai.projects.SkillsAsyncSample.deleteSkill
+
+String skillName = "product-support-skill";
+
+return skillsAsyncClient.deleteSkill(skillName)
+    .doOnSuccess(unused -> System.out.println("Deleted skill: " + skillName));
+
 ```
 
 ### Service API versions

--- a/sdk/ai/azure-ai-projects/src/samples/java/com/azure/ai/projects/IndexesSample.java
+++ b/sdk/ai/azure-ai-projects/src/samples/java/com/azure/ai/projects/IndexesSample.java
@@ -86,7 +86,7 @@ public class IndexesSample {
     public static void deleteIndex() {
         // BEGIN:com.azure.ai.projects.IndexesDeleteSample.deleteIndex
 
-        String indexName = "test-index"; //Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
+        String indexName = Configuration.getGlobalConfiguration().get("INDEX_NAME", "my-index");
         String indexVersion = Configuration.getGlobalConfiguration().get("INDEX_VERSION", "1.0");
 
         // Delete the index version

--- a/sdk/ai/azure-ai-projects/src/samples/java/com/azure/ai/projects/ReadmeSamples.java
+++ b/sdk/ai/azure-ai-projects/src/samples/java/com/azure/ai/projects/ReadmeSamples.java
@@ -15,9 +15,6 @@ import com.openai.services.blocking.EvalService;
 
 public final class ReadmeSamples {
     public void readmeSamples() {
-        // BEGIN: com.azure.ai.projects.readme
-        // END: com.azure.ai.projects.readme
-
         // BEGIN: com.azure.ai.projects.clientInitialization
         AIProjectClientBuilder builder = new AIProjectClientBuilder();
 


### PR DESCRIPTION
This pull request makes a minor cleanup in the `ReadmeSamples.java` file by removing unused sample code comment markers. No functional code changes are included.

Using all unused snippets in the README