### PR TITLE
eng, use dev feed for set_versions.py

### DIFF
--- a/eng/versioning/set_versions.py
+++ b/eng/versioning/set_versions.py
@@ -328,7 +328,7 @@ def increment_or_set_library_version(artifact_id, group_id, new_version=None):
 def get_beta_version_to_use(group_id: str, artifact_id: str, major_version: int, minor_version: int):
     # Pull version information from Maven central to determine which beta version to use.
     # If beta.1 exists then use beta.2, etc. If beta.1 doesn't exist then use beta.1
-    url = 'https://repo1.maven.org/maven2/{}/{}/maven-metadata.xml'.format(group_id.replace('.', '/'), artifact_id)
+    url = 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1/{}/{}/maven-metadata.xml'.format(group_id.replace('.', '/'), artifact_id)
     headers = { "Content-signal": "search=yes,ai-train=no", "User-Agent": "azure-sdk-for-java" }
     with urllib.request.urlopen(urllib.request.Request(url=url, method='GET', headers=headers)) as f:
         if (f.status != 200):


### PR DESCRIPTION
I've got notified on a failure at https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6317099&view=logs&j=208dcf4f-4fd2-5394-66fe-0e5d645dfa88&t=2d0224ac-cc83-5fc2-566e-147fad79a24e&s=fb8721da-f31e-5e13-c1dd-d438ce197aa6

I cannot really test the fix, as it in release pipeline.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
