### PR TITLE
Responses protocol methods

### DIFF
--- a/sdk/ai/azure-ai-agents/CHANGELOG.md
+++ b/sdk/ai/azure-ai-agents/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added protocol-style methods on `ResponsesClient` and `ResponsesAsyncClient` that accept a raw JSON request body (`BinaryData`) and a `com.openai.core.RequestOptions`, and return the openai-java raw HTTP response (`HttpResponseFor<Response>`, `HttpResponseFor<StreamResponse<ResponseStreamEvent>>`, and `HttpResponse`). New methods: `createResponseWithResponse`, `createResponseStreamWithResponse`, `getResponseWithResponse`, `deleteResponseWithResponse`, and `cancelResponseWithResponse`. These delegate to the underlying openai-java `ResponseService.withRawResponse()` surface and continue to flow through the Azure HTTP pipeline.
 
+### Other Changes
+
+- Enabled `ResponsesTests` and `ResponsesAsyncTests` (previously `@Disabled`) with full create/retrieve/delete/input-items and background-cancel coverage for both the typed (`ResponseService` / `ResponseServiceAsync`) and new protocol-method surfaces. Recordings published to `Azure/azure-sdk-assets` and referenced from `assets.json`.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/ai/azure-ai-agents/CHANGELOG.md
+++ b/sdk/ai/azure-ai-agents/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Features Added
 
-- Added protocol-style methods on `ResponsesClient` and `ResponsesAsyncClient` that accept a raw JSON request body (`BinaryData`) and a `com.openai.core.RequestOptions`, and return the openai-java raw HTTP response (`HttpResponseFor<Response>`, `HttpResponseFor<StreamResponse<ResponseStreamEvent>>`, and `HttpResponse`). New methods: `createResponseWithResponse`, `createResponseStreamWithResponse`, `getResponseWithResponse`, `deleteResponseWithResponse`, and `cancelResponseWithResponse`. These delegate to the underlying openai-java `ResponseService.withRawResponse()` surface and continue to flow through the Azure HTTP pipeline.
+- Added protocol-style methods on `ResponsesClient` and `ResponsesAsyncClient` that accept a raw JSON request body (`BinaryData`) and a `com.openai.core.RequestOptions`, and return the openai-java raw HTTP response. These mirror the existing `createAzureResponse` and `createStreamingAzureResponse` typed surface: `createResponseWithResponse` (returns `HttpResponseFor<Response>`) and `createResponseStreamWithResponse` (returns `HttpResponseFor<StreamResponse<ResponseStreamEvent>>`). They delegate to the underlying openai-java `ResponseService.withRawResponse()` surface and continue to flow through the Azure HTTP pipeline.
 
 ### Other Changes
 
-- Enabled `ResponsesTests` and `ResponsesAsyncTests` (previously `@Disabled`) with full create/retrieve/delete/input-items and background-cancel coverage for both the typed (`ResponseService` / `ResponseServiceAsync`) and new protocol-method surfaces. Recordings published to `Azure/azure-sdk-assets` and referenced from `assets.json`.
+- Enabled `ResponsesTests` and `ResponsesAsyncTests` (previously `@Disabled`) with create/retrieve/delete/input-items and background-cancel coverage for the typed (`ResponseService` / `ResponseServiceAsync`) surface, plus coverage for the new protocol-method surface. Recordings published to `Azure/azure-sdk-assets` and referenced from `assets.json`.
 
 ### Breaking Changes
 

--- a/sdk/ai/azure-ai-agents/CHANGELOG.md
+++ b/sdk/ai/azure-ai-agents/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added protocol-style methods on `ResponsesClient` and `ResponsesAsyncClient` that accept a raw JSON request body (`BinaryData`) and a `com.openai.core.RequestOptions`, and return the openai-java raw HTTP response (`HttpResponseFor<Response>`, `HttpResponseFor<StreamResponse<ResponseStreamEvent>>`, and `HttpResponse`). New methods: `createResponseWithResponse`, `createResponseStreamWithResponse`, `getResponseWithResponse`, `deleteResponseWithResponse`, and `cancelResponseWithResponse`. These delegate to the underlying openai-java `ResponseService.withRawResponse()` surface and continue to flow through the Azure HTTP pipeline.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/ai/azure-ai-agents/assets.json
+++ b/sdk/ai/azure-ai-agents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "java",
   "TagPrefix": "java/ai/azure-ai-agents",
-  "Tag": "java/ai/azure-ai-agents_7a1b5ec037"
+  "Tag": "java/ai/azure-ai-agents_a3142fe843"
 }

--- a/sdk/ai/azure-ai-agents/assets.json
+++ b/sdk/ai/azure-ai-agents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "java",
   "TagPrefix": "java/ai/azure-ai-agents",
-  "Tag": "java/ai/azure-ai-agents_69308f6d56"
+  "Tag": "java/ai/azure-ai-agents_7a1b5ec037"
 }

--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesAsyncClient.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesAsyncClient.java
@@ -10,8 +10,13 @@ import com.azure.ai.agents.models.AzureCreateResponseOptions;
 import com.azure.core.annotation.ReturnType;
 import com.azure.core.annotation.ServiceClient;
 import com.azure.core.annotation.ServiceMethod;
+import com.azure.core.util.BinaryData;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
+import com.openai.core.RequestOptions;
+import com.openai.core.http.HttpResponse;
+import com.openai.core.http.HttpResponseFor;
+import com.openai.core.http.StreamResponse;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCreateParams;
 import com.openai.models.responses.ResponseStreamEvent;
@@ -83,5 +88,130 @@ public final class ResponsesAsyncClient {
         Map<String, JsonValue> additionalBodyProperties = OpenAIJsonHelper.toJsonValueMap(createResponse);
         params.additionalBodyProperties(additionalBodyProperties);
         return StreamingUtils.toFlux(this.responseServiceAsync.createStreaming(params.build()));
+    }
+
+    /**
+     * Creates a response from a raw JSON request body and returns the raw HTTP response.
+     *
+     * <p>This protocol method delegates to the OpenAI Java SDK's
+     * {@link ResponseServiceAsync.WithRawResponse#create(ResponseCreateParams, RequestOptions)}. The
+     * {@code createResponseRequest} payload is forwarded verbatim as the request body, so callers can
+     * include Azure-specific extensions (such as
+     * {@link com.azure.ai.agents.models.AgentReference}) without going through the strongly-typed
+     * {@link ResponseCreateParams.Builder}.</p>
+     *
+     * <p>The returned {@link HttpResponseFor} exposes the status code, headers, and the raw
+     * response stream via {@code body()}, or the typed {@link Response} via {@code parse()}. Only
+     * one of {@code body()} or {@code parse()} may be invoked per response, and the caller must
+     * close the response (e.g. via try-with-resources) to release the underlying connection.</p>
+     *
+     * <p>Note: the second parameter is the openai-java {@link RequestOptions} (not the azure-core
+     * type) so that the OpenAI-supported options (timeout, response validation) translate
+     * faithfully. Additional headers or query parameters must be supplied via the OpenAI request
+     * builder pattern (e.g. by using {@link #createAzureResponse} for fully-typed requests).</p>
+     *
+     * @param createResponseRequest the JSON body representing the create-response request; must be a JSON object.
+     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
+     * @return a {@link Mono} emitting the raw HTTP response, parseable as a {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpResponseFor<Response>> createResponseWithResponse(BinaryData createResponseRequest,
+        RequestOptions requestOptions) {
+        Objects.requireNonNull(createResponseRequest, "createResponseRequest cannot be null");
+
+        ResponseCreateParams params = ResponseCreateParams.builder()
+            .additionalBodyProperties(OpenAIJsonHelper.jsonBodyToValueMap(createResponseRequest))
+            .build();
+        return Mono.fromFuture(this.responseServiceAsync.withRawResponse()
+            .create(params, requestOptions == null ? RequestOptions.none() : requestOptions));
+    }
+
+    /**
+     * Creates a streaming response from a raw JSON request body and returns the raw HTTP response.
+     *
+     * <p>Delegates to the OpenAI Java SDK's
+     * {@link ResponseServiceAsync.WithRawResponse#createStreaming(ResponseCreateParams, RequestOptions)}.
+     * The {@code createResponseRequest} payload is forwarded verbatim as the request body.</p>
+     *
+     * <p>The returned {@link HttpResponseFor} wraps a {@link StreamResponse} of
+     * {@link ResponseStreamEvent} items, which the caller iterates via {@link HttpResponseFor#parse()}.
+     * Note that the underlying stream produced by the openai-java SDK's raw async streaming API is
+     * iterator-based and blocking; for a Reactor-friendly streaming surface use
+     * {@link #createStreamingAzureResponse(AzureCreateResponseOptions, ResponseCreateParams.Builder)}
+     * instead.</p>
+     *
+     * @param createResponseRequest the JSON body representing the create-response request; must be a JSON object.
+     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
+     * @return a {@link Mono} emitting the raw HTTP response, parseable as a {@link StreamResponse} of {@link ResponseStreamEvent}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public Mono<HttpResponseFor<StreamResponse<ResponseStreamEvent>>>
+        createResponseStreamWithResponse(BinaryData createResponseRequest, RequestOptions requestOptions) {
+        Objects.requireNonNull(createResponseRequest, "createResponseRequest cannot be null");
+
+        ResponseCreateParams params = ResponseCreateParams.builder()
+            .additionalBodyProperties(OpenAIJsonHelper.jsonBodyToValueMap(createResponseRequest))
+            .build();
+        return Mono.fromFuture(this.responseServiceAsync.withRawResponse()
+            .createStreaming(params, requestOptions == null ? RequestOptions.none() : requestOptions));
+    }
+
+    /**
+     * Retrieves a previously created response by id and returns the raw HTTP response.
+     *
+     * <p>Delegates to the OpenAI Java SDK's
+     * {@link ResponseServiceAsync.WithRawResponse#retrieve(String, RequestOptions)}.</p>
+     *
+     * @param responseId the id of the response to retrieve.
+     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
+     * @return a {@link Mono} emitting the raw HTTP response, parseable as a {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpResponseFor<Response>> getResponseWithResponse(String responseId, RequestOptions requestOptions) {
+        Objects.requireNonNull(responseId, "responseId cannot be null");
+
+        return Mono.fromFuture(this.responseServiceAsync.withRawResponse()
+            .retrieve(responseId, requestOptions == null ? RequestOptions.none() : requestOptions));
+    }
+
+    /**
+     * Deletes a previously created response and returns the raw HTTP response.
+     *
+     * <p>Delegates to the OpenAI Java SDK's
+     * {@link ResponseServiceAsync.WithRawResponse#delete(String, RequestOptions)}.</p>
+     *
+     * <p>The returned {@link HttpResponse} exposes the status code and headers; the body (if any)
+     * can be read via {@link HttpResponse#body()}. Callers must close the response to release the
+     * underlying connection.</p>
+     *
+     * @param responseId the id of the response to delete.
+     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
+     * @return a {@link Mono} emitting the raw HTTP response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpResponse> deleteResponseWithResponse(String responseId, RequestOptions requestOptions) {
+        Objects.requireNonNull(responseId, "responseId cannot be null");
+
+        return Mono.fromFuture(this.responseServiceAsync.withRawResponse()
+            .delete(responseId, requestOptions == null ? RequestOptions.none() : requestOptions));
+    }
+
+    /**
+     * Cancels a previously created response and returns the raw HTTP response.
+     *
+     * <p>Delegates to the OpenAI Java SDK's
+     * {@link ResponseServiceAsync.WithRawResponse#cancel(String, RequestOptions)}.</p>
+     *
+     * @param responseId the id of the response to cancel.
+     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
+     * @return a {@link Mono} emitting the raw HTTP response, parseable as a {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<HttpResponseFor<Response>> cancelResponseWithResponse(String responseId,
+        RequestOptions requestOptions) {
+        Objects.requireNonNull(responseId, "responseId cannot be null");
+
+        return Mono.fromFuture(this.responseServiceAsync.withRawResponse()
+            .cancel(responseId, requestOptions == null ? RequestOptions.none() : requestOptions));
     }
 }

--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesAsyncClient.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesAsyncClient.java
@@ -14,7 +14,6 @@ import com.azure.core.util.BinaryData;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
 import com.openai.core.RequestOptions;
-import com.openai.core.http.HttpResponse;
 import com.openai.core.http.HttpResponseFor;
 import com.openai.core.http.StreamResponse;
 import com.openai.models.responses.Response;
@@ -154,64 +153,5 @@ public final class ResponsesAsyncClient {
             .build();
         return Mono.fromFuture(this.responseServiceAsync.withRawResponse()
             .createStreaming(params, requestOptions == null ? RequestOptions.none() : requestOptions));
-    }
-
-    /**
-     * Retrieves a previously created response by id and returns the raw HTTP response.
-     *
-     * <p>Delegates to the OpenAI Java SDK's
-     * {@link ResponseServiceAsync.WithRawResponse#retrieve(String, RequestOptions)}.</p>
-     *
-     * @param responseId the id of the response to retrieve.
-     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
-     * @return a {@link Mono} emitting the raw HTTP response, parseable as a {@link Response}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<HttpResponseFor<Response>> getResponseWithResponse(String responseId, RequestOptions requestOptions) {
-        Objects.requireNonNull(responseId, "responseId cannot be null");
-
-        return Mono.fromFuture(this.responseServiceAsync.withRawResponse()
-            .retrieve(responseId, requestOptions == null ? RequestOptions.none() : requestOptions));
-    }
-
-    /**
-     * Deletes a previously created response and returns the raw HTTP response.
-     *
-     * <p>Delegates to the OpenAI Java SDK's
-     * {@link ResponseServiceAsync.WithRawResponse#delete(String, RequestOptions)}.</p>
-     *
-     * <p>The returned {@link HttpResponse} exposes the status code and headers; the body (if any)
-     * can be read via {@link HttpResponse#body()}. Callers must close the response to release the
-     * underlying connection.</p>
-     *
-     * @param responseId the id of the response to delete.
-     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
-     * @return a {@link Mono} emitting the raw HTTP response.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<HttpResponse> deleteResponseWithResponse(String responseId, RequestOptions requestOptions) {
-        Objects.requireNonNull(responseId, "responseId cannot be null");
-
-        return Mono.fromFuture(this.responseServiceAsync.withRawResponse()
-            .delete(responseId, requestOptions == null ? RequestOptions.none() : requestOptions));
-    }
-
-    /**
-     * Cancels a previously created response and returns the raw HTTP response.
-     *
-     * <p>Delegates to the OpenAI Java SDK's
-     * {@link ResponseServiceAsync.WithRawResponse#cancel(String, RequestOptions)}.</p>
-     *
-     * @param responseId the id of the response to cancel.
-     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
-     * @return a {@link Mono} emitting the raw HTTP response, parseable as a {@link Response}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<HttpResponseFor<Response>> cancelResponseWithResponse(String responseId,
-        RequestOptions requestOptions) {
-        Objects.requireNonNull(responseId, "responseId cannot be null");
-
-        return Mono.fromFuture(this.responseServiceAsync.withRawResponse()
-            .cancel(responseId, requestOptions == null ? RequestOptions.none() : requestOptions));
     }
 }

--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesAsyncClient.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesAsyncClient.java
@@ -94,8 +94,10 @@ public final class ResponsesAsyncClient {
      *
      * <p>This protocol method delegates to the OpenAI Java SDK's
      * {@link ResponseServiceAsync.WithRawResponse#create(ResponseCreateParams, RequestOptions)}. The
-     * {@code createResponseRequest} payload is forwarded verbatim as the request body, so callers can
-     * include Azure-specific extensions (such as
+     * {@code createResponseRequest} payload is forwarded as the request body (semantically, not
+     * byte-for-byte: the JSON is parsed and re-serialized via {@code additionalBodyProperties},
+     * so property ordering and exact formatting may change and duplicate top-level keys are not
+     * preserved), so callers can include Azure-specific extensions (such as
      * {@link com.azure.ai.agents.models.AgentReference}) without going through the strongly-typed
      * {@link ResponseCreateParams.Builder}.</p>
      *
@@ -130,7 +132,9 @@ public final class ResponsesAsyncClient {
      *
      * <p>Delegates to the OpenAI Java SDK's
      * {@link ResponseServiceAsync.WithRawResponse#createStreaming(ResponseCreateParams, RequestOptions)}.
-     * The {@code createResponseRequest} payload is forwarded verbatim as the request body.</p>
+     * The {@code createResponseRequest} payload is forwarded as the request body (semantically,
+     * not byte-for-byte: the JSON is parsed and re-serialized, so property ordering and exact
+     * formatting may change and duplicate top-level keys are not preserved).</p>
      *
      * <p>The returned {@link HttpResponseFor} wraps a {@link StreamResponse} of
      * {@link ResponseStreamEvent} items, which the caller iterates via {@link HttpResponseFor#parse()}.

--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesClient.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesClient.java
@@ -16,7 +16,6 @@ import com.azure.core.util.IterableStream;
 import com.openai.client.OpenAIClient;
 import com.openai.core.JsonValue;
 import com.openai.core.RequestOptions;
-import com.openai.core.http.HttpResponse;
 import com.openai.core.http.HttpResponseFor;
 import com.openai.core.http.StreamResponse;
 import com.openai.models.responses.Response;
@@ -164,64 +163,6 @@ public final class ResponsesClient {
             .build();
         return this.responseService.withRawResponse()
             .createStreaming(params, requestOptions == null ? RequestOptions.none() : requestOptions);
-    }
-
-    /**
-     * Retrieves a previously created response by id and returns the raw HTTP response.
-     *
-     * <p>Delegates to the OpenAI Java SDK's
-     * {@link ResponseService.WithRawResponse#retrieve(String, RequestOptions)}.</p>
-     *
-     * @param responseId the id of the response to retrieve.
-     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
-     * @return the raw HTTP response, parseable as a {@link Response}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpResponseFor<Response> getResponseWithResponse(String responseId, RequestOptions requestOptions) {
-        Objects.requireNonNull(responseId, "responseId cannot be null");
-
-        return this.responseService.withRawResponse()
-            .retrieve(responseId, requestOptions == null ? RequestOptions.none() : requestOptions);
-    }
-
-    /**
-     * Deletes a previously created response and returns the raw HTTP response.
-     *
-     * <p>Delegates to the OpenAI Java SDK's
-     * {@link ResponseService.WithRawResponse#delete(String, RequestOptions)}.</p>
-     *
-     * <p>The returned {@link HttpResponse} exposes the status code and headers; the body (if any)
-     * can be read via {@link HttpResponse#body()}. Callers must close the response to release the
-     * underlying connection.</p>
-     *
-     * @param responseId the id of the response to delete.
-     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
-     * @return the raw HTTP response.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpResponse deleteResponseWithResponse(String responseId, RequestOptions requestOptions) {
-        Objects.requireNonNull(responseId, "responseId cannot be null");
-
-        return this.responseService.withRawResponse()
-            .delete(responseId, requestOptions == null ? RequestOptions.none() : requestOptions);
-    }
-
-    /**
-     * Cancels a previously created response and returns the raw HTTP response.
-     *
-     * <p>Delegates to the OpenAI Java SDK's
-     * {@link ResponseService.WithRawResponse#cancel(String, RequestOptions)}.</p>
-     *
-     * @param responseId the id of the response to cancel.
-     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
-     * @return the raw HTTP response, parseable as a {@link Response}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public HttpResponseFor<Response> cancelResponseWithResponse(String responseId, RequestOptions requestOptions) {
-        Objects.requireNonNull(responseId, "responseId cannot be null");
-
-        return this.responseService.withRawResponse()
-            .cancel(responseId, requestOptions == null ? RequestOptions.none() : requestOptions);
     }
 
 }

--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesClient.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesClient.java
@@ -106,8 +106,10 @@ public final class ResponsesClient {
      *
      * <p>This protocol method delegates to the OpenAI Java SDK's
      * {@link ResponseService.WithRawResponse#create(ResponseCreateParams, RequestOptions)}. The
-     * {@code createResponseRequest} payload is forwarded verbatim as the request body, so callers can
-     * include Azure-specific extensions (such as
+     * {@code createResponseRequest} payload is forwarded as the request body (semantically, not
+     * byte-for-byte: the JSON is parsed and re-serialized via {@code additionalBodyProperties},
+     * so property ordering and exact formatting may change and duplicate top-level keys are not
+     * preserved), so callers can include Azure-specific extensions (such as
      * {@link com.azure.ai.agents.models.AgentReference}) without going through the strongly-typed
      * {@link ResponseCreateParams.Builder}.</p>
      *
@@ -142,7 +144,9 @@ public final class ResponsesClient {
      *
      * <p>Delegates to the OpenAI Java SDK's
      * {@link ResponseService.WithRawResponse#createStreaming(ResponseCreateParams, RequestOptions)}.
-     * The {@code createResponseRequest} payload is forwarded verbatim as the request body.</p>
+     * The {@code createResponseRequest} payload is forwarded as the request body (semantically,
+     * not byte-for-byte: the JSON is parsed and re-serialized, so property ordering and exact
+     * formatting may change and duplicate top-level keys are not preserved).</p>
      *
      * <p>The returned {@link HttpResponseFor} wraps a {@link StreamResponse} of
      * {@link ResponseStreamEvent} items, which the caller iterates via {@link HttpResponseFor#parse()}.

--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesClient.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/ResponsesClient.java
@@ -11,9 +11,14 @@ import com.azure.ai.agents.models.AzureCreateResponseOptions;
 import com.azure.core.annotation.ServiceClient;
 import com.azure.core.annotation.ServiceMethod;
 import com.azure.core.annotation.ReturnType;
+import com.azure.core.util.BinaryData;
 import com.azure.core.util.IterableStream;
 import com.openai.client.OpenAIClient;
 import com.openai.core.JsonValue;
+import com.openai.core.RequestOptions;
+import com.openai.core.http.HttpResponse;
+import com.openai.core.http.HttpResponseFor;
+import com.openai.core.http.StreamResponse;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCreateParams;
 import com.openai.models.responses.ResponseStreamEvent;
@@ -95,6 +100,128 @@ public final class ResponsesClient {
         Objects.requireNonNull(response, "response cannot be null");
         return OpenAIJsonHelper.fromAdditionalProperties(response._additionalProperties(),
             AzureCreateResponseDetails::fromJson);
+    }
+
+    /**
+     * Creates a response from a raw JSON request body and returns the raw HTTP response.
+     *
+     * <p>This protocol method delegates to the OpenAI Java SDK's
+     * {@link ResponseService.WithRawResponse#create(ResponseCreateParams, RequestOptions)}. The
+     * {@code createResponseRequest} payload is forwarded verbatim as the request body, so callers can
+     * include Azure-specific extensions (such as
+     * {@link com.azure.ai.agents.models.AgentReference}) without going through the strongly-typed
+     * {@link ResponseCreateParams.Builder}.</p>
+     *
+     * <p>The returned {@link HttpResponseFor} exposes the status code, headers, and the raw
+     * response stream via {@code body()}, or the typed {@link Response} via {@code parse()}. Only
+     * one of {@code body()} or {@code parse()} may be invoked per response, and the caller must
+     * close the response (e.g. via try-with-resources) to release the underlying connection.</p>
+     *
+     * <p>Note: the second parameter is the openai-java {@link RequestOptions} (not the azure-core
+     * type) so that the OpenAI-supported options (timeout, response validation) translate
+     * faithfully. Additional headers or query parameters must be supplied via the OpenAI request
+     * builder pattern (e.g. by using {@link #createAzureResponse} for fully-typed requests).</p>
+     *
+     * @param createResponseRequest the JSON body representing the create-response request; must be a JSON object.
+     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
+     * @return the raw HTTP response, parseable as a {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HttpResponseFor<Response> createResponseWithResponse(BinaryData createResponseRequest,
+        RequestOptions requestOptions) {
+        Objects.requireNonNull(createResponseRequest, "createResponseRequest cannot be null");
+
+        ResponseCreateParams params = ResponseCreateParams.builder()
+            .additionalBodyProperties(OpenAIJsonHelper.jsonBodyToValueMap(createResponseRequest))
+            .build();
+        return this.responseService.withRawResponse()
+            .create(params, requestOptions == null ? RequestOptions.none() : requestOptions);
+    }
+
+    /**
+     * Creates a streaming response from a raw JSON request body and returns the raw HTTP response.
+     *
+     * <p>Delegates to the OpenAI Java SDK's
+     * {@link ResponseService.WithRawResponse#createStreaming(ResponseCreateParams, RequestOptions)}.
+     * The {@code createResponseRequest} payload is forwarded verbatim as the request body.</p>
+     *
+     * <p>The returned {@link HttpResponseFor} wraps a {@link StreamResponse} of
+     * {@link ResponseStreamEvent} items, which the caller iterates via {@link HttpResponseFor#parse()}.
+     * The underlying stream must be closed when iteration completes; the typical pattern is
+     * try-with-resources on either the {@link HttpResponseFor} or the parsed {@link StreamResponse}.</p>
+     *
+     * @param createResponseRequest the JSON body representing the create-response request; must be a JSON object.
+     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
+     * @return the raw HTTP response, parseable as a {@link StreamResponse} of {@link ResponseStreamEvent}.
+     */
+    @ServiceMethod(returns = ReturnType.COLLECTION)
+    public HttpResponseFor<StreamResponse<ResponseStreamEvent>>
+        createResponseStreamWithResponse(BinaryData createResponseRequest, RequestOptions requestOptions) {
+        Objects.requireNonNull(createResponseRequest, "createResponseRequest cannot be null");
+
+        ResponseCreateParams params = ResponseCreateParams.builder()
+            .additionalBodyProperties(OpenAIJsonHelper.jsonBodyToValueMap(createResponseRequest))
+            .build();
+        return this.responseService.withRawResponse()
+            .createStreaming(params, requestOptions == null ? RequestOptions.none() : requestOptions);
+    }
+
+    /**
+     * Retrieves a previously created response by id and returns the raw HTTP response.
+     *
+     * <p>Delegates to the OpenAI Java SDK's
+     * {@link ResponseService.WithRawResponse#retrieve(String, RequestOptions)}.</p>
+     *
+     * @param responseId the id of the response to retrieve.
+     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
+     * @return the raw HTTP response, parseable as a {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HttpResponseFor<Response> getResponseWithResponse(String responseId, RequestOptions requestOptions) {
+        Objects.requireNonNull(responseId, "responseId cannot be null");
+
+        return this.responseService.withRawResponse()
+            .retrieve(responseId, requestOptions == null ? RequestOptions.none() : requestOptions);
+    }
+
+    /**
+     * Deletes a previously created response and returns the raw HTTP response.
+     *
+     * <p>Delegates to the OpenAI Java SDK's
+     * {@link ResponseService.WithRawResponse#delete(String, RequestOptions)}.</p>
+     *
+     * <p>The returned {@link HttpResponse} exposes the status code and headers; the body (if any)
+     * can be read via {@link HttpResponse#body()}. Callers must close the response to release the
+     * underlying connection.</p>
+     *
+     * @param responseId the id of the response to delete.
+     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
+     * @return the raw HTTP response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HttpResponse deleteResponseWithResponse(String responseId, RequestOptions requestOptions) {
+        Objects.requireNonNull(responseId, "responseId cannot be null");
+
+        return this.responseService.withRawResponse()
+            .delete(responseId, requestOptions == null ? RequestOptions.none() : requestOptions);
+    }
+
+    /**
+     * Cancels a previously created response and returns the raw HTTP response.
+     *
+     * <p>Delegates to the OpenAI Java SDK's
+     * {@link ResponseService.WithRawResponse#cancel(String, RequestOptions)}.</p>
+     *
+     * @param responseId the id of the response to cancel.
+     * @param requestOptions optional OpenAI request options; pass {@code null} to use the defaults.
+     * @return the raw HTTP response, parseable as a {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public HttpResponseFor<Response> cancelResponseWithResponse(String responseId, RequestOptions requestOptions) {
+        Objects.requireNonNull(responseId, "responseId cannot be null");
+
+        return this.responseService.withRawResponse()
+            .cancel(responseId, requestOptions == null ? RequestOptions.none() : requestOptions);
     }
 
 }

--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/implementation/OpenAIJsonHelper.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/implementation/OpenAIJsonHelper.java
@@ -160,16 +160,41 @@ public final class OpenAIJsonHelper {
         }
         try {
             String json = BinaryData.fromObject(obj).toString();
-            Map<String, Object> map = MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {
-            });
-            Map<String, JsonValue> result = new HashMap<>();
-            for (Map.Entry<String, Object> entry : map.entrySet()) {
-                result.put(entry.getKey(), JsonValue.from(entry.getValue()));
-            }
-            return result;
+            return jsonStringToJsonValueMap(json);
         } catch (IOException e) {
             throw new RuntimeException("Failed to flatten JsonSerializable to JsonValue map", e);
         }
+    }
+
+    /**
+     * Parses raw JSON bytes representing a top-level JSON object into a map of property names to
+     * {@link JsonValue} entries, suitable for placing on an openai-java request builder via
+     * {@code additionalBodyProperties(Map)}. The strongly-typed builder fields remain unset, so
+     * the serialized output of the resulting params matches the original JSON.
+     *
+     * @param body the JSON body bytes; the content must represent a JSON object.
+     * @return a map of property names to {@link JsonValue} entries, or an empty map if the input is null.
+     * @throws RuntimeException if the input is not a valid JSON object.
+     */
+    public static Map<String, JsonValue> jsonBodyToValueMap(BinaryData body) {
+        if (body == null) {
+            return new HashMap<>();
+        }
+        try {
+            return jsonStringToJsonValueMap(body.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse JSON body to JsonValue map", e);
+        }
+    }
+
+    private static Map<String, JsonValue> jsonStringToJsonValueMap(String json) throws IOException {
+        Map<String, Object> map = MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {
+        });
+        Map<String, JsonValue> result = new HashMap<>();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            result.put(entry.getKey(), JsonValue.from(entry.getValue()));
+        }
+        return result;
     }
 
     /**

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ClientTestBase.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ClientTestBase.java
@@ -15,7 +15,9 @@ import com.azure.core.test.utils.MockTokenCredential;
 import com.azure.core.util.Configuration;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.openai.services.async.ConversationServiceAsync;
+import com.openai.services.async.ResponseServiceAsync;
 import com.openai.services.blocking.ConversationService;
+import com.openai.services.blocking.ResponseService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,6 +84,16 @@ public class ClientTestBase extends TestProxyTestBase {
     protected ResponsesAsyncClient getResponsesAsyncClient(HttpClient httpClient,
         AgentsServiceVersion agentsServiceVersion) {
         return getClientBuilder(httpClient, agentsServiceVersion).buildResponsesAsyncClient();
+    }
+
+    protected ResponseService getResponseServiceSyncClient(HttpClient httpClient,
+        AgentsServiceVersion agentsServiceVersion) {
+        return getClientBuilder(httpClient, agentsServiceVersion).buildOpenAIClient().responses();
+    }
+
+    protected ResponseServiceAsync getResponseServiceAsyncClient(HttpClient httpClient,
+        AgentsServiceVersion agentsServiceVersion) {
+        return getClientBuilder(httpClient, agentsServiceVersion).buildOpenAIAsyncClient().responses();
     }
 
     protected MemoryStoresClient getMemoryStoresSyncClient(HttpClient httpClient,

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesAsyncTests.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesAsyncTests.java
@@ -5,11 +5,12 @@ package com.azure.ai.agents;
 
 import com.azure.core.http.HttpClient;
 import com.azure.core.util.BinaryData;
-import com.openai.core.http.HttpResponse;
 import com.openai.core.http.HttpResponseFor;
+import com.openai.core.http.StreamResponse;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCreateParams;
 import com.openai.models.responses.ResponseStatus;
+import com.openai.models.responses.ResponseStreamEvent;
 import com.openai.models.responses.inputitems.InputItemListPageAsync;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -26,6 +27,9 @@ public class ResponsesAsyncTests extends ClientTestBase {
 
     private static final String CREATE_RESPONSE_BODY
         = "{\"input\":\"Hello, how can you help me?\",\"model\":\"gpt-4o\"}";
+
+    private static final String CREATE_STREAM_RESPONSE_BODY
+        = "{\"input\":\"Hello, how can you help me?\",\"model\":\"gpt-4o\",\"stream\":true}";
 
     private static final String CREATE_BACKGROUND_RESPONSE_BODY
         = "{\"input\":\"Tell me a very long story about a chicken trying to cross the road.\","
@@ -89,47 +93,26 @@ public class ResponsesAsyncTests extends ClientTestBase {
     public void basicCRUDOperationsWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
         ResponsesAsyncClient client = getResponsesAsyncClient(httpClient, serviceVersion);
 
-        // create
         HttpResponseFor<Response> createdRaw
             = client.createResponseWithResponse(BinaryData.fromString(CREATE_RESPONSE_BODY), null).block();
         assertNotNull(createdRaw);
         Response createdResponse = createdRaw.parse();
         assertNotNull(createdResponse);
         assertNotNull(createdResponse.id());
-
-        // retrieve
-        HttpResponseFor<Response> retrievedRaw = client.getResponseWithResponse(createdResponse.id(), null).block();
-        assertNotNull(retrievedRaw);
-        Response retrievedResponse = retrievedRaw.parse();
-        assertNotNull(retrievedResponse);
-        assertEquals(createdResponse.id(), retrievedResponse.id());
-
-        // delete
-        HttpResponse deletedRaw = client.deleteResponseWithResponse(createdResponse.id(), null).block();
-        assertNotNull(deletedRaw);
     }
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
-    public void cancelBackgroundResponseWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
+    public void basicStreamingOperationsWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
         ResponsesAsyncClient client = getResponsesAsyncClient(httpClient, serviceVersion);
 
-        HttpResponseFor<Response> backgroundRaw
-            = client.createResponseWithResponse(BinaryData.fromString(CREATE_BACKGROUND_RESPONSE_BODY), null).block();
-        assertNotNull(backgroundRaw);
-        Response backgroundResponse = backgroundRaw.parse();
-        assertNotNull(backgroundResponse);
-        assertNotNull(backgroundResponse.id());
-
-        HttpResponseFor<Response> cancelledRaw
-            = client.cancelResponseWithResponse(backgroundResponse.id(), null).block();
-        assertNotNull(cancelledRaw);
-        Response cancelledResponse = cancelledRaw.parse();
-        assertNotNull(cancelledResponse);
-        assertEquals(backgroundResponse.id(), cancelledResponse.id());
-        assertTrue(cancelledResponse.status().isPresent());
-        ResponseStatus status = cancelledResponse.status().get();
-        assertTrue(status.equals(ResponseStatus.CANCELLED) || status.equals(ResponseStatus.COMPLETED),
-            "Expected CANCELLED or COMPLETED status but was " + status);
+        try (HttpResponseFor<StreamResponse<ResponseStreamEvent>> raw
+            = client.createResponseStreamWithResponse(BinaryData.fromString(CREATE_STREAM_RESPONSE_BODY), null).block();
+            StreamResponse<ResponseStreamEvent> events = raw.parse()) {
+            assertNotNull(raw);
+            assertNotNull(events);
+            long count = events.stream().peek(e -> assertNotNull(e)).count();
+            assertTrue(count > 0, "Expected at least one stream event but received none");
+        }
     }
 }

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesAsyncTests.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesAsyncTests.java
@@ -32,10 +32,6 @@ public class ResponsesAsyncTests extends ClientTestBase {
     private static final String CREATE_STREAM_RESPONSE_BODY
         = "{\"input\":\"Hello, how can you help me?\",\"model\":\"gpt-4o\",\"stream\":true}";
 
-    private static final String CREATE_BACKGROUND_RESPONSE_BODY
-        = "{\"input\":\"Tell me a very long story about a chicken trying to cross the road.\","
-            + "\"model\":\"gpt-4o\",\"background\":true}";
-
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
     public void basicCRUDOperations(HttpClient httpClient, AgentsServiceVersion serviceVersion)
@@ -96,12 +92,13 @@ public class ResponsesAsyncTests extends ClientTestBase {
     public void basicCRUDOperationsWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
         ResponsesAsyncClient client = getResponsesAsyncClient(httpClient, serviceVersion);
 
-        HttpResponseFor<Response> createdRaw
-            = client.createResponseWithResponse(BinaryData.fromString(CREATE_RESPONSE_BODY), null).block();
-        assertNotNull(createdRaw);
-        Response createdResponse = createdRaw.parse();
-        assertNotNull(createdResponse);
-        assertNotNull(createdResponse.id());
+        try (HttpResponseFor<Response> createdRaw
+            = client.createResponseWithResponse(BinaryData.fromString(CREATE_RESPONSE_BODY), null).block()) {
+            assertNotNull(createdRaw);
+            Response createdResponse = createdRaw.parse();
+            assertNotNull(createdResponse);
+            assertNotNull(createdResponse.id());
+        }
     }
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesAsyncTests.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesAsyncTests.java
@@ -5,23 +5,31 @@ package com.azure.ai.agents;
 
 import com.azure.core.http.HttpClient;
 import com.azure.core.util.BinaryData;
+import com.openai.core.http.HttpResponse;
 import com.openai.core.http.HttpResponseFor;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCreateParams;
-import org.junit.jupiter.api.Disabled;
+import com.openai.models.responses.ResponseStatus;
+import com.openai.models.responses.inputitems.InputItemListPageAsync;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.concurrent.ExecutionException;
 
 import static com.azure.ai.agents.TestUtils.DISPLAY_NAME_WITH_ARGUMENTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled("Disabled for lack of recordings. Needs to be enabled on the Public Preview release.")
 public class ResponsesAsyncTests extends ClientTestBase {
 
     private static final String CREATE_RESPONSE_BODY
         = "{\"input\":\"Hello, how can you help me?\",\"model\":\"gpt-4o\"}";
+
+    private static final String CREATE_BACKGROUND_RESPONSE_BODY
+        = "{\"input\":\"Tell me a very long story about a chicken trying to cross the road.\","
+            + "\"model\":\"gpt-4o\",\"background\":true}";
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
@@ -29,11 +37,51 @@ public class ResponsesAsyncTests extends ClientTestBase {
         throws ExecutionException, InterruptedException {
         ResponsesAsyncClient client = getResponsesAsyncClient(httpClient, serviceVersion);
 
-        ResponseCreateParams responsesRequest
-            = new ResponseCreateParams.Builder().input("Hello, how can you help me?").model("gpt-4o").build();
+        // create
+        ResponseCreateParams createRequest
+            = ResponseCreateParams.builder().input("Hello, how can you help me?").model("gpt-4o").build();
+        Response createdResponse = client.getResponseServiceAsync().create(createRequest).get();
+        assertNotNull(createdResponse);
+        assertNotNull(createdResponse.id());
 
-        Response response = client.getResponseServiceAsync().create(responsesRequest).get();
-        System.out.println(response);
+        // retrieve
+        Response retrievedResponse = client.getResponseServiceAsync().retrieve(createdResponse.id()).get();
+        assertNotNull(retrievedResponse);
+        assertEquals(createdResponse.id(), retrievedResponse.id());
+
+        // input items
+        InputItemListPageAsync inputItems
+            = client.getResponseServiceAsync().inputItems().list(createdResponse.id()).get();
+        assertNotNull(inputItems);
+        assertNotNull(inputItems.data());
+        assertFalse(inputItems.data().isEmpty());
+
+        // delete
+        client.getResponseServiceAsync().delete(createdResponse.id()).get();
+    }
+
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
+    public void cancelBackgroundResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion)
+        throws ExecutionException, InterruptedException {
+        ResponsesAsyncClient client = getResponsesAsyncClient(httpClient, serviceVersion);
+
+        ResponseCreateParams createRequest = ResponseCreateParams.builder()
+            .input("Tell me a very long story about a chicken trying to cross the road.")
+            .model("gpt-4o")
+            .background(true)
+            .build();
+        Response backgroundResponse = client.getResponseServiceAsync().create(createRequest).get();
+        assertNotNull(backgroundResponse);
+        assertNotNull(backgroundResponse.id());
+
+        Response cancelledResponse = client.getResponseServiceAsync().cancel(backgroundResponse.id()).get();
+        assertNotNull(cancelledResponse);
+        assertEquals(backgroundResponse.id(), cancelledResponse.id());
+        assertTrue(cancelledResponse.status().isPresent());
+        ResponseStatus status = cancelledResponse.status().get();
+        assertTrue(status.equals(ResponseStatus.CANCELLED) || status.equals(ResponseStatus.COMPLETED),
+            "Expected CANCELLED or COMPLETED status but was " + status);
     }
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
@@ -41,12 +89,47 @@ public class ResponsesAsyncTests extends ClientTestBase {
     public void basicCRUDOperationsWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
         ResponsesAsyncClient client = getResponsesAsyncClient(httpClient, serviceVersion);
 
-        HttpResponseFor<Response> rawResponse
+        // create
+        HttpResponseFor<Response> createdRaw
             = client.createResponseWithResponse(BinaryData.fromString(CREATE_RESPONSE_BODY), null).block();
+        assertNotNull(createdRaw);
+        Response createdResponse = createdRaw.parse();
+        assertNotNull(createdResponse);
+        assertNotNull(createdResponse.id());
 
-        assertNotNull(rawResponse);
-        Response response = rawResponse.parse();
-        assertNotNull(response);
-        System.out.println(response);
+        // retrieve
+        HttpResponseFor<Response> retrievedRaw = client.getResponseWithResponse(createdResponse.id(), null).block();
+        assertNotNull(retrievedRaw);
+        Response retrievedResponse = retrievedRaw.parse();
+        assertNotNull(retrievedResponse);
+        assertEquals(createdResponse.id(), retrievedResponse.id());
+
+        // delete
+        HttpResponse deletedRaw = client.deleteResponseWithResponse(createdResponse.id(), null).block();
+        assertNotNull(deletedRaw);
+    }
+
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
+    public void cancelBackgroundResponseWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
+        ResponsesAsyncClient client = getResponsesAsyncClient(httpClient, serviceVersion);
+
+        HttpResponseFor<Response> backgroundRaw
+            = client.createResponseWithResponse(BinaryData.fromString(CREATE_BACKGROUND_RESPONSE_BODY), null).block();
+        assertNotNull(backgroundRaw);
+        Response backgroundResponse = backgroundRaw.parse();
+        assertNotNull(backgroundResponse);
+        assertNotNull(backgroundResponse.id());
+
+        HttpResponseFor<Response> cancelledRaw
+            = client.cancelResponseWithResponse(backgroundResponse.id(), null).block();
+        assertNotNull(cancelledRaw);
+        Response cancelledResponse = cancelledRaw.parse();
+        assertNotNull(cancelledResponse);
+        assertEquals(backgroundResponse.id(), cancelledResponse.id());
+        assertTrue(cancelledResponse.status().isPresent());
+        ResponseStatus status = cancelledResponse.status().get();
+        assertTrue(status.equals(ResponseStatus.CANCELLED) || status.equals(ResponseStatus.COMPLETED),
+            "Expected CANCELLED or COMPLETED status but was " + status);
     }
 }

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesAsyncTests.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesAsyncTests.java
@@ -4,6 +4,8 @@
 package com.azure.ai.agents;
 
 import com.azure.core.http.HttpClient;
+import com.azure.core.util.BinaryData;
+import com.openai.core.http.HttpResponseFor;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCreateParams;
 import org.junit.jupiter.api.Disabled;
@@ -13,9 +15,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.concurrent.ExecutionException;
 
 import static com.azure.ai.agents.TestUtils.DISPLAY_NAME_WITH_ARGUMENTS;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Disabled("Disabled for lack of recordings. Needs to be enabled on the Public Preview release.")
 public class ResponsesAsyncTests extends ClientTestBase {
+
+    private static final String CREATE_RESPONSE_BODY
+        = "{\"input\":\"Hello, how can you help me?\",\"model\":\"gpt-4o\"}";
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
@@ -27,6 +33,20 @@ public class ResponsesAsyncTests extends ClientTestBase {
             = new ResponseCreateParams.Builder().input("Hello, how can you help me?").model("gpt-4o").build();
 
         Response response = client.getResponseServiceAsync().create(responsesRequest).get();
+        System.out.println(response);
+    }
+
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
+    public void basicCRUDOperationsWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
+        ResponsesAsyncClient client = getResponsesAsyncClient(httpClient, serviceVersion);
+
+        HttpResponseFor<Response> rawResponse
+            = client.createResponseWithResponse(BinaryData.fromString(CREATE_RESPONSE_BODY), null).block();
+
+        assertNotNull(rawResponse);
+        Response response = rawResponse.parse();
+        assertNotNull(response);
         System.out.println(response);
     }
 }

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesAsyncTests.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesAsyncTests.java
@@ -12,6 +12,7 @@ import com.openai.models.responses.ResponseCreateParams;
 import com.openai.models.responses.ResponseStatus;
 import com.openai.models.responses.ResponseStreamEvent;
 import com.openai.models.responses.inputitems.InputItemListPageAsync;
+import com.openai.services.async.ResponseServiceAsync;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -40,6 +41,7 @@ public class ResponsesAsyncTests extends ClientTestBase {
     public void basicCRUDOperations(HttpClient httpClient, AgentsServiceVersion serviceVersion)
         throws ExecutionException, InterruptedException {
         ResponsesAsyncClient client = getResponsesAsyncClient(httpClient, serviceVersion);
+        ResponseServiceAsync responseService = getResponseServiceAsyncClient(httpClient, serviceVersion);
 
         // create
         ResponseCreateParams createRequest
@@ -49,7 +51,7 @@ public class ResponsesAsyncTests extends ClientTestBase {
         assertNotNull(createdResponse.id());
 
         // retrieve
-        Response retrievedResponse = client.getResponseServiceAsync().retrieve(createdResponse.id()).get();
+        Response retrievedResponse = responseService.retrieve(createdResponse.id()).get();
         assertNotNull(retrievedResponse);
         assertEquals(createdResponse.id(), retrievedResponse.id());
 
@@ -61,7 +63,7 @@ public class ResponsesAsyncTests extends ClientTestBase {
         assertFalse(inputItems.data().isEmpty());
 
         // delete
-        client.getResponseServiceAsync().delete(createdResponse.id()).get();
+        responseService.delete(createdResponse.id()).get();
     }
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
@@ -69,6 +71,7 @@ public class ResponsesAsyncTests extends ClientTestBase {
     public void cancelBackgroundResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion)
         throws ExecutionException, InterruptedException {
         ResponsesAsyncClient client = getResponsesAsyncClient(httpClient, serviceVersion);
+        ResponseServiceAsync responseService = getResponseServiceAsyncClient(httpClient, serviceVersion);
 
         ResponseCreateParams createRequest = ResponseCreateParams.builder()
             .input("Tell me a very long story about a chicken trying to cross the road.")
@@ -79,7 +82,7 @@ public class ResponsesAsyncTests extends ClientTestBase {
         assertNotNull(backgroundResponse);
         assertNotNull(backgroundResponse.id());
 
-        Response cancelledResponse = client.getResponseServiceAsync().cancel(backgroundResponse.id()).get();
+        Response cancelledResponse = responseService.cancel(backgroundResponse.id()).get();
         assertNotNull(cancelledResponse);
         assertEquals(backgroundResponse.id(), cancelledResponse.id());
         assertTrue(cancelledResponse.status().isPresent());

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesTests.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesTests.java
@@ -4,6 +4,8 @@
 package com.azure.ai.agents;
 
 import com.azure.core.http.HttpClient;
+import com.azure.core.util.BinaryData;
+import com.openai.core.http.HttpResponseFor;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCreateParams;
 import org.junit.jupiter.api.Disabled;
@@ -15,6 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Disabled("Disabled for lack of recordings. Needs to be enabled on the Public Preview release.")
 public class ResponsesTests extends ClientTestBase {
+
+    private static final String CREATE_RESPONSE_BODY
+        = "{\"input\":\"Hello, how can you help me?\",\"model\":\"gpt-4o\"}";
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
@@ -58,5 +63,44 @@ public class ResponsesTests extends ClientTestBase {
 
         // Deletion - currently returning 500
         //        client.getOpenAIClient().delete(createdResponse.id());
+    }
+
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
+    public void basicCRUDOperationsWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion)
+        throws InterruptedException {
+        ResponsesClient client = getResponsesSyncClient(httpClient, serviceVersion);
+
+        // Creation
+        HttpResponseFor<Response> rawResponse
+            = client.createResponseWithResponse(BinaryData.fromString(CREATE_RESPONSE_BODY), null);
+
+        assertNotNull(rawResponse);
+        Response createdResponse = rawResponse.parse();
+        assertNotNull(createdResponse);
+        assertNotNull(createdResponse.id());
+
+        // Retrieval - currently returning 500
+        //        HttpResponseFor<Response> retrievedRaw = client.getResponseWithResponse(createdResponse.id(), null);
+        //        assertNotNull(retrievedRaw);
+        //        Response retrievedResponse = retrievedRaw.parse();
+        //        assertNotNull(retrievedResponse);
+        //        assertNotNull(retrievedResponse.id());
+
+        // Cancel - will have to look into the async tests for this
+        //        HttpResponseFor<Response> cancelableRaw = client.createResponseWithResponse(
+        //            BinaryData.fromString("{\"previous_response_id\":\"" + createdResponse.previousResponseId().orElse(null)
+        //                + "\",\"input\":\"Tell me a long story about a chicken trying to cross the road.\","
+        //                + "\"reasoning\":{\"effort\":\"high\"},\"background\":true}"),
+        //            null);
+        //        HttpResponseFor<Response> cancellationRaw
+        //            = client.cancelResponseWithResponse(cancelableRaw.parse().id(), null);
+        //        assertNotNull(cancellationRaw);
+        //        Response cancellationResponse = cancellationRaw.parse();
+        //        assertNotNull(cancellationResponse);
+        //        assertNotNull(cancellationResponse.id());
+
+        // Deletion - currently returning 500
+        //        client.deleteResponseWithResponse(createdResponse.id(), null);
     }
 }

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesTests.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesTests.java
@@ -5,11 +5,12 @@ package com.azure.ai.agents;
 
 import com.azure.core.http.HttpClient;
 import com.azure.core.util.BinaryData;
-import com.openai.core.http.HttpResponse;
 import com.openai.core.http.HttpResponseFor;
+import com.openai.core.http.StreamResponse;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCreateParams;
 import com.openai.models.responses.ResponseStatus;
+import com.openai.models.responses.ResponseStreamEvent;
 import com.openai.models.responses.inputitems.InputItemListPage;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -24,6 +25,9 @@ public class ResponsesTests extends ClientTestBase {
 
     private static final String CREATE_RESPONSE_BODY
         = "{\"input\":\"Hello, how can you help me?\",\"model\":\"gpt-4o\"}";
+
+    private static final String CREATE_STREAM_RESPONSE_BODY
+        = "{\"input\":\"Hello, how can you help me?\",\"model\":\"gpt-4o\",\"stream\":true}";
 
     private static final String CREATE_BACKGROUND_RESPONSE_BODY
         = "{\"input\":\"Tell me a very long story about a chicken trying to cross the road.\","
@@ -85,46 +89,27 @@ public class ResponsesTests extends ClientTestBase {
     public void basicCRUDOperationsWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
         ResponsesClient client = getResponsesSyncClient(httpClient, serviceVersion);
 
-        // create
         HttpResponseFor<Response> createdRaw
             = client.createResponseWithResponse(BinaryData.fromString(CREATE_RESPONSE_BODY), null);
         assertNotNull(createdRaw);
         Response createdResponse = createdRaw.parse();
         assertNotNull(createdResponse);
         assertNotNull(createdResponse.id());
-
-        // retrieve
-        HttpResponseFor<Response> retrievedRaw = client.getResponseWithResponse(createdResponse.id(), null);
-        assertNotNull(retrievedRaw);
-        Response retrievedResponse = retrievedRaw.parse();
-        assertNotNull(retrievedResponse);
-        assertEquals(createdResponse.id(), retrievedResponse.id());
-
-        // delete
-        HttpResponse deletedRaw = client.deleteResponseWithResponse(createdResponse.id(), null);
-        assertNotNull(deletedRaw);
     }
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
-    public void cancelBackgroundResponseWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
+    public void basicStreamingOperationsWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
         ResponsesClient client = getResponsesSyncClient(httpClient, serviceVersion);
 
-        HttpResponseFor<Response> backgroundRaw
-            = client.createResponseWithResponse(BinaryData.fromString(CREATE_BACKGROUND_RESPONSE_BODY), null);
-        assertNotNull(backgroundRaw);
-        Response backgroundResponse = backgroundRaw.parse();
-        assertNotNull(backgroundResponse);
-        assertNotNull(backgroundResponse.id());
-
-        HttpResponseFor<Response> cancelledRaw = client.cancelResponseWithResponse(backgroundResponse.id(), null);
-        assertNotNull(cancelledRaw);
-        Response cancelledResponse = cancelledRaw.parse();
-        assertNotNull(cancelledResponse);
-        assertEquals(backgroundResponse.id(), cancelledResponse.id());
-        assertTrue(cancelledResponse.status().isPresent());
-        ResponseStatus status = cancelledResponse.status().get();
-        assertTrue(status.equals(ResponseStatus.CANCELLED) || status.equals(ResponseStatus.COMPLETED),
-            "Expected CANCELLED or COMPLETED status but was " + status);
+        try (
+            HttpResponseFor<StreamResponse<ResponseStreamEvent>> raw
+                = client.createResponseStreamWithResponse(BinaryData.fromString(CREATE_STREAM_RESPONSE_BODY), null);
+            StreamResponse<ResponseStreamEvent> events = raw.parse()) {
+            assertNotNull(raw);
+            assertNotNull(events);
+            long count = events.stream().peek(e -> assertNotNull(e)).count();
+            assertTrue(count > 0, "Expected at least one stream event but received none");
+        }
     }
 }

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesTests.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesTests.java
@@ -30,10 +30,6 @@ public class ResponsesTests extends ClientTestBase {
     private static final String CREATE_STREAM_RESPONSE_BODY
         = "{\"input\":\"Hello, how can you help me?\",\"model\":\"gpt-4o\",\"stream\":true}";
 
-    private static final String CREATE_BACKGROUND_RESPONSE_BODY
-        = "{\"input\":\"Tell me a very long story about a chicken trying to cross the road.\","
-            + "\"model\":\"gpt-4o\",\"background\":true}";
-
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
     public void basicCRUDOperations(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
@@ -92,12 +88,13 @@ public class ResponsesTests extends ClientTestBase {
     public void basicCRUDOperationsWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
         ResponsesClient client = getResponsesSyncClient(httpClient, serviceVersion);
 
-        HttpResponseFor<Response> createdRaw
-            = client.createResponseWithResponse(BinaryData.fromString(CREATE_RESPONSE_BODY), null);
-        assertNotNull(createdRaw);
-        Response createdResponse = createdRaw.parse();
-        assertNotNull(createdResponse);
-        assertNotNull(createdResponse.id());
+        try (HttpResponseFor<Response> createdRaw
+            = client.createResponseWithResponse(BinaryData.fromString(CREATE_RESPONSE_BODY), null)) {
+            assertNotNull(createdRaw);
+            Response createdResponse = createdRaw.parse();
+            assertNotNull(createdResponse);
+            assertNotNull(createdResponse.id());
+        }
     }
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesTests.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesTests.java
@@ -12,6 +12,7 @@ import com.openai.models.responses.ResponseCreateParams;
 import com.openai.models.responses.ResponseStatus;
 import com.openai.models.responses.ResponseStreamEvent;
 import com.openai.models.responses.inputitems.InputItemListPage;
+import com.openai.services.blocking.ResponseService;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -37,6 +38,7 @@ public class ResponsesTests extends ClientTestBase {
     @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
     public void basicCRUDOperations(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
         ResponsesClient client = getResponsesSyncClient(httpClient, serviceVersion);
+        ResponseService responseService = getResponseServiceSyncClient(httpClient, serviceVersion);
 
         // create
         ResponseCreateParams createRequest
@@ -46,7 +48,7 @@ public class ResponsesTests extends ClientTestBase {
         assertNotNull(createdResponse.id());
 
         // retrieve
-        Response retrievedResponse = client.getResponseService().retrieve(createdResponse.id());
+        Response retrievedResponse = responseService.retrieve(createdResponse.id());
         assertNotNull(retrievedResponse);
         assertEquals(createdResponse.id(), retrievedResponse.id());
 
@@ -57,13 +59,14 @@ public class ResponsesTests extends ClientTestBase {
         assertFalse(inputItems.data().isEmpty());
 
         // delete
-        client.getResponseService().delete(createdResponse.id());
+        responseService.delete(createdResponse.id());
     }
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
     public void cancelBackgroundResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
         ResponsesClient client = getResponsesSyncClient(httpClient, serviceVersion);
+        ResponseService responseService = getResponseServiceSyncClient(httpClient, serviceVersion);
 
         ResponseCreateParams createRequest = ResponseCreateParams.builder()
             .input("Tell me a very long story about a chicken trying to cross the road.")
@@ -74,7 +77,7 @@ public class ResponsesTests extends ClientTestBase {
         assertNotNull(backgroundResponse);
         assertNotNull(backgroundResponse.id());
 
-        Response cancelledResponse = client.getResponseService().cancel(backgroundResponse.id());
+        Response cancelledResponse = responseService.cancel(backgroundResponse.id());
         assertNotNull(cancelledResponse);
         assertEquals(backgroundResponse.id(), cancelledResponse.id());
         assertTrue(cancelledResponse.status().isPresent());

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesTests.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/ResponsesTests.java
@@ -5,102 +5,126 @@ package com.azure.ai.agents;
 
 import com.azure.core.http.HttpClient;
 import com.azure.core.util.BinaryData;
+import com.openai.core.http.HttpResponse;
 import com.openai.core.http.HttpResponseFor;
 import com.openai.models.responses.Response;
 import com.openai.models.responses.ResponseCreateParams;
-import org.junit.jupiter.api.Disabled;
+import com.openai.models.responses.ResponseStatus;
+import com.openai.models.responses.inputitems.InputItemListPage;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static com.azure.ai.agents.TestUtils.DISPLAY_NAME_WITH_ARGUMENTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled("Disabled for lack of recordings. Needs to be enabled on the Public Preview release.")
 public class ResponsesTests extends ClientTestBase {
 
     private static final String CREATE_RESPONSE_BODY
         = "{\"input\":\"Hello, how can you help me?\",\"model\":\"gpt-4o\"}";
 
+    private static final String CREATE_BACKGROUND_RESPONSE_BODY
+        = "{\"input\":\"Tell me a very long story about a chicken trying to cross the road.\","
+            + "\"model\":\"gpt-4o\",\"background\":true}";
+
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
-    public void basicCRUDOperations(HttpClient httpClient, AgentsServiceVersion serviceVersion)
-        throws InterruptedException {
+    public void basicCRUDOperations(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
         ResponsesClient client = getResponsesSyncClient(httpClient, serviceVersion);
 
-        ResponseCreateParams responsesRequest
-            = new ResponseCreateParams.Builder().input("Hello, how can you help me?").model("gpt-4o").build();
-
-        // Creation
-        Response createdResponse = client.getResponseService().create(responsesRequest);
-
+        // create
+        ResponseCreateParams createRequest
+            = ResponseCreateParams.builder().input("Hello, how can you help me?").model("gpt-4o").build();
+        Response createdResponse = client.getResponseService().create(createRequest);
         assertNotNull(createdResponse);
         assertNotNull(createdResponse.id());
 
-        // Retrieval - currently returning 500
-        //        Response retrievedResponse = client.getOpenAIClient().retrieve(createdResponse.id());
-        //
-        //        assertNotNull(retrievedResponse);
-        //        assertNotNull(retrievedResponse.id());
+        // retrieve
+        Response retrievedResponse = client.getResponseService().retrieve(createdResponse.id());
+        assertNotNull(retrievedResponse);
+        assertEquals(createdResponse.id(), retrievedResponse.id());
 
-        // Cancel - will have to look into the async tests for this
-        //        Response cancelableResponse = client.getOpenAIClient().create(
-        //                ResponseCreateParams.builder().previousResponseId(createdResponse.previousResponseId())
-        //                    .input("Tell me a long story about a chicken trying to cross the road.")
-        //                    .reasoning(Reasoning.builder().effort(ReasoningEffort.HIGH).build())
-        //                    .background(true)
-        //                    .build());
-        //        Response cancelationResponse = client.getOpenAIClient().cancel(cancelableResponse.id());
-        //
-        //        assertNotNull(cancelationResponse);
-        //        assertNotNull(cancelationResponse.id());
+        // input items
+        InputItemListPage inputItems = client.getResponseService().inputItems().list(createdResponse.id());
+        assertNotNull(inputItems);
+        assertNotNull(inputItems.data());
+        assertFalse(inputItems.data().isEmpty());
 
-        // Input items - currently returning 500
-        //        InputItemListPage itemList = client.getOpenAIClient().inputItems().list(createdResponse.id());
-        //
-        //        assertNotNull(itemList);
-        //        assertNotNull(itemList.data());
-        //        assertFalse(itemList.data().isEmpty());
-
-        // Deletion - currently returning 500
-        //        client.getOpenAIClient().delete(createdResponse.id());
+        // delete
+        client.getResponseService().delete(createdResponse.id());
     }
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
-    public void basicCRUDOperationsWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion)
-        throws InterruptedException {
+    public void cancelBackgroundResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
         ResponsesClient client = getResponsesSyncClient(httpClient, serviceVersion);
 
-        // Creation
-        HttpResponseFor<Response> rawResponse
-            = client.createResponseWithResponse(BinaryData.fromString(CREATE_RESPONSE_BODY), null);
+        ResponseCreateParams createRequest = ResponseCreateParams.builder()
+            .input("Tell me a very long story about a chicken trying to cross the road.")
+            .model("gpt-4o")
+            .background(true)
+            .build();
+        Response backgroundResponse = client.getResponseService().create(createRequest);
+        assertNotNull(backgroundResponse);
+        assertNotNull(backgroundResponse.id());
 
-        assertNotNull(rawResponse);
-        Response createdResponse = rawResponse.parse();
+        Response cancelledResponse = client.getResponseService().cancel(backgroundResponse.id());
+        assertNotNull(cancelledResponse);
+        assertEquals(backgroundResponse.id(), cancelledResponse.id());
+        assertTrue(cancelledResponse.status().isPresent());
+        ResponseStatus status = cancelledResponse.status().get();
+        // Background responses may finish between create and cancel; accept either terminal state.
+        assertTrue(status.equals(ResponseStatus.CANCELLED) || status.equals(ResponseStatus.COMPLETED),
+            "Expected CANCELLED or COMPLETED status but was " + status);
+    }
+
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
+    public void basicCRUDOperationsWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
+        ResponsesClient client = getResponsesSyncClient(httpClient, serviceVersion);
+
+        // create
+        HttpResponseFor<Response> createdRaw
+            = client.createResponseWithResponse(BinaryData.fromString(CREATE_RESPONSE_BODY), null);
+        assertNotNull(createdRaw);
+        Response createdResponse = createdRaw.parse();
         assertNotNull(createdResponse);
         assertNotNull(createdResponse.id());
 
-        // Retrieval - currently returning 500
-        //        HttpResponseFor<Response> retrievedRaw = client.getResponseWithResponse(createdResponse.id(), null);
-        //        assertNotNull(retrievedRaw);
-        //        Response retrievedResponse = retrievedRaw.parse();
-        //        assertNotNull(retrievedResponse);
-        //        assertNotNull(retrievedResponse.id());
+        // retrieve
+        HttpResponseFor<Response> retrievedRaw = client.getResponseWithResponse(createdResponse.id(), null);
+        assertNotNull(retrievedRaw);
+        Response retrievedResponse = retrievedRaw.parse();
+        assertNotNull(retrievedResponse);
+        assertEquals(createdResponse.id(), retrievedResponse.id());
 
-        // Cancel - will have to look into the async tests for this
-        //        HttpResponseFor<Response> cancelableRaw = client.createResponseWithResponse(
-        //            BinaryData.fromString("{\"previous_response_id\":\"" + createdResponse.previousResponseId().orElse(null)
-        //                + "\",\"input\":\"Tell me a long story about a chicken trying to cross the road.\","
-        //                + "\"reasoning\":{\"effort\":\"high\"},\"background\":true}"),
-        //            null);
-        //        HttpResponseFor<Response> cancellationRaw
-        //            = client.cancelResponseWithResponse(cancelableRaw.parse().id(), null);
-        //        assertNotNull(cancellationRaw);
-        //        Response cancellationResponse = cancellationRaw.parse();
-        //        assertNotNull(cancellationResponse);
-        //        assertNotNull(cancellationResponse.id());
+        // delete
+        HttpResponse deletedRaw = client.deleteResponseWithResponse(createdResponse.id(), null);
+        assertNotNull(deletedRaw);
+    }
 
-        // Deletion - currently returning 500
-        //        client.deleteResponseWithResponse(createdResponse.id(), null);
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.agents.TestUtils#getTestParameters")
+    public void cancelBackgroundResponseWithResponse(HttpClient httpClient, AgentsServiceVersion serviceVersion) {
+        ResponsesClient client = getResponsesSyncClient(httpClient, serviceVersion);
+
+        HttpResponseFor<Response> backgroundRaw
+            = client.createResponseWithResponse(BinaryData.fromString(CREATE_BACKGROUND_RESPONSE_BODY), null);
+        assertNotNull(backgroundRaw);
+        Response backgroundResponse = backgroundRaw.parse();
+        assertNotNull(backgroundResponse);
+        assertNotNull(backgroundResponse.id());
+
+        HttpResponseFor<Response> cancelledRaw = client.cancelResponseWithResponse(backgroundResponse.id(), null);
+        assertNotNull(cancelledRaw);
+        Response cancelledResponse = cancelledRaw.parse();
+        assertNotNull(cancelledResponse);
+        assertEquals(backgroundResponse.id(), cancelledResponse.id());
+        assertTrue(cancelledResponse.status().isPresent());
+        ResponseStatus status = cancelledResponse.status().get();
+        assertTrue(status.equals(ResponseStatus.CANCELLED) || status.equals(ResponseStatus.COMPLETED),
+            "Expected CANCELLED or COMPLETED status but was " + status);
     }
 }


### PR DESCRIPTION
This pull request adds new protocol-style methods to both the `ResponsesClient` and `ResponsesAsyncClient` classes, enabling users to send raw JSON request bodies and receive raw HTTP responses. It also enables and expands test coverage for these new methods and the existing typed surfaces, and updates asset references accordingly.

**Protocol method additions:**

* Added `createResponseWithResponse` and `createResponseStreamWithResponse` methods to `ResponsesClient` and `ResponsesAsyncClient`. These methods accept a raw JSON body (`BinaryData`) and OpenAI `RequestOptions`, and return the raw HTTP response (`HttpResponseFor<Response>` or `HttpResponseFor<StreamResponse<ResponseStreamEvent>>`). This allows advanced scenarios, such as including Azure-specific extensions, without relying on the strongly-typed builder. [[1]](diffhunk://#diff-3b25a20aa97238b6aeed8483e364cc8f0d1c388cd0b72ca50d6968d2fbd11e33R91-R156) [[2]](diffhunk://#diff-25dd831ce28cd95422fac1a59a499c142f866c5c72fbd2ef9dbe926f8334ae01R104-R167) [[3]](diffhunk://#diff-d8e7e6b12a2057d86c7205b983100c9123ec076f0fa137c39ed9f121a9ff467dR7-R12)

* Introduced the `OpenAIJsonHelper.jsonBodyToValueMap(BinaryData)` utility method to convert raw JSON request bodies into the map format required by the OpenAI Java SDK.

**Test enhancements:**

* Enabled and expanded `ResponsesTests` and `ResponsesAsyncTests` (previously disabled), adding CRUD, input-items, and background-cancel coverage for both the typed and new protocol-style methods. [[1]](diffhunk://#diff-4f6d9af5d58a2439a60941a1bb91cc00943641070d431557dbbf07f36f34b847R7-R116) [[2]](diffhunk://#diff-d8e7e6b12a2057d86c7205b983100c9123ec076f0fa137c39ed9f121a9ff467dR7-R12)

**Asset updates:**

* Updated the `assets.json` file to reference the latest published test recordings.

**Documentation:**

* Updated the `CHANGELOG.md` to describe the new protocol methods and test coverage.