### PR TITLE
chore: add @SwayGom and @sagar0207 to CODEOWNERS alongside @j7nw4r

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -343,10 +343,10 @@
 /sdk/eventhubs/microsoft-azure-eventhubs-eph/                      @axisc @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak @Azure/azure-java-sdk
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/microsoft-azure-eventhubs/                          @axisc @hmlam @sjkwak @Azure/azure-java-sdk
+/sdk/eventhubs/microsoft-azure-eventhubs/                          @axisc @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak @Azure/azure-java-sdk
 
 # ServiceLabel: %Event Hubs
-# ServiceOwners:                                                   @axisc @hmlam @sjkwak
+# ServiceOwners:                                                   @axisc @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak
 
 # PRLabel: %Health Deidentification
 /sdk/healthdataaiservices/                                         @alexathomases @Azure/healthdatadeidentification @Azure/azure-java-sdk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -340,7 +340,7 @@
 /sdk/eventhubs/                                                    @axisc @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak @Azure/azure-java-sdk
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/microsoft-azure-eventhubs-eph/                      @axisc @hmlam @sjkwak @Azure/azure-java-sdk
+/sdk/eventhubs/microsoft-azure-eventhubs-eph/                      @axisc @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak @Azure/azure-java-sdk
 
 # PRLabel: %Event Hubs
 /sdk/eventhubs/microsoft-azure-eventhubs/                          @axisc @hmlam @sjkwak @Azure/azure-java-sdk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -337,7 +337,7 @@
 # ServiceOwners:                                                   @Kishp01 @rajeshka @shankarsama
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/                                                    @axisc @hmlam @j7nw4r @SwayGom @sjkwak @Azure/azure-java-sdk
+/sdk/eventhubs/                                                    @axisc @hmlam @j7nw4r @SwayGom @sagar0207 @sjkwak @Azure/azure-java-sdk
 
 # PRLabel: %Event Hubs
 /sdk/eventhubs/microsoft-azure-eventhubs-eph/                      @axisc @hmlam @sjkwak @Azure/azure-java-sdk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -337,7 +337,7 @@
 # ServiceOwners:                                                   @Kishp01 @rajeshka @shankarsama
 
 # PRLabel: %Event Hubs
-/sdk/eventhubs/                                                    @axisc @hmlam @j7nw4r @sjkwak @Azure/azure-java-sdk
+/sdk/eventhubs/                                                    @axisc @hmlam @j7nw4r @SwayGom @sjkwak @Azure/azure-java-sdk
 
 # PRLabel: %Event Hubs
 /sdk/eventhubs/microsoft-azure-eventhubs-eph/                      @axisc @hmlam @sjkwak @Azure/azure-java-sdk


### PR DESCRIPTION
Adding my coworkers @SwayGom and @sagar0207 to every CODEOWNERS line I'm currently on, and opting all three of us in on both legacy Event Hubs libraries (`/sdk/eventhubs/microsoft-azure-eventhubs-eph/` and `/sdk/eventhubs/microsoft-azure-eventhubs/`) plus the `# ServiceOwners:` block under `# ServiceLabel: %Event Hubs` so reviews and notifications reach the messaging team consistently.

Everywhere `@j7nw4r` already appeared, the entry becomes `@j7nw4r @SwayGom @sagar0207`. No other entries changed.
