### PR TITLE
Security: Harden B2C resource server token validation defaults

### DIFF
--- a/sdk/spring/CHANGELOG.md
+++ b/sdk/spring/CHANGELOG.md
@@ -10,6 +10,7 @@ This section includes changes in `spring-cloud-azure-autoconfigure` module.
 
 - AAD resource server now requires `spring.cloud.azure.active-directory.profile.tenant-id` to be set to a specific (non-reserved) tenant ID. Empty string, `common`, `organizations`, and `consumers` are no longer accepted and will cause application startup to fail with an `IllegalArgumentException`. ([#49033](https://github.com/Azure/azure-sdk-for-java/pull/49033))
 - `AadAuthenticationFilter` now enables explicit audience validation by default. The filter will verify that the JWT's `aud` (audience) claim matches either `spring.cloud.azure.active-directory.credential.client-id` or `spring.cloud.azure.active-directory.app-id-uri`. Tokens issued for other applications will be rejected with `BadJWTException`. This prevents cross-application token reuse and aligns with OAuth2/OIDC security best practices. ([#49033](https://github.com/Azure/azure-sdk-for-java/pull/49033))
+- B2C resource server now requires `spring.cloud.azure.active-directory.b2c.profile.tenant-id` to be set to a specific (non-reserved) tenant ID. Empty string, `common`, `organizations`, and `consumers` are no longer accepted. In addition, default token validation is hardened to enforce tenant-bound `tid`, stricter `aud` validation, and B2C-only trusted issuers. ([#49252](https://github.com/Azure/azure-sdk-for-java/pull/49252))
 
 #### Bugs Fixed
 

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aad/security/jwt/AadTrustedIssuerRepository.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aad/security/jwt/AadTrustedIssuerRepository.java
@@ -53,9 +53,21 @@ public class AadTrustedIssuerRepository {
      * @param tenantId the tenant ID
      */
     public AadTrustedIssuerRepository(String tenantId) {
+        this(tenantId, true);
+    }
+
+    /**
+     * Creates a new instance of {@link AadTrustedIssuerRepository} with optional AAD issuer defaults.
+     *
+     * @param tenantId the tenant ID
+     * @param includeAadIssuers whether to include default AAD trusted issuers
+     */
+    protected AadTrustedIssuerRepository(String tenantId, boolean includeAadIssuers) {
         this.tenantId = tenantId;
-        trustedIssuers.addAll(buildAadIssuers(PATH_DELIMITER));
-        trustedIssuers.addAll(buildAadIssuers(PATH_DELIMITER_V2));
+        if (includeAadIssuers) {
+            trustedIssuers.addAll(buildAadIssuers(PATH_DELIMITER));
+            trustedIssuers.addAll(buildAadIssuers(PATH_DELIMITER_V2));
+        }
     }
 
     private List<String> buildAadIssuers(String delimiter) {

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/configuration/AadB2cResourceServerAutoConfiguration.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/configuration/AadB2cResourceServerAutoConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Configure necessary beans for Azure AD B2C resource server beans, and import {@link AadB2cOAuth2ClientConfiguration} class for Azure AD
@@ -58,6 +59,7 @@ public class AadB2cResourceServerAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     AadTrustedIssuerRepository trustedIssuerRepository() {
+        validateTenantId(getTrimmedTenantId(properties));
         return new AadB2cTrustedIssuerRepository(properties);
     }
 
@@ -93,6 +95,8 @@ public class AadB2cResourceServerAutoConfiguration {
         NimbusJwtDecoder decoder = new NimbusJwtDecoder(jwtProcessor);
         List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
         List<String> validAudiences = new ArrayList<>();
+        String tenantId = getTrimmedTenantId(properties);
+        validateTenantId(tenantId);
         if (StringUtils.hasText(properties.getAppIdUri())) {
             validAudiences.add(properties.getAppIdUri());
         }
@@ -100,12 +104,40 @@ public class AadB2cResourceServerAutoConfiguration {
             validAudiences.add(properties.getCredential().getClientId());
         }
         if (!validAudiences.isEmpty()) {
-            validators.add(new JwtClaimValidator<List<String>>(AadJwtClaimNames.AUD, validAudiences::containsAll));
+            validators.add(new JwtClaimValidator<List<String>>(AadJwtClaimNames.AUD,
+                audiences -> audiences != null
+                    && !audiences.isEmpty()
+                    && audiences.stream().anyMatch(validAudiences::contains)));
         }
+        validators.add(new JwtClaimValidator<String>(AadJwtClaimNames.TID, tenantId::equals));
         validators.add(new AadJwtIssuerValidator(trustedIssuerRepository));
         validators.add(new JwtTimestampValidator());
         decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(validators));
         return decoder;
+    }
+
+    private static String getTrimmedTenantId(AadB2cProperties aadB2cProperties) {
+        String tenantId = aadB2cProperties.getProfile().getTenantId();
+        return tenantId != null ? tenantId.trim().toLowerCase(Locale.ROOT) : null;
+    }
+
+    private static void validateTenantId(String tenantId) {
+        if (!StringUtils.hasText(tenantId)
+            || "common".equalsIgnoreCase(tenantId)
+            || "organizations".equalsIgnoreCase(tenantId)
+            || "consumers".equalsIgnoreCase(tenantId)) {
+            throw new IllegalArgumentException(
+                "For B2C resource server, "
+                    + "'spring.cloud.azure.active-directory.b2c.profile.tenant-id' "
+                    + "cannot be null, empty, or set to 'common', "
+                    + "'organizations', or 'consumers'. "
+                    + "These values are not supported for resource server token "
+                    + "validation because a specific tenant ID is required to "
+                    + "validate the token 'tid' claim and issuer against a "
+                    + "single B2C tenant. "
+                    + "Please configure an explicit tenant ID for your "
+                    + "organization's tenant.");
+        }
     }
 }
 

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/jwt/AadB2cTrustedIssuerRepository.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/jwt/AadB2cTrustedIssuerRepository.java
@@ -27,12 +27,17 @@ public class AadB2cTrustedIssuerRepository extends AadTrustedIssuerRepository {
      * @param aadB2cProperties the AAD B2C properties
      */
     public AadB2cTrustedIssuerRepository(AadB2cProperties aadB2cProperties) {
-        super(aadB2cProperties.getProfile().getTenantId());
+        super(getTrimmedTenantId(aadB2cProperties), false);
         this.aadB2cProperties = aadB2cProperties;
         this.resolvedBaseUri = resolveBaseUri(this.aadB2cProperties.getBaseUri());
         this.userFlows = this.aadB2cProperties.getUserFlows();
         this.addB2cIssuer();
         this.addB2cUserFlowIssuers();
+    }
+
+    private static String getTrimmedTenantId(AadB2cProperties aadB2cProperties) {
+        String tenantId = aadB2cProperties != null ? aadB2cProperties.getProfile().getTenantId() : null;
+        return tenantId != null ? tenantId.trim().toLowerCase(ROOT) : null;
     }
 
     private void addB2cIssuer() {

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/configuration/AadB2cResourceServerAutoConfigurationTests.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/configuration/AadB2cResourceServerAutoConfigurationTests.java
@@ -29,6 +29,8 @@ import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationF
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -182,6 +184,40 @@ class AadB2cResourceServerAutoConfigurationTests extends AbstractAadB2cOAuth2Cli
                     context.getBean(AadB2cTrustedIssuerRepository.class);
                 assertThat(aadb2CTrustedIssuerRepository).isNotNull();
                 assertThat(aadb2CTrustedIssuerRepository).isExactlyInstanceOf(AadB2cTrustedIssuerRepository.class);
+
+                Set<String> trustedIssuers = aadb2CTrustedIssuerRepository.getTrustedIssuers();
+                assertThat(trustedIssuers)
+                    .noneMatch(issuer -> issuer.startsWith("https://login.microsoftonline.com/"))
+                    .noneMatch(issuer -> issuer.startsWith("https://sts.windows.net/"))
+                    .noneMatch(issuer -> issuer.startsWith("https://sts.chinacloudapi.cn/"));
+            });
+    }
+
+    @Test
+    void testValidateTenantIdRejectsCommon() {
+        getDefaultContextRunner()
+            .withPropertyValues(getB2CResourceServerProperties())
+            .withPropertyValues(String.format("%s=common", AadB2cConstants.TENANT_ID))
+            .withUserConfiguration(AadB2cResourceServerAutoConfiguration.class)
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot be null, empty, or set to");
+            });
+    }
+
+    @Test
+    void testValidateTenantIdRejectsEmptyString() {
+        getDefaultContextRunner()
+            .withPropertyValues(getB2CResourceServerProperties())
+            .withPropertyValues(String.format("%s=", AadB2cConstants.TENANT_ID))
+            .withUserConfiguration(AadB2cResourceServerAutoConfiguration.class)
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot be null, empty, or set to");
             });
     }
 

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/configuration/AadB2cResourceServerAutoConfigurationTests.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/configuration/AadB2cResourceServerAutoConfigurationTests.java
@@ -222,6 +222,48 @@ class AadB2cResourceServerAutoConfigurationTests extends AbstractAadB2cOAuth2Cli
     }
 
     @Test
+    void testValidateTenantIdRejectsOrganizations() {
+        getDefaultContextRunner()
+            .withPropertyValues(getB2CResourceServerProperties())
+            .withPropertyValues(String.format("%s=organizations", AadB2cConstants.TENANT_ID))
+            .withUserConfiguration(AadB2cResourceServerAutoConfiguration.class)
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot be null, empty, or set to");
+            });
+    }
+
+    @Test
+    void testValidateTenantIdRejectsConsumers() {
+        getDefaultContextRunner()
+            .withPropertyValues(getB2CResourceServerProperties())
+            .withPropertyValues(String.format("%s=consumers", AadB2cConstants.TENANT_ID))
+            .withUserConfiguration(AadB2cResourceServerAutoConfiguration.class)
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot be null, empty, or set to");
+            });
+    }
+
+    @Test
+    void testValidateTenantIdRejectsReservedValuesWithWhitespaceAndCase() {
+        getDefaultContextRunner()
+            .withPropertyValues(getB2CResourceServerProperties())
+            .withPropertyValues(String.format("%s=  COMMON  ", AadB2cConstants.TENANT_ID))
+            .withUserConfiguration(AadB2cResourceServerAutoConfiguration.class)
+            .run(context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot be null, empty, or set to");
+            });
+    }
+
+    @Test
     @SuppressWarnings({ "unchecked", "rawtypes" })
     void testExistjwtProcessorBean() {
         getDefaultContextRunner()


### PR DESCRIPTION
# Description

## Summary
This PR fixes security gaps in B2C resource-server JWT validation by mirroring the hardening introduced for AAD in #49033.

The previous B2C default configuration could accept tokens from unintended issuers because:
- tenant-id values such as `common` were not rejected,
- `tid` claim validation was missing,
- audience validation used a `containsAll` predicate that allowed unsafe cases,
- B2C trusted issuers inherited default AAD issuer entries.

## What changed
### 1. Enforced tenant-id validation in B2C resource server
Updated `AadB2cResourceServerAutoConfiguration` to reject null/empty/reserved tenant IDs (`common`, `organizations`, `consumers`) and normalize tenant ID for comparison.

### 2. Added `tid` claim validator
Added `JwtClaimValidator<String>(AadJwtClaimNames.TID, tenantId::equals)` to bind tokens to the configured tenant.

### 3. Hardened `aud` claim predicate
Replaced `validAudiences::containsAll` with a strict predicate requiring:
- non-null audience claim,
- non-empty audience list,
- at least one audience matching configured valid audiences.

### 4. Removed unintended AAD issuer inheritance from B2C trusted issuer repository
Refactored `AadTrustedIssuerRepository` with an overload that can skip default AAD issuer seeding.
`AadB2cTrustedIssuerRepository` now calls the new constructor with `includeAadIssuers=false`, so B2C trusts only B2C issuers it explicitly adds.

## Tests
Added/updated tests in `AadB2cResourceServerAutoConfigurationTests` to verify:
- invalid tenant IDs are rejected at startup,
- B2C trusted issuers do not contain AAD-line issuers.

Executed tests:
- `mvn -pl spring-cloud-azure-autoconfigure -Dtest=AadB2cResourceServerAutoConfigurationTests test`
- `mvn -pl spring-cloud-azure-autoconfigure test`

Result:
- `BUILD SUCCESS`
- full artifact run: `Tests run: 1090, Failures: 0, Errors: 0, Skipped: 7`

## Impact
This change prevents cross-issuer acceptance paths in the B2C resource-server default configuration and aligns B2C token validation posture with recent AAD hardening.


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
