### PR TITLE
[Cosmos] Make JsonSerializable.propertyBag final to fix sporadic NPE in DatabaseAccount lazy getters

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 #### Other Changes
 * Replaced per-client `Schedulers.newSingle()` schedulers in `GlobalEndpointManager` and `GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker` with shared `BoundedElastic` schedulers in `CosmosSchedulers` to prevent thread count from scaling linearly with client/tenant count. - See [PR 49062](https://github.com/Azure/azure-sdk-for-java/pull/49062)
+* Fixed a sporadic `NullPointerException` in `JsonSerializable.getWithMapping` triggered by concurrent first-time calls to `DatabaseAccount.getConsistencyPolicy()` and its sibling lazy getters (`getReplicationPolicy`, `getSystemReplicationPolicy`, `getQueryEngineConfiguration`). The fix makes `JsonSerializable.propertyBag` `final`, closing an unsafe-publication race in the lazy-initialisation pattern. - See [Issue 49256](https://github.com/Azure/azure-sdk-for-java/issues/49256) and [PR #49258](https://github.com/Azure/azure-sdk-for-java/pull/49258)
 
 ### 4.80.0 (2026-05-01)
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/JsonSerializable.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/JsonSerializable.java
@@ -65,7 +65,7 @@ public class JsonSerializable {
 
     private static final ObjectMapper OBJECT_MAPPER= Utils.getSimpleObjectMapper();
     private static final Logger LOGGER = LoggerFactory.getLogger(JsonSerializable.class);
-    transient ObjectNode propertyBag = null;
+    final transient ObjectNode propertyBag;
     private ObjectMapper om;
 
     public JsonSerializable() {


### PR DESCRIPTION
Fixes #49256.

`JsonSerializable.propertyBag` is non-`volatile` and non-`final`, assigned exactly once in each of the six `JsonSerializable` constructors and never written to outside them in the SDK. Combined with the lazy-initialised, non-`volatile` field assignments in `DatabaseAccount.getConsistencyPolicy()` (and its three siblings), this enables an unsafe publication: a concurrent reader can observe `consistencyPolicy != null` while observing the new `ConsistencyPolicy`'s `propertyBag` field at its default value `null`, producing the `NullPointerException` reported in #49256.

Making `propertyBag` `final` invokes final-field publication semantics ([JLS §17.5](https://docs.oracle.com/javase/specs/jls/se21/html/jls-17.html#jls-17.5), [JSR-133 FAQ](https://www.cs.umd.edu/~pugh/java/memoryModel/jsr-133-faq.html)): a thread that sees the reference to the constructed object after its constructor completes is guaranteed to see the correctly-initialised final field without requiring a synchronizes-with edge from the publishing thread. This closes the race window for `ConsistencyPolicy` and for every other `JsonSerializable` subclass that could be lazy-published in the same way.

The change is one keyword. Every existing constructor already assigns `propertyBag`, so the only other mechanical change is dropping the redundant `= null` default initialiser.

## Why this fix vs. the alternatives

* **`volatile` on `consistencyPolicy` (and siblings) in `DatabaseAccount`**: also closes the window, but only for those four fields, and leaves the latent risk for every other `JsonSerializable` subclass that could be lazy-published anywhere in the SDK.
* **Eager initialisation in `DatabaseAccount(ObjectNode)`**: works for `DatabaseAccount` specifically but is structurally larger, doesn't generalise to other subclasses, and changes when work happens (eagerly per `DatabaseAccount` construction, including on every `GlobalEndpointManager` refresh).

`final propertyBag` is the smallest patch that closes the bug class globally.

## Safety / compatibility

* **Source compatibility**: `propertyBag` is package-private to `com.azure.cosmos.implementation`. A grep across `sdk/cosmos` for `propertyBag\s*=` finds zero writes outside the six `JsonSerializable` constructors, zero reflective writes, and no setter. The only out-of-class mention is `@JsonIgnoreProperties("propertyBag")` on `Range`, which doesn't touch the field.
* **`populatePropertyBag()` overrides**: Several subclasses (e.g. `DatabaseAccount`, `DocumentCollection`, the `FeedRange*Impl` and `ChangeFeedStartFrom*Impl` families) override `populatePropertyBag()` and mutate the bag via `this.set(...)` or `setProperties(this, false)`. These mutate the `ObjectNode` contents *through* the reference, not the reference itself, so `final` doesn't affect them.
* **Binary compatibility**: Technically binary-incompatible for any out-of-tree code in the same internal package that assigned to `propertyBag`. Nothing in this SDK does, but flagging in case there's a downstream/private consumer to check.

## Testing

Existing unit tests cover the `JsonSerializable` constructor paths and the `getString`/`getObject`/`getWithMapping` reads, with no expected behaviour change for correctly-published instances. The actual bug is a non-deterministic JMM unsafe-publication race that doesn't reproduce reliably in a standard JUnit test, a JCStress harness would be the right tool. Happy to add one in a follow-up if the team finds it useful.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]** (see "Safety / compatibility" above)
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.

See "Testing" section above for why a deterministic functional regression test isn't included with this PR.