### PR TITLE
Fix bannedDependencies failure for jackson-module-scala in Cosmos Spark POMs

### DIFF
--- a/sdk/cosmos/azure-cosmos-spark_3-5/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3-5/pom.xml
@@ -27,7 +27,6 @@
     <scala.binary.version>2.12</scala.binary.version>
     <spark35.version>3.5.0</spark35.version> <!-- {x-version-update;cosmos-spark_3-5_org.apache.spark:spark-sql_2.12;external_dependency} -->
     <spark-hive-version>3.5.0</spark-hive-version> <!-- {x-version-update;cosmos-spark_3-5_org.apache.spark:spark-hive_2.12;external_dependency} -->
-    <scala-jackson.version>2.18.4</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
   </properties>
   <profiles>
     <profile>
@@ -135,7 +134,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-      <version>${scala-jackson.version}</version>
+      <version>2.18.7</version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
     </dependency>
   </dependencies>
 </project>

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-12/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-12/pom.xml
@@ -51,7 +51,6 @@
     <scalatest-flatspec.version>3.2.3</scalatest-flatspec.version> <!-- {x-version-update;cosmos_org.scalatest:scalatest-flatspec_2.12;external_dependency} -->
     <scalactic.version>3.2.3</scalactic.version> <!-- {x-version-update;cosmos_org.scalactic:scalactic_2.12;external_dependency} -->
     <scalamock.version>5.0.0</scalamock.version> <!-- {x-version-update;cosmos_org.scalamock:scalamock_2.12;external_dependency} -->
-    <scala-jackson.version>2.18.4</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
   </properties>
   <build>
     <plugins>

--- a/sdk/cosmos/azure-cosmos-spark_3/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3/pom.xml
@@ -51,7 +51,6 @@
     <scalatest-flatspec.version>3.2.3</scalatest-flatspec.version> <!-- {x-version-update;cosmos_org.scalatest:scalatest-flatspec_2.12;external_dependency} -->
     <scalactic.version>3.2.3</scalactic.version> <!-- {x-version-update;cosmos_org.scalactic:scalactic_2.12;external_dependency} -->
     <scalamock.version>5.0.0</scalamock.version> <!-- {x-version-update;cosmos_org.scalamock:scalamock_2.12;external_dependency} -->
-    <scala-jackson.version>2.18.6</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
     <pinned-resourcemanager-cosmos.version>2.53.4</pinned-resourcemanager-cosmos.version> <!-- This should not exceed the latest stable version that has been deployed across all clouds - including non-public clouds -->
   </properties>
 
@@ -338,8 +337,8 @@
                 <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310:[2.18.7]</include> <!-- {x-include-update;com.fasterxml.jackson.datatype:jackson-datatype-jsr310;external_dependency} -->
                 <include>com.fasterxml.jackson.module:jackson-module-afterburner:[2.18.7]</include> <!-- {x-include-update;com.fasterxml.jackson.module:jackson-module-afterburner;external_dependency} -->
                 <include>com.fasterxml.jackson.dataformat:jackson-dataformat-xml:[2.18.7]</include> <!-- {x-include-update;com.fasterxml.jackson.dataformat:jackson-dataformat-xml;external_dependency} -->
-                <include>com.fasterxml.jackson.module:jackson-module-scala_2.12:[${scala-jackson.version}]</include>
-                <include>com.fasterxml.jackson.module:jackson-module-scala_2.13:[${scala-jackson.version}]</include>
+                <include>com.fasterxml.jackson.module:jackson-module-scala_2.12:[2.18.7]</include> <!-- {x-include-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
+                <include>com.fasterxml.jackson.module:jackson-module-scala_2.13:[2.18.7]</include> <!-- {x-include-update;com.fasterxml.jackson.module:jackson-module-scala_2.13;external_dependency} -->
                 <include>io.micrometer:micrometer-registry-azure-monitor:[1.15.1]</include> <!-- {x-include-update;cosmos_io.micrometer:micrometer-registry-azure-monitor;external_dependency} -->
                 <include>io.micrometer:micrometer-core:[1.15.1]</include> <!-- {x-include-update;cosmos_io.micrometer:micrometer-core;external_dependency} -->
                 <include>com.microsoft.azure:applicationinsights-core:[2.6.4]</include> <!-- {x-include-update;cosmos_com.microsoft.azure:applicationinsights-core;external_dependency} -->

--- a/sdk/cosmos/azure-cosmos-spark_4/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_4/pom.xml
@@ -32,7 +32,6 @@
     <scalatest-flatspec.version>3.2.3</scalatest-flatspec.version> <!-- {x-version-update;cosmos-scala213_org.scalatest:scalatest-flatspec_2.13;external_dependency} -->
     <scalactic.version>3.2.3</scalactic.version> <!-- {x-version-update;cosmos-scala213_org.scalactic:scalactic_2.13;external_dependency} -->
     <scalamock.version>5.0.0</scalamock.version> <!-- {x-version-update;cosmos-scala213_org.scalamock:scalamock_2.13;external_dependency} -->
-    <scala-jackson.version>2.18.6</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.13;external_dependency} -->
   </properties>
   <profiles>
     <!-- build-scala profile: serves as template for child modules (spark_4-0, spark_4-1).
@@ -112,7 +111,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
-      <version>${scala-jackson.version}</version>
+      <version>2.18.7</version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
## Problem

After the Jackson 2.18.6 to 2.18.7 dependency bump in PR #49180, the maven-enforcer-plugin bannedDependencies rule in azure-cosmos-spark_3/pom.xml rejects jackson-module-scala 2.18.7 as banned. This blocks **all PRs** that trigger Cosmos Spark builds (e.g., #49095, #49258).

### Root Cause

The Spark parent POM used a custom Maven property `<scala-jackson.version>` for the jackson-module-scala version. While this property had a valid `{x-version-update}` comment, the update_versions.py script's regex (`external_dependency_version_regex` in `eng/versioning/utils.py`) only matches values inside `<version>...</version>` XML elements -- **not** custom property tags like `<scala-jackson.version>...</scala-jackson.version>`.

When PR #49180 ran update_versions.py, it:
- Updated all `<version>` tags (afterburner, dataformat-xml, databind) to 2.18.7
- Updated all `{x-include-update}` enforcer entries to [2.18.7]
- **Silently skipped** the `<scala-jackson.version>` property (left at 2.18.6)

Result: The enforcer allowlist permits only [2.18.6] for jackson-module-scala, but Maven resolves 2.18.7 -- **banned**.

## Fix

Eliminate the `scala-jackson.version` property indirection entirely and replace all usages with explicit versions + standard `{x-version-update}`/`{x-include-update}` tags -- the same pattern used by all other Jackson modules in these POMs.

**Changes (4 files, net -4 lines):**
- **Remove** `<scala-jackson.version>` property from spark_3, spark_3-5, spark_3-5_2-12, and spark_4 parent POMs
- **Replace** enforcer `<include>` entries with hardcoded [2.18.7] + `{x-include-update}` tags (spark_3/pom.xml)
- **Replace** dependency `<version>` elements with explicit 2.18.7 + `{x-version-update}` tags (spark_3-5, spark_4)

Future update_versions.py runs will update these versions correctly since they now use standard `<version>` tags.

## Note

The underlying tooling limitation (`external_dependency_version_regex` in `eng/versioning/utils.py` line 30 only matching `<version>` tags) will be addressed in a separate eng-sys PR.