### PR TITLE
[INTERNAL]: Fix bannedDependencies failure: bump scala-jackson.version to 2.18.7

### DIFF
--- a/sdk/cosmos/azure-cosmos-spark_3-5/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3-5/pom.xml
@@ -27,7 +27,7 @@
     <scala.binary.version>2.12</scala.binary.version>
     <spark35.version>3.5.0</spark35.version> <!-- {x-version-update;cosmos-spark_3-5_org.apache.spark:spark-sql_2.12;external_dependency} -->
     <spark-hive-version>3.5.0</spark-hive-version> <!-- {x-version-update;cosmos-spark_3-5_org.apache.spark:spark-hive_2.12;external_dependency} -->
-    <scala-jackson.version>2.18.4</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
+    <scala-jackson.version>2.18.7</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
   </properties>
   <profiles>
     <profile>

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-12/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-12/pom.xml
@@ -51,7 +51,7 @@
     <scalatest-flatspec.version>3.2.3</scalatest-flatspec.version> <!-- {x-version-update;cosmos_org.scalatest:scalatest-flatspec_2.12;external_dependency} -->
     <scalactic.version>3.2.3</scalactic.version> <!-- {x-version-update;cosmos_org.scalactic:scalactic_2.12;external_dependency} -->
     <scalamock.version>5.0.0</scalamock.version> <!-- {x-version-update;cosmos_org.scalamock:scalamock_2.12;external_dependency} -->
-    <scala-jackson.version>2.18.4</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
+    <scala-jackson.version>2.18.7</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
   </properties>
   <build>
     <plugins>

--- a/sdk/cosmos/azure-cosmos-spark_3/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_3/pom.xml
@@ -51,7 +51,7 @@
     <scalatest-flatspec.version>3.2.3</scalatest-flatspec.version> <!-- {x-version-update;cosmos_org.scalatest:scalatest-flatspec_2.12;external_dependency} -->
     <scalactic.version>3.2.3</scalactic.version> <!-- {x-version-update;cosmos_org.scalactic:scalactic_2.12;external_dependency} -->
     <scalamock.version>5.0.0</scalamock.version> <!-- {x-version-update;cosmos_org.scalamock:scalamock_2.12;external_dependency} -->
-    <scala-jackson.version>2.18.6</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
+    <scala-jackson.version>2.18.7</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.12;external_dependency} -->
     <pinned-resourcemanager-cosmos.version>2.53.4</pinned-resourcemanager-cosmos.version> <!-- This should not exceed the latest stable version that has been deployed across all clouds - including non-public clouds -->
   </properties>
 

--- a/sdk/cosmos/azure-cosmos-spark_4/pom.xml
+++ b/sdk/cosmos/azure-cosmos-spark_4/pom.xml
@@ -32,7 +32,7 @@
     <scalatest-flatspec.version>3.2.3</scalatest-flatspec.version> <!-- {x-version-update;cosmos-scala213_org.scalatest:scalatest-flatspec_2.13;external_dependency} -->
     <scalactic.version>3.2.3</scalactic.version> <!-- {x-version-update;cosmos-scala213_org.scalactic:scalactic_2.13;external_dependency} -->
     <scalamock.version>5.0.0</scalamock.version> <!-- {x-version-update;cosmos-scala213_org.scalamock:scalamock_2.13;external_dependency} -->
-    <scala-jackson.version>2.18.6</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.13;external_dependency} -->
+    <scala-jackson.version>2.18.7</scala-jackson.version> <!-- {x-version-update;com.fasterxml.jackson.module:jackson-module-scala_2.13;external_dependency} -->
   </properties>
   <profiles>
     <!-- build-scala profile: serves as template for child modules (spark_4-0, spark_4-1).

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Features Added
 
+
 #### Breaking Changes
 
 #### Bugs Fixed


### PR DESCRIPTION
## Problem

After the Jackson 2.18.6 to 2.18.7 dependency bump in PR #49180, the maven-enforcer-plugin bannedDependencies rule in azure-cosmos-spark_3/pom.xml rejects jackson-module-scala 2.18.7 as banned. This blocks **all PRs** that trigger Cosmos Spark builds (e.g., #49095, #49258).

### Root Cause

The `update_versions.py` script's regex (`external_dependency_version_regex` in `eng/versioning/utils.py`) only matches values inside `<version>...</version>` XML elements. Custom Maven property tags like `<scala-jackson.version>` are silently skipped despite having valid `{x-version-update}` comments.

When PR #49180 ran update_versions.py:
- Updated all `<version>` tags to 2.18.7
- Updated all `{x-include-update}` enforcer entries to [2.18.7]
- **Silently skipped** the `<scala-jackson.version>` properties (left at 2.18.6 or 2.18.4)

The enforcer allowlist (which uses `$`{scala-jackson.version}) then permits only the stale version, while Maven resolves 2.18.7 -- **banned**.

## Fix

Bump `<scala-jackson.version>` to 2.18.7 in all four Spark parent POMs:
- `azure-cosmos-spark_3/pom.xml` (2.18.6 -> 2.18.7)
- `azure-cosmos-spark_3-5/pom.xml` (2.18.4 -> 2.18.7)
- `azure-cosmos-spark_3-5_2-12/pom.xml` (2.18.4 -> 2.18.7)
- `azure-cosmos-spark_4/pom.xml` (2.18.6 -> 2.18.7)

The underlying script limitation is tracked in draft PR #49262.

Supersedes #49261 (closed due to branch update).