### PR TITLE
Tighten update_versions.py regex to match <version> and <*.version> tags

### DIFF
--- a/eng/versioning/utils.py
+++ b/eng/versioning/utils.py
@@ -27,7 +27,10 @@ external_dependency_include_regex = r'(?<=<include>).+?(?=</include>)'
 
 # External dependency versions do not have to match semver format and the semver regular expressions
 # will partially match and produce some hilarious results.
-external_dependency_version_regex = r'(?<=<version>).+?(?=</version>)'
+# Match version content inside <version> or custom property tags ending with .version
+# (e.g. <scala-jackson.version>). The lookahead restricts to closing tags that are
+# either </version> or </something.version>, rejecting unrelated tags like </description>.
+external_dependency_version_regex = r'(?<=>)[^<]+(?=</(?:[\w.\-]+\.)?version>)'
 
 # This is the original regular expression for semver. This differs from the
 # previous one in that start of line and end of line anchors are left in place.


### PR DESCRIPTION
## Problem

`update_versions.py` uses `external_dependency_version_regex` (in `eng/versioning/utils.py`) to find and replace version values when processing `{x-version-update}` comments. The old regex:

```python
r'(?<=<version>).+?(?=</version>)'
```

only matches content inside `<version>...</version>` elements. Custom Maven property tags like:

```xml
<scala-jackson.version>2.18.6</scala-jackson.version> <!-- {x-version-update;...;external_dependency} -->
```

carry valid `{x-version-update}` comments, but the regex substitution silently no-ops on them. This caused `bannedDependencies` CI failures when Jackson was bumped to 2.18.7 (see PR #49263 for the immediate fix).

## Fix

Replace the regex with:

```python
r'(?<=>)[^<]+(?=</(?:[\w.\-]+\.)?version>)'
```

### Component breakdown

| Component | Purpose |
|---|---|
| `(?<=>)` | Fixed-width lookbehind — anchors after `>` (Python `re` requires fixed-width lookbehinds) |
| `[^<]+` | Captures version content (everything up to the next `<`) |
| `(?=</` | Start of lookahead — next chars must be `</` |
| `(?:[\w.\-]+\.)?` | Optional non-capturing group: one or more word/dot/hyphen chars followed by a dot (e.g., `scala-jackson.`) |
| `version>)` | Literal `version>` — closing the tag |

### What it matches / rejects

| Input | Old regex | New regex | Correct? |
|---|---|---|---|
| `<version>2.18.7</version>` | ✅ match | ✅ match | ✅ |
| `<scala-jackson.version>2.18.6</scala-jackson.version>` | ❌ no match | ✅ match | ✅ |
| `<scalatest.version>3.2.3</scalatest.version>` | ❌ no match | ✅ match | ✅ |
| `<description>Some text</description>` | ❌ no match | ❌ no match | ✅ |
| `<subversion>1.0</subversion>` | ❌ no match | ❌ no match | ✅ |
| `<!-- version 1.0 -->` | ❌ no match | ❌ no match | ✅ |

### Python `re` limitation

Alan's suggested regex `(?<=<((?:[\w-.]+\.)?version)>).+?(?=<\/\1>)` uses a variable-length lookbehind with a backreference, which Python's `re` module does not support (`error: look-behind requires fixed-width pattern`). The alternative places all variable-width logic in the lookahead, which has no such restriction.

## Validation

Ran `update_versions.py --sr` across all 874 POM files:

| Regex | Files changed | Files |
|---|---|---|
| Old (`<version>` only) | 0 | — |
| New (tightened) | 4 | `azure-cosmos-spark_3/pom.xml`, `spark_3-5/pom.xml`, `spark_3-5_2-12/pom.xml`, `spark_4/pom.xml` |

All 4 changes are `scala-jackson.version` property bumps from stale values (2.18.4 / 2.18.6) to 2.18.7 — identical to the manual fix in PR #49263.

### Known limitation

Tags like `<my-custom-property>` (no `.version` suffix) would still be skipped. This is intentional — the script should only auto-update version-related properties.