### PR TITLE
[NO REVIEW YET]fix: isolate per-record ID-generation failures in Kafka sink transformer (#49268)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,5 @@ TempTypeSpecFiles/
 
 # Azure Artifacts Credential Provider runtime
 .azure-artifacts/
+.coding-harness/
 

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosSinkTask.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosSinkTask.java
@@ -50,9 +50,19 @@ public class CosmosSinkTask extends SinkTask {
                     this.sinkTaskConfig.getClientMetadataCachesSnapshot());
             LOGGER.info("The taskId is " + this.sinkTaskConfig.getTaskId());
             this.throughputControlClientItem = this.getThroughputControlCosmosClient();
+
+            ErrantRecordReporter errantRecordReporter = null;
+            try {
+                errantRecordReporter = this.context.errantRecordReporter();
+            } catch (NoClassDefFoundError | NoSuchMethodError e) {
+                LOGGER.info(
+                    "ErrantRecordReporter not available in this Kafka Connect runtime; "
+                        + "DLQ will not be used for transform errors.");
+            }
+
             this.sinkRecordTransformer = new SinkRecordTransformer(
                 this.sinkTaskConfig,
-                this.context.errantRecordReporter(),
+                errantRecordReporter,
                 this.sinkTaskConfig.getWriteConfig().getToleranceOnErrorLevel());
 
             if (this.sinkTaskConfig.getWriteConfig().isBulkEnabled()) {

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosSinkTask.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosSinkTask.java
@@ -50,7 +50,10 @@ public class CosmosSinkTask extends SinkTask {
                     this.sinkTaskConfig.getClientMetadataCachesSnapshot());
             LOGGER.info("The taskId is " + this.sinkTaskConfig.getTaskId());
             this.throughputControlClientItem = this.getThroughputControlCosmosClient();
-            this.sinkRecordTransformer = new SinkRecordTransformer(this.sinkTaskConfig);
+            this.sinkRecordTransformer = new SinkRecordTransformer(
+                this.sinkTaskConfig,
+                this.context.errantRecordReporter(),
+                this.sinkTaskConfig.getWriteConfig().getToleranceOnErrorLevel());
 
             if (this.sinkTaskConfig.getWriteConfig().isBulkEnabled()) {
                 this.cosmosWriter =
@@ -129,7 +132,7 @@ public class CosmosSinkTask extends SinkTask {
             List<SinkRecord> transformedRecords = sinkRecordTransformer.transform(containerName, entry.getValue());
             this.cosmosWriter.write(container, transformedRecords);
 
-            totalWrittenRecordsPerContainer.merge(containerName, (long) entry.getValue().size(), Long::sum);
+            totalWrittenRecordsPerContainer.merge(containerName, (long) transformedRecords.size(), Long::sum);
         }
 
         logWrittenRecordCount();

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformer.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformer.java
@@ -32,7 +32,15 @@ public class SinkRecordTransformer {
         CosmosSinkTaskConfig sinkTaskConfig,
         ErrantRecordReporter errantRecordReporter,
         ToleranceOnErrorLevel toleranceOnErrorLevel) {
-        this.idStrategy = this.createIdStrategy(sinkTaskConfig);
+        this(createIdStrategy(sinkTaskConfig), errantRecordReporter, toleranceOnErrorLevel);
+    }
+
+    // Package-private constructor for unit testing without requiring CosmosSinkTaskConfig.
+    SinkRecordTransformer(
+        IdStrategy idStrategy,
+        ErrantRecordReporter errantRecordReporter,
+        ToleranceOnErrorLevel toleranceOnErrorLevel) {
+        this.idStrategy = idStrategy;
         this.errantRecordReporter = errantRecordReporter;
         this.toleranceOnErrorLevel = toleranceOnErrorLevel;
     }
@@ -77,13 +85,8 @@ public class SinkRecordTransformer {
 
                 toBeWrittenRecordList.add(updatedRecord);
             } catch (Exception e) {
-                LOGGER.warn(
-                    "Failed to transform record from topic {}, partition {}, offset {}, container {}.",
-                    record.topic(),
-                    record.kafkaPartition(),
-                    record.kafkaOffset(),
-                    containerName,
-                    e);
+                // Report to DLQ if configured (fire-and-forget, guarded against reporter failures).
+                // This is consistent with the writer-level pattern in CosmosWriterBase.sendToDlqIfConfigured().
                 if (this.errantRecordReporter != null) {
                     try {
                         this.errantRecordReporter.report(record, e);
@@ -95,26 +98,27 @@ public class SinkRecordTransformer {
                             record.kafkaOffset(),
                             containerName,
                             reportException);
-                        if (this.toleranceOnErrorLevel != ToleranceOnErrorLevel.ALL) {
-                            throw e;
-                        }
                     }
-                } else if (this.toleranceOnErrorLevel == ToleranceOnErrorLevel.ALL) {
+                }
+
+                // Use tolerance level to decide continue-vs-throw (consistent with writer pattern).
+                if (this.toleranceOnErrorLevel == ToleranceOnErrorLevel.ALL) {
                     LOGGER.warn(
-                        "Skipping record from topic {}, partition {}, offset {}, container {} due to transform error "
-                            + "and ToleranceOnErrorLevel is ALL.",
+                        "Skipping record from topic {}, partition {}, offset {}, container {} due to transform error.",
                         record.topic(),
                         record.kafkaPartition(),
                         record.kafkaOffset(),
-                        containerName);
+                        containerName,
+                        e);
                 } else {
                     LOGGER.error(
-                        "Failing record from topic {}, partition {}, offset {}, container {} because no DLQ reporter "
-                            + "is configured and ToleranceOnErrorLevel is NONE.",
+                        "Failing task due to transform error for record from topic {}, partition {}, offset {}, "
+                            + "container {}.",
                         record.topic(),
                         record.kafkaPartition(),
                         record.kafkaOffset(),
-                        containerName);
+                        containerName,
+                        e);
                     throw e;
                 }
             }
@@ -132,7 +136,7 @@ public class SinkRecordTransformer {
         recordMap.put("id", this.idStrategy.generateId(sinkRecord));
     }
 
-    private IdStrategy createIdStrategy(CosmosSinkTaskConfig sinkTaskConfig) {
+    private static IdStrategy createIdStrategy(CosmosSinkTaskConfig sinkTaskConfig) {
         IdStrategy idStrategyClass;
         switch (sinkTaskConfig.getIdStrategy()) {
             case FULL_KEY_STRATEGY:

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformer.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformer.java
@@ -11,6 +11,7 @@ import com.azure.cosmos.kafka.connect.implementation.sink.idstrategy.ProvidedInK
 import com.azure.cosmos.kafka.connect.implementation.sink.idstrategy.ProvidedInValueStrategy;
 import com.azure.cosmos.kafka.connect.implementation.sink.idstrategy.TemplateStrategy;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,9 +25,16 @@ public class SinkRecordTransformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(SinkRecordTransformer.class);
 
     private final IdStrategy idStrategy;
+    private final ErrantRecordReporter errantRecordReporter;
+    private final ToleranceOnErrorLevel toleranceOnErrorLevel;
 
-    public SinkRecordTransformer(CosmosSinkTaskConfig sinkTaskConfig) {
+    public SinkRecordTransformer(
+        CosmosSinkTaskConfig sinkTaskConfig,
+        ErrantRecordReporter errantRecordReporter,
+        ToleranceOnErrorLevel toleranceOnErrorLevel) {
         this.idStrategy = this.createIdStrategy(sinkTaskConfig);
+        this.errantRecordReporter = errantRecordReporter;
+        this.toleranceOnErrorLevel = toleranceOnErrorLevel;
     }
 
     @SuppressWarnings("unchecked")
@@ -44,30 +52,59 @@ public class SinkRecordTransformer {
                 record.value() == null ? null : record.value().getClass().getName(),
                 record.value() == null ? null : record.valueSchema());
 
-            Object recordValue;
-            if (record.value() instanceof Struct) {
-                recordValue = StructToJsonMap.toJsonMap((Struct) record.value());
-            } else if (record.value() instanceof Map) {
-                recordValue = StructToJsonMap.handleMap((Map<String, Object>) record.value());
-            } else {
-                recordValue = record.value();
+            try {
+                Object recordValue;
+                if (record.value() instanceof Struct) {
+                    recordValue = StructToJsonMap.toJsonMap((Struct) record.value());
+                } else if (record.value() instanceof Map) {
+                    recordValue = StructToJsonMap.handleMap((Map<String, Object>) record.value());
+                } else {
+                    recordValue = record.value();
+                }
+
+                maybeInsertId(recordValue, record);
+
+                final SinkRecord updatedRecord = new SinkRecord(record.topic(),
+                    record.kafkaPartition(),
+                    record.keySchema(),
+                    record.key(),
+                    record.valueSchema(),
+                    recordValue,
+                    record.kafkaOffset(),
+                    record.timestamp(),
+                    record.timestampType(),
+                    record.headers());
+
+                toBeWrittenRecordList.add(updatedRecord);
+            } catch (Exception e) {
+                LOGGER.warn(
+                    "Failed to transform record from topic {}, partition {}, offset {}, container {}.",
+                    record.topic(),
+                    record.kafkaPartition(),
+                    record.kafkaOffset(),
+                    containerName,
+                    e);
+                if (this.errantRecordReporter != null) {
+                    this.errantRecordReporter.report(record, e);
+                } else if (this.toleranceOnErrorLevel == ToleranceOnErrorLevel.ALL) {
+                    LOGGER.warn(
+                        "Skipping record from topic {}, partition {}, offset {}, container {} due to transform error "
+                            + "and ToleranceOnErrorLevel is ALL.",
+                        record.topic(),
+                        record.kafkaPartition(),
+                        record.kafkaOffset(),
+                        containerName);
+                } else {
+                    LOGGER.error(
+                        "Failing record from topic {}, partition {}, offset {}, container {} because no DLQ reporter "
+                            + "is configured and ToleranceOnErrorLevel is NONE.",
+                        record.topic(),
+                        record.kafkaPartition(),
+                        record.kafkaOffset(),
+                        containerName);
+                    throw e;
+                }
             }
-
-            maybeInsertId(recordValue, record);
-
-            //  Create an updated record with from the current record and the updated record value
-            final SinkRecord updatedRecord = new SinkRecord(record.topic(),
-                record.kafkaPartition(),
-                record.keySchema(),
-                record.key(),
-                record.valueSchema(),
-                recordValue,
-                record.kafkaOffset(),
-                record.timestamp(),
-                record.timestampType(),
-                record.headers());
-
-            toBeWrittenRecordList.add(updatedRecord);
         }
 
         return toBeWrittenRecordList;

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformer.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformer.java
@@ -85,7 +85,20 @@ public class SinkRecordTransformer {
                     containerName,
                     e);
                 if (this.errantRecordReporter != null) {
-                    this.errantRecordReporter.report(record, e);
+                    try {
+                        this.errantRecordReporter.report(record, e);
+                    } catch (Exception reportException) {
+                        LOGGER.error(
+                            "Failed to report errant record to DLQ for topic {}, partition {}, offset {}, container {}.",
+                            record.topic(),
+                            record.kafkaPartition(),
+                            record.kafkaOffset(),
+                            containerName,
+                            reportException);
+                        if (this.toleranceOnErrorLevel != ToleranceOnErrorLevel.ALL) {
+                            throw e;
+                        }
+                    }
                 } else if (this.toleranceOnErrorLevel == ToleranceOnErrorLevel.ALL) {
                     LOGGER.warn(
                         "Skipping record from topic {}, partition {}, offset {}, container {} due to transform error "

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformer.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformer.java
@@ -84,7 +84,7 @@ public class SinkRecordTransformer {
                     record.headers());
 
                 toBeWrittenRecordList.add(updatedRecord);
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 // Report to DLQ if configured (fire-and-forget, guarded against reporter failures).
                 // This is consistent with the writer-level pattern in CosmosWriterBase.sendToDlqIfConfigured().
                 if (this.errantRecordReporter != null) {

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformerTest.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformerTest.java
@@ -1,0 +1,287 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.kafka.connect.implementation.sink;
+
+import com.azure.cosmos.kafka.connect.implementation.sink.idstrategy.IdStrategy;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+public class SinkRecordTransformerTest {
+    private static final int TIMEOUT = 60000;
+
+    /**
+     * Creates a SinkRecordTransformer bypassing the constructor that needs CosmosSinkTaskConfig.
+     * Uses Mockito with CALLS_REAL_METHODS so the transform() method executes real code,
+     * then injects the fields via reflection.
+     */
+    private SinkRecordTransformer createTransformer(
+        IdStrategy idStrategy,
+        ErrantRecordReporter reporter,
+        ToleranceOnErrorLevel toleranceLevel) throws Exception {
+
+        SinkRecordTransformer transformer = Mockito.mock(
+            SinkRecordTransformer.class,
+            withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        FieldUtils.writeField(transformer, "idStrategy", idStrategy, true);
+        FieldUtils.writeField(transformer, "errantRecordReporter", reporter, true);
+        FieldUtils.writeField(transformer, "toleranceOnErrorLevel", toleranceLevel, true);
+        return transformer;
+    }
+
+    /**
+     * Creates a SinkRecord with a Map value containing the given fields.
+     */
+    private SinkRecord createMapRecord(String topic, int partition, long offset, Map<String, Object> value) {
+        return new SinkRecord(topic, partition, null, "key-" + offset, null, value, offset);
+    }
+
+    /**
+     * Creates an IdStrategy that fails (throws ConnectException) when generating an ID
+     * for records whose value map contains a field "fail" set to true,
+     * and returns a valid ID otherwise.
+     */
+    private IdStrategy createSelectivelyFailingIdStrategy() {
+        IdStrategy idStrategy = Mockito.mock(IdStrategy.class);
+        when(idStrategy.generateId(any(SinkRecord.class))).thenAnswer(invocation -> {
+            SinkRecord record = invocation.getArgument(0);
+            Object value = record.value();
+            if (value instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> map = (Map<String, Object>) value;
+                if (Boolean.TRUE.equals(map.get("fail"))) {
+                    throw new ConnectException("Cannot generate ID: missing required field");
+                }
+            }
+            return "generated-id-" + record.kafkaOffset();
+        });
+        return idStrategy;
+    }
+
+    // ============================================================
+    // T1: Mixed batch with reporter — bad record goes to DLQ, valid records in output
+    // ============================================================
+    @Test(groups = {"unit"}, timeOut = TIMEOUT)
+    @SuppressWarnings("unchecked")
+    public void mixedBatchWithReporter_badRecordReportedValidRecordsInOutput() throws Exception {
+        // Arrange
+        IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
+        ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
+        Future<?> mockFuture = Mockito.mock(Future.class);
+        when(reporter.report(any(SinkRecord.class), any(Throwable.class))).thenReturn(mockFuture);
+
+        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
+
+        Map<String, Object> goodValue1 = new HashMap<>();
+        goodValue1.put("data", "hello");
+
+        Map<String, Object> badValue = new HashMap<>();
+        badValue.put("fail", true);
+
+        Map<String, Object> goodValue2 = new HashMap<>();
+        goodValue2.put("data", "world");
+
+        List<SinkRecord> batch = Arrays.asList(
+            createMapRecord("topic1", 0, 0L, goodValue1),
+            createMapRecord("topic1", 0, 1L, badValue),
+            createMapRecord("topic1", 0, 2L, goodValue2)
+        );
+
+        // Act
+        List<SinkRecord> result = transformer.transform("container1", batch);
+
+        // Assert — only 2 valid records in output
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(((Map<String, Object>) result.get(0).value()).get("id")).isEqualTo("generated-id-0");
+        assertThat(((Map<String, Object>) result.get(1).value()).get("id")).isEqualTo("generated-id-2");
+
+        // Assert — reporter called exactly once with the bad record
+        ArgumentCaptor<SinkRecord> recordCaptor = ArgumentCaptor.forClass(SinkRecord.class);
+        ArgumentCaptor<Throwable> errorCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(reporter, times(1)).report(recordCaptor.capture(), errorCaptor.capture());
+        assertThat(recordCaptor.getValue().kafkaOffset()).isEqualTo(1L);
+        assertThat(errorCaptor.getValue()).isInstanceOf(ConnectException.class);
+    }
+
+    // ============================================================
+    // T2: Mixed batch with tolerance ALL, no reporter — bad record skipped
+    // ============================================================
+    @Test(groups = {"unit"}, timeOut = TIMEOUT)
+    @SuppressWarnings("unchecked")
+    public void mixedBatchToleranceAll_noReporter_badRecordSkipped() throws Exception {
+        // Arrange
+        IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
+        SinkRecordTransformer transformer = createTransformer(idStrategy, null, ToleranceOnErrorLevel.ALL);
+
+        Map<String, Object> goodValue = new HashMap<>();
+        goodValue.put("data", "hello");
+
+        Map<String, Object> badValue = new HashMap<>();
+        badValue.put("fail", true);
+
+        List<SinkRecord> batch = Arrays.asList(
+            createMapRecord("topicA", 1, 10L, goodValue),
+            createMapRecord("topicA", 1, 11L, badValue)
+        );
+
+        // Act — should NOT throw
+        List<SinkRecord> result = transformer.transform("container2", batch);
+
+        // Assert — only 1 valid record
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(((Map<String, Object>) result.get(0).value()).get("id")).isEqualTo("generated-id-10");
+    }
+
+    // ============================================================
+    // T3: Mixed batch with tolerance NONE, no reporter — exception thrown
+    // ============================================================
+    @Test(groups = {"unit"}, timeOut = TIMEOUT)
+    public void mixedBatchToleranceNone_noReporter_exceptionThrown() throws Exception {
+        // Arrange
+        IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
+        SinkRecordTransformer transformer = createTransformer(idStrategy, null, ToleranceOnErrorLevel.NONE);
+
+        Map<String, Object> goodValue = new HashMap<>();
+        goodValue.put("data", "hello");
+
+        Map<String, Object> badValue = new HashMap<>();
+        badValue.put("fail", true);
+
+        List<SinkRecord> batch = Arrays.asList(
+            createMapRecord("topicB", 2, 20L, goodValue),
+            createMapRecord("topicB", 2, 21L, badValue)
+        );
+
+        // Act
+        Throwable thrown = catchThrowable(() -> transformer.transform("container3", batch));
+
+        // Assert — exception is thrown (fail-fast preserved)
+        assertThat(thrown).isInstanceOf(ConnectException.class);
+        assertThat(thrown.getMessage()).contains("Cannot generate ID");
+    }
+
+    // ============================================================
+    // T4: All records valid — no errors, all records in output (regression)
+    // ============================================================
+    @Test(groups = {"unit"}, timeOut = TIMEOUT)
+    @SuppressWarnings("unchecked")
+    public void allValidRecords_allInOutput() throws Exception {
+        // Arrange
+        IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
+        ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
+        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
+
+        Map<String, Object> value1 = new HashMap<>();
+        value1.put("data", "a");
+        Map<String, Object> value2 = new HashMap<>();
+        value2.put("data", "b");
+        Map<String, Object> value3 = new HashMap<>();
+        value3.put("data", "c");
+
+        List<SinkRecord> batch = Arrays.asList(
+            createMapRecord("topicC", 0, 100L, value1),
+            createMapRecord("topicC", 0, 101L, value2),
+            createMapRecord("topicC", 0, 102L, value3)
+        );
+
+        // Act
+        List<SinkRecord> result = transformer.transform("container4", batch);
+
+        // Assert — all 3 records in output
+        assertThat(result.size()).isEqualTo(3);
+        for (int i = 0; i < 3; i++) {
+            assertThat(((Map<String, Object>) result.get(i).value()).get("id"))
+                .isEqualTo("generated-id-" + (100 + i));
+        }
+
+        // Assert — reporter never called
+        verify(reporter, never()).report(any(), any());
+    }
+
+    // ============================================================
+    // T5: All records bad with reporter — all reported to DLQ, empty output
+    // ============================================================
+    @Test(groups = {"unit"}, timeOut = TIMEOUT)
+    public void allBadRecordsWithReporter_allReportedEmptyOutput() throws Exception {
+        // Arrange
+        IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
+        ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
+        Future<?> mockFuture = Mockito.mock(Future.class);
+        when(reporter.report(any(SinkRecord.class), any(Throwable.class))).thenReturn(mockFuture);
+
+        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
+
+        Map<String, Object> bad1 = new HashMap<>();
+        bad1.put("fail", true);
+        Map<String, Object> bad2 = new HashMap<>();
+        bad2.put("fail", true);
+        Map<String, Object> bad3 = new HashMap<>();
+        bad3.put("fail", true);
+
+        List<SinkRecord> batch = Arrays.asList(
+            createMapRecord("topicD", 0, 50L, bad1),
+            createMapRecord("topicD", 0, 51L, bad2),
+            createMapRecord("topicD", 0, 52L, bad3)
+        );
+
+        // Act
+        List<SinkRecord> result = transformer.transform("container5", batch);
+
+        // Assert — empty output
+        assertThat(result.size()).isEqualTo(0);
+
+        // Assert — reporter called 3 times
+        verify(reporter, times(3)).report(any(SinkRecord.class), any(ConnectException.class));
+    }
+
+    // ============================================================
+    // T6: Reporter takes precedence over tolerance NONE — when reporter is present,
+    //     report instead of throwing even when tolerance is NONE
+    // ============================================================
+    @Test(groups = {"unit"}, timeOut = TIMEOUT)
+    public void reporterTakesPrecedenceOverToleranceNone() throws Exception {
+        // Arrange
+        IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
+        ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
+        Future<?> mockFuture = Mockito.mock(Future.class);
+        when(reporter.report(any(SinkRecord.class), any(Throwable.class))).thenReturn(mockFuture);
+
+        // Tolerance is NONE but reporter is available
+        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
+
+        Map<String, Object> badValue = new HashMap<>();
+        badValue.put("fail", true);
+
+        List<SinkRecord> batch = Arrays.asList(
+            createMapRecord("topicE", 0, 0L, badValue)
+        );
+
+        // Act — should NOT throw because reporter handles it
+        Throwable thrown = catchThrowable(() -> transformer.transform("container6", batch));
+
+        // Assert
+        assertThat(thrown).isNull();
+        verify(reporter, times(1)).report(any(SinkRecord.class), any(ConnectException.class));
+    }
+}

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformerTest.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformerTest.java
@@ -4,7 +4,6 @@
 package com.azure.cosmos.kafka.connect.implementation.sink;
 
 import com.azure.cosmos.kafka.connect.implementation.sink.idstrategy.IdStrategy;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -21,34 +20,13 @@ import java.util.concurrent.Future;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
 public class SinkRecordTransformerTest {
     private static final int TIMEOUT = 60000;
-
-    /**
-     * Creates a SinkRecordTransformer bypassing the constructor that needs CosmosSinkTaskConfig.
-     * Uses Mockito with CALLS_REAL_METHODS so the transform() method executes real code,
-     * then injects the fields via reflection.
-     */
-    private SinkRecordTransformer createTransformer(
-        IdStrategy idStrategy,
-        ErrantRecordReporter reporter,
-        ToleranceOnErrorLevel toleranceLevel) throws Exception {
-
-        SinkRecordTransformer transformer = Mockito.mock(
-            SinkRecordTransformer.class,
-            withSettings().defaultAnswer(CALLS_REAL_METHODS));
-        FieldUtils.writeField(transformer, "idStrategy", idStrategy, true);
-        FieldUtils.writeField(transformer, "errantRecordReporter", reporter, true);
-        FieldUtils.writeField(transformer, "toleranceOnErrorLevel", toleranceLevel, true);
-        return transformer;
-    }
 
     /**
      * Creates a SinkRecord with a Map value containing the given fields.
@@ -80,18 +58,18 @@ public class SinkRecordTransformerTest {
     }
 
     // ============================================================
-    // T1: Mixed batch with reporter — bad record goes to DLQ, valid records in output
+    // T1: Mixed batch with reporter + tolerance ALL — bad record goes to DLQ, valid records in output
     // ============================================================
     @Test(groups = {"unit"}, timeOut = TIMEOUT)
     @SuppressWarnings("unchecked")
-    public void mixedBatchWithReporter_badRecordReportedValidRecordsInOutput() throws Exception {
+    public void mixedBatchWithReporterToleranceAll_badRecordReportedValidRecordsInOutput() throws Exception {
         // Arrange
         IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
         ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
         Future<?> mockFuture = Mockito.mock(Future.class);
         when(reporter.report(any(SinkRecord.class), any(Throwable.class))).thenReturn(mockFuture);
 
-        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
+        SinkRecordTransformer transformer = new SinkRecordTransformer(idStrategy, reporter, ToleranceOnErrorLevel.ALL);
 
         Map<String, Object> goodValue1 = new HashMap<>();
         goodValue1.put("data", "hello");
@@ -132,7 +110,7 @@ public class SinkRecordTransformerTest {
     public void mixedBatchToleranceAll_noReporter_badRecordSkipped() throws Exception {
         // Arrange
         IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
-        SinkRecordTransformer transformer = createTransformer(idStrategy, null, ToleranceOnErrorLevel.ALL);
+        SinkRecordTransformer transformer = new SinkRecordTransformer(idStrategy, null, ToleranceOnErrorLevel.ALL);
 
         Map<String, Object> goodValue = new HashMap<>();
         goodValue.put("data", "hello");
@@ -154,13 +132,13 @@ public class SinkRecordTransformerTest {
     }
 
     // ============================================================
-    // T3: Mixed batch with tolerance NONE, no reporter — exception thrown
+    // T3: Mixed batch with tolerance NONE, no reporter — exception thrown (fail-fast)
     // ============================================================
     @Test(groups = {"unit"}, timeOut = TIMEOUT)
     public void mixedBatchToleranceNone_noReporter_exceptionThrown() throws Exception {
         // Arrange
         IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
-        SinkRecordTransformer transformer = createTransformer(idStrategy, null, ToleranceOnErrorLevel.NONE);
+        SinkRecordTransformer transformer = new SinkRecordTransformer(idStrategy, null, ToleranceOnErrorLevel.NONE);
 
         Map<String, Object> goodValue = new HashMap<>();
         goodValue.put("data", "hello");
@@ -190,7 +168,7 @@ public class SinkRecordTransformerTest {
         // Arrange
         IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
         ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
-        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
+        SinkRecordTransformer transformer = new SinkRecordTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
 
         Map<String, Object> value1 = new HashMap<>();
         value1.put("data", "a");
@@ -220,17 +198,17 @@ public class SinkRecordTransformerTest {
     }
 
     // ============================================================
-    // T5: All records bad with reporter — all reported to DLQ, empty output
+    // T5: All records bad with reporter + tolerance ALL — all reported to DLQ, empty output
     // ============================================================
     @Test(groups = {"unit"}, timeOut = TIMEOUT)
-    public void allBadRecordsWithReporter_allReportedEmptyOutput() throws Exception {
+    public void allBadRecordsWithReporterToleranceAll_allReportedEmptyOutput() throws Exception {
         // Arrange
         IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
         ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
         Future<?> mockFuture = Mockito.mock(Future.class);
         when(reporter.report(any(SinkRecord.class), any(Throwable.class))).thenReturn(mockFuture);
 
-        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
+        SinkRecordTransformer transformer = new SinkRecordTransformer(idStrategy, reporter, ToleranceOnErrorLevel.ALL);
 
         Map<String, Object> bad1 = new HashMap<>();
         bad1.put("fail", true);
@@ -266,7 +244,7 @@ public class SinkRecordTransformerTest {
         when(reporter.report(any(SinkRecord.class), any(Throwable.class)))
             .thenThrow(new ConnectException("DLQ write failed"));
 
-        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
+        SinkRecordTransformer transformer = new SinkRecordTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
 
         Map<String, Object> badValue = new HashMap<>();
         badValue.put("fail", true);
@@ -298,7 +276,7 @@ public class SinkRecordTransformerTest {
         when(reporter.report(any(SinkRecord.class), any(Throwable.class)))
             .thenThrow(new ConnectException("DLQ write failed"));
 
-        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.ALL);
+        SinkRecordTransformer transformer = new SinkRecordTransformer(idStrategy, reporter, ToleranceOnErrorLevel.ALL);
 
         Map<String, Object> badValue = new HashMap<>();
         badValue.put("fail", true);
@@ -319,32 +297,35 @@ public class SinkRecordTransformerTest {
     }
 
     // ============================================================
-    // T8: Reporter takes precedence over tolerance NONE — when reporter is present,
-    //     report instead of throwing even when tolerance is NONE
+    // T8: Tolerance NONE with reporter — record reported to DLQ AND exception thrown
+    //     (consistent with writer-level pattern: DLQ is side-effect, tolerance controls flow)
     // ============================================================
     @Test(groups = {"unit"}, timeOut = TIMEOUT)
-    public void reporterTakesPrecedenceOverToleranceNone() throws Exception {
+    public void toleranceNoneWithReporter_reportedToDlqAndExceptionThrown() throws Exception {
         // Arrange
         IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
         ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
         Future<?> mockFuture = Mockito.mock(Future.class);
         when(reporter.report(any(SinkRecord.class), any(Throwable.class))).thenReturn(mockFuture);
 
-        // Tolerance is NONE but reporter is available
-        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
+        // Tolerance is NONE — task should fail even though reporter is available
+        SinkRecordTransformer transformer = new SinkRecordTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
 
         Map<String, Object> badValue = new HashMap<>();
         badValue.put("fail", true);
 
         List<SinkRecord> batch = Arrays.asList(
-            createMapRecord("topicE", 0, 0L, badValue)
+            createMapRecord("topicH", 0, 0L, badValue)
         );
 
-        // Act — should NOT throw because reporter handles it
-        Throwable thrown = catchThrowable(() -> transformer.transform("container6", batch));
+        // Act
+        Throwable thrown = catchThrowable(() -> transformer.transform("container9", batch));
 
-        // Assert
-        assertThat(thrown).isNull();
+        // Assert — exception IS thrown (tolerance NONE means fail)
+        assertThat(thrown).isInstanceOf(ConnectException.class);
+        assertThat(thrown.getMessage()).contains("Cannot generate ID");
+
+        // Assert — reporter WAS called (DLQ is side-effect for observability)
         verify(reporter, times(1)).report(any(SinkRecord.class), any(ConnectException.class));
     }
 }

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformerTest.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformerTest.java
@@ -256,7 +256,70 @@ public class SinkRecordTransformerTest {
     }
 
     // ============================================================
-    // T6: Reporter takes precedence over tolerance NONE — when reporter is present,
+    // T6: Reporter itself throws — with tolerance NONE, original exception rethrown
+    // ============================================================
+    @Test(groups = {"unit"}, timeOut = TIMEOUT)
+    public void reporterThrows_toleranceNone_originalExceptionRethrown() throws Exception {
+        // Arrange
+        IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
+        ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
+        when(reporter.report(any(SinkRecord.class), any(Throwable.class)))
+            .thenThrow(new ConnectException("DLQ write failed"));
+
+        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.NONE);
+
+        Map<String, Object> badValue = new HashMap<>();
+        badValue.put("fail", true);
+        Map<String, Object> goodValue = new HashMap<>();
+        goodValue.put("data", "after-bad");
+
+        List<SinkRecord> batch = Arrays.asList(
+            createMapRecord("topicF", 0, 0L, badValue),
+            createMapRecord("topicF", 0, 1L, goodValue)
+        );
+
+        // Act
+        Throwable thrown = catchThrowable(() -> transformer.transform("container7", batch));
+
+        // Assert — original transform exception, NOT the DLQ exception
+        assertThat(thrown).isInstanceOf(ConnectException.class);
+        assertThat(thrown.getMessage()).contains("Cannot generate ID");
+    }
+
+    // ============================================================
+    // T7: Reporter itself throws — with tolerance ALL, record skipped and processing continues
+    // ============================================================
+    @Test(groups = {"unit"}, timeOut = TIMEOUT)
+    @SuppressWarnings("unchecked")
+    public void reporterThrows_toleranceAll_recordSkippedProcessingContinues() throws Exception {
+        // Arrange
+        IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
+        ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
+        when(reporter.report(any(SinkRecord.class), any(Throwable.class)))
+            .thenThrow(new ConnectException("DLQ write failed"));
+
+        SinkRecordTransformer transformer = createTransformer(idStrategy, reporter, ToleranceOnErrorLevel.ALL);
+
+        Map<String, Object> badValue = new HashMap<>();
+        badValue.put("fail", true);
+        Map<String, Object> goodValue = new HashMap<>();
+        goodValue.put("data", "survives");
+
+        List<SinkRecord> batch = Arrays.asList(
+            createMapRecord("topicG", 0, 0L, badValue),
+            createMapRecord("topicG", 0, 1L, goodValue)
+        );
+
+        // Act — should NOT throw
+        List<SinkRecord> result = transformer.transform("container8", batch);
+
+        // Assert — only the good record survives
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(((Map<String, Object>) result.get(0).value()).get("id")).isEqualTo("generated-id-1");
+    }
+
+    // ============================================================
+    // T8: Reporter takes precedence over tolerance NONE — when reporter is present,
     //     report instead of throwing even when tolerance is NONE
     // ============================================================
     @Test(groups = {"unit"}, timeOut = TIMEOUT)


### PR DESCRIPTION
## Fix: Single record failing ID parsing should not fail entire batch (#49268)

### Problem
When a single `SinkRecord` in a batch fails during ID generation (e.g., due to an invalid JsonPath in `ProvidedInStrategy.generateId()`), the entire batch fails and all records are routed to the DLQ — not just the malformed record.

**Root cause:** `SinkRecordTransformer.transform()` lacked per-record error isolation. An exception from `idStrategy.generateId()` would abort the entire `transform()` call before records reached the writer-level DLQ handling in `CosmosWriterBase.sendToDlqIfConfigured()`.

### Solution
Added per-record try-catch in `SinkRecordTransformer.transform()` that is consistent with the writer-level pattern in `CosmosWriterBase`:

1. **DLQ report is fire-and-forget side-effect** — always report to `ErrantRecordReporter` if available (guarded against reporter failures)
2. **Tolerance level controls flow** — `ALL` skips and continues, `NONE` throws (regardless of whether DLQ reporter is present)

| Scenario | `ErrantRecordReporter` | `ToleranceOnErrorLevel` | Behavior |
|----------|----------------------|------------------------|----------|
| DLQ configured | Available | `ALL` | Report to DLQ, skip bad record, continue |
| DLQ configured | Available | `NONE` | Report to DLQ, then throw (fail-fast) |
| DLQ not configured | `null` | `ALL` | Log warning, skip bad record, continue |
| DLQ not configured | `null` | `NONE` | Throw (fail-fast, preserves existing behavior) |
| DLQ reporter fails | Available (throws) | `ALL` | Log DLQ error, skip bad record, continue |
| DLQ reporter fails | Available (throws) | `NONE` | Log DLQ error, throw original exception |

### Changes
- **`SinkRecordTransformer.java`**
  - Added `ErrantRecordReporter` and `ToleranceOnErrorLevel` fields
  - Wrapped per-record processing in try-catch with DLQ/tolerance handling
  - Guarded `ErrantRecordReporter.report()` against secondary failures
  - Added package-private constructor for testability
  - Made `createIdStrategy()` static for constructor chain
- **`CosmosSinkTask.java`**
  - Pass `errantRecordReporter` and `toleranceOnErrorLevel` to `SinkRecordTransformer`
  - Guard `context.errantRecordReporter()` against older Kafka Connect runtimes
  - Fix bookkeeping to count `transformedRecords.size()` (post-filter) instead of `entry.getValue().size()` (pre-filter)
- **`SinkRecordTransformerTest.java`** — 8 new unit tests:
  - T1: Mixed batch with reporter + tolerance ALL → bad→DLQ, good records survive
  - T2: Tolerance ALL without reporter → bad record skipped
  - T3: Tolerance NONE without reporter → exception thrown (fail-fast)
  - T4: All valid records → all in output, reporter never called (regression)
  - T5: All bad with reporter + tolerance ALL → all→DLQ, empty output
  - T6: Reporter throws + tolerance NONE → original exception rethrown
  - T7: Reporter throws + tolerance ALL → record skipped, continues
  - T8: Tolerance NONE with reporter → DLQ report AND exception thrown

Fixes #49268