### PR TITLE
Cosmos: Promote Full Fidelity Change Feed (AllVersionsAndDeletes) API to GA

### DIFF
--- a/eng/lintingconfigs/revapi/track2/revapi.json
+++ b/eng/lintingconfigs/revapi/track2/revapi.json
@@ -312,12 +312,11 @@
           "justification": "Generated classes were moved into public API, these annotations were already being used in implementation used during serialization and deserialization."
         },
         {
-          "code": "java.annotation.removed",
-          "new": {
-            "matcher": "regex",
-            "match": "(class|interface|method|parameter) com\\.azure\\.cosmos\\..*"
-          },
-          "justification": "Cosmos SDK removes Beta annotation to GA its APIs and classes."
+          "regex": true,
+          "code": "java\\.annotation\\.removed",
+          "new": "(class|interface|enum|method|parameter) com\\.azure\\.cosmos\\..*",
+          "annotationType": "com\\.azure\\.cosmos\\.util\\.Beta",
+          "justification": "Cosmos SDK removes the Beta annotation to GA its APIs. Only Beta annotation removals are permitted; removal of any other annotation (Deprecated, Jackson, etc.) will still fail the build."
         },
         {
           "code": "java.method.removed",

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 4.81.0-beta.1 (Unreleased)
 
 #### Features Added
-
+* Promoted the Full Fidelity Change Feed (AllVersionsAndDeletes) APIs to GA - See [PR 49283](https://github.com/Azure/azure-sdk-for-java/pull/49283)
 
 #### Breaking Changes
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/ChangeFeedProcessorBuilder.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/ChangeFeedProcessorBuilder.java
@@ -9,7 +9,6 @@ import com.azure.cosmos.implementation.changefeed.pkversion.IncrementalChangeFee
 import com.azure.cosmos.implementation.changefeed.epkversion.FullFidelityChangeFeedProcessorImpl;
 import com.azure.cosmos.models.ChangeFeedProcessorItem;
 import com.azure.cosmos.models.ChangeFeedProcessorOptions;
-import com.azure.cosmos.util.Beta;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.List;
@@ -255,7 +254,6 @@ public class ChangeFeedProcessorBuilder {
      * @param consumer the {@link Consumer} to call for handling the feeds.
      * @return current Builder.
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public ChangeFeedProcessorBuilder handleAllVersionsAndDeletesChanges(Consumer<List<ChangeFeedProcessorItem>> consumer) {
         checkNotNull(consumer, "consumer cannot be null");
         checkArgument(this.fullFidelityModeLeaseWithContextConsumer == null,
@@ -285,7 +283,6 @@ public class ChangeFeedProcessorBuilder {
      * @param biConsumer the {@link BiConsumer} to call for handling the feeds and the {@link ChangeFeedProcessorContext} instance.
      * @return current Builder.
      */
-    @Beta(value = Beta.SinceVersion.V4_51_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public ChangeFeedProcessorBuilder handleAllVersionsAndDeletesChanges(
         BiConsumer<List<ChangeFeedProcessorItem>, ChangeFeedProcessorContext> biConsumer) {
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/ChangeFeedProcessorContext.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/ChangeFeedProcessorContext.java
@@ -4,7 +4,6 @@
 package com.azure.cosmos;
 
 import com.azure.cosmos.implementation.apachecommons.lang.NotImplementedException;
-import com.azure.cosmos.util.Beta;
 
 import java.util.function.BiConsumer;
 
@@ -16,7 +15,6 @@ import java.util.function.BiConsumer;
  * <br>
  * NOTE: This interface is not designed to be implemented by end users.
  * */
-@Beta(value = Beta.SinceVersion.V4_51_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
 public interface ChangeFeedProcessorContext {
     /**
      * Gets the lease token corresponding to the source of
@@ -24,7 +22,6 @@ public interface ChangeFeedProcessorContext {
      *
      * @return the lease token
      * */
-    @Beta(value = Beta.SinceVersion.V4_51_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     String getLeaseToken();
 
     /**
@@ -32,7 +29,6 @@ public interface ChangeFeedProcessorContext {
      *
      * @return The diagnostics object.
      */
-    @Beta(value = Beta.SinceVersion.V4_64_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     default CosmosDiagnosticsContext getDiagnostics() {
         throw new NotImplementedException("Method has not been implemented. NOTE: This method is not designed to be implemented by end users.");
     }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/CosmosChangeFeedRequestOptionsImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/CosmosChangeFeedRequestOptionsImpl.java
@@ -269,7 +269,6 @@ public final class CosmosChangeFeedRequestOptionsImpl implements OverridableRequ
         return this;
     }
 
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public CosmosChangeFeedRequestOptionsImpl allVersionsAndDeletes() {
 
         if (!this.startFromInternal.supportsFullFidelityRetention()) {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/ChangeFeedMetaData.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/ChangeFeedMetaData.java
@@ -3,7 +3,6 @@
 package com.azure.cosmos.models;
 
 import com.azure.cosmos.implementation.Utils;
-import com.azure.cosmos.util.Beta;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -13,7 +12,6 @@ import java.time.Instant;
 /**
  * Change Feed response meta data
  */
-@Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
 public final class ChangeFeedMetaData {
     @JsonProperty("crts")
     private long conflictResolutionTimestamp;
@@ -31,7 +29,6 @@ public final class ChangeFeedMetaData {
      *
      * @return conflict resolution timestamp
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     @JsonIgnore
     public Instant getConflictResolutionTimestamp() {
         return Instant.ofEpochSecond(conflictResolutionTimestamp);
@@ -42,7 +39,6 @@ public final class ChangeFeedMetaData {
      *
      * @return current logical sequence number
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public long getLogSequenceNumber() {
         return logSequenceNumber;
     }
@@ -52,7 +48,6 @@ public final class ChangeFeedMetaData {
      *
      * @return change Feed operation type
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public ChangeFeedOperationType getOperationType() {
         return operationType;
     }
@@ -62,7 +57,6 @@ public final class ChangeFeedMetaData {
      *
      * @return previous logical sequence number
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public long getPreviousLogSequenceNumber() {
         return previousLogSequenceNumber;
     }
@@ -73,7 +67,6 @@ public final class ChangeFeedMetaData {
      *
      * @return true if ttlExpiration caused the delete.
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public boolean isTimeToLiveExpired() {
         return timeToLiveExpired;
     }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/ChangeFeedOperationType.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/ChangeFeedOperationType.java
@@ -2,13 +2,11 @@
 // Licensed under the MIT License.
 package com.azure.cosmos.models;
 
-import com.azure.cosmos.util.Beta;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Change feed operation type
  */
-@Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
 public enum ChangeFeedOperationType {
     /**
      * Represents Create operation

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/ChangeFeedPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/ChangeFeedPolicy.java
@@ -52,8 +52,6 @@ import java.time.Duration;
  * }
  * </pre>
  */
-@Beta(value = Beta.SinceVersion.V4_12_0,
-    warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
 public final class ChangeFeedPolicy {
 
     private final JsonSerializable jsonSerializable;
@@ -94,8 +92,6 @@ public final class ChangeFeedPolicy {
      *
      * @return ChangeFeedPolicy for AllVersionsAndDeletes change feed.
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0,
-        warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public static ChangeFeedPolicy createAllVersionsAndDeletesPolicy(Duration retentionDuration) {
 
         if (retentionDuration.isNegative() ||
@@ -141,8 +137,6 @@ public final class ChangeFeedPolicy {
      *
      * @return ChangeFeedPolicy for default/LatestVersion change feed without AllVersionsAndDeletes.
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0,
-        warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public static ChangeFeedPolicy createLatestVersionPolicy() {
 
         ChangeFeedPolicy policy = new ChangeFeedPolicy();
@@ -199,8 +193,6 @@ public final class ChangeFeedPolicy {
      *
      * @return AllVersionsAndDeletes retention duration.
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0,
-        warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public Duration getRetentionDurationForAllVersionsAndDeletesPolicy() {
         return Duration.ofMinutes(this.getRetentionDurationForAllVersionsAndDeletesPolicyInMinutes());
     }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/ChangeFeedProcessorItem.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/ChangeFeedProcessorItem.java
@@ -3,7 +3,6 @@
 package com.azure.cosmos.models;
 
 import com.azure.cosmos.implementation.Utils;
-import com.azure.cosmos.util.Beta;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,7 +16,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  *
  * Caller is recommended to type cast {@link JsonNode} to cosmos item structure.
  */
-@Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
 public final class ChangeFeedProcessorItem {
     @JsonProperty("current")
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -37,7 +35,6 @@ public final class ChangeFeedProcessorItem {
      *
      * @return change feed current item.
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public JsonNode getCurrent() {
         return current;
     }
@@ -49,7 +46,6 @@ public final class ChangeFeedProcessorItem {
      *
      * @return change feed previous item.
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public JsonNode getPrevious() {
         return previous;
     }
@@ -59,7 +55,6 @@ public final class ChangeFeedProcessorItem {
      *
      * @return change feed metadata.
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     @JsonIgnore
     public ChangeFeedMetaData getChangeFeedMetaData() {
 
@@ -78,7 +73,6 @@ public final class ChangeFeedProcessorItem {
      * @throws IllegalArgumentException If conversion fails due to incompatible type;
      * if so, root cause will contain underlying checked exception data binding functionality threw
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public JsonNode toJsonNode() {
 
         if (this.changeFeedProcessorItemAsJsonNode == null) {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosChangeFeedRequestOptions.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosChangeFeedRequestOptions.java
@@ -513,7 +513,6 @@ public final class CosmosChangeFeedRequestOptions {
      *
      * @return a {@link CosmosChangeFeedRequestOptions} instance with AllVersionsAndDeletes mode enabled
      */
-    @Beta(value = Beta.SinceVersion.V4_37_0, warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public CosmosChangeFeedRequestOptions allVersionsAndDeletes() {
         this.actualRequestOptions.allVersionsAndDeletes();
         return this;

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosContainerProperties.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosContainerProperties.java
@@ -6,7 +6,6 @@ import com.azure.cosmos.implementation.DocumentCollection;
 import com.azure.cosmos.implementation.ImplementationBridgeHelpers;
 import com.azure.cosmos.implementation.Resource;
 import com.azure.cosmos.implementation.apachecommons.lang.StringUtils;
-import com.azure.cosmos.util.Beta;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.time.Instant;
@@ -161,8 +160,6 @@ public final class CosmosContainerProperties {
      *
      * @return ChangeFeedPolicy
      */
-    @Beta(value = Beta.SinceVersion.V4_12_0,
-        warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public ChangeFeedPolicy getChangeFeedPolicy() {
         return this.documentCollection.getChangeFeedPolicy();
     }
@@ -173,8 +170,6 @@ public final class CosmosContainerProperties {
      * @param value ChangeFeedPolicy to be used.
      * @return the CosmosContainerProperties.
      */
-    @Beta(value = Beta.SinceVersion.V4_12_0,
-        warningText = Beta.PREVIEW_SUBJECT_TO_CHANGE_WARNING)
     public CosmosContainerProperties setChangeFeedPolicy(ChangeFeedPolicy value) {
         this.documentCollection.setChangeFeedPolicy(value);
         return this;


### PR DESCRIPTION
Promote Full Fidelity Change Feed (AllVersionsAndDeletes) APIs to GA

Removes @Beta from FFCF / AllVersionsAndDeletes public APIs. The deprecated fullFidelity / createFullFidelityPolicy / createIncrementalPolicy / getFullFidelityRetentionDuration methods are intentionally kept for back-compat. ChangeFeedMode.FULL_FIDELITY enum is also kept (continuation token wire format).

Resolves https://github.com/Azure/azure-sdk-for-java/issues/48959

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
