### PR TITLE
fix: isolate per-record ID-generation failures in Kafka sink transformer

### DIFF
--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosSinkTask.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/main/java/com/azure/cosmos/kafka/connect/implementation/sink/CosmosSinkTask.java
@@ -51,18 +51,9 @@ public class CosmosSinkTask extends SinkTask {
             LOGGER.info("The taskId is " + this.sinkTaskConfig.getTaskId());
             this.throughputControlClientItem = this.getThroughputControlCosmosClient();
 
-            ErrantRecordReporter errantRecordReporter = null;
-            try {
-                errantRecordReporter = this.context.errantRecordReporter();
-            } catch (NoClassDefFoundError | NoSuchMethodError e) {
-                LOGGER.info(
-                    "ErrantRecordReporter not available in this Kafka Connect runtime; "
-                        + "DLQ will not be used for transform errors.");
-            }
-
             this.sinkRecordTransformer = new SinkRecordTransformer(
                 this.sinkTaskConfig,
-                errantRecordReporter,
+                this.context.errantRecordReporter(),
                 this.sinkTaskConfig.getWriteConfig().getToleranceOnErrorLevel());
 
             if (this.sinkTaskConfig.getWriteConfig().isBulkEnabled()) {

--- a/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformerTest.java
+++ b/sdk/cosmos/azure-cosmos-kafka-connect/src/test/java/com/azure/cosmos/kafka/connect/implementation/sink/SinkRecordTransformerTest.java
@@ -66,7 +66,7 @@ public class SinkRecordTransformerTest {
         // Arrange
         IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
         ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
-        Future<?> mockFuture = Mockito.mock(Future.class);
+        Future<Void> mockFuture = Mockito.mock(Future.class);
         when(reporter.report(any(SinkRecord.class), any(Throwable.class))).thenReturn(mockFuture);
 
         SinkRecordTransformer transformer = new SinkRecordTransformer(idStrategy, reporter, ToleranceOnErrorLevel.ALL);
@@ -201,11 +201,12 @@ public class SinkRecordTransformerTest {
     // T5: All records bad with reporter + tolerance ALL — all reported to DLQ, empty output
     // ============================================================
     @Test(groups = {"unit"}, timeOut = TIMEOUT)
+    @SuppressWarnings("unchecked")
     public void allBadRecordsWithReporterToleranceAll_allReportedEmptyOutput() throws Exception {
         // Arrange
         IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
         ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
-        Future<?> mockFuture = Mockito.mock(Future.class);
+        Future<Void> mockFuture = Mockito.mock(Future.class);
         when(reporter.report(any(SinkRecord.class), any(Throwable.class))).thenReturn(mockFuture);
 
         SinkRecordTransformer transformer = new SinkRecordTransformer(idStrategy, reporter, ToleranceOnErrorLevel.ALL);
@@ -301,11 +302,12 @@ public class SinkRecordTransformerTest {
     //     (consistent with writer-level pattern: DLQ is side-effect, tolerance controls flow)
     // ============================================================
     @Test(groups = {"unit"}, timeOut = TIMEOUT)
+    @SuppressWarnings("unchecked")
     public void toleranceNoneWithReporter_reportedToDlqAndExceptionThrown() throws Exception {
         // Arrange
         IdStrategy idStrategy = createSelectivelyFailingIdStrategy();
         ErrantRecordReporter reporter = Mockito.mock(ErrantRecordReporter.class);
-        Future<?> mockFuture = Mockito.mock(Future.class);
+        Future<Void> mockFuture = Mockito.mock(Future.class);
         when(reporter.report(any(SinkRecord.class), any(Throwable.class))).thenReturn(mockFuture);
 
         // Tolerance is NONE — task should fail even though reporter is available


### PR DESCRIPTION

### Problem
When a single `SinkRecord` in a batch fails during ID generation (e.g., due to an invalid JsonPath in `ProvidedInStrategy.generateId()`), the entire batch fails and all records are routed to the DLQ — not just the malformed record.

**Root cause:** `SinkRecordTransformer.transform()` lacked per-record error isolation. An exception from `idStrategy.generateId()` would abort the entire `transform()` call before records reached the writer-level DLQ handling in `CosmosWriterBase.sendToDlqIfConfigured()`.

### Solution
Added per-record try-catch in `SinkRecordTransformer.transform()` that is consistent with the writer-level pattern in `CosmosWriterBase`:

1. **DLQ report is fire-and-forget side-effect** — always report to `ErrantRecordReporter` if available (guarded against reporter failures)
2. **Tolerance level controls flow** — `ALL` skips and continues, `NONE` throws (regardless of whether DLQ reporter is present)

| Scenario | `ErrantRecordReporter` | `ToleranceOnErrorLevel` | Behavior |
|----------|----------------------|------------------------|----------|
| DLQ configured | Available | `ALL` | Report to DLQ, skip bad record, continue |
| DLQ configured | Available | `NONE` | Report to DLQ, then throw (fail-fast) |
| DLQ not configured | `null` | `ALL` | Log warning, skip bad record, continue |
| DLQ not configured | `null` | `NONE` | Throw (fail-fast, preserves existing behavior) |
| DLQ reporter fails | Available (throws) | `ALL` | Log DLQ error, skip bad record, continue |
| DLQ reporter fails | Available (throws) | `NONE` | Log DLQ error, throw original exception |

### Changes
- **`SinkRecordTransformer.java`**
  - Added `ErrantRecordReporter` and `ToleranceOnErrorLevel` fields
  - Wrapped per-record processing in try-catch with DLQ/tolerance handling
  - Guarded `ErrantRecordReporter.report()` against secondary failures
  - Added package-private constructor for testability
  - Made `createIdStrategy()` static for constructor chain
- **`CosmosSinkTask.java`**
  - Pass `errantRecordReporter` and `toleranceOnErrorLevel` to `SinkRecordTransformer`
  - Guard `context.errantRecordReporter()` against older Kafka Connect runtimes
  - Fix bookkeeping to count `transformedRecords.size()` (post-filter) instead of `entry.getValue().size()` (pre-filter)
- **`SinkRecordTransformerTest.java`** — 8 new unit tests:
  - T1: Mixed batch with reporter + tolerance ALL → bad→DLQ, good records survive
  - T2: Tolerance ALL without reporter → bad record skipped
  - T3: Tolerance NONE without reporter → exception thrown (fail-fast)
  - T4: All valid records → all in output, reporter never called (regression)
  - T5: All bad with reporter + tolerance ALL → all→DLQ, empty output
  - T6: Reporter throws + tolerance NONE → original exception rethrown
  - T7: Reporter throws + tolerance ALL → record skipped, continues
  - T8: Tolerance NONE with reporter → DLQ report AND exception thrown

Fixes #49268