### PR TITLE
Added missing getters for `FileSearchTool` filter types

### DIFF
--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/models/FileSearchTool.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/models/FileSearchTool.java
@@ -246,6 +246,21 @@ public final class FileSearchTool extends Tool {
     }
 
     /**
+     * Gets the file search filters as an openai-java {@link ComparisonFilter}.
+     *
+     * @return the openai-java ComparisonFilter, or {@code null} if filters are not set or contain a different filter
+     * type.
+     */
+    public ComparisonFilter getComparisonFilter() {
+        // AI Tooling: openai-java de-dup
+        Object filter = getOpenAIFileSearchFilter();
+        if (filter instanceof ComparisonFilter) {
+            return (ComparisonFilter) filter;
+        }
+        return null;
+    }
+
+    /**
      * Sets the file search filters using an openai-java {@link CompoundFilter}.
      * <p>
      * The provided filter is serialized using the openai-java JSON schema and stored in the
@@ -258,6 +273,51 @@ public final class FileSearchTool extends Tool {
         // AI Tooling: openai-java de-dup
         this.filters = com.azure.ai.agents.implementation.OpenAIJsonHelper.toBinaryData(filter);
         return this;
+    }
+
+    /**
+     * Gets the file search filters as an openai-java {@link CompoundFilter}.
+     *
+     * @return the openai-java CompoundFilter, or {@code null} if filters are not set or contain a different filter
+     * type.
+     */
+    public CompoundFilter getCompoundFilter() {
+        // AI Tooling: openai-java de-dup
+        Object filter = getOpenAIFileSearchFilter();
+        if (filter instanceof CompoundFilter) {
+            return (CompoundFilter) filter;
+        }
+        return null;
+    }
+
+    private Object getOpenAIFileSearchFilter() {
+        // AI Tooling: openai-java de-dup
+        com.openai.models.responses.FileSearchTool.Filters filter = com.azure.ai.agents.implementation.OpenAIJsonHelper
+            .fromBinaryData(this.filters, com.openai.models.responses.FileSearchTool.Filters.class);
+        if (filter == null) {
+            return null;
+        }
+        if (filter.isComparisonFilter()) {
+            ComparisonFilter comparisonFilter = filter.asComparisonFilter();
+            if (!comparisonFilter._key().isMissing()
+                && !comparisonFilter._key().isNull()
+                && !comparisonFilter._type().isMissing()
+                && !comparisonFilter._type().isNull()
+                && !comparisonFilter._value().isMissing()
+                && !comparisonFilter._value().isNull()) {
+                return comparisonFilter;
+            }
+        }
+        if (filter.isCompoundFilter()) {
+            CompoundFilter compoundFilter = filter.asCompoundFilter();
+            if (!compoundFilter._type().isMissing()
+                && !compoundFilter._type().isNull()
+                && !compoundFilter._filters().isMissing()
+                && !compoundFilter._filters().isNull()) {
+                return compoundFilter;
+            }
+        }
+        return null;
     }
 
     /*

--- a/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/models/FileSearchToolSerializationTests.java
+++ b/sdk/ai/azure-ai-agents/src/test/java/com/azure/ai/agents/models/FileSearchToolSerializationTests.java
@@ -66,6 +66,8 @@ public class FileSearchToolSerializationTests {
         assertNull(tool.getMaxResults());
         assertNull(tool.getRankingOptions());
         assertNull(tool.getFilters());
+        assertNull(tool.getComparisonFilter());
+        assertNull(tool.getCompoundFilter());
     }
 
     @Test
@@ -86,6 +88,18 @@ public class FileSearchToolSerializationTests {
         assertEquals(0.7, tool.getRankingOptions().getHybridSearch().getEmbeddingWeight());
         assertEquals(0.3, tool.getRankingOptions().getHybridSearch().getTextWeight());
         assertNotNull(tool.getFilters());
+    }
+
+    @Test
+    public void testFilterGettersReturnNullForUnexpectedFilterShape() throws IOException {
+        String json
+            = "{\"type\":\"file_search\",\"vector_store_ids\":[\"vs_unknown\"]," + "\"filters\":{\"foo\":\"bar\"}}";
+
+        FileSearchTool tool = deserialize(json);
+
+        assertNotNull(tool.getFilters());
+        assertNull(tool.getComparisonFilter());
+        assertNull(tool.getCompoundFilter());
     }
 
     // -----------------------------------------------------------------------
@@ -139,6 +153,12 @@ public class FileSearchToolSerializationTests {
 
         FileSearchTool tool = new FileSearchTool(Collections.singletonList("vs_f1")).setComparisonFilter(filter);
 
+        ComparisonFilter retrievedFilter = tool.getComparisonFilter();
+        assertNotNull(retrievedFilter);
+        assertEquals("category", retrievedFilter.key());
+        assertEquals("science", retrievedFilter.value().asString());
+        assertNull(tool.getCompoundFilter());
+
         String json = serialize(tool);
 
         assertTrue(json.contains("\"key\":\"category\""), "Missing key, got: " + json);
@@ -163,6 +183,11 @@ public class FileSearchToolSerializationTests {
         assertEquals(original.getVectorStoreIds(), deserialized.getVectorStoreIds());
         assertEquals(original.getMaxResults(), deserialized.getMaxResults());
         assertNotNull(deserialized.getFilters());
+        ComparisonFilter deserializedFilter = deserialized.getComparisonFilter();
+        assertNotNull(deserializedFilter);
+        assertEquals("year", deserializedFilter.key());
+        assertEquals(2020.0, deserializedFilter.value().asNumber());
+        assertNull(deserialized.getCompoundFilter());
 
         // Re-serialize and compare JSON
         String reserializedJson = serialize(deserialized);
@@ -217,6 +242,12 @@ public class FileSearchToolSerializationTests {
 
         FileSearchTool tool = new FileSearchTool(Collections.singletonList("vs_c1")).setCompoundFilter(filter);
 
+        CompoundFilter retrievedFilter = tool.getCompoundFilter();
+        assertNotNull(retrievedFilter);
+        assertEquals(CompoundFilter.Type.AND, retrievedFilter.type());
+        assertEquals(2, retrievedFilter.filters().size());
+        assertNull(tool.getComparisonFilter());
+
         String json = serialize(tool);
 
         assertTrue(json.contains("\"key\":\"status\""), "Missing status key, got: " + json);
@@ -241,6 +272,11 @@ public class FileSearchToolSerializationTests {
         FileSearchTool deserialized = deserialize(json);
 
         assertNotNull(deserialized.getFilters());
+        CompoundFilter deserializedFilter = deserialized.getCompoundFilter();
+        assertNotNull(deserializedFilter);
+        assertEquals(CompoundFilter.Type.OR, deserializedFilter.type());
+        assertEquals(1, deserializedFilter.filters().size());
+        assertNull(deserialized.getComparisonFilter());
 
         String reserializedJson = serialize(deserialized);
         assertEquals(json, reserializedJson);


### PR DESCRIPTION
This pull request enhances the `FileSearchTool` model by adding getter methods for retrieving file search filters as either `ComparisonFilter` or `CompoundFilter` types. It also introduces robust logic to distinguish between filter types and updates the test suite to ensure correct behavior for these getters, including handling unexpected or malformed filter shapes.

Enhancements to filter access and logic:

* Added `getComparisonFilter()` and `getCompoundFilter()` methods to `FileSearchTool`, allowing retrieval of the filter as the correct type or `null` if not applicable. A private helper, `getOpenAIFileSearchFilter()`, encapsulates the logic to parse and validate the filter type and contents. [[1]](diffhunk://#diff-69c6346a3fd22f040c5ee40881e824c48cc86830a774409f2324e44a0a560f7bR248-R262) [[2]](diffhunk://#diff-69c6346a3fd22f040c5ee40881e824c48cc86830a774409f2324e44a0a560f7bR278-R322)

Test improvements:

* Updated and extended tests in `FileSearchToolSerializationTests.java` to verify the new getter methods, including:
  - Checking that the getters return `null` for missing or unexpected filter shapes. [[1]](diffhunk://#diff-c81c536fbff02c8a61a76164609db3eae74253554c30aae96238fc72dd600bb5R69-R70) [[2]](diffhunk://#diff-c81c536fbff02c8a61a76164609db3eae74253554c30aae96238fc72dd600bb5R93-R104)
  - Validating correct deserialization, serialization, and round-trip behavior for both `ComparisonFilter` and `CompoundFilter` cases, and ensuring only one filter type is set at a time. [[1]](diffhunk://#diff-c81c536fbff02c8a61a76164609db3eae74253554c30aae96238fc72dd600bb5R156-R161) [[2]](diffhunk://#diff-c81c536fbff02c8a61a76164609db3eae74253554c30aae96238fc72dd600bb5R186-R190) [[3]](diffhunk://#diff-c81c536fbff02c8a61a76164609db3eae74253554c30aae96238fc72dd600bb5R245-R250) [[4]](diffhunk://#diff-c81c536fbff02c8a61a76164609db3eae74253554c30aae96238fc72dd600bb5R275-R279)