### PR TITLE
Added missing protocol methods

### DIFF
--- a/sdk/ai/azure-ai-projects/assets.json
+++ b/sdk/ai/azure-ai-projects/assets.json
@@ -1,1 +1,1 @@
-{"AssetsRepo":"Azure/azure-sdk-assets","AssetsRepoPrefixPath":"java","TagPrefix":"java/ai/azure-ai-projects","Tag": "java/ai/azure-ai-projects_c4dd2a11a3"}
+{"AssetsRepo":"Azure/azure-sdk-assets","AssetsRepoPrefixPath":"java","TagPrefix":"java/ai/azure-ai-projects","Tag": "java/ai/azure-ai-projects_1d956abc13"}

--- a/sdk/ai/azure-ai-projects/src/main/java/com/azure/ai/projects/ConnectionsAsyncClient.java
+++ b/sdk/ai/azure-ai-projects/src/main/java/com/azure/ai/projects/ConnectionsAsyncClient.java
@@ -119,6 +119,28 @@ public final class ConnectionsAsyncClient {
     }
 
     /**
+     * Get a connection by name.
+     *
+     * @param name The friendly name of the connection, provided by the user.
+     * @param includeCredentials Whether to include connection credentials in the response.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return a connection by name along with {@link Response} on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> getConnectionWithResponse(String name, boolean includeCredentials,
+        RequestOptions requestOptions) {
+        if (includeCredentials) {
+            return getConnectionWithCredentialsWithResponse(name, requestOptions);
+        } else {
+            return getConnectionWithResponse(name, requestOptions);
+        }
+    }
+
+    /**
      * List all connections in the project, without populating connection credentials.
      * <p><strong>Query Parameters</strong></p>
      * <table border="1">
@@ -290,11 +312,9 @@ public final class ConnectionsAsyncClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<Connection> getConnection(String name, boolean includeCredentials) {
-        if (includeCredentials) {
-            return getConnectionWithCredentials(name);
-        } else {
-            return getConnection(name);
-        }
+        RequestOptions requestOptions = new RequestOptions();
+        return getConnectionWithResponse(name, includeCredentials, requestOptions).flatMap(FluxUtil::toMono)
+            .map(protocolMethodData -> protocolMethodData.toObject(Connection.class));
     }
 
     /**

--- a/sdk/ai/azure-ai-projects/src/main/java/com/azure/ai/projects/ConnectionsClient.java
+++ b/sdk/ai/azure-ai-projects/src/main/java/com/azure/ai/projects/ConnectionsClient.java
@@ -114,6 +114,28 @@ public final class ConnectionsClient {
     }
 
     /**
+     * Get a connection by name.
+     *
+     * @param name The friendly name of the connection, provided by the user.
+     * @param includeCredentials Whether to include connection credentials in the response.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return a connection by name along with {@link Response}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> getConnectionWithResponse(String name, boolean includeCredentials,
+        RequestOptions requestOptions) {
+        if (includeCredentials) {
+            return getConnectionWithCredentialsWithResponse(name, requestOptions);
+        } else {
+            return getConnectionWithResponse(name, requestOptions);
+        }
+    }
+
+    /**
      * List all connections in the project, without populating connection credentials.
      * <p><strong>Query Parameters</strong></p>
      * <table border="1">
@@ -261,11 +283,9 @@ public final class ConnectionsClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Connection getConnection(String name, boolean includeCredentials) {
-        if (includeCredentials) {
-            return getConnectionWithCredentials(name);
-        } else {
-            return getConnection(name);
-        }
+        RequestOptions requestOptions = new RequestOptions();
+        return getConnectionWithResponse(name, includeCredentials, requestOptions).getValue()
+            .toObject(Connection.class);
     }
 
     /**

--- a/sdk/ai/azure-ai-projects/src/main/java/com/azure/ai/projects/DatasetsAsyncClient.java
+++ b/sdk/ai/azure-ai-projects/src/main/java/com/azure/ai/projects/DatasetsAsyncClient.java
@@ -125,7 +125,7 @@ public final class DatasetsAsyncClient {
      * @param version The specific version id of the DatasetVersion to create or replace.
      * @param filePath The path to the file to upload.
      * @return A Mono that completes with a FileDatasetVersion representing the created dataset.
-     * @throws IllegalArgumentException If the provided path is not a file
+     * @throws IllegalArgumentException If the provided path is not a file.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<FileDatasetVersion> createDatasetWithFile(String name, String version, Path filePath) {
@@ -141,11 +141,58 @@ public final class DatasetsAsyncClient {
      * @param connectionName The name of an Azure Storage Account connection to use for uploading.
      * If null, the default Azure Storage Account connection will be used.
      * @return A Mono that completes with a FileDatasetVersion representing the created dataset.
-     * @throws IllegalArgumentException If the provided path is not a file
+     * @throws IllegalArgumentException If the provided path is not a file.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<FileDatasetVersion> createDatasetWithFile(String name, String version, Path filePath,
         String connectionName) {
+        RequestOptions requestOptions = new RequestOptions();
+        return createDatasetWithFileWithResponse(name, version, filePath, connectionName, requestOptions)
+            .flatMap(FluxUtil::toMono)
+            .map(data -> data.toObject(FileDatasetVersion.class));
+    }
+
+    /**
+     * Creates a dataset from a file. Uploads the file to blob storage and registers the dataset.
+     *
+     * @param name The name of the resource.
+     * @param version The specific version id of the DatasetVersion to create or replace.
+     * @param filePath The path to the file to upload.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return A FileDatasetVersion representing the created dataset along with {@link Response} on successful
+     * completion of {@link Mono}.
+     * @throws IllegalArgumentException If the provided path is not a file.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> createDatasetWithFileWithResponse(String name, String version, Path filePath,
+        RequestOptions requestOptions) {
+        return createDatasetWithFileWithResponse(name, version, filePath, null, requestOptions);
+    }
+
+    /**
+     * Creates a dataset from a single file. Uploads the file to blob storage and registers the dataset.
+     *
+     * @param name The name of the resource.
+     * @param version The specific version id of the DatasetVersion to create or replace.
+     * @param filePath The path to the file to upload.
+     * @param connectionName The name of an Azure Storage Account connection to use for uploading.
+     * If null, the default Azure Storage Account connection will be used.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return A FileDatasetVersion representing the created dataset along with {@link Response} on successful
+     * completion of {@link Mono}.
+     * @throws IllegalArgumentException If the provided path is not a file.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> createDatasetWithFileWithResponse(String name, String version, Path filePath,
+        String connectionName, RequestOptions requestOptions) {
         if (!Files.isRegularFile(filePath)) {
             return Mono.error(new IllegalArgumentException("The provided path is not a file: " + filePath));
         }
@@ -153,21 +200,21 @@ public final class DatasetsAsyncClient {
         if (connectionName != null) {
             request.setConnectionName(connectionName);
         }
-        return this.pendingUpload(name, version, request).flatMap(pendingUploadResponse -> {
-            String sasUri = pendingUploadResponse.getBlobReference().getCredential().getSasUrl();
-            BlobAsyncClient blobClient = new BlobClientBuilder().endpoint(sasUri)
-                .blobName(filePath.getFileName().toString())
-                .buildAsyncClient();
-            return blobClient.upload(BinaryData.fromFile(filePath), true).thenReturn(blobClient.getBlobUrl());
-        }).flatMap(blobUrl -> {
-            RequestOptions requestOptions = new RequestOptions();
-            FileDatasetVersion fileDataset = new FileDatasetVersion().setDataUrl(blobUrl);
-            return this
-                .createOrUpdateDatasetVersionWithResponse(name, version, BinaryData.fromObject(fileDataset),
-                    requestOptions)
-                .flatMap(FluxUtil::toMono)
-                .map(data -> data.toObject(FileDatasetVersion.class));
-        });
+        return this.pendingUploadWithResponse(name, version, BinaryData.fromObject(request), requestOptions)
+            .flatMap(FluxUtil::toMono)
+            .map(protocolMethodData -> protocolMethodData.toObject(PendingUploadResponse.class))
+            .flatMap(pendingUploadResponse -> {
+                String sasUri = pendingUploadResponse.getBlobReference().getCredential().getSasUrl();
+                BlobAsyncClient blobClient = new BlobClientBuilder().endpoint(sasUri)
+                    .blobName(filePath.getFileName().toString())
+                    .buildAsyncClient();
+                return blobClient.upload(BinaryData.fromFile(filePath), true).thenReturn(blobClient.getBlobUrl());
+            })
+            .flatMap(blobUrl -> {
+                FileDatasetVersion fileDataset = new FileDatasetVersion().setDataUrl(blobUrl);
+                return this.createOrUpdateDatasetVersionWithResponse(name, version, BinaryData.fromObject(fileDataset),
+                    requestOptions);
+            });
     }
 
     /**
@@ -198,6 +245,53 @@ public final class DatasetsAsyncClient {
     @ServiceMethod(returns = ReturnType.SINGLE)
     public Mono<FolderDatasetVersion> createDatasetWithFolder(String name, String version, Path folderPath,
         String connectionName) {
+        RequestOptions requestOptions = new RequestOptions();
+        return createDatasetWithFolderWithResponse(name, version, folderPath, connectionName, requestOptions)
+            .flatMap(FluxUtil::toMono)
+            .map(data -> data.toObject(FolderDatasetVersion.class));
+    }
+
+    /**
+     * Creates a dataset from a folder. Uploads all files in the folder to blob storage and registers the dataset.
+     *
+     * @param name The name of the resource.
+     * @param version The specific version id of the DatasetVersion to create or replace.
+     * @param folderPath The path to the folder containing files to upload.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return A FolderDatasetVersion representing the created dataset along with {@link Response} on successful
+     * completion of {@link Mono}.
+     * @throws IllegalArgumentException If the provided path is not a directory.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> createDatasetWithFolderWithResponse(String name, String version, Path folderPath,
+        RequestOptions requestOptions) {
+        return createDatasetWithFolderWithResponse(name, version, folderPath, null, requestOptions);
+    }
+
+    /**
+     * Creates a dataset from a folder. Uploads all files in the folder to blob storage and registers the dataset.
+     *
+     * @param name The name of the resource.
+     * @param version The specific version id of the DatasetVersion to create or replace.
+     * @param folderPath The path to the folder containing files to upload.
+     * @param connectionName The name of an Azure Storage Account connection to use for uploading.
+     * If null, the default Azure Storage Account connection will be used.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return A FolderDatasetVersion representing the created dataset along with {@link Response} on successful
+     * completion of {@link Mono}.
+     * @throws IllegalArgumentException If the provided path is not a directory.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Response<BinaryData>> createDatasetWithFolderWithResponse(String name, String version, Path folderPath,
+        String connectionName, RequestOptions requestOptions) {
         if (!Files.isDirectory(folderPath)) {
             return Mono.error(new IllegalArgumentException("The provided path is not a folder: " + folderPath));
         }
@@ -205,34 +299,35 @@ public final class DatasetsAsyncClient {
         if (connectionName != null) {
             request.setConnectionName(connectionName);
         }
-        return this.pendingUpload(name, version, request).flatMap(pendingUploadResponse -> {
-            String containerUrl = pendingUploadResponse.getBlobReference().getBlobUrl();
-            String sasUri = pendingUploadResponse.getBlobReference().getCredential().getSasUrl();
-            BlobContainerAsyncClient containerClient
-                = new BlobContainerClientBuilder().endpoint(sasUri).buildAsyncClient();
-            try {
-                List<Path> files;
-                try (Stream<Path> fileStream = Files.walk(folderPath)) {
-                    files = fileStream.filter(Files::isRegularFile).collect(Collectors.toList());
+        return this.pendingUploadWithResponse(name, version, BinaryData.fromObject(request), requestOptions)
+            .flatMap(FluxUtil::toMono)
+            .map(protocolMethodData -> protocolMethodData.toObject(PendingUploadResponse.class))
+            .flatMap(pendingUploadResponse -> {
+                String containerUrl = pendingUploadResponse.getBlobReference().getBlobUrl();
+                String sasUri = pendingUploadResponse.getBlobReference().getCredential().getSasUrl();
+                BlobContainerAsyncClient containerClient
+                    = new BlobContainerClientBuilder().endpoint(sasUri).buildAsyncClient();
+                try {
+                    List<Path> files;
+                    try (Stream<Path> fileStream = Files.walk(folderPath)) {
+                        files = fileStream.filter(Files::isRegularFile).collect(Collectors.toList());
+                    }
+                    return Flux.fromIterable(files).flatMap(filePath -> {
+                        String relativePath = folderPath.relativize(filePath).toString().replace('\\', '/');
+                        return containerClient.getBlobAsyncClient(relativePath)
+                            .upload(BinaryData.fromFile(filePath), true);
+                    }).then(Mono.just(containerUrl));
+                } catch (IOException e) {
+                    return Mono.error(new UncheckedIOException("Failed to walk folder path: " + folderPath, e));
+                } catch (RuntimeException e) {
+                    return Mono.error(e);
                 }
-                return Flux.fromIterable(files).flatMap(filePath -> {
-                    String relativePath = folderPath.relativize(filePath).toString().replace('\\', '/');
-                    return containerClient.getBlobAsyncClient(relativePath).upload(BinaryData.fromFile(filePath), true);
-                }).then(Mono.just(containerUrl));
-            } catch (IOException e) {
-                return Mono.error(new UncheckedIOException("Failed to walk folder path: " + folderPath, e));
-            } catch (RuntimeException e) {
-                return Mono.error(e);
-            }
-        }).flatMap(containerUrl -> {
-            RequestOptions requestOptions = new RequestOptions();
-            FolderDatasetVersion folderDataset = new FolderDatasetVersion().setDataUrl(containerUrl);
-            return this
-                .createOrUpdateDatasetVersionWithResponse(name, version, BinaryData.fromObject(folderDataset),
-                    requestOptions)
-                .flatMap(FluxUtil::toMono)
-                .map(data -> data.toObject(FolderDatasetVersion.class));
-        });
+            })
+            .flatMap(containerUrl -> {
+                FolderDatasetVersion folderDataset = new FolderDatasetVersion().setDataUrl(containerUrl);
+                return this.createOrUpdateDatasetVersionWithResponse(name, version,
+                    BinaryData.fromObject(folderDataset), requestOptions);
+            });
     }
 
     /**

--- a/sdk/ai/azure-ai-projects/src/main/java/com/azure/ai/projects/DatasetsClient.java
+++ b/sdk/ai/azure-ai-projects/src/main/java/com/azure/ai/projects/DatasetsClient.java
@@ -113,13 +113,13 @@ public final class DatasetsClient {
     }
 
     /**
-     * Creates a dataset from a folder.
+     * Creates a dataset from a file.
      *
      * @param name The name of the resource.
      * @param version The specific version id of the DatasetVersion to create or replace.
-     * @param filePath The path to the folder containing files to upload.
+     * @param filePath The path to the file to upload.
      * @return A FileDatasetVersion representing the created dataset.
-     * @throws IllegalArgumentException If the provided path is not a file
+     * @throws IllegalArgumentException If the provided path is not a file.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public FileDatasetVersion createDatasetWithFile(String name, String version, Path filePath) {
@@ -139,6 +139,50 @@ public final class DatasetsClient {
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public FileDatasetVersion createDatasetWithFile(String name, String version, Path filePath, String connectionName) {
+        RequestOptions requestOptions = new RequestOptions();
+        return createDatasetWithFileWithResponse(name, version, filePath, connectionName, requestOptions).getValue()
+            .toObject(FileDatasetVersion.class);
+    }
+
+    /**
+     * Creates a dataset from a file. Uploads the file to blob storage and registers the dataset.
+     *
+     * @param name The name of the resource.
+     * @param version The specific version id of the DatasetVersion to create or replace.
+     * @param filePath The path to the file to upload.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return A FileDatasetVersion representing the created dataset along with {@link Response}.
+     * @throws IllegalArgumentException If the provided path is not a file.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> createDatasetWithFileWithResponse(String name, String version, Path filePath,
+        RequestOptions requestOptions) {
+        return createDatasetWithFileWithResponse(name, version, filePath, null, requestOptions);
+    }
+
+    /**
+     * Creates a dataset from a single file. Uploads the file to blob storage and registers the dataset.
+     *
+     * @param name The name of the resource.
+     * @param version The specific version id of the DatasetVersion to create or replace.
+     * @param filePath The path to the file to upload.
+     * @param connectionName The name of an Azure Storage Account connection to use for uploading.
+     * If null, the default Azure Storage Account connection will be used.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return A FileDatasetVersion representing the created dataset along with {@link Response}.
+     * @throws IllegalArgumentException If the provided path is not a file.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> createDatasetWithFileWithResponse(String name, String version, Path filePath,
+        String connectionName, RequestOptions requestOptions) {
         if (!Files.isRegularFile(filePath)) {
             throw LOGGER
                 .logThrowableAsError(new IllegalArgumentException("The provided path is not a file: " + filePath));
@@ -147,19 +191,17 @@ public final class DatasetsClient {
         if (connectionName != null) {
             body.setConnectionName(connectionName);
         }
-        PendingUploadResponse pendingUploadResponse = this.pendingUpload(name, version, body);
+        PendingUploadResponse pendingUploadResponse
+            = this.pendingUploadWithResponse(name, version, BinaryData.fromObject(body), requestOptions)
+                .getValue()
+                .toObject(PendingUploadResponse.class);
         BlobReferenceSasCredential credential = pendingUploadResponse.getBlobReference().getCredential();
         BlobClient blobClient = new BlobClientBuilder().endpoint(credential.getSasUrl())
             .blobName(filePath.getFileName().toString())
             .buildClient();
         blobClient.upload(BinaryData.fromFile(filePath), true);
-        RequestOptions requestOptions = new RequestOptions();
-        FileDatasetVersion datasetVersion = this
-            .createOrUpdateDatasetVersionWithResponse(name, version,
-                BinaryData.fromObject(new FileDatasetVersion().setDataUrl(blobClient.getBlobUrl())), requestOptions)
-            .getValue()
-            .toObject(FileDatasetVersion.class);
-        return datasetVersion;
+        return this.createOrUpdateDatasetVersionWithResponse(name, version,
+            BinaryData.fromObject(new FileDatasetVersion().setDataUrl(blobClient.getBlobUrl())), requestOptions);
     }
 
     /**
@@ -170,7 +212,7 @@ public final class DatasetsClient {
      * @param folderPath The path to the folder containing files to upload.
      * @return A FolderDatasetVersion representing the created dataset.
      * @throws IllegalArgumentException If the provided path is not a directory.
-     * @throws UncheckedIOException if an I/ O error is thrown when accessing the starting file
+     * @throws UncheckedIOException if an I/O error is thrown when accessing the starting file.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public FolderDatasetVersion createDatasetWithFolder(String name, String version, Path folderPath) {
@@ -187,11 +229,57 @@ public final class DatasetsClient {
      * If null, the default Azure Storage Account connection will be used.
      * @return A FolderDatasetVersion representing the created dataset.
      * @throws IllegalArgumentException If the provided path is not a directory.
-     * @throws UncheckedIOException if an I/O error is thrown when accessing the starting file
+     * @throws UncheckedIOException if an I/O error is thrown when accessing the starting file.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public FolderDatasetVersion createDatasetWithFolder(String name, String version, Path folderPath,
         String connectionName) {
+        RequestOptions requestOptions = new RequestOptions();
+        return createDatasetWithFolderWithResponse(name, version, folderPath, connectionName, requestOptions).getValue()
+            .toObject(FolderDatasetVersion.class);
+    }
+
+    /**
+     * Creates a dataset from a folder. Uploads all files in the folder to blob storage and registers the dataset.
+     *
+     * @param name The name of the resource.
+     * @param version The specific version id of the DatasetVersion to create or replace.
+     * @param folderPath The path to the folder containing files to upload.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return A FolderDatasetVersion representing the created dataset along with {@link Response}.
+     * @throws IllegalArgumentException If the provided path is not a directory.
+     * @throws UncheckedIOException if an I/O error is thrown when accessing the starting file.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> createDatasetWithFolderWithResponse(String name, String version, Path folderPath,
+        RequestOptions requestOptions) {
+        return createDatasetWithFolderWithResponse(name, version, folderPath, null, requestOptions);
+    }
+
+    /**
+     * Creates a dataset from a folder. Uploads all files in the folder to blob storage and registers the dataset.
+     *
+     * @param name The name of the resource.
+     * @param version The specific version id of the DatasetVersion to create or replace.
+     * @param folderPath The path to the folder containing files to upload.
+     * @param connectionName The name of an Azure Storage Account connection to use for uploading.
+     * If null, the default Azure Storage Account connection will be used.
+     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @return A FolderDatasetVersion representing the created dataset along with {@link Response}.
+     * @throws IllegalArgumentException If the provided path is not a directory.
+     * @throws UncheckedIOException if an I/O error is thrown when accessing the starting file.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Response<BinaryData> createDatasetWithFolderWithResponse(String name, String version, Path folderPath,
+        String connectionName, RequestOptions requestOptions) {
         if (!Files.isDirectory(folderPath)) {
             throw LOGGER
                 .logExceptionAsError(new IllegalArgumentException("The provided path is not a folder: " + folderPath));
@@ -200,7 +288,10 @@ public final class DatasetsClient {
         if (connectionName != null) {
             request.setConnectionName(connectionName);
         }
-        PendingUploadResponse pendingUploadResponse = this.pendingUpload(name, version, request);
+        PendingUploadResponse pendingUploadResponse
+            = this.pendingUploadWithResponse(name, version, BinaryData.fromObject(request), requestOptions)
+                .getValue()
+                .toObject(PendingUploadResponse.class);
         String containerUrl = pendingUploadResponse.getBlobReference().getBlobUrl();
         BlobReferenceSasCredential credential = pendingUploadResponse.getBlobReference().getCredential();
         BlobContainerClient containerClient
@@ -214,13 +305,8 @@ public final class DatasetsClient {
         } catch (IOException e) {
             throw LOGGER.logExceptionAsError(new UncheckedIOException("Failed to walk folder path: " + folderPath, e));
         }
-        RequestOptions requestOptions = new RequestOptions();
-        FolderDatasetVersion datasetVersion = this
-            .createOrUpdateDatasetVersionWithResponse(name, version,
-                BinaryData.fromObject(new FolderDatasetVersion().setDataUrl(containerUrl)), requestOptions)
-            .getValue()
-            .toObject(FolderDatasetVersion.class);
-        return datasetVersion;
+        return this.createOrUpdateDatasetVersionWithResponse(name, version,
+            BinaryData.fromObject(new FolderDatasetVersion().setDataUrl(containerUrl)), requestOptions);
     }
 
     /**

--- a/sdk/ai/azure-ai-projects/src/test/java/com/azure/ai/projects/ConnectionsAsyncClientTest.java
+++ b/sdk/ai/azure-ai-projects/src/test/java/com/azure/ai/projects/ConnectionsAsyncClientTest.java
@@ -6,6 +6,7 @@ import com.azure.ai.projects.models.Connection;
 import com.azure.ai.projects.models.ConnectionType;
 import com.azure.core.http.HttpClient;
 import com.azure.core.http.rest.PagedFlux;
+import com.azure.core.http.rest.RequestOptions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -78,6 +79,28 @@ public class ConnectionsAsyncClientTest extends ClientTestBase {
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
+    public void testGetConnectionWithResponseWithoutCredentialsAsync(HttpClient httpClient,
+        AIProjectsServiceVersion serviceVersion) {
+        ConnectionsAsyncClient connectionsAsyncClient = getConnectionsAsyncClient(httpClient, serviceVersion);
+
+        // Discover a real connection name from the list
+        String connectionName
+            = connectionsAsyncClient.listConnections().next().map(Connection::getName).block(Duration.ofSeconds(20));
+        Assertions.assertNotNull(connectionName, "Expected at least one connection");
+
+        StepVerifier
+            .create(connectionsAsyncClient.getConnectionWithResponse(connectionName, false, new RequestOptions()))
+            .assertNext(response -> {
+                Connection connection = response.getValue().toObject(Connection.class);
+                assertValidConnection(connection, connectionName, null, null);
+                Assertions.assertNotNull(connection.getCredential().getType());
+                System.out.println("Connection retrieved successfully: " + connection.getName());
+            })
+            .verifyComplete();
+    }
+
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
     public void testGetConnectionWithCredentialsAsync(HttpClient httpClient, AIProjectsServiceVersion serviceVersion) {
         ConnectionsAsyncClient connectionsAsyncClient = getConnectionsAsyncClient(httpClient, serviceVersion);
 
@@ -88,6 +111,29 @@ public class ConnectionsAsyncClientTest extends ClientTestBase {
 
         StepVerifier.create(connectionsAsyncClient.getConnectionWithCredentials(connectionName))
             .assertNext(connection -> {
+                assertValidConnection(connection, connectionName, null, null);
+                Assertions.assertNotNull(connection.getCredential().getType());
+                System.out.println("Connection with credentials retrieved successfully: " + connection.getName());
+                System.out.println("Credential type: " + connection.getCredential().getType());
+            })
+            .verifyComplete();
+    }
+
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
+    public void testGetConnectionWithResponseWithCredentialsAsync(HttpClient httpClient,
+        AIProjectsServiceVersion serviceVersion) {
+        ConnectionsAsyncClient connectionsAsyncClient = getConnectionsAsyncClient(httpClient, serviceVersion);
+
+        // Discover a real connection name from the list
+        String connectionName
+            = connectionsAsyncClient.listConnections().next().map(Connection::getName).block(Duration.ofSeconds(20));
+        Assertions.assertNotNull(connectionName, "Expected at least one connection");
+
+        StepVerifier
+            .create(connectionsAsyncClient.getConnectionWithResponse(connectionName, true, new RequestOptions()))
+            .assertNext(response -> {
+                Connection connection = response.getValue().toObject(Connection.class);
                 assertValidConnection(connection, connectionName, null, null);
                 Assertions.assertNotNull(connection.getCredential().getType());
                 System.out.println("Connection with credentials retrieved successfully: " + connection.getName());

--- a/sdk/ai/azure-ai-projects/src/test/java/com/azure/ai/projects/ConnectionsClientTest.java
+++ b/sdk/ai/azure-ai-projects/src/test/java/com/azure/ai/projects/ConnectionsClientTest.java
@@ -5,6 +5,7 @@ package com.azure.ai.projects;
 import com.azure.ai.projects.models.Connection;
 import com.azure.ai.projects.models.ConnectionType;
 import com.azure.core.http.HttpClient;
+import com.azure.core.http.rest.RequestOptions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -83,6 +84,31 @@ public class ConnectionsClientTest extends ClientTestBase {
 
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
+    public void testGetConnectionWithResponseWithoutCredentials(HttpClient httpClient,
+        AIProjectsServiceVersion serviceVersion) {
+        ConnectionsClient connectionsClient = getConnectionsClient(httpClient, serviceVersion);
+
+        // Discover a real connection name from the list
+        String connectionName = null;
+        for (Connection c : connectionsClient.listConnections()) {
+            connectionName = c.getName();
+            break;
+        }
+        Assertions.assertNotNull(connectionName, "Expected at least one connection to test getConnection");
+
+        Connection connection = connectionsClient.getConnectionWithResponse(connectionName, false, new RequestOptions())
+            .getValue()
+            .toObject(Connection.class);
+
+        // Verify the connection properties
+        assertValidConnection(connection, connectionName, null, null);
+        Assertions.assertNotNull(connection.getCredential().getType());
+
+        System.out.println("Connection retrieved successfully: " + connection.getName());
+    }
+
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
     public void testGetConnectionWithCredentials(HttpClient httpClient, AIProjectsServiceVersion serviceVersion) {
         ConnectionsClient connectionsClient = getConnectionsClient(httpClient, serviceVersion);
 
@@ -96,6 +122,33 @@ public class ConnectionsClientTest extends ClientTestBase {
             "Expected at least one connection to test getConnectionWithCredentials");
 
         Connection connection = connectionsClient.getConnectionWithCredentials(connectionName);
+
+        // Verify the connection properties
+        assertValidConnection(connection, connectionName, null, null);
+        Assertions.assertNotNull(connection.getCredential().getType());
+
+        System.out.println("Connection with credentials retrieved successfully: " + connection.getName());
+        System.out.println("Credential type: " + connection.getCredential().getType());
+    }
+
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
+    public void testGetConnectionWithResponseWithCredentials(HttpClient httpClient,
+        AIProjectsServiceVersion serviceVersion) {
+        ConnectionsClient connectionsClient = getConnectionsClient(httpClient, serviceVersion);
+
+        // Discover a real connection name from the list
+        String connectionName = null;
+        for (Connection c : connectionsClient.listConnections()) {
+            connectionName = c.getName();
+            break;
+        }
+        Assertions.assertNotNull(connectionName,
+            "Expected at least one connection to test getConnectionWithCredentials");
+
+        Connection connection = connectionsClient.getConnectionWithResponse(connectionName, true, new RequestOptions())
+            .getValue()
+            .toObject(Connection.class);
 
         // Verify the connection properties
         assertValidConnection(connection, connectionName, null, null);

--- a/sdk/ai/azure-ai-projects/src/test/java/com/azure/ai/projects/DatasetsAsyncClientTest.java
+++ b/sdk/ai/azure-ai-projects/src/test/java/com/azure/ai/projects/DatasetsAsyncClientTest.java
@@ -3,8 +3,11 @@
 package com.azure.ai.projects;
 
 import com.azure.ai.projects.models.DatasetVersion;
+import com.azure.ai.projects.models.FileDatasetVersion;
+import com.azure.ai.projects.models.FolderDatasetVersion;
 import com.azure.ai.projects.models.PendingUploadRequest;
 import com.azure.core.http.HttpClient;
+import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.test.annotation.LiveOnly;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -48,6 +51,28 @@ public class DatasetsAsyncClientTest extends ClientTestBase {
     @LiveOnly
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
+    public void testCreateDatasetWithFileWithResponse(HttpClient httpClient, AIProjectsServiceVersion serviceVersion)
+        throws FileNotFoundException, URISyntaxException {
+        DatasetsAsyncClient datasetsAsyncClient = getDatasetsAsyncClient(httpClient, serviceVersion);
+
+        String datasetName = "java-test-async-file-response-" + UUID.randomUUID().toString().substring(0, 8);
+        String datasetVersionString = "1";
+
+        Path filePath = getPath("product_info.md");
+
+        StepVerifier.create(datasetsAsyncClient.createDatasetWithFileWithResponse(datasetName, datasetVersionString,
+            filePath, new RequestOptions())).assertNext(response -> {
+                FileDatasetVersion createdDatasetVersion = response.getValue().toObject(FileDatasetVersion.class);
+                assertFileDatasetVersion(createdDatasetVersion, datasetName, datasetVersionString, null);
+            }).verifyComplete();
+
+        StepVerifier.create(datasetsAsyncClient.deleteDatasetVersion(datasetName, datasetVersionString))
+            .verifyComplete();
+    }
+
+    @LiveOnly
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
     public void testCreateDatasetWithFolder(HttpClient httpClient, AIProjectsServiceVersion serviceVersion)
         throws IOException {
         DatasetsAsyncClient datasetsAsyncClient = getDatasetsAsyncClient(httpClient, serviceVersion);
@@ -66,6 +91,42 @@ public class DatasetsAsyncClientTest extends ClientTestBase {
                 .create(datasetsAsyncClient.createDatasetWithFolder(datasetName, datasetVersionString, tempFolder))
                 .assertNext(createdDatasetVersion -> assertDatasetVersion(createdDatasetVersion, datasetName,
                     datasetVersionString))
+                .verifyComplete();
+
+            StepVerifier.create(datasetsAsyncClient.deleteDatasetVersion(datasetName, datasetVersionString))
+                .verifyComplete();
+        } finally {
+            Files.deleteIfExists(file1);
+            Files.deleteIfExists(file2);
+            Files.deleteIfExists(tempFolder);
+        }
+    }
+
+    @LiveOnly
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
+    public void testCreateDatasetWithFolderWithResponse(HttpClient httpClient, AIProjectsServiceVersion serviceVersion)
+        throws IOException {
+        DatasetsAsyncClient datasetsAsyncClient = getDatasetsAsyncClient(httpClient, serviceVersion);
+
+        String datasetName = "java-test-async-folder-response-" + UUID.randomUUID().toString().substring(0, 8);
+        String datasetVersionString = "1";
+
+        Path tempFolder = Files.createTempDirectory("test-folder-dataset");
+        Path file1 = tempFolder.resolve("file1.txt");
+        Path file2 = tempFolder.resolve("file2.txt");
+        Files.write(file1, "Test content 1".getBytes());
+        Files.write(file2, "Test content 2".getBytes());
+
+        try {
+            StepVerifier
+                .create(datasetsAsyncClient.createDatasetWithFolderWithResponse(datasetName, datasetVersionString,
+                    tempFolder, new RequestOptions()))
+                .assertNext(response -> {
+                    FolderDatasetVersion createdDatasetVersion
+                        = response.getValue().toObject(FolderDatasetVersion.class);
+                    assertDatasetVersion(createdDatasetVersion, datasetName, datasetVersionString);
+                })
                 .verifyComplete();
 
             StepVerifier.create(datasetsAsyncClient.deleteDatasetVersion(datasetName, datasetVersionString))

--- a/sdk/ai/azure-ai-projects/src/test/java/com/azure/ai/projects/DatasetsClientTest.java
+++ b/sdk/ai/azure-ai-projects/src/test/java/com/azure/ai/projects/DatasetsClientTest.java
@@ -8,6 +8,7 @@ import com.azure.ai.projects.models.FolderDatasetVersion;
 import com.azure.ai.projects.models.PendingUploadRequest;
 import com.azure.ai.projects.models.PendingUploadResponse;
 import com.azure.core.http.HttpClient;
+import com.azure.core.http.rest.RequestOptions;
 import com.azure.core.test.annotation.LiveOnly;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,6 +47,28 @@ public class DatasetsClientTest extends ClientTestBase {
     @LiveOnly
     @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
     @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
+    public void testCreateDatasetWithFileWithResponse(HttpClient httpClient, AIProjectsServiceVersion serviceVersion)
+        throws FileNotFoundException, URISyntaxException {
+        DatasetsClient datasetsClient = getDatasetsClient(httpClient, serviceVersion);
+
+        String datasetName = "java-test-file-response-" + UUID.randomUUID().toString().substring(0, 8);
+        String datasetVersionString = "1";
+
+        Path filePath = getPath("product_info.md");
+
+        FileDatasetVersion createdDatasetVersion = datasetsClient
+            .createDatasetWithFileWithResponse(datasetName, datasetVersionString, filePath, new RequestOptions())
+            .getValue()
+            .toObject(FileDatasetVersion.class);
+
+        assertFileDatasetVersion(createdDatasetVersion, datasetName, datasetVersionString, null);
+
+        datasetsClient.deleteDatasetVersion(datasetName, datasetVersionString);
+    }
+
+    @LiveOnly
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
     public void testCreateDatasetWithFolder(HttpClient httpClient, AIProjectsServiceVersion serviceVersion)
         throws IOException {
         DatasetsClient datasetsClient = getDatasetsClient(httpClient, serviceVersion);
@@ -62,6 +85,40 @@ public class DatasetsClientTest extends ClientTestBase {
         try {
             FolderDatasetVersion createdDatasetVersion
                 = datasetsClient.createDatasetWithFolder(datasetName, datasetVersionString, tempFolder);
+
+            assertDatasetVersion(createdDatasetVersion, datasetName, datasetVersionString);
+
+            datasetsClient.deleteDatasetVersion(datasetName, datasetVersionString);
+        } finally {
+            Files.deleteIfExists(file1);
+            Files.deleteIfExists(file2);
+            Files.deleteIfExists(tempFolder);
+        }
+    }
+
+    @LiveOnly
+    @ParameterizedTest(name = DISPLAY_NAME_WITH_ARGUMENTS)
+    @MethodSource("com.azure.ai.projects.TestUtils#getTestParameters")
+    public void testCreateDatasetWithFolderWithResponse(HttpClient httpClient, AIProjectsServiceVersion serviceVersion)
+        throws IOException {
+        DatasetsClient datasetsClient = getDatasetsClient(httpClient, serviceVersion);
+
+        String datasetName = "java-test-folder-response-" + UUID.randomUUID().toString().substring(0, 8);
+        String datasetVersionString = "1";
+
+        Path tempFolder = Files.createTempDirectory("test-folder-dataset");
+        Path file1 = tempFolder.resolve("file1.txt");
+        Path file2 = tempFolder.resolve("file2.txt");
+        Files.write(file1, "Test content 1".getBytes());
+        Files.write(file2, "Test content 2".getBytes());
+
+        try {
+            FolderDatasetVersion createdDatasetVersion
+                = datasetsClient
+                    .createDatasetWithFolderWithResponse(datasetName, datasetVersionString, tempFolder,
+                        new RequestOptions())
+                    .getValue()
+                    .toObject(FolderDatasetVersion.class);
 
             assertDatasetVersion(createdDatasetVersion, datasetName, datasetVersionString);
 


### PR DESCRIPTION
This pull request introduces new overloads and improved options handling for dataset and connection management in the Azure AI Projects SDK. The main focus is to provide more flexible methods that accept `RequestOptions` and to allow for more granular control over including credentials in connection retrievals. It also adds more detailed Javadoc comments for new and existing methods.

**Enhancements to Connection Retrieval APIs:**

* Added new overloads `getConnectionWithResponse` to both `ConnectionsAsyncClient` and `ConnectionsClient` that accept a `boolean includeCredentials` parameter and `RequestOptions`, allowing callers to specify whether to include credentials in the response. The internal logic now consistently uses these overloads for both async and sync clients. [[1]](diffhunk://#diff-e4df351ca0ddf7d0b6ebf6e0b54d5c13f1e77f273fd50f84c3965c97b30934e1R121-R142) [[2]](diffhunk://#diff-af508b551fc7d965e27b5150dac876de83e446696f1cac279febc10e07f6c5b5R116-R137)
* Updated the implementation of `getConnection` in both async and sync clients to use the new overloads, simplifying the code and ensuring consistent handling of credentials and request options. [[1]](diffhunk://#diff-e4df351ca0ddf7d0b6ebf6e0b54d5c13f1e77f273fd50f84c3965c97b30934e1L293-R317) [[2]](diffhunk://#diff-af508b551fc7d965e27b5150dac876de83e446696f1cac279febc10e07f6c5b5L264-R288)

**Enhancements to Dataset Creation APIs:**

* Added new overloads for creating datasets from files and folders in both async and sync dataset clients (`DatasetsAsyncClient`, `DatasetsClient`). These overloads accept `RequestOptions` and provide both `Mono<Response<BinaryData>>`/`Response<BinaryData>` and strongly-typed return values, improving flexibility and consistency. [[1]](diffhunk://#diff-e88d629815ee907305e511e335c45681bf17857cd1c3e1ba3cd82fe392de1563L144-R216) [[2]](diffhunk://#diff-e88d629815ee907305e511e335c45681bf17857cd1c3e1ba3cd82fe392de1563R248-R305) [[3]](diffhunk://#diff-00819dd070822607f9e4d08a85d9a7b32d0375054ffec848b7c728efeec66e62R142-R185)
* Refactored internal logic to use the new overloads, passing `RequestOptions` through all relevant steps, and updated the upload and registration workflow accordingly. [[1]](diffhunk://#diff-e88d629815ee907305e511e335c45681bf17857cd1c3e1ba3cd82fe392de1563L220-R329) [[2]](diffhunk://#diff-00819dd070822607f9e4d08a85d9a7b32d0375054ffec848b7c728efeec66e62L150-R204)

**Documentation Improvements:**

* Improved and standardized Javadoc comments for new and existing methods, clarifying parameter usage, exceptions, and return values. [[1]](diffhunk://#diff-e88d629815ee907305e511e335c45681bf17857cd1c3e1ba3cd82fe392de1563L128-R128) [[2]](diffhunk://#diff-00819dd070822607f9e4d08a85d9a7b32d0375054ffec848b7c728efeec66e62L116-R122)

These changes improve the SDK's usability by making it easier to customize HTTP requests and control credential inclusion, while also enhancing documentation for end users.