### PR TITLE
Add timeouts for JWT decoder in AadResourceServerConfiguration

### DIFF
--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aad/configuration/AadResourceServerConfiguration.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aad/configuration/AadResourceServerConfiguration.java
@@ -44,8 +44,8 @@ import static com.azure.spring.cloud.autoconfigure.implementation.aad.utils.AadR
 @Conditional(ResourceServerCondition.class)
 class AadResourceServerConfiguration {
 
-    private Duration JWT_DECODER_CONNECT_TIMEOUT = Duration.ofMillis(500);
-    private Duration JWT_DECODER_READ_TIMEOUT = Duration.ofMillis(500);
+    private static final Duration JWT_DECODER_CONNECT_TIMEOUT = Duration.ofMillis(500);
+    private static final Duration JWT_DECODER_READ_TIMEOUT = Duration.ofMillis(500);
 
     private final RestTemplateBuilder restTemplateBuilder;
 

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aad/configuration/AadResourceServerConfiguration.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aad/configuration/AadResourceServerConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.util.StringUtils;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -42,6 +43,9 @@ import static com.azure.spring.cloud.autoconfigure.implementation.aad.utils.AadR
 @Configuration(proxyBeanMethods = false)
 @Conditional(ResourceServerCondition.class)
 class AadResourceServerConfiguration {
+
+    private Duration JWT_DECODER_CONNECT_TIMEOUT = Duration.ofMillis(500);
+    private Duration JWT_DECODER_READ_TIMEOUT = Duration.ofMillis(500);
 
     private final RestTemplateBuilder restTemplateBuilder;
 
@@ -57,8 +61,10 @@ class AadResourceServerConfiguration {
             aadAuthenticationProperties.getProfile().getEnvironment().getActiveDirectoryEndpoint(), tenantId);
         NimbusJwtDecoder nimbusJwtDecoder = NimbusJwtDecoder
             .withJwkSetUri(identityEndpoints.getJwkSetEndpoint())
-                .restOperations(createRestTemplate(restTemplateBuilder))
-                .build();
+            .restOperations(createRestTemplate(restTemplateBuilder
+                .connectTimeout(JWT_DECODER_CONNECT_TIMEOUT)
+                .readTimeout(JWT_DECODER_READ_TIMEOUT)))
+            .build();
         List<OAuth2TokenValidator<Jwt>> validators = createDefaultValidator(aadAuthenticationProperties);
         nimbusJwtDecoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(validators));
         return nimbusJwtDecoder;


### PR DESCRIPTION
Set default read & connect timeouts on NimbusJwtDecoder.

# Description

This [spring security issue](https://github.com/spring-projects/spring-security/pull/17669) highlighted the potential for 15 minute (or longer) hangs due to the absence of explicit connect & read timeouts on the NimbusJwtDecoder. This is fixed in Spring Security, however the Azure SDK explicitly overrides `restOperations` in the NimbusJwtDecoder it creates, meaning we need the fix explicitly here, too.

As a current workaround, the following can be defined as a bean on a configuration class:

```
    @Bean
    RestTemplateBuilder restTemplateBuilder(RestTemplateBuilderConfigurer configurer) {
        return configurer.configure(new RestTemplateBuilder())
            .connectTimeout(Duration.ofMillis(JWKSourceBuilder.DEFAULT_HTTP_CONNECT_TIMEOUT))
            .readTimeout(Duration.ofMillis(JWKSourceBuilder.DEFAULT_HTTP_READ_TIMEOUT));
    }
```

However, this isn't ideal as it applies globally, and has to be specified in each project.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
