### PR TITLE
Enable JVM proxy system properties in Key Vault JCA HTTP client

### DIFF
--- a/sdk/keyvault/azure-security-keyvault-jca/CHANGELOG.md
+++ b/sdk/keyvault/azure-security-keyvault-jca/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Fixed bug: `jarsigner` reports invalid certificate chain (`PKIX path building failed: unable to find valid certification path to requested target`) when using a non-exportable Azure Key Vault certificate. When the certificate chain returned by Azure Key Vault does not end in a self-signed root, the missing issuer certificates are now resolved at runtime using the CA Issuers URL in the AIA (Authority Information Access) extension of each certificate. Responses are cached by URL so subsequent loads can reuse them without another network request. ([#44267](https://github.com/Azure/azure-sdk-for-java/issues/44267))
 - Fixed an issue where `KeyStore.load(KeyVaultLoadStoreParameter)` could combine explicit client settings with certificate cache and path settings captured earlier from system properties. The parameter now carries the complete key store configuration. ([#50163](https://github.com/Azure/azure-sdk-for-java/pull/50163))
 
+- Fixed an issue where the internal HTTP client did not honor JVM proxy system properties.
+  ([#28801](https://github.com/Azure/azure-sdk-for-java/issues/28801))
+
 ### Other Changes
 - Added system property `azure.keyvault.jca.disable-aia-download` to disable automatic AIA chain completion. AIA chain completion downloads certificates from URLs embedded in certificate extensions, so this allows locked-down environments to prevent those outbound HTTP(S) requests, mitigating potential SSRF-like attack vectors when loading untrusted certificates. The value is captured when each Key Vault client is initialized and retained for lazy certificate-chain loading, so multiple keystores can use different settings without overwriting one another. Set to `true` to disable (defaults to `false`).
 - Added `KeyVaultJcaPropertyNames` as the central source for the system property names supported by the Azure Key Vault JCA provider. ([#50163](https://github.com/Azure/azure-sdk-for-java/pull/50163))

--- a/sdk/keyvault/azure-security-keyvault-jca/README.md
+++ b/sdk/keyvault/azure-security-keyvault-jca/README.md
@@ -598,20 +598,22 @@ az role assignment create \
  ```
 
 If you run `jarsigner` behind a proxy, pass the standard JVM proxy system properties with `-J`:
- ```bash
- jarsigner   -keystore NONE -storetype AzureKeyVault \
-             -signedjar signerjar.jar ${PARAM_YOUR_JAR_FILE_PATH} "${CERT_NAME}" \
-             -verbose  -storepass "" \
-             -providerName AzureKeyVault \
-             -providerClass com.azure.security.keyvault.jca.KeyVaultJcaProvider \
-             -J-Dazure.keyvault.uri=${KEYVAULT_URL} \
-             -J-Dazure.keyvault.tenant-id=${TENANT} \
-             -J-Dazure.keyvault.client-id=${CLIENT_ID} \
-             -J-Dazure.keyvault.client-secret=${CLIENT_SECRET} \
-             -J-Dhttps.proxyHost=proxy.company.local \
-             -J-Dhttps.proxyPort=8080 \
-             '-J-Dhttp.nonProxyHosts=169.254.169.254|localhost|127.*'
- ```
+
+```bash
+jarsigner   -keystore NONE -storetype AzureKeyVault \
+            -signedjar signerjar.jar ${PARAM_YOUR_JAR_FILE_PATH} "${CERT_NAME}" \
+            -verbose  -storepass "" \
+            -providerName AzureKeyVault \
+            -providerClass com.azure.security.keyvault.jca.KeyVaultJcaProvider \
+            -J-Dazure.keyvault.uri=${KEYVAULT_URL} \
+            -J-Dazure.keyvault.tenant-id=${TENANT} \
+            -J-Dazure.keyvault.client-id=${CLIENT_ID} \
+            -J-Dazure.keyvault.client-secret=${CLIENT_SECRET} \
+            -J-Dhttps.proxyHost=proxy.company.local \
+            -J-Dhttps.proxyPort=8080 \
+            '-J-Dhttp.nonProxyHosts=169.254.169.254|localhost|127.*'
+```
+
 `http.nonProxyHosts` may be needed for local or managed identity endpoints, such as `169.254.169.254`,
 that should bypass the proxy.
 

--- a/sdk/keyvault/azure-security-keyvault-jca/README.md
+++ b/sdk/keyvault/azure-security-keyvault-jca/README.md
@@ -597,6 +597,24 @@ az role assignment create \
              -J-Dazure.keyvault.client-secret=${CLIENT_SECRET}
  ```
 
+If you run `jarsigner` behind a proxy, pass the standard JVM proxy system properties with `-J`:
+ ```bash
+ jarsigner   -keystore NONE -storetype AzureKeyVault \
+             -signedjar signerjar.jar ${PARAM_YOUR_JAR_FILE_PATH} "${CERT_NAME}" \
+             -verbose  -storepass "" \
+             -providerName AzureKeyVault \
+             -providerClass com.azure.security.keyvault.jca.KeyVaultJcaProvider \
+             -J-Dazure.keyvault.uri=${KEYVAULT_URL} \
+             -J-Dazure.keyvault.tenant-id=${TENANT} \
+             -J-Dazure.keyvault.client-id=${CLIENT_ID} \
+             -J-Dazure.keyvault.client-secret=${CLIENT_SECRET} \
+             -J-Dhttps.proxyHost=proxy.company.local \
+             -J-Dhttps.proxyPort=8080 \
+             '-J-Dhttp.nonProxyHosts=169.254.169.254|localhost|127.*'
+ ```
+`http.nonProxyHosts` may be needed for local or managed identity endpoints, such as `169.254.169.254`,
+that should bypass the proxy.
+
 replace ${PARAM_YOUR_JAR_FILE_PATH} with the path of your jar file, replace ${PARAM_JCA_PROVIDER_JAR_PATH} with the path of the jca provider jar.
 
 Check your output, if you see the `jar signed` message, it means the jar is signed successfully.
@@ -734,5 +752,3 @@ This project has adopted the [Microsoft Open Source Code of Conduct][microsoft_c
 [jca_reference_guide]: https://docs.oracle.com/javase/8/docs/technotes/guides/security/crypto/CryptoSpec.html
 [microsoft_code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 [non-exportable]: https://learn.microsoft.com/azure/key-vault/certificates/about-certificates#exportable-or-non-exportable-key
-
-

--- a/sdk/keyvault/azure-security-keyvault-jca/README.md
+++ b/sdk/keyvault/azure-security-keyvault-jca/README.md
@@ -597,25 +597,21 @@ az role assignment create \
              -J-Dazure.keyvault.client-secret=${CLIENT_SECRET}
  ```
 
-If you run `jarsigner` behind a proxy, pass the standard JVM proxy system properties with `-J`:
+If you run either `jarsigner` command above behind a proxy, append the standard JVM proxy system
+properties that apply to your environment:
 
 ```bash
-jarsigner   -keystore NONE -storetype AzureKeyVault \
-            -signedjar signerjar.jar ${PARAM_YOUR_JAR_FILE_PATH} "${CERT_NAME}" \
-            -verbose  -storepass "" \
-            -providerName AzureKeyVault \
-            -providerClass com.azure.security.keyvault.jca.KeyVaultJcaProvider \
-            -J-Dazure.keyvault.uri=${KEYVAULT_URL} \
-            -J-Dazure.keyvault.tenant-id=${TENANT} \
-            -J-Dazure.keyvault.client-id=${CLIENT_ID} \
-            -J-Dazure.keyvault.client-secret=${CLIENT_SECRET} \
-            -J-Dhttps.proxyHost=proxy.company.local \
-            -J-Dhttps.proxyPort=8080 \
-            '-J-Dhttp.nonProxyHosts=169.254.169.254|localhost|127.*'
+-J-Dhttps.proxyHost=proxy.company.local \
+-J-Dhttps.proxyPort=8080 \
+-J-Dhttp.proxyHost=proxy.company.local \
+-J-Dhttp.proxyPort=8080 \
+'-J-Dhttp.nonProxyHosts=169.254.169.254|localhost|127.*'
 ```
 
-`http.nonProxyHosts` may be needed for local or managed identity endpoints, such as `169.254.169.254`,
-that should bypass the proxy.
+`https.*` properties configure HTTPS requests, such as those to Key Vault. `http.*` properties configure
+HTTP requests, such as those to a managed identity endpoint. `http.nonProxyHosts` may be needed for local
+or managed identity endpoints, such as `169.254.169.254`, that should bypass the proxy. The single quotes
+around `-J-Dhttp.nonProxyHosts` prevent the shell from interpreting `|` as a pipe.
 
 replace ${PARAM_YOUR_JAR_FILE_PATH} with the path of your jar file, replace ${PARAM_JCA_PROVIDER_JAR_PATH} with the path of the jca provider jar.
 

--- a/sdk/keyvault/azure-security-keyvault-jca/src/main/java/com/azure/security/keyvault/jca/implementation/utils/HttpUtil.java
+++ b/sdk/keyvault/azure-security-keyvault-jca/src/main/java/com/azure/security/keyvault/jca/implementation/utils/HttpUtil.java
@@ -297,7 +297,7 @@ public final class HttpUtil {
                 .register("https", sslConnectionSocketFactory)
                 .build());
 
-        return HttpClients.custom().setConnectionManager(manager).build();
+        return HttpClients.custom().useSystemProperties().setConnectionManager(manager).build();
     }
 
     public static String validateUri(String uri, String propertyName) {

--- a/sdk/keyvault/azure-security-keyvault-jca/src/test/java/com/azure/security/keyvault/jca/implementation/utils/HttpUtilTest.java
+++ b/sdk/keyvault/azure-security-keyvault-jca/src/test/java/com/azure/security/keyvault/jca/implementation/utils/HttpUtilTest.java
@@ -9,6 +9,16 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static com.azure.security.keyvault.jca.implementation.utils.HttpUtil.DEFAULT_USER_AGENT_VALUE_PREFIX;
 import static com.azure.security.keyvault.jca.implementation.utils.HttpUtil.VERSION;
 import static org.junit.jupiter.api.Assertions.*;
@@ -19,6 +29,39 @@ public class HttpUtilTest {
     public void getUserAgentPrefixTest() {
         assertEquals(DEFAULT_USER_AGENT_VALUE_PREFIX, HttpUtil.getUserAgentPrefix());
         assertEquals(DEFAULT_USER_AGENT_VALUE_PREFIX + VERSION, HttpUtil.USER_AGENT_VALUE);
+    }
+
+    @Test
+    public void getUsesJvmProxySystemProperties() throws Exception {
+        String previousProxyHost = System.getProperty("http.proxyHost");
+        String previousProxyPort = System.getProperty("http.proxyPort");
+        String previousNonProxyHosts = System.getProperty("http.nonProxyHosts");
+
+        try (ServerSocket proxyServer = new ServerSocket(0)) {
+            CountDownLatch requestReceived = new CountDownLatch(1);
+            AtomicReference<String> requestLine = new AtomicReference<>();
+            AtomicReference<Exception> proxyFailure = new AtomicReference<>();
+
+            Thread proxyThread
+                = new Thread(() -> handleProxyRequest(proxyServer, requestLine, requestReceived, proxyFailure));
+            proxyThread.setDaemon(true);
+            proxyThread.start();
+
+            System.setProperty("http.proxyHost", "localhost");
+            System.setProperty("http.proxyPort", String.valueOf(proxyServer.getLocalPort()));
+            System.clearProperty("http.nonProxyHosts");
+
+            String response = HttpUtil.get("http://azure-keyvault-jca-proxy-test.invalid/path", null);
+
+            assertTrue(requestReceived.await(5, TimeUnit.SECONDS), "Expected proxy server to receive the request.");
+            assertNull(proxyFailure.get(), "Proxy server failed while handling the request.");
+            assertEquals("proxied", response);
+            assertEquals("GET http://azure-keyvault-jca-proxy-test.invalid/path HTTP/1.1", requestLine.get());
+        } finally {
+            restoreProperty("http.proxyHost", previousProxyHost);
+            restoreProperty("http.proxyPort", previousProxyPort);
+            restoreProperty("http.nonProxyHosts", previousNonProxyHosts);
+        }
     }
 
     @Test
@@ -82,5 +125,38 @@ public class HttpUtilTest {
         HttpUtil.BinaryHttpResponse result = HttpUtil.toBinaryResponse(response, "https://example.test/cert.crt");
 
         assertEquals("public, max-age=300, no-store", result.getCacheControl());
+    }
+
+    private static void handleProxyRequest(ServerSocket proxyServer, AtomicReference<String> requestLine,
+        CountDownLatch requestReceived, AtomicReference<Exception> proxyFailure) {
+        try (Socket socket = proxyServer.accept();
+            BufferedReader reader = new BufferedReader(
+                new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+            OutputStream outputStream = socket.getOutputStream()) {
+
+            requestLine.set(reader.readLine());
+            String line;
+            while ((line = reader.readLine()) != null && !line.isEmpty()) {
+                // Consume request headers before writing the response.
+            }
+
+            byte[] body = "proxied".getBytes(StandardCharsets.UTF_8);
+            outputStream.write(("HTTP/1.1 200 OK\r\nContent-Length: " + body.length + "\r\n\r\n")
+                .getBytes(StandardCharsets.UTF_8));
+            outputStream.write(body);
+            outputStream.flush();
+            requestReceived.countDown();
+        } catch (Exception e) {
+            proxyFailure.set(e);
+            requestReceived.countDown();
+        }
+    }
+
+    private static void restoreProperty(String name, String value) {
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
     }
 }

--- a/sdk/keyvault/azure-security-keyvault-jca/src/test/java/com/azure/security/keyvault/jca/implementation/utils/HttpUtilTest.java
+++ b/sdk/keyvault/azure-security-keyvault-jca/src/test/java/com/azure/security/keyvault/jca/implementation/utils/HttpUtilTest.java
@@ -3,11 +3,13 @@
 
 package com.azure.security.keyvault.jca.implementation.utils;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -32,6 +34,7 @@ public class HttpUtilTest {
     }
 
     @Test
+    @ResourceLock(Resources.SYSTEM_PROPERTIES)
     public void getUsesJvmProxySystemProperties() throws Exception {
         String previousProxyHost = System.getProperty("http.proxyHost");
         String previousProxyPort = System.getProperty("http.proxyPort");

--- a/sdk/keyvault/azure-security-keyvault-jca/src/test/java/com/azure/security/keyvault/jca/implementation/utils/HttpUtilTest.java
+++ b/sdk/keyvault/azure-security-keyvault-jca/src/test/java/com/azure/security/keyvault/jca/implementation/utils/HttpUtilTest.java
@@ -133,19 +133,21 @@ public class HttpUtilTest {
     private static void handleProxyRequest(ServerSocket proxyServer, AtomicReference<String> requestLine,
         CountDownLatch requestReceived, AtomicReference<Exception> proxyFailure) {
         try (Socket socket = proxyServer.accept();
-            BufferedReader reader = new BufferedReader(
-                new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+            BufferedReader reader
+                = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
             OutputStream outputStream = socket.getOutputStream()) {
 
             requestLine.set(reader.readLine());
             String line;
-            while ((line = reader.readLine()) != null && !line.isEmpty()) {
-                // Consume request headers before writing the response.
+            while ((line = reader.readLine()) != null) {
+                if (line.isEmpty()) {
+                    break;
+                }
             }
 
             byte[] body = "proxied".getBytes(StandardCharsets.UTF_8);
-            outputStream.write(("HTTP/1.1 200 OK\r\nContent-Length: " + body.length + "\r\n\r\n")
-                .getBytes(StandardCharsets.UTF_8));
+            outputStream.write(
+                ("HTTP/1.1 200 OK\r\nContent-Length: " + body.length + "\r\n\r\n").getBytes(StandardCharsets.UTF_8));
             outputStream.write(body);
             outputStream.flush();
             requestReceived.countDown();


### PR DESCRIPTION
## Problem
Fixes #28801.

The Key Vault JCA provider uses an internal Apache HttpClient in `HttpUtil` instead of the standard Azure SDK HTTP pipeline. As a result, standard JVM proxy properties such as `https.proxyHost`, `https.proxyPort`, `http.proxyHost`, `http.proxyPort`, and `http.nonProxyHosts` were not honored when the provider was used behind a corporate proxy.

## Solution
Configure the internal Apache HttpClient builder with `useSystemProperties()` while preserving the existing SSL/truststore connection manager behavior.

This PR also adds unit-level proxy coverage and documents a `jarsigner` proxy example using standard JVM system properties.

## Testing
Added a unit test that sets `http.proxyHost` and `http.proxyPort`, serves a local proxy response, and verifies `HttpUtil.get` routes through the proxy. The test locks JVM system properties while it runs to avoid interference with parallel JUnit execution.

Validated with module-level tests:
`mvn -f sdk/keyvault/azure-security-keyvault-jca/pom.xml -DskipITs -Dgpg.skip -Dspotbugs.skip -Drevapi.skip -Dspotless.skip=true -Dcodesnippet.skip=true -Djacoco.skip=true -DheapDumpOnOom= test`

Result: 80 tests, 0 failures, 0 errors, 29 skipped.

The root `mvn -pl sdk/keyvault/azure-security-keyvault-jca -DskipITs -Dgpg.skip -Dspotbugs.skip -Drevapi.skip test` command could not run in this sparse checkout because the root POM references modules not present locally.