### PR TITLE
[SFI] Apply CFSClean policy explicitly in the pipeline template

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -42,7 +42,7 @@ extends:
       skipBuildTagsForGitHubPullRequests: true
       # Set network isolation policy to Preferred to allow access to common public services like GitHub, NuGet, Maven Central, etc.
       # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/cloudbuild/security/1espt-network-isolation#shared-policies-for-common-use-cases
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'java - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -42,7 +42,7 @@ extends:
       skipBuildTagsForGitHubPullRequests: true
       # Set network isolation policy to Preferred to allow access to common public services like GitHub, NuGet, Maven Central, etc.
       # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/cloudbuild/security/1espt-network-isolation#shared-policies-for-common-use-cases
-      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
+      networkIsolationPolicy: Permissive, CFSClean
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'java - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,7 +40,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      # Set network isolation policy to Preferred to allow access to common public services like GitHub, NuGet, Maven Central, etc.
+      # Set network isolation policy to Permissive, CFSClean which our pipeline are currently compliant with.
       # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/cloudbuild/security/1espt-network-isolation#shared-policies-for-common-use-cases
       networkIsolationPolicy: Permissive, CFSClean
     sdl:


### PR DESCRIPTION
- Updated the `networkIsolationPolicy` setting from `Permissive` to `Permissive, CFSClean` in `1es-redirect.yml`

The Java pipelines are already compliant with the `CFSClean` policy, and this PR makes it applied to source code. We are not compliant with `CFSClean2` and `CFSClean3` policies. The `CFSClean2` violation come from outreach to `docker hub`, and the `CFSClean3` violations come from outreach to `package.confluent.io`.  I'm working with Cosmos team and 1ES team on the mitigations.

**Test runs**
template: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6372605&view=results
spring: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6372601&view=results
cosmos: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6372590&view=results


