### PR TITLE
[Cosmos] Fix ClassCastException when building CosmosException from an empty error response body

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/JsonSerializableTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/JsonSerializableTest.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -32,6 +34,24 @@ public class JsonSerializableTest {
             JsonSerializable jsonSerializable = JsonSerializable.instantiateFromObjectNodeAndType(objectNode, klass);
             assertThat(jsonSerializable).isNotNull();
             assertThat(jsonSerializable).isInstanceOf(klass);
+        }
+    }
+
+    @Test(groups = {"unit"})
+    public void instantiateFromNonObjectJsonReturnsEmptyObject() {
+        for (String body : Arrays.asList("", "   ", "null", "[]", "123")) {
+            JsonSerializable jsonSerializable = new JsonSerializable(body);
+            assertThat(jsonSerializable.propertyBag).isNotNull();
+            assertThat(jsonSerializable.propertyBag.isEmpty()).isTrue();
+        }
+    }
+
+    @Test(groups = {"unit"})
+    public void instantiateFromNonObjectJsonBytesReturnsEmptyObject() {
+        for (String body : Arrays.asList("", "null", "[]", "123")) {
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            assertThat(new JsonSerializable(bytes).propertyBag.isEmpty()).isTrue();
+            assertThat(new JsonSerializable(ByteBuffer.wrap(bytes)).propertyBag.isEmpty()).isTrue();
         }
     }
 }

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### Other Changes
 * Replaced per-client `Schedulers.newSingle()` schedulers in `GlobalEndpointManager` and `GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker` with shared `BoundedElastic` schedulers in `CosmosSchedulers` to prevent thread count from scaling linearly with client/tenant count. - See [PR 49062](https://github.com/Azure/azure-sdk-for-java/pull/49062)
 * Fixed a sporadic `NullPointerException` in `JsonSerializable.getWithMapping` triggered by concurrent first-time calls to `DatabaseAccount.getConsistencyPolicy()` and its sibling lazy getters (`getReplicationPolicy`, `getSystemReplicationPolicy`, `getQueryEngineConfiguration`). The fix makes `JsonSerializable.propertyBag` `final`, closing an unsafe-publication race in the lazy-initialisation pattern. - See [Issue 49256](https://github.com/Azure/azure-sdk-for-java/issues/49256) and [PR #49258](https://github.com/Azure/azure-sdk-for-java/pull/49258)
+* Fixed a `ClassCastException` (`MissingNode cannot be cast to ObjectNode`) thrown by `JsonSerializable` when parsing an empty, blank or non-object payload. Non-object payloads are now treated as an empty object across the `String`, `byte[]` and `ByteBuffer` parsing paths. - See [Issue 49322](https://github.com/Azure/azure-sdk-for-java/issues/49322)
 
 ### 4.80.0 (2026-05-01)
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/JsonSerializable.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/JsonSerializable.java
@@ -606,7 +606,11 @@ public class JsonSerializable {
 
     private ObjectNode fromJson(byte[] bytes) {
         try {
-            return (ObjectNode) OBJECT_MAPPER.readTree(bytes);
+            JsonNode jsonNode = OBJECT_MAPPER.readTree(bytes);
+            if (jsonNode instanceof ObjectNode) {
+                return (ObjectNode) jsonNode;
+            }
+            return OBJECT_MAPPER.createObjectNode();
         } catch (IOException e) {
             throw new IllegalArgumentException(
                 String.format("Unable to parse JSON %s", Arrays.toString(bytes)), e);
@@ -615,7 +619,11 @@ public class JsonSerializable {
 
     private ObjectNode fromJson(String json, ObjectMapper objectMapper) {
         try {
-            return (ObjectNode) objectMapper.readTree(json);
+            JsonNode jsonNode = objectMapper.readTree(json);
+            if (jsonNode instanceof ObjectNode) {
+                return (ObjectNode) jsonNode;
+            }
+            return objectMapper.createObjectNode();
         } catch (IOException e) {
             throw new IllegalArgumentException(
                 String.format("Unable to parse JSON %s", json), e);
@@ -624,7 +632,11 @@ public class JsonSerializable {
 
     private ObjectNode fromJson(ByteBuffer json) {
         try {
-            return (ObjectNode) OBJECT_MAPPER.readTree(new ByteBufferBackedInputStream(json));
+            JsonNode jsonNode = OBJECT_MAPPER.readTree(new ByteBufferBackedInputStream(json));
+            if (jsonNode instanceof ObjectNode) {
+                return (ObjectNode) jsonNode;
+            }
+            return OBJECT_MAPPER.createObjectNode();
         } catch (IOException e) {
             throw new IllegalArgumentException("Unable to parse JSON from ByteBuffer", e);
         }


### PR DESCRIPTION
# Description

JsonSerializable.fromJson(String, ObjectMapper) performs an unchecked cast of the parsed tree to ObjectNode:

```
return (ObjectNode) objectMapper.readTree(json);
```

When json is empty or blank, ObjectMapper.readTree(...) returns a MissingNode (not an ObjectNode), so the cast throws ClassCastException: class ...MissingNode cannot be cast to class ...ObjectNode.

fixes https://github.com/Azure/azure-sdk-for-java/issues/49322

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
