### PR TITLE
Add ACR login step to Kafka CI pipeline for Testcontainers cache

### DIFF
--- a/sdk/cosmos/kafka.yml
+++ b/sdk/cosmos/kafka.yml
@@ -14,6 +14,7 @@ extends:
             COSMOS.CLIENT_TELEMETRY_ENDPOINT: $(cosmos-client-telemetry-endpoint)
             COSMOS.CLIENT_TELEMETRY_COSMOS_ACCOUNT: $(cosmos-client-telemetry-cosmos-account)
             COSMOS_ACR_NAME: $(kafka-mcr-name)
+            TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: $(kafka-acr-login-server)/
           CloudConfig:
             Public:
               ServiceConnection: azure-sdk-tests-cosmos
@@ -57,3 +58,10 @@ extends:
                   exit 1
                 fi
               displayName: 'Ensure Docker is installed and running'
+            - script: |
+                printf '%s' "$(kafka-acr-sp-client-secret)" | docker login "$(kafka-acr-login-server)" --username "$(kafka-acr-sp-client-id)" --password-stdin
+              displayName: 'Login to ACR for Testcontainers image cache'
+          PostSteps:
+            - script: docker logout "$(kafka-acr-login-server)"
+              displayName: 'Logout from ACR'
+              condition: always()


### PR DESCRIPTION
## What

Add a pre-test step in `kafka.yml` that authenticates Docker to the Azure Container Registry (ACR) before Testcontainers integration tests run.

## Why

The Kafka connector CI pipeline uses Testcontainers to spin up Kafka, Schema Registry, and Kafka Connect containers. These images are pulled from Docker Hub, which has a **100 pulls / 6 hr** rate limit for anonymous users. An ACR with cache rules acts as a pull-through cache, eliminating Docker Hub rate-limit failures.

## Changes

- **`sdk/cosmos/kafka.yml`**: Added a `docker login` pre-test step that authenticates to the ACR using service principal credentials stored in ADO pipeline variables.
- **`sdk/cosmos/kafka.yml`**: Added `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` env var to redirect internal Testcontainers images (ryuk, alpine) to ACR.

## Architecture — Component Interactions

```
┌─────────────────────────────────────────────────────────────────────┐
│                        CI Pipeline (ADO)                            │
│                                                                     │
│  1. docker login cosmoskafkaci202606.azurecr.io                     │
│     (using Service Principal credentials from pipeline variables)   │
│                                                                     │
│  2. Maven runs Kafka integration tests                              │
│     └─ Testcontainers starts containers:                            │
│        • COSMOS_ACR_NAME → confluentinc images (cp-kafka, etc.)     │
│        • TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX → internal images     │
│          (ryuk, alpine)                                             │
│        • All image refs prefixed with ACR login server              │
│                                                                     │
│  3. Docker pulls from ACR (authenticated via step 1)                │
└────────────────────────┬────────────────────────────────────────────┘
                         │ docker pull
                         ▼
┌─────────────────────────────────────────────────────────────────────┐
│              Azure Container Registry (ACR)                         │
│              cosmoskafkaci202606.azurecr.io                         │
│                                                                     │
│  • Cache Rules map ACR paths → Docker Hub sources:                  │
│    confluentinc/cp-kafka       → docker.io/confluentinc/cp-kafka    │
│    confluentinc/cp-schema-reg  → docker.io/confluentinc/cp-schema…  │
│    confluentinc/cp-kafka-conn  → docker.io/confluentinc/cp-kafka…   │
│    testcontainers/ryuk         → docker.io/testcontainers/ryuk      │
│    library/alpine              → docker.io/library/alpine           │
│                                                                     │
│  • Cache HIT  → serves image directly (no Docker Hub call)          │
│  • Cache MISS → fetches from Docker Hub via Credential Set          │
│                                                                     │
│  ┌─────────────────────────────────────────────────┐                │
│  │ ACR Managed Identity                            │                │
│  │ (system-assigned)                               │                │
│  │ Has Key Vault GET secret access policy          │                │
│  └──────────────────────┬──────────────────────────┘                │
└─────────────────────────┼───────────────────────────────────────────┘
                          │ reads secrets
                          ▼
┌─────────────────────────────────────────────────────────────────────┐
│                    Azure Key Vault                                   │
│                    kafkacikv202606                                   │
│                                                                     │
│  Secrets:                                                           │
│  • dockerhub-username  → Docker Hub username                        │
│  • dockerhub-password  → Docker Hub PAT                             │
│                                                                     │
│  These are used by the ACR Credential Set to authenticate           │
│  to Docker Hub on cache misses. CI pipeline never sees them.        │
└─────────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────┐
│              Service Principal (Entra ID)                            │
│              cosmos-kafka-ci-acr-202606                              │
│                                                                     │
│  • Role: AcrPull                                                    │
│  • Scope: cosmos-kafka-ci-ephemeral-202606-rg                       │
│  • Used by: CI pipeline (docker login)                              │
│  • Cannot access Key Vault or Docker Hub creds                      │
└─────────────────────────────────────────────────────────────────────┘
```

### Data Flow Summary

| Flow | From | To | Auth Mechanism |
|------|------|----|---------------|
| CI agent → ACR (image pull) | ADO pipeline | ACR | Service Principal (AcrPull) via `docker login` |
| ACR → Key Vault (read Docker Hub creds) | ACR managed identity | Key Vault | Key Vault access policy (GET secrets) |
| ACR → Docker Hub (cache miss) | ACR credential set | Docker Hub | Docker Hub PAT (from Key Vault) |

### Security Boundaries

- **Service Principal** only has `AcrPull` on the resource group — cannot read Key Vault secrets or manage ACR
- **ACR Managed Identity** only has Key Vault `GET` secret permission — cannot modify secrets
- **Docker Hub credentials** are never exposed to CI agents — they are server-side on ACR only
- **CI pipeline** authenticates to ACR only — never talks to Docker Hub directly

## ADO Pipeline Variables Required

The following pipeline variables must be configured in the ADO pipeline (or a Key Vault-backed variable group):

| Variable | Value | Secret? |
|----------|-------|---------|
| `kafka-acr-login-server` | `cosmoskafkaci202606.azurecr.io` | No |
| `kafka-acr-sp-client-id` | `ebf7365b-eecf-4a5e-8840-5d90bd992a44` | No |
| `kafka-acr-sp-client-secret` | *(SP password from provisioning)* | **Yes** |
| `kafka-mcr-name` | `cosmoskafkaci202606.azurecr.io/confluentinc` | No |

## How It Works

1. Existing step ensures Docker is installed and running
2. **New step**: `docker login` authenticates to ACR using SP credentials
3. Tests run — Testcontainers pulls images from ACR (e.g., `cosmoskafkaci202606.azurecr.io/confluentinc/cp-kafka:7.6.0`)
4. ACR serves cached images; on cache miss, ACR fetches from Docker Hub using its credential set (server-side, CI never talks to Docker Hub)

## ACR Resources

Provisioned in ephemeral tenant `97691679-dcf9-49bd-b784-4eff5649fac5`:
- **ACR**: `cosmoskafkaci202606` (login: `cosmoskafkaci202606.azurecr.io`)
- **Service Principal**: `cosmos-kafka-ci-acr-202606` (AcrPull scoped to RG)
- **Cache Rules**: ryuk, alpine, cp-kafka, cp-schema-registry, cp-kafka-connect
- **Key Vault**: `kafkacikv202606` (Docker Hub creds for ACR cache miss pulls)
