### PR TITLE
[confidentialledger] Enforce stricter redirect destination policy

### DIFF
--- a/sdk/confidentialledger/azure-security-confidentialledger/CHANGELOG.md
+++ b/sdk/confidentialledger/azure-security-confidentialledger/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Release History
 
-## 1.1.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.1.0-beta.3 (2026-06-05)
 
 ### Bugs Fixed
+
+- Hardened `ConfidentialLedgerRedirectPolicy` to enforce a stricter redirect destination policy. The client now
+  only follows HTTP redirects whose target host is the original ledger host or one of its subdomains (using the
+  same scheme). Redirects to sibling ledgers, parent domains, unrelated hosts, or look-alike suffix domains are
+  refused, logged at the warning level, and never followed, preventing the sensitive `Authorization` header from
+  being forwarded to an unintended destination.
 
 ## 1.0.35 (2026-05-05)
 

--- a/sdk/confidentialledger/azure-security-confidentialledger/src/main/java/com/azure/security/confidentialledger/ConfidentialLedgerRedirectPolicy.java
+++ b/sdk/confidentialledger/azure-security-confidentialledger/src/main/java/com/azure/security/confidentialledger/ConfidentialLedgerRedirectPolicy.java
@@ -20,27 +20,30 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * A redirect policy for Confidential Ledger that preserves the Authorization header on redirect.
+ * A redirect policy for Confidential Ledger that preserves the Authorization header on trusted
+ * redirects while enforcing a strict redirect destination policy.
  *
  * <p>The Confidential Ledger service uses a distributed network of nodes. Write operations (POST)
- * may be redirected from a secondary node to the primary node via HTTP 307/308 redirects. The
- * standard {@link com.azure.core.http.policy.RedirectPolicy RedirectPolicy} in azure-core strips
+ * may be redirected from the load-balanced endpoint to a specific node via HTTP 307/308 redirects.
+ * The standard {@link com.azure.core.http.policy.RedirectPolicy RedirectPolicy} in azure-core strips
  * the Authorization header on redirect for security, and only allows GET/HEAD methods by default.
  * This policy addresses both issues for Confidential Ledger by:</p>
  *
  * <ul>
  *   <li>Following redirects for all HTTP methods including POST</li>
- *   <li>Preserving the Authorization header when the redirect target shares the same scheme and
- *       the same host or a subdomain of the original Confidential Ledger endpoint</li>
+ *   <li>Preserving the Authorization header when the redirect target is a trusted Confidential
+ *       Ledger destination</li>
  * </ul>
  *
- * <p>The Authorization header is preserved when the redirect target is a trusted Confidential
- * Ledger destination — specifically when the redirect URL has the same scheme and the redirect
- * host is the same as, or a subdomain of, the original host (e.g.,
+ * <p><strong>Redirect destination policy.</strong> A redirect is only followed when the target uses
+ * the same scheme and the target host is the original ledger host or one of its subdomains (e.g.,
  * {@code accledger-2.myledger.confidential-ledger.azure.com} is a subdomain of
- * {@code myledger.confidential-ledger.azure.com}). The port is not considered as part of this
- * trust decision; if the redirect goes to an unrelated host, the Authorization header is
- * stripped for security.</p>
+ * {@code myledger.confidential-ledger.azure.com}). The host comparison is case-insensitive and
+ * ignores the port. Redirects to sibling ledgers, parent domains, unrelated hosts, or look-alike
+ * suffix domains are refused: they are logged at the warning level and never followed, so the
+ * sensitive Authorization header is never forwarded to an unintended destination. This prevents a
+ * misconfigured or malicious load balancer from redirecting a request — along with its sensitive
+ * headers — to a destination outside the original ledger.</p>
  *
  * <p>This class is intended to be used internally by the Confidential Ledger client builders.</p>
  */
@@ -58,16 +61,23 @@ public final class ConfidentialLedgerRedirectPolicy implements HttpPipelinePolic
 
     @Override
     public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next) {
-        return attemptRedirect(context, next, context.getHttpRequest(), 1, new HashSet<>());
+        // Capture the pristine request URL so that every redirect hop is validated against the
+        // original ledger endpoint rather than the previous (already-redirected) target.
+        String originalRequestUrl = context.getHttpRequest().getUrl().toString();
+        return attemptRedirect(context, next, context.getHttpRequest(), 1, new HashSet<>(), originalRequestUrl);
     }
 
     @Override
     public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next) {
-        return attemptRedirectSync(context, next, context.getHttpRequest(), 1, new HashSet<>());
+        // Capture the pristine request URL so that every redirect hop is validated against the
+        // original ledger endpoint rather than the previous (already-redirected) target.
+        String originalRequestUrl = context.getHttpRequest().getUrl().toString();
+        return attemptRedirectSync(context, next, context.getHttpRequest(), 1, new HashSet<>(), originalRequestUrl);
     }
 
     private Mono<HttpResponse> attemptRedirect(HttpPipelineCallContext context, HttpPipelineNextPolicy next,
-        HttpRequest originalHttpRequest, int redirectAttempt, Set<String> attemptedRedirectUrls) {
+        HttpRequest originalHttpRequest, int redirectAttempt, Set<String> attemptedRedirectUrls,
+        String originalRequestUrl) {
 
         HttpRequest requestCopy = originalHttpRequest.copy();
         // Save the Authorization header before sending. Downstream policies or the HTTP client
@@ -76,16 +86,18 @@ public final class ConfidentialLedgerRedirectPolicy implements HttpPipelinePolic
         context.setHttpRequest(requestCopy);
 
         return next.clone().process().flatMap(httpResponse -> {
-            if (shouldRedirect(httpResponse, redirectAttempt, attemptedRedirectUrls)) {
+            if (shouldRedirect(httpResponse, redirectAttempt, attemptedRedirectUrls, originalRequestUrl)) {
                 HttpRequest redirectRequest = createRedirectRequest(httpResponse, originalHttpRequest, savedAuthHeader);
-                return attemptRedirect(context, next, redirectRequest, redirectAttempt + 1, attemptedRedirectUrls);
+                return attemptRedirect(context, next, redirectRequest, redirectAttempt + 1, attemptedRedirectUrls,
+                    originalRequestUrl);
             }
             return Mono.just(httpResponse);
         });
     }
 
     private HttpResponse attemptRedirectSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next,
-        HttpRequest originalHttpRequest, int redirectAttempt, Set<String> attemptedRedirectUrls) {
+        HttpRequest originalHttpRequest, int redirectAttempt, Set<String> attemptedRedirectUrls,
+        String originalRequestUrl) {
 
         HttpRequest requestCopy = originalHttpRequest.copy();
         // Save the Authorization header before sending. Downstream policies or the HTTP client
@@ -95,9 +107,10 @@ public final class ConfidentialLedgerRedirectPolicy implements HttpPipelinePolic
 
         HttpResponse httpResponse = next.clone().processSync();
 
-        if (shouldRedirect(httpResponse, redirectAttempt, attemptedRedirectUrls)) {
+        if (shouldRedirect(httpResponse, redirectAttempt, attemptedRedirectUrls, originalRequestUrl)) {
             HttpRequest redirectRequest = createRedirectRequest(httpResponse, originalHttpRequest, savedAuthHeader);
-            return attemptRedirectSync(context, next, redirectRequest, redirectAttempt + 1, attemptedRedirectUrls);
+            return attemptRedirectSync(context, next, redirectRequest, redirectAttempt + 1, attemptedRedirectUrls,
+                originalRequestUrl);
         }
 
         return httpResponse;
@@ -106,7 +119,8 @@ public final class ConfidentialLedgerRedirectPolicy implements HttpPipelinePolic
     /**
      * Determines whether the response is a redirect that should be followed.
      */
-    private boolean shouldRedirect(HttpResponse httpResponse, int tryCount, Set<String> attemptedRedirectUrls) {
+    private boolean shouldRedirect(HttpResponse httpResponse, int tryCount, Set<String> attemptedRedirectUrls,
+        String originalRequestUrl) {
         if (!isRedirectStatusCode(httpResponse.getStatusCode())) {
             return false;
         }
@@ -121,6 +135,17 @@ public final class ConfidentialLedgerRedirectPolicy implements HttpPipelinePolic
         String redirectUrl = httpResponse.getHeaderValue(HttpHeaderName.LOCATION);
         if (redirectUrl == null) {
             LOGGER.atWarning().log("Redirect status code received but no Location header present.");
+            return false;
+        }
+
+        // Enforce the redirect destination policy: only follow redirects whose target is the
+        // original ledger host (or one of its subdomains) using the same scheme. Anything else —
+        // sibling ledgers, parent domains, unrelated hosts, or look-alike suffix domains — is
+        // refused and never followed, so the Authorization header is not forwarded to it.
+        if (!isAllowedRedirectTarget(originalRequestUrl, redirectUrl)) {
+            LOGGER.atWarning()
+                .addKeyValue("redirectUrl", redirectUrl)
+                .log("Refusing to follow redirect to disallowed target.");
             return false;
         }
 
@@ -141,8 +166,11 @@ public final class ConfidentialLedgerRedirectPolicy implements HttpPipelinePolic
     }
 
     /**
-     * Creates a redirect request, preserving the Authorization header if the redirect stays within
-     * the same host (same-origin).
+     * Creates a redirect request from the original (pre-send) request, re-adding the saved
+     * Authorization header.
+     *
+     * <p>The redirect target has already been validated as an allowed Confidential Ledger
+     * destination by {@link #shouldRedirect}, so the Authorization header is safe to forward.</p>
      *
      * @param httpResponse the redirect response containing the Location header
      * @param originalRequest the original request before it was sent downstream
@@ -158,13 +186,7 @@ public final class ConfidentialLedgerRedirectPolicy implements HttpPipelinePolic
         redirectRequest.setUrl(redirectUrl);
 
         if (savedAuthHeader != null) {
-            if (isTrustedRedirect(originalRequest.getUrl().toString(), redirectUrl)) {
-                // Re-add the saved Authorization header for trusted ACL redirects.
-                redirectRequest.getHeaders().set(HttpHeaderName.AUTHORIZATION, savedAuthHeader);
-            } else {
-                LOGGER.atVerbose().log("Redirect target is not a trusted host; stripping Authorization header.");
-                redirectRequest.getHeaders().remove(HttpHeaderName.AUTHORIZATION);
-            }
+            redirectRequest.getHeaders().set(HttpHeaderName.AUTHORIZATION, savedAuthHeader);
         }
 
         httpResponse.close();
@@ -179,17 +201,19 @@ public final class ConfidentialLedgerRedirectPolicy implements HttpPipelinePolic
     }
 
     /**
-     * Checks if the redirect target is a trusted Confidential Ledger destination.
+     * Checks whether the redirect target is an allowed Confidential Ledger destination.
      *
      * <p>Confidential Ledger redirects from the load-balanced endpoint
      * (e.g., {@code myledger.confidential-ledger.azure.com}) to a specific node
      * (e.g., {@code accledger-2.myledger.confidential-ledger.azure.com:16385}).
      * The node hostname is a subdomain of the original host, so a simple host equality check
-     * would incorrectly treat this as cross-origin. This method checks that the redirect target
-     * shares the same scheme and that the redirect host is either the same as or a subdomain of
-     * the original host, which covers the ACL node redirect pattern.</p>
+     * would incorrectly reject this legitimate redirect. A redirect target is allowed only when it
+     * shares the same scheme and the redirect host is either the same as, or a subdomain of, the
+     * original host. The comparison is case-insensitive and ignores the port. Sibling ledgers,
+     * parent domains, unrelated hosts, and look-alike suffix domains are rejected. If either URL
+     * cannot be parsed, or either host is empty, the redirect is rejected (fail safe).</p>
      */
-    private static boolean isTrustedRedirect(String originalUrl, String redirectUrl) {
+    private static boolean isAllowedRedirectTarget(String originalUrl, String redirectUrl) {
         try {
             URL original = new URL(originalUrl);
             URL redirect = new URL(redirectUrl);
@@ -201,12 +225,17 @@ public final class ConfidentialLedgerRedirectPolicy implements HttpPipelinePolic
             String originalHost = original.getHost().toLowerCase(java.util.Locale.ROOT);
             String redirectHost = redirect.getHost().toLowerCase(java.util.Locale.ROOT);
 
+            // Fail safe: if either host cannot be determined, do not follow the redirect.
+            if (originalHost.isEmpty() || redirectHost.isEmpty()) {
+                return false;
+            }
+
             // Exact host match or the redirect host is a subdomain of the original host.
             // e.g., accledger-2.myledger.confidential-ledger.azure.com is a subdomain of
             //        myledger.confidential-ledger.azure.com
             return redirectHost.equals(originalHost) || redirectHost.endsWith("." + originalHost);
         } catch (MalformedURLException e) {
-            LOGGER.atWarning().log("Failed to parse URL for trusted redirect check; stripping Authorization header.");
+            LOGGER.atWarning().log("Failed to parse URL for redirect destination check; refusing to follow redirect.");
             return false;
         }
     }

--- a/sdk/confidentialledger/azure-security-confidentialledger/src/test/java/com/azure/security/confidentialledger/ConfidentialLedgerRedirectPolicyTest.java
+++ b/sdk/confidentialledger/azure-security-confidentialledger/src/test/java/com/azure/security/confidentialledger/ConfidentialLedgerRedirectPolicyTest.java
@@ -25,7 +25,6 @@ import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Unit tests for {@link ConfidentialLedgerRedirectPolicy}.
@@ -105,7 +104,7 @@ public class ConfidentialLedgerRedirectPolicyTest {
     }
 
     @Test
-    public void authorizationHeaderStrippedOnCrossOriginRedirect() throws Exception {
+    public void crossOriginRedirectNotFollowed() throws Exception {
         RecordingHttpClient httpClient = new RecordingHttpClient(request -> {
             if (request.getUrl().toString().equals(ORIGINAL_URL)) {
                 HttpHeaders headers = new HttpHeaders().set(HttpHeaderName.LOCATION, CROSS_ORIGIN_URL);
@@ -122,9 +121,10 @@ public class ConfidentialLedgerRedirectPolicyTest {
 
         try (HttpResponse response = pipeline.send(request).block()) {
             assertNotNull(response);
-            assertEquals(200, response.getStatusCode());
-            // The authorization header should be stripped for cross-origin redirect
-            assertNull(response.getRequest().getHeaders().getValue(HttpHeaderName.AUTHORIZATION));
+            // A cross-origin redirect is refused: the 307 is returned as-is and never followed,
+            // so the disallowed host is never contacted.
+            assertEquals(307, response.getStatusCode());
+            assertEquals(1, httpClient.getCount());
         }
     }
 
@@ -239,7 +239,7 @@ public class ConfidentialLedgerRedirectPolicyTest {
     }
 
     @Test
-    public void authorizationHeaderStrippedOnCrossOriginRedirectSync() throws Exception {
+    public void crossOriginRedirectNotFollowedSync() throws Exception {
         RecordingHttpClient httpClient = new RecordingHttpClient(request -> {
             if (request.getUrl().toString().equals(ORIGINAL_URL)) {
                 HttpHeaders headers = new HttpHeaders().set(HttpHeaderName.LOCATION, CROSS_ORIGIN_URL);
@@ -255,8 +255,9 @@ public class ConfidentialLedgerRedirectPolicyTest {
         request.getHeaders().set(HttpHeaderName.AUTHORIZATION, AUTH_TOKEN);
 
         try (HttpResponse response = pipeline.sendSync(request, Context.NONE)) {
-            assertEquals(200, response.getStatusCode());
-            assertNull(response.getRequest().getHeaders().getValue(HttpHeaderName.AUTHORIZATION));
+            // A cross-origin redirect is refused: the 307 is returned as-is and never followed.
+            assertEquals(307, response.getStatusCode());
+            assertEquals(1, httpClient.getCount());
         }
     }
 
@@ -318,8 +319,8 @@ public class ConfidentialLedgerRedirectPolicyTest {
     }
 
     @Test
-    public void authorizationStrippedWhenSchemeChanges() throws Exception {
-        // http vs https = different origin, auth should be stripped
+    public void schemeChangeRedirectNotFollowed() throws Exception {
+        // http vs https = different origin; the redirect must not be followed.
         String httpRedirectUrl = "http://ledger.confidential-ledger.azure.com/primary";
         RecordingHttpClient httpClient = new RecordingHttpClient(request -> {
             if (request.getUrl().toString().equals(ORIGINAL_URL)) {
@@ -337,8 +338,9 @@ public class ConfidentialLedgerRedirectPolicyTest {
 
         try (HttpResponse response = pipeline.send(request).block()) {
             assertNotNull(response);
-            assertEquals(200, response.getStatusCode());
-            assertNull(response.getRequest().getHeaders().getValue(HttpHeaderName.AUTHORIZATION));
+            // A scheme downgrade (https -> http) is refused and never followed.
+            assertEquals(307, response.getStatusCode());
+            assertEquals(1, httpClient.getCount());
         }
     }
 
@@ -427,8 +429,41 @@ public class ConfidentialLedgerRedirectPolicyTest {
     }
 
     @Test
-    public void authorizationStrippedOnUnrelatedHostRedirect() throws Exception {
-        // Redirect to a completely different host that is not a subdomain — auth should be stripped.
+    public void multipleSubdomainRedirectsFollowedAndValidatedAgainstOriginalHost() throws Exception {
+        // A node may redirect to another node; every hop is validated against the ORIGINAL ledger
+        // host (not the previous hop), so both subdomains of the original host are followed.
+        String node1 = "https://node-1.ledger.confidential-ledger.azure.com:16385/app/transactions";
+        String node2 = "https://node-2.ledger.confidential-ledger.azure.com:16385/app/transactions";
+        RecordingHttpClient httpClient = new RecordingHttpClient(request -> {
+            String url = request.getUrl().toString();
+            if (url.equals(ORIGINAL_URL)) {
+                HttpHeaders headers = new HttpHeaders().set(HttpHeaderName.LOCATION, node1);
+                return Mono.just(new MockHttpResponse(request, 307, headers));
+            } else if (url.equals(node1)) {
+                HttpHeaders headers = new HttpHeaders().set(HttpHeaderName.LOCATION, node2);
+                return Mono.just(new MockHttpResponse(request, 307, headers));
+            } else {
+                return Mono.just(new MockHttpResponse(request, 200));
+            }
+        });
+
+        HttpPipeline pipeline = createPipeline(httpClient);
+
+        HttpRequest request = new HttpRequest(HttpMethod.POST, new URL(ORIGINAL_URL));
+        request.getHeaders().set(HttpHeaderName.AUTHORIZATION, AUTH_TOKEN);
+
+        try (HttpResponse response = pipeline.send(request).block()) {
+            assertNotNull(response);
+            assertEquals(200, response.getStatusCode());
+            assertEquals(3, httpClient.getCount());
+            // Both subdomains of the original host are trusted, so auth is preserved across hops.
+            assertEquals(AUTH_TOKEN, response.getRequest().getHeaders().getValue(HttpHeaderName.AUTHORIZATION));
+        }
+    }
+
+    @Test
+    public void unrelatedHostRedirectNotFollowed() throws Exception {
+        // Redirect to a completely different host that is not a subdomain — must not be followed.
         String unrelatedUrl = "https://malicious.example.com/steal-token";
         RecordingHttpClient httpClient = new RecordingHttpClient(request -> {
             if (request.getUrl().toString().equals(ORIGINAL_URL)) {
@@ -446,18 +481,17 @@ public class ConfidentialLedgerRedirectPolicyTest {
 
         try (HttpResponse response = pipeline.send(request).block()) {
             assertNotNull(response);
-            assertEquals(200, response.getStatusCode());
-            assertNull(response.getRequest().getHeaders().getValue(HttpHeaderName.AUTHORIZATION));
+            // An unrelated host is refused: the redirect is never followed and the host is never contacted.
+            assertEquals(307, response.getStatusCode());
+            assertEquals(1, httpClient.getCount());
         }
     }
 
     @Test
-    public void authorizationStrippedOnPartialHostMatchRedirect() throws Exception {
-        // "evil-ledger.confidential-ledger.azure.com" ends with the original host string
-        // but is NOT a subdomain of "ledger.confidential-ledger.azure.com" (no dot separator).
-        // This verifies the subdomain check uses "." + originalHost.
-        String partialMatchUrl = "https://evil-ledger.confidential-ledger.azure.com/target";
-        // Use a shorter original so the partial match is meaningful
+    public void partialHostMatchRedirectNotFollowed() throws Exception {
+        // "notmyacl.azure.com" ends with "myacl.azure.com" but is NOT a subdomain of it
+        // (no dot separator). This verifies the subdomain check uses "." + originalHost and that a
+        // look-alike suffix host is refused.
         String shortOriginal = "https://myacl.azure.com";
         String evilRedirect = "https://notmyacl.azure.com/steal";
         RecordingHttpClient httpClient = new RecordingHttpClient(request -> {
@@ -476,9 +510,9 @@ public class ConfidentialLedgerRedirectPolicyTest {
 
         try (HttpResponse response = pipeline.send(request).block()) {
             assertNotNull(response);
-            assertEquals(200, response.getStatusCode());
-            // "notmyacl.azure.com" is not a subdomain of "myacl.azure.com" — auth stripped.
-            assertNull(response.getRequest().getHeaders().getValue(HttpHeaderName.AUTHORIZATION));
+            // "notmyacl.azure.com" is not a subdomain of "myacl.azure.com" — redirect refused.
+            assertEquals(307, response.getStatusCode());
+            assertEquals(1, httpClient.getCount());
         }
     }
 


### PR DESCRIPTION
## Summary

Hardens the data-plane redirect handling in `azure-security-confidentialledger` so that the client only follows HTTP redirects whose target host is the original ledger host or one of its subdomains (using the **same scheme**). Redirects to sibling ledgers, parent domains, unrelated hosts, or look-alike suffix domains are now refused, logged at the warning level, and never followed or used.

Java port of [Azure/azure-sdk-for-python#47368](https://github.com/Azure/azure-sdk-for-python/pull/47368).

Fixes ICM 31000000622491.

## Problem

`ConfidentialLedgerRedirectPolicy` is used in place of the default `RedirectPolicy` so that write operations (POST) can be redirected from the load-balanced ledger endpoint to a specific node, **preserving the `Authorization` header** across the service-managed redirect. Previously, the policy *followed* any `Location` target and merely stripped the `Authorization` header on cross-origin redirects. Because Confidential Ledger intentionally preserves auth headers across its node redirects, a misconfigured or malicious load balancer could redirect a request — along with its sensitive headers — to an unintended destination.

## Policy

Given an original request to `https://test-ledger.confidential-ledger.azure.com`, redirects are now evaluated as follows:

| Redirect target | Followed? |
| --- | --- |
| `https://test-ledger.confidential-ledger.azure.com/...` (same host) | Yes |
| `https://node3.test-ledger.confidential-ledger.azure.com/...` (subdomain / node) | Yes |
| `https://accledger-2.test-ledger.confidential-ledger.azure.com/...` (subdomain / node) | Yes |
| `https://other-ledger.confidential-ledger.azure.com/...` (sibling ledger) | No |
| `https://confidential-ledger.azure.com/...` (parent domain) | No |
| `https://evil.example.com/...` (unrelated host) | No |
| `https://test-ledger.confidential-ledger.azure.com.evil.com/...` (suffix look-alike) | No |
| `http://test-ledger.confidential-ledger.azure.com/...` (scheme downgrade) | No |

## Changes

- **Allow-check** (`isAllowedRedirectTarget`): requires an exact (case-insensitive) scheme match, then permits the redirect only when the target host equals the original host or is a subdomain of it (`host == original || host.endsWith("." + original)`). The port is ignored. Fails safe (rejects) if either URL cannot be parsed or either host is empty.
- Every redirect hop is now validated against the **pristine original request URL** (captured before any redirect), not the previous hop.
- Disallowed targets are **refused** (not followed) and logged at warning level: `Refusing to follow redirect to disallowed target`.
- The legitimate load-balancer → node (subdomain) redirect the service depends on is preserved, and the `Authorization` header continues to be forwarded on allowed redirects.
- CHANGELOG entry added under `1.1.0-beta.3`.

## Testing

**Unit tests** (`ConfidentialLedgerRedirectPolicyTest`) — 30/30 passing:
- Allowed: same host, subdomain/node (sync + async), differing port, multi-hop subdomain — followed, auth preserved.
- Refused: cross-origin host, scheme downgrade (`https` → `http`), unrelated host, look-alike suffix domain — the `307` is returned as-is and the disallowed host is never contacted.

**Live validation** against a real ledger (`ryan-sdk-acl`, AAD auth):
- Legitimate `307` redirect to an `accledger-2.<ledger>.confidential-ledger.azure.com` node subdomain is followed, and writes succeed end-to-end (single write/commit/read round-trip and 15 consecutive writes).
- A simulated misconfigured/malicious redirect (genuine `307` whose `Location` is rewritten to `evil.example.com`) is correctly refused — the policy never sends a request to the dangerous host.

> The live test is intentionally **not** included in this PR; the refusal path is covered by the mock-based unit tests since the real service never emits a disallowed redirect.

## Scope / notes

- This change affects only the data-plane `azure-security-confidentialledger` redirect policy.
- No public API changes; behavior change only.
