### PR TITLE
Default first mgmt-plane TypeSpec SDK release to 1.0.0-beta.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -168,12 +168,6 @@ When possible, refer to the Azure SDK for Java Design Guidelines for specific ex
     - Instructions on how to verify the changes.
     - Any additional context or information that reviewers should be aware of.
 
-## PR Review Guidelines
-
-When reviewing a pull request, in addition to the general behavior rules above, apply the following SDK-specific checks and leave a review comment when any of them is violated:
-
-- **First SDK release should be a Beta (management-plane only).** Per the [Azure SDK Beta releases and stable graduation policy](https://azure.github.io/azure-sdk/policies_releases.html#beta-releases-and-stable-graduation), the first public release of a management-plane client library (Maven group `com.azure.resourcemanager`) should be a Beta and remain available for at least one month to allow community feedback. Detect a first release by checking whether the PR **adds a new entry** for the library in `eng/versioning/version_client.txt` (i.e. the `com.azure.resourcemanager:{module};stable;current` line did not exist on the base branch and is introduced by this PR); the value of the current version column alone is not a reliable signal because already-released packages can also legitimately carry a `-beta.N` current version. When the PR adds a new entry but sets the version to a stable (non-`-beta`) value such as `1.0.0`, leave a review comment asking the author to either change the version back to `1.0.0-beta.1`, or — if an exception to the GA CloudLifecycle SDK KPIs is required — follow [Request an exception for Azure SDKs](https://eng.ms/docs/products/azure-developer-experience/onboard/request-exception) (submitted in CloudLifecycle) and link the approved exception in the PR.
-
 ## Release Process
 
 - Version numbers follow [Semantic Versioning](https://semver.org/)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -168,6 +168,12 @@ When possible, refer to the Azure SDK for Java Design Guidelines for specific ex
     - Instructions on how to verify the changes.
     - Any additional context or information that reviewers should be aware of.
 
+## PR Review Guidelines
+
+When reviewing a pull request, in addition to the general behavior rules above, apply the following SDK-specific checks and leave a review comment when any of them is violated:
+
+- **First SDK release should be a Beta (management-plane only).** Per the [Azure SDK Beta releases and stable graduation policy](https://azure.github.io/azure-sdk/policies_releases.html#beta-releases-and-stable-graduation), the first public release of a management-plane client library (Maven group `com.azure.resourcemanager`) should be a Beta and remain available for at least one month to allow community feedback. Detect a first release by checking whether the PR **adds a new entry** for the library in `eng/versioning/version_client.txt` (i.e. the `com.azure.resourcemanager:{module};stable;current` line did not exist on the base branch and is introduced by this PR); the value of the current version column alone is not a reliable signal because already-released packages can also legitimately carry a `-beta.N` current version. When the PR adds a new entry but sets the version to a stable (non-`-beta`) value such as `1.0.0`, leave a review comment asking the author to either change the version back to `1.0.0-beta.1`, or — if an exception to the GA CloudLifecycle SDK KPIs is required — follow [Request an exception for Azure SDKs](https://eng.ms/docs/products/azure-developer-experience/onboard/request-exception) (submitted in CloudLifecycle) and link the approved exception in the PR.
+
 ## Release Process
 
 - Version numbers follow [Semantic Versioning](https://semver.org/)

--- a/eng/automation/generate.py
+++ b/eng/automation/generate.py
@@ -18,6 +18,7 @@ from utils import (
     update_version,
     get_latest_ga_version,
     get_latest_release_version,
+    is_first_release,
 )
 from generate_data import (
     sdk_automation as sdk_automation_data,
@@ -368,10 +369,19 @@ def sdk_automation_typespec_project(tsp_project: str, config: dict) -> dict:
     )
 
     if succeeded:
-        # Infer sdk release type from generated metadata when not explicitly provided
+        # Infer sdk release type from generated metadata when not explicitly provided.
+        # However, if the package has never been released, always force a beta first release
+        # (1.0.0-beta.1) regardless of whether the API version is GA or preview.
         if not sdk_release_type and sdk_folder and module:
-            inferred_type = infer_sdk_release_type(sdk_root, sdk_folder, module)
-            release_beta_sdk = inferred_type == "beta"
+            if is_first_release(sdk_root, GROUP_ID, module):
+                logging.info(
+                    f"[SelfServe] Package {GROUP_ID}:{module} has never been released; "
+                    f"forcing first release to {DEFAULT_VERSION} (sdkReleaseType=beta)."
+                )
+                release_beta_sdk = True
+            else:
+                inferred_type = infer_sdk_release_type(sdk_root, sdk_folder, module)
+                release_beta_sdk = inferred_type == "beta"
 
         # TODO (weidxu): move to typespec-java
         if require_sdk_integration:

--- a/eng/automation/test_generate.py
+++ b/eng/automation/test_generate.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 
 from generate import update_revapi_skip
+from utils import is_first_release
 
 POM_WITH_REVAPI_TRUE = """\
 <project>
@@ -78,6 +79,59 @@ class TestUpdateRevapiSkip(unittest.TestCase):
         result = self._write_and_update(POM_WITHOUT_REVAPI, beta=False)
         self.assertNotIn("revapi.skip", result)
         self.assertEqual(result, POM_WITHOUT_REVAPI)
+
+
+class TestIsFirstRelease(unittest.TestCase):
+
+    GROUP = "com.azure.resourcemanager"
+    MODULE = "azure-resourcemanager-foo"
+
+    def _make_sdk_root(self, version_file_content):
+        sdk_root = tempfile.mkdtemp()
+        versioning_dir = os.path.join(sdk_root, "eng", "versioning")
+        os.makedirs(versioning_dir, exist_ok=True)
+        if version_file_content is not None:
+            with open(os.path.join(versioning_dir, "version_client.txt"), "w") as f:
+                f.write(version_file_content)
+        return sdk_root
+
+    def test_entry_missing_returns_true(self):
+        content = (
+            "# comment line\n"
+            "com.azure.resourcemanager:azure-resourcemanager-other;1.2.0;1.2.0\n"
+        )
+        sdk_root = self._make_sdk_root(content)
+        self.assertTrue(is_first_release(sdk_root, self.GROUP, self.MODULE))
+
+    def test_entry_with_default_versions_returns_true(self):
+        content = (
+            "com.azure.resourcemanager:azure-resourcemanager-foo;1.0.0-beta.1;1.0.0-beta.1\n"
+        )
+        sdk_root = self._make_sdk_root(content)
+        self.assertTrue(is_first_release(sdk_root, self.GROUP, self.MODULE))
+
+    def test_entry_with_published_stable_returns_false(self):
+        content = (
+            "com.azure.resourcemanager:azure-resourcemanager-foo;1.2.0;1.3.0-beta.1\n"
+        )
+        sdk_root = self._make_sdk_root(content)
+        self.assertFalse(is_first_release(sdk_root, self.GROUP, self.MODULE))
+
+    def test_entry_with_bumped_beta_returns_false(self):
+        content = (
+            "com.azure.resourcemanager:azure-resourcemanager-foo;1.0.0-beta.2;1.0.0-beta.2\n"
+        )
+        sdk_root = self._make_sdk_root(content)
+        self.assertFalse(is_first_release(sdk_root, self.GROUP, self.MODULE))
+
+    def test_malformed_entry_returns_false(self):
+        content = "com.azure.resourcemanager:azure-resourcemanager-foo;1.0.0-beta.1\n"
+        sdk_root = self._make_sdk_root(content)
+        self.assertFalse(is_first_release(sdk_root, self.GROUP, self.MODULE))
+
+    def test_missing_file_returns_false(self):
+        sdk_root = self._make_sdk_root(None)
+        self.assertFalse(is_first_release(sdk_root, self.GROUP, self.MODULE))
 
 
 if __name__ == "__main__":

--- a/eng/automation/utils.py
+++ b/eng/automation/utils.py
@@ -297,6 +297,43 @@ def set_or_default_version(
     return stable_version, current_version
 
 
+def is_first_release(sdk_root: str, group: str, module: str) -> bool:
+    """Return True when the package has never been released.
+
+    A package is considered "never released" when either of the following is true
+    based solely on ``eng/versioning/version_client.txt``:
+
+    - The ``{group}:{module}`` entry is missing.
+    - Both the stable and current version columns equal ``DEFAULT_VERSION``
+      (``1.0.0-beta.1``), i.e. only the initial placeholder is present.
+
+    No side effects, no network calls.
+    """
+    version_file = os.path.join(sdk_root, "eng/versioning/version_client.txt")
+    project = "{0}:{1}".format(group, module)
+    try:
+        with open(version_file, "r") as fin:
+            for version_line in fin:
+                version_line = version_line.strip()
+                if not version_line or version_line.startswith("#"):
+                    continue
+                versions = version_line.split(";")
+                if versions[0] != project:
+                    continue
+                if len(versions) != 3:
+                    # Malformed line: be conservative and treat as not-first-release
+                    # so we don't override existing release semantics.
+                    return False
+                stable_version = versions[1].strip()
+                current_version = versions[2].strip()
+                return stable_version == DEFAULT_VERSION and current_version == DEFAULT_VERSION
+        # Entry not found at all -> never released
+        return True
+    except FileNotFoundError:
+        # Without the version file we cannot decide; be conservative.
+        return False
+
+
 def set_or_increase_version(
     sdk_root: str,
     group: str,


### PR DESCRIPTION
## Summary

For mgmt-plane TypeSpec generation in `eng/automation/generate.py`, when `sdkReleaseType` is **not** provided in the SDK automation config **and** the package has never been released, force the first release to `1.0.0-beta.1` regardless of whether the underlying API version is GA or preview.

This avoids the need to manually flip a stable `1.0.0` first release back to `1.0.0-beta.1` for new mgmt libraries, per the [Azure SDK Beta releases and stable graduation policy](https://azure.github.io/azure-sdk/policies_releases.html#beta-releases-and-stable-graduation).

Refs: Azure/azure-sdk-tools#10669

## Changes

- `eng/automation/utils.py` — new `is_first_release(sdk_root, group, module)` helper. Pure read of `eng/versioning/version_client.txt`; returns `True` when the entry is missing, or when both the stable and current version columns equal `DEFAULT_VERSION` (`1.0.0-beta.1`).
- `eng/automation/generate.py` → `sdk_automation_typespec_project`: when `sdkReleaseType` is absent, consult `is_first_release` first. If it returns `True`, force `release_beta_sdk=True` and skip `infer_sdk_release_type`. Otherwise the existing inference runs unchanged.
- `eng/automation/test_generate.py` — added 6 unit tests for `is_first_release` (missing entry, default versions, published stable, bumped beta, malformed line, missing file).

