### PR TITLE
Release Verification and Retry

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -271,6 +271,22 @@ jobs:
           ArtifactPath: $(Build.ArtifactStagingDirectory)
           ArtifactName: 'packages'
 
+      - task: PowerShell@2
+        displayName: 'Stage Maven Settings for publishing'
+        inputs:
+          pwsh: true
+          targetType: inline
+          script: |
+            $settingsArtifactDirectory = Join-Path '$(Agent.TempDirectory)' 'maven-settings'
+            New-Item -Path $settingsArtifactDirectory -ItemType Directory -Force | Out-Null
+            Copy-Item -Path '$(Build.SourcesDirectory)/eng/settings.xml' -Destination (Join-Path $settingsArtifactDirectory 'settings.xml')
+
+      - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+        parameters:
+          ArtifactPath: $(Agent.TempDirectory)/maven-settings
+          ArtifactName: 'maven-settings'
+          SbomEnabled: false
+
       # Troubleshooting artifacts are creating in the staging directory under the folder 'troubleshooting'.
       # This will contain things such as heap dumps hprofs if testing hit OutOfMemory errors, log files captured
       # during testing if tests failed, and linting reports.

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -285,7 +285,6 @@ jobs:
         parameters:
           ArtifactPath: $(Agent.TempDirectory)/maven-settings
           ArtifactName: 'maven-settings'
-          SbomEnabled: false
 
       # Troubleshooting artifacts are creating in the staging directory under the folder 'troubleshooting'.
       # This will contain things such as heap dumps hprofs if testing hit OutOfMemory errors, log files captured

--- a/eng/pipelines/templates/stages/archetype-java-release-batch.yml
+++ b/eng/pipelines/templates/stages/archetype-java-release-batch.yml
@@ -20,6 +20,9 @@ parameters:
   - name: PublicFeedUrl
     type: string
     default: 'maven.org'
+  - name: VerifyJarPublish
+    type: boolean
+    default: true
 
 stages:
   # The signing stage is responsible for submitting binaries to ESRP for our official signing
@@ -237,6 +240,7 @@ stages:
                     - template: /eng/pipelines/templates/steps/java-esrp-publishing.yml
                       parameters:
                         FlattenedDirectory: $(Pipeline.Workspace)/packages-esrp-flattened
+                        VerifyJarPublish: ${{ parameters.VerifyJarPublish }}
 
         - job: PublishDevFeedPackage
           displayName: "Publish to Java Dev feed"

--- a/eng/pipelines/templates/stages/archetype-java-release-batch.yml
+++ b/eng/pipelines/templates/stages/archetype-java-release-batch.yml
@@ -229,6 +229,9 @@ stages:
               - input: pipelineArtifact
                 artifactName: 'packages-esrp-flattened'
                 targetPath: '$(Pipeline.Workspace)/packages-esrp-flattened'
+              - input: pipelineArtifact
+                artifactName: 'maven-settings'
+                targetPath: '$(Pipeline.Workspace)/maven-settings'
             pool:
               name: azsdk-pool
               image: windows-2022
@@ -237,10 +240,15 @@ stages:
               runOnce:
                 deploy:
                   steps:
+                    - pwsh: |
+                        $m2Dir = if ($env:USERPROFILE) { "$env:USERPROFILE\.m2" } else { "$HOME/.m2" }
+                        New-Item -ItemType Directory -Force -Path $m2Dir | Out-Null
+                        Copy-Item -Path '$(Pipeline.Workspace)/maven-settings/settings.xml' -Destination "$m2Dir/settings.xml"
+                      displayName: 'Setup Maven mirror settings'
                     - template: /eng/pipelines/templates/steps/java-esrp-publishing.yml
                       parameters:
                         FlattenedDirectory: $(Pipeline.Workspace)/packages-esrp-flattened
-                        VerifyJarPublish: ${{ parameters.VerifyJarPublish }}
+                        VerifyJarPublish: true
 
         - job: PublishDevFeedPackage
           displayName: "Publish to Java Dev feed"

--- a/eng/pipelines/templates/steps/java-esrp-publishing.yml
+++ b/eng/pipelines/templates/steps/java-esrp-publishing.yml
@@ -6,6 +6,27 @@ parameters:
 
 steps:
   - ${{if eq(parameters.ShouldPublish, 'true')}}:
+
+    # TODO: REMOVE BEFORE MERGE
+    - task: PowerShell@2
+      displayName: 'Delete one package from flattened ESRP directory (test)'
+      condition: and(succeeded(), eq(variables['System.JobAttempt'], '1'))
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          $flattenedDirectory = (Resolve-Path '${{ parameters.FlattenedDirectory }}').Path
+          $packagePom = Get-ChildItem -Path $flattenedDirectory -Filter *.pom -File | Sort-Object Name | Select-Object -First 1
+          $packagePrefix = $packagePom.BaseName
+          $packageFiles = Get-ChildItem -Path $flattenedDirectory -File | Where-Object { $_.Name -like "$packagePrefix*" }
+
+          Write-Host "Deleting package prefix: $packagePrefix"
+          foreach ($packageFile in $packageFiles) {
+            Write-Host "  Removing $($packageFile.Name)"
+          }
+
+          Remove-Item -Path $packageFiles.FullName -Force
+
     - task: EsrpRelease@9
       displayName: 'Publish to ESRP'
       inputs:

--- a/eng/pipelines/templates/steps/java-esrp-publishing.yml
+++ b/eng/pipelines/templates/steps/java-esrp-publishing.yml
@@ -6,6 +6,33 @@ parameters:
 
 steps:
   - ${{if eq(parameters.ShouldPublish, 'true')}}:
+    # TODO: REMOVE BEFORE MERGE
+    - task: PowerShell@2
+      displayName: 'Move one package out of flattened ESRP directory (test)'
+      condition: and(succeeded(), eq(variables['System.JobAttempt'], '1'))
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          $flattenedDirectory = (Resolve-Path '${{ parameters.FlattenedDirectory }}').Path
+          $stagedDirectory = Join-Path '$(Agent.TempDirectory)' 'java-esrp-publishing-test-package'
+          $packagePom = Get-ChildItem -Path $flattenedDirectory -Filter *.pom -File | Sort-Object Name | Select-Object -First 1
+          $packagePrefix = $packagePom.BaseName
+          $packageFiles = Get-ChildItem -Path $flattenedDirectory -File | Where-Object { $_.Name -like "$packagePrefix*" }
+
+          if (Test-Path $stagedDirectory) {
+            Remove-Item -Path $stagedDirectory -Recurse -Force
+          }
+
+          New-Item -Path $stagedDirectory -ItemType Directory -Force | Out-Null
+
+          Write-Host "Moving package prefix out of flattened directory: $packagePrefix"
+          foreach ($packageFile in $packageFiles) {
+            Write-Host "  Moving $($packageFile.Name)"
+          }
+
+          Move-Item -Path $packageFiles.FullName -Destination $stagedDirectory -Force
+
     - task: EsrpRelease@9
       displayName: 'Publish to ESRP'
       inputs:
@@ -22,6 +49,29 @@ steps:
         Approvers: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
         ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
         MainPublisher: 'ESRPRELPACMANTEST'
+
+    # TODO: REMOVE BEFORE MERGE
+    - task: PowerShell@2
+      displayName: 'Move one package back into flattened ESRP directory (test)'
+      condition: and(always(), eq(variables['System.JobAttempt'], '1'))
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          $flattenedDirectory = (Resolve-Path '${{ parameters.FlattenedDirectory }}').Path
+          $stagedDirectory = Join-Path '$(Agent.TempDirectory)' 'java-esrp-publishing-test-package'
+
+          if (Test-Path $stagedDirectory) {
+            $packageFiles = Get-ChildItem -Path $stagedDirectory -File | Sort-Object Name
+
+            Write-Host "Moving package back into flattened directory"
+            foreach ($packageFile in $packageFiles) {
+              Write-Host "  Restoring $($packageFile.Name)"
+            }
+
+            Move-Item -Path $packageFiles.FullName -Destination $flattenedDirectory -Force
+            Remove-Item -Path $stagedDirectory -Recurse -Force
+          }
 
     - ${{ if eq('true', parameters.VerifyJarPublish) }}:
       - task: MavenAuthenticate@0
@@ -45,7 +95,7 @@ steps:
             $metadataRepo = Join-Path $workRoot 'maven-metadata-repo'
             $downloadRoot = Join-Path $workRoot 'jar-downloads'
             $retrySeconds = 60
-            $maxAttempts = 10
+            $maxAttempts = 20
 
             function Get-MavenValue([string]$PomPath, [string]$Expression) {
               Set-Location $mavenWork
@@ -120,7 +170,7 @@ steps:
                   --batch-mode `
                   -q `
                   org.apache.maven.plugins:maven-dependency-plugin:copy `
-                  -DremoteRepositories=central::default::https://repo.maven.apache.org/maven2 `
+                  -DremoteRepositories=azure-sdk-for-java::default::https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1 `
                   "-Dmaven.repo.local=$repoPath" `
                   "-Dartifact=$($package.Coordinate)" `
                   "-DoutputDirectory=$downloadRoot" `

--- a/eng/pipelines/templates/steps/java-esrp-publishing.yml
+++ b/eng/pipelines/templates/steps/java-esrp-publishing.yml
@@ -170,7 +170,6 @@ steps:
                   --batch-mode `
                   -q `
                   org.apache.maven.plugins:maven-dependency-plugin:copy `
-                  -DremoteRepositories=azure-sdk-for-java::default::https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1 `
                   "-Dmaven.repo.local=$repoPath" `
                   "-Dartifact=$($package.Coordinate)" `
                   "-DoutputDirectory=$downloadRoot" `

--- a/eng/pipelines/templates/steps/java-esrp-publishing.yml
+++ b/eng/pipelines/templates/steps/java-esrp-publishing.yml
@@ -9,23 +9,30 @@ steps:
 
     # TODO: REMOVE BEFORE MERGE
     - task: PowerShell@2
-      displayName: 'Delete one package from flattened ESRP directory (test)'
+      displayName: 'Move one package out of flattened ESRP directory (test)'
       condition: and(succeeded(), eq(variables['System.JobAttempt'], '1'))
       inputs:
         pwsh: true
         targetType: inline
         script: |
           $flattenedDirectory = (Resolve-Path '${{ parameters.FlattenedDirectory }}').Path
+          $stagedDirectory = Join-Path '$(Agent.TempDirectory)' 'java-esrp-publishing-test-package'
           $packagePom = Get-ChildItem -Path $flattenedDirectory -Filter *.pom -File | Sort-Object Name | Select-Object -First 1
           $packagePrefix = $packagePom.BaseName
           $packageFiles = Get-ChildItem -Path $flattenedDirectory -File | Where-Object { $_.Name -like "$packagePrefix*" }
 
-          Write-Host "Deleting package prefix: $packagePrefix"
-          foreach ($packageFile in $packageFiles) {
-            Write-Host "  Removing $($packageFile.Name)"
+          if (Test-Path $stagedDirectory) {
+            Remove-Item -Path $stagedDirectory -Recurse -Force
           }
 
-          Remove-Item -Path $packageFiles.FullName -Force
+          New-Item -Path $stagedDirectory -ItemType Directory -Force | Out-Null
+
+          Write-Host "Moving package prefix out of flattened directory: $packagePrefix"
+          foreach ($packageFile in $packageFiles) {
+            Write-Host "  Moving $($packageFile.Name)"
+          }
+
+          Move-Item -Path $packageFiles.FullName -Destination $stagedDirectory -Force
 
     - task: EsrpRelease@9
       displayName: 'Publish to ESRP'
@@ -43,6 +50,29 @@ steps:
         Approvers: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
         ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
         MainPublisher: 'ESRPRELPACMANTEST'
+
+    # TODO: REMOVE BEFORE MERGE
+    - task: PowerShell@2
+      displayName: 'Move one package back into flattened ESRP directory (test)'
+      condition: and(always(), eq(variables['System.JobAttempt'], '1'))
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          $flattenedDirectory = (Resolve-Path '${{ parameters.FlattenedDirectory }}').Path
+          $stagedDirectory = Join-Path '$(Agent.TempDirectory)' 'java-esrp-publishing-test-package'
+
+          if (Test-Path $stagedDirectory) {
+            $packageFiles = Get-ChildItem -Path $stagedDirectory -File | Sort-Object Name
+
+            Write-Host "Moving package back into flattened directory"
+            foreach ($packageFile in $packageFiles) {
+              Write-Host "  Restoring $($packageFile.Name)"
+            }
+
+            Move-Item -Path $packageFiles.FullName -Destination $flattenedDirectory -Force
+            Remove-Item -Path $stagedDirectory -Recurse -Force
+          }
 
     - ${{ if eq(parameters.VerifyJarPublish, 'true') }}:
       - task: PowerShell@2

--- a/eng/pipelines/templates/steps/java-esrp-publishing.yml
+++ b/eng/pipelines/templates/steps/java-esrp-publishing.yml
@@ -24,6 +24,11 @@ steps:
         MainPublisher: 'ESRPRELPACMANTEST'
 
     - ${{ if eq('true', parameters.VerifyJarPublish) }}:
+      - task: MavenAuthenticate@0
+        displayName: 'Maven Authenticate'
+        inputs:
+          artifactsFeeds: 'azure-sdk-for-java'
+
       - task: PowerShell@2
         displayName: 'Verify ESRP published package jars are downloadable'
         inputs:

--- a/eng/pipelines/templates/steps/java-esrp-publishing.yml
+++ b/eng/pipelines/templates/steps/java-esrp-publishing.yml
@@ -23,7 +23,7 @@ steps:
         ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
         MainPublisher: 'ESRPRELPACMANTEST'
 
-    - ${{ if eq(parameters.VerifyJarPublish, 'true') }}:
+    - ${{ if eq('true', parameters.VerifyJarPublish) }}:
       - task: PowerShell@2
         displayName: 'Verify ESRP published package jars are downloadable'
         inputs:

--- a/eng/pipelines/templates/steps/java-esrp-publishing.yml
+++ b/eng/pipelines/templates/steps/java-esrp-publishing.yml
@@ -6,34 +6,6 @@ parameters:
 
 steps:
   - ${{if eq(parameters.ShouldPublish, 'true')}}:
-
-    # TODO: REMOVE BEFORE MERGE
-    - task: PowerShell@2
-      displayName: 'Move one package out of flattened ESRP directory (test)'
-      condition: and(succeeded(), eq(variables['System.JobAttempt'], '1'))
-      inputs:
-        pwsh: true
-        targetType: inline
-        script: |
-          $flattenedDirectory = (Resolve-Path '${{ parameters.FlattenedDirectory }}').Path
-          $stagedDirectory = Join-Path '$(Agent.TempDirectory)' 'java-esrp-publishing-test-package'
-          $packagePom = Get-ChildItem -Path $flattenedDirectory -Filter *.pom -File | Sort-Object Name | Select-Object -First 1
-          $packagePrefix = $packagePom.BaseName
-          $packageFiles = Get-ChildItem -Path $flattenedDirectory -File | Where-Object { $_.Name -like "$packagePrefix*" }
-
-          if (Test-Path $stagedDirectory) {
-            Remove-Item -Path $stagedDirectory -Recurse -Force
-          }
-
-          New-Item -Path $stagedDirectory -ItemType Directory -Force | Out-Null
-
-          Write-Host "Moving package prefix out of flattened directory: $packagePrefix"
-          foreach ($packageFile in $packageFiles) {
-            Write-Host "  Moving $($packageFile.Name)"
-          }
-
-          Move-Item -Path $packageFiles.FullName -Destination $stagedDirectory -Force
-
     - task: EsrpRelease@9
       displayName: 'Publish to ESRP'
       inputs:
@@ -50,29 +22,6 @@ steps:
         Approvers: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
         ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
         MainPublisher: 'ESRPRELPACMANTEST'
-
-    # TODO: REMOVE BEFORE MERGE
-    - task: PowerShell@2
-      displayName: 'Move one package back into flattened ESRP directory (test)'
-      condition: and(always(), eq(variables['System.JobAttempt'], '1'))
-      inputs:
-        pwsh: true
-        targetType: inline
-        script: |
-          $flattenedDirectory = (Resolve-Path '${{ parameters.FlattenedDirectory }}').Path
-          $stagedDirectory = Join-Path '$(Agent.TempDirectory)' 'java-esrp-publishing-test-package'
-
-          if (Test-Path $stagedDirectory) {
-            $packageFiles = Get-ChildItem -Path $stagedDirectory -File | Sort-Object Name
-
-            Write-Host "Moving package back into flattened directory"
-            foreach ($packageFile in $packageFiles) {
-              Write-Host "  Restoring $($packageFile.Name)"
-            }
-
-            Move-Item -Path $packageFiles.FullName -Destination $flattenedDirectory -Force
-            Remove-Item -Path $stagedDirectory -Recurse -Force
-          }
 
     - ${{ if eq(parameters.VerifyJarPublish, 'true') }}:
       - task: PowerShell@2

--- a/eng/pipelines/templates/steps/java-esrp-publishing.yml
+++ b/eng/pipelines/templates/steps/java-esrp-publishing.yml
@@ -2,6 +2,7 @@ parameters:
   # This is the flattened
   FlattenedDirectory: not-specified
   ShouldPublish: true
+  VerifyJarPublish: false
 
 steps:
   - ${{if eq(parameters.ShouldPublish, 'true')}}:
@@ -21,3 +22,128 @@ steps:
         Approvers: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
         ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
         MainPublisher: 'ESRPRELPACMANTEST'
+
+    - ${{ if eq(parameters.VerifyJarPublish, 'true') }}:
+      - task: PowerShell@2
+        displayName: 'Verify ESRP published package jars are downloadable'
+        inputs:
+          pwsh: true
+          targetType: inline
+          workingDirectory: $(Agent.BuildDirectory)
+          script: |
+            $ErrorActionPreference = 'Stop'
+            $PSNativeCommandUseErrorActionPreference = $false
+
+            $flattenedDirectory = (Resolve-Path '${{ parameters.FlattenedDirectory }}').Path
+            $workRoot = Join-Path (Get-Location) 'work'
+            $mavenWork = Join-Path $workRoot 'maven-work'
+            $metadataRepo = Join-Path $workRoot 'maven-metadata-repo'
+            $downloadRoot = Join-Path $workRoot 'jar-downloads'
+            $retrySeconds = 60
+            $maxAttempts = 10
+
+            function Get-MavenValue([string]$PomPath, [string]$Expression) {
+              Set-Location $mavenWork
+              $mvnArguments = @(
+                '--batch-mode',
+                '-q',
+                '--file',
+                $PomPath,
+                'help:evaluate',
+                "-Dmaven.repo.local=$metadataRepo",
+                "-Dexpression=$Expression",
+                '-DforceStdout'
+              )
+
+              [string[]]$output = & mvn @mvnArguments
+              if ($LASTEXITCODE -ne 0) {
+                throw "Failed to read $Expression from $PomPath."
+              }
+
+              return ($output | Where-Object { $_ -and $_.Trim() } | Select-Object -Last 1).Trim()
+            }
+
+            New-Item -Path $workRoot -ItemType Directory -Force | Out-Null
+            New-Item -Path $mavenWork -ItemType Directory -Force | Out-Null
+            if (Test-Path $metadataRepo) {
+              Remove-Item -Path $metadataRepo -Recurse -Force
+            }
+            New-Item -Path $metadataRepo -ItemType Directory -Force | Out-Null
+            if (Test-Path $downloadRoot) {
+              Remove-Item -Path $downloadRoot -Recurse -Force
+            }
+            New-Item -Path $downloadRoot -ItemType Directory -Force | Out-Null
+
+            $packages = @()
+            $pomFiles = Get-ChildItem -Path $flattenedDirectory -Filter *.pom -File | Sort-Object Name
+
+            foreach ($pomFile in $pomFiles) {
+              $groupId = Get-MavenValue $pomFile.FullName 'project.groupId'
+              $artifactId = Get-MavenValue $pomFile.FullName 'project.artifactId'
+              $version = Get-MavenValue $pomFile.FullName 'project.version'
+              $expectedFile = "$artifactId-$version.jar"
+
+              if (-not (Test-Path (Join-Path $flattenedDirectory $expectedFile))) {
+                Write-Host "  Skipping $artifactId-$version (JAR file not found)"
+                continue
+              }
+
+              $packages += [PSCustomObject]@{
+                Coordinate = "${groupId}:${artifactId}:${version}:jar"
+                ExpectedFile = $expectedFile
+              }
+            }
+
+            Write-Host "Found $($packages.Count) package jar(s) to verify."
+            foreach ($package in $packages) {
+              Write-Host "  $($package.Coordinate)"
+            }
+
+            $pending = @($packages)
+
+            for ($attempt = 1; $attempt -le $maxAttempts -and $pending.Count -gt 0; $attempt++) {
+              $failed = @()
+              $repoPath = Join-Path $workRoot "maven-repo-$attempt"
+              New-Item -Path $repoPath -ItemType Directory -Force | Out-Null
+
+              Write-Host "Attempt: $attempt"
+
+              foreach ($package in $pending) {
+                Write-Host "  Downloading $($package.Coordinate)..."
+                Set-Location $mavenWork
+                & mvn `
+                  --batch-mode `
+                  -q `
+                  org.apache.maven.plugins:maven-dependency-plugin:copy `
+                  -DremoteRepositories=central::default::https://repo.maven.apache.org/maven2 `
+                  "-Dmaven.repo.local=$repoPath" `
+                  "-Dartifact=$($package.Coordinate)" `
+                  "-DoutputDirectory=$downloadRoot" `
+                  -Dtransitive=false
+
+                $expectedPath = Join-Path $downloadRoot $package.ExpectedFile
+                if ($LASTEXITCODE -eq 0 -and (Test-Path $expectedPath)) {
+                  Write-Host "    Verified $($package.ExpectedFile)"
+                }
+                else {
+                  Write-Host "    Failed $($package.ExpectedFile)"
+                  $failed += $package
+                }
+              }
+
+              $pending = @($failed)
+              if ($pending.Count -gt 0 -and $attempt -lt $maxAttempts) {
+                Write-Host "Retrying $($pending.Count) package(s) in $retrySeconds seconds."
+                Start-Sleep -Seconds $retrySeconds
+              }
+            }
+
+            if ($pending.Count -gt 0) {
+              Write-Host "These package jars still failed:"
+              foreach ($package in $pending) {
+                Write-Host "  $($package.Coordinate)"
+              }
+              exit 1
+            }
+
+            Write-Host 'All package jars were verified published.'


### PR DESCRIPTION
## Summary

This PR adds optional post-publish verification for the Java ESRP Maven Central flow. When enabled, the release pipeline verifies that the published package **main JARs** are actually downloadable from Maven Central after the ESRP publish step completes.

Example release with a "failed" package release and success on retry (see attempts 1 and 2): https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6402988&view=logs&j=db16c569-aaa8-51c6-7af6-7a4439e8b73c&t=a4b20b29-bac1-5de5-989a-c44c74ee2b32&s=c3fcf85f-577d-5e17-eee8-b87fb40e1fa5


## Code changes

1. **`eng/pipelines/templates/steps/java-esrp-publishing.yml`**
   - Adds a new `VerifyJarPublish` template parameter.
   - Adds an optional PowerShell verification step that runs after `EsrpRelease@9` when `VerifyJarPublish` is `true`.
   - The verification step:
     - scans the flattened ESRP directory for `*.pom` files
     - uses `mvn help:evaluate` to read `groupId`, `artifactId`, and `version`
     - filters to packages that have a matching main `${artifactId}-${version}.jar`
     - attempts to download each published JAR from Maven Central using `maven-dependency-plugin:copy`
     - retries failed downloads with a fresh local Maven repo per attempt
     - fails the job if any package JAR still cannot be downloaded

2. **`eng/pipelines/templates/stages/archetype-java-release-batch.yml`**
   - Adds the `VerifyJarPublish` stage parameter.
   - Passes that parameter into `java-esrp-publishing.yml` so the verification step can be turned on for batch Java releases.

## Behavior

- The new verification is **opt-in** through `VerifyJarPublish`.
- It validates **package JAR publication**, not sources/javadocs/modules/readmes.
- It is intended to catch cases where ESRP publish succeeds but Maven Central availability lags or fails for specific packages.
