### PR TITLE
Fix and update stress tests for Event Hubs and Service Bus

### DIFF
--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/Dockerfile
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/Dockerfile
@@ -3,40 +3,46 @@ FROM ${REGISTRY}/java/jdk-mariner-mvn:jdk11-latest AS builder
 
 RUN yum update -y
 
-RUN mkdir /stress-eh
-WORKDIR /stress-eh
+RUN mkdir /stress
+WORKDIR /stress
 
-ADD ./.vscode /stress-eh/.vscode
-ADD ./sdk/tools /stress-eh/sdk/tools
-ADD ./sdk/parents /stress-eh/sdk/parents
-ADD ./sdk/core /stress-eh/sdk/core
-ADD ./sdk/monitor /stress-eh/sdk/monitor
-ADD ./sdk/eventhubs /stress-eh/sdk/eventhubs
-ADD ./eng /stress-eh/eng
+ADD ./.vscode /stress/.vscode
+ADD ./sdk/tools /stress/sdk/tools
+ADD ./sdk/parents /stress/sdk/parents
+ADD ./sdk/appconfiguration-v2 /stress/sdk/appconfiguration-v2
+ADD ./sdk/core /stress/sdk/core
+ADD ./sdk/core-v2 /stress/sdk/core-v2
+ADD ./sdk/identity-v2 /stress/sdk/identity-v2
+ADD ./sdk/monitor /stress/sdk/monitor
+ADD ./sdk/eventhubs /stress/sdk/eventhubs
+ADD ./eng /stress/eng
 
 ARG SKIP_CHECKS="-Dcheckstyle.skip -Dgpg.skip -Dmaven.javadoc.skip -Drevapi.skip -Dspotbugs.skip -Djacoco.skip -Dmaven.test.skip -Dcodesnippet.skip -Dspotless.skip"
 
 RUN --mount=type=cache,target=/root/.m2 \
- mvn -f /stress-eh/sdk/tools/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/core/azure-core/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/core/azure-core-http-netty/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/core/azure-core-http-okhttp/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/core/azure-core-http-vertx/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/core/azure-core-http-jdk-httpclient/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/core/azure-core-test/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/core/azure-core-amqp/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/core/azure-core-http-netty/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/monitor/azure-monitor-opentelemetry-exporter/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/eventhubs/azure-messaging-eventhubs/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-eh/sdk/eventhubs/azure-messaging-eventhubs-stress/pom.xml clean install ${SKIP_CHECKS}
+ mvn -f /stress/sdk/core-v2/azure-core/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core-v2/azure-core-test/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/identity-v2/azure-identity/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/appconfiguration-v2/azure-data-appconfiguration/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/tools/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/tools/azure-openrewrite/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core-http-netty/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core-http-okhttp/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core-http-vertx/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core-http-jdk-httpclient/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core-test/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core-amqp/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core-http-netty/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/monitor/azure-monitor-opentelemetry-exporter/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/eventhubs/azure-messaging-eventhubs/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/eventhubs/azure-messaging-eventhubs-stress/pom.xml clean install ${SKIP_CHECKS}
 
 FROM mcr.microsoft.com/openjdk/jdk:21-mariner
 
-RUN yum update -y
-
 WORKDIR /app
-COPY --from=builder /stress-eh/sdk/eventhubs/azure-messaging-eventhubs-stress/target .
+COPY --from=builder /stress/sdk/eventhubs/azure-messaging-eventhubs-stress/target .
 
 # This is never executed (since job yaml overrides it)
 ENTRYPOINT ["bash"]

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/Dockerfile
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/Dockerfile
@@ -1,48 +1,11 @@
-ARG REGISTRY="azsdkengsys.azurecr.io"
-FROM ${REGISTRY}/java/jdk-mariner-mvn:jdk11-latest AS builder
-
-RUN yum update -y
-
-RUN mkdir /stress
-WORKDIR /stress
-
-ADD ./.vscode /stress/.vscode
-ADD ./sdk/tools /stress/sdk/tools
-ADD ./sdk/parents /stress/sdk/parents
-ADD ./sdk/appconfiguration-v2 /stress/sdk/appconfiguration-v2
-ADD ./sdk/core /stress/sdk/core
-ADD ./sdk/core-v2 /stress/sdk/core-v2
-ADD ./sdk/identity-v2 /stress/sdk/identity-v2
-ADD ./sdk/monitor /stress/sdk/monitor
-ADD ./sdk/eventhubs /stress/sdk/eventhubs
-ADD ./eng /stress/eng
-
-ARG SKIP_CHECKS="-Dcheckstyle.skip -Dgpg.skip -Dmaven.javadoc.skip -Drevapi.skip -Dspotbugs.skip -Djacoco.skip -Dmaven.test.skip -Dcodesnippet.skip -Dspotless.skip"
-
-RUN --mount=type=cache,target=/root/.m2 \
- mvn -f /stress/sdk/core-v2/azure-core/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core-v2/azure-core-test/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/identity-v2/azure-identity/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/appconfiguration-v2/azure-data-appconfiguration/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/tools/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/tools/azure-openrewrite/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core-http-netty/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core-http-okhttp/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core-http-vertx/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core-http-jdk-httpclient/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core-test/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core-amqp/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core-http-netty/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/monitor/azure-monitor-opentelemetry-exporter/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/eventhubs/azure-messaging-eventhubs/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/eventhubs/azure-messaging-eventhubs-checkpointstore-blob/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/eventhubs/azure-messaging-eventhubs-stress/pom.xml clean install ${SKIP_CHECKS}
-
 FROM mcr.microsoft.com/openjdk/jdk:21-mariner
 
 WORKDIR /app
-COPY --from=builder /stress/sdk/eventhubs/azure-messaging-eventhubs-stress/target .
+
+# Copy the jar files built by New-StressTestRun.ps1 to the container.
+COPY ./target .
+
+RUN ls /app/azure-messaging-eventhubs-stress* >/dev/null 2>&1 || (echo "ERROR: no file starting with azure-messaging-eventhubs-stress was copied to /app." && exit 1)
 
 # This is never executed (since job yaml overrides it)
 ENTRYPOINT ["bash"]

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/New-StressTestRun.ps1
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/New-StressTestRun.ps1
@@ -1,0 +1,65 @@
+<#
+.DESCRIPTION
+This script compiles the stress test module, optionally performs Azure login, and deploys 
+the Event Hubs stress tests with the provided namespace and environment.
+
+.PARAMETER Namespace
+The namespace in AKS for the stress test run. This is a required parameter.
+
+.PARAMETER Environment
+The stress deployment environment name. Defaults to "storage".
+
+.PARAMETER SkipCompile
+Skips the Maven compile/install step when specified.
+
+.PARAMETER SkipLogin
+Skips the Azure CLI login step when specified.
+
+.EXAMPLE
+./New-StressTestRun.ps1 -Namespace stress-test-namespace
+
+Builds the stress module, signs in to Azure, and deploys using the default environment.
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Namespace,
+
+    [Parameter()]
+    [string]$Environment = "storage",
+
+    [Parameter()]
+    [switch]$SkipCompile,
+
+    [Parameter()]
+    [switch]$SkipLogin
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($Environment)) {
+     throw "Environment is required"
+}
+
+$scriptDir = $PSScriptRoot
+Set-Location $scriptDir
+
+if ($SkipCompile) {
+    Write-Host "Skipping compile step"
+} else {
+    mvn clean install --% -am -pl com.azure:azure-messaging-eventhubs-stress -Dcheckstyle.skip -Dgpg.skip -Dmaven.javadoc.skip -Drevapi.skip -Dspotbugs.skip -Djacoco.skip -Dmaven.test.skip -Dcodesnippet.skip -Dspotless.skip
+}
+
+if ($SkipLogin) {
+    Write-Host "Skipping login step"
+} else {
+    az login --scope https://management.core.windows.net//.default
+}
+
+try {
+    $resolvedDeployScript = Resolve-Path (Join-Path $PSScriptRoot "../../../eng/common/scripts/stress-testing/deploy-stress-tests.ps1")
+} catch {
+    throw "Unable to find deploy script relative to $PSScriptRoot"
+}
+
+$resolvedDeployScript = $resolvedDeployScript.Path
+& $resolvedDeployScript -Namespace $Namespace -Environment $Environment

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/README.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/README.md
@@ -21,8 +21,7 @@ To learn how to develop a stress test project, first review the [Azure SDK Stres
 ### Deploying stress tests
 
 1. In a terminal, navigate to the `azure-sdk-for-java` root folder
-2. Execute: `.\sdk\servicebus\azure-messaging-servicebus-stress\New-StressTestRun.ps1 -Namespace <stress test namespace>`
-
+2. Execute: `.\sdk\eventhubs\azure-messaging-eventhubs-stress\New-StressTestRun.ps1 -Namespace <stress test namespace>`
 > NOTE: The default environment for stress test deployments is "storage". This may change depending on EngSys resources.
 
 ### Monitoring and validating stress tests

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/README.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/README.md
@@ -4,9 +4,9 @@ Represents stress tests for Event Hubs client.
 
 ## Getting started
 
-The stress tests for event hubs client is developed from [azure-sdk-chaos][azure_sdk_chaos]. 
+The stress tests for the Event Hubs client are developed from [azure-sdk-chaos][azure_sdk_chaos].
 
-To know how to develop a stress test project, you should first go through the [Azure SDK Stress Test Wiki][azure_sdk_stress_test].
+To learn how to develop a stress test project, first review the [Azure SDK Stress Test Wiki][azure_sdk_stress_test].
 
 ### Prerequisites
 
@@ -18,77 +18,52 @@ To know how to develop a stress test project, you should first go through the [A
 - [Azure CLI][azure_cli]
 - [Powershell 7.0+][powershell]
 
-### Deploy Stress Test
+### Deploying stress tests
 
-Cd into `azure-sdk-for-java` root folder and run command to deploy the package to cluster
+1. In a terminal, navigate to the `azure-sdk-for-java` root folder
+2. Execute: `.\sdk\servicebus\azure-messaging-servicebus-stress\New-StressTestRun.ps1 -Namespace <stress test namespace>`
 
-```shell
-..\..\..\eng\common\scripts\stress-testing\deploy-stress-tests.ps1 -SearchDirectory .\sdk\eventhubs\
-``` 
+> NOTE: The default environment for stress test deployments is "storage". This may change depending on EngSys resources.
 
-### Validate Status
+### Monitoring and validating stress tests
 
-Only the most frequently used commands are listed below. See [Deploying A Stress Test][deploy_stress_test] for more details. 
+#### Azure portal
 
-List deployed packages:
+1. Navigate to: https://ms.portal.azure.com/#settings/directory
+2. Select the TME directory
+3. Choose the resource group
+4. Open the Azure Workbook named "Azure SDK Stress Testing - storage"
+5. Filter the "Namespace" by `<stress test namespace>` used to deploy the tests
 
-```shell
-helm list -n <stress test namespace>
-helm list --all-namespaces -l deployId=<your deployment id>
-```
+Validate the events in the dashboard and examine "Container Logs" at the bottom of the dashboard.
 
-Get stress test pods and status:
+#### Command-line
 
-```shell
-kubectl get pods -n <stress test namespace>
-```
+See [Deploying A Stress Test][deploy_stress_test] for more commands.
 
-Get stress test pod logs:
+| Command | Description | 
+|--|--|
+| `helm list -n <stress test namespace>` | List deployed packages |
+| `kubectl get pods -n <stress test namespace>` | Get stress test pods and status |
+| `kubectl logs -n <stress test namespace> <stress test pod name>` | Get stress test pod logs |
+| `kubectl logs -n <stress test namespace> <stress test pod name> -c <container name>`| Get logs for a specific container (ex. "sender" and "receiver") |
+| `helm uninstall <stress test name> -n <stress test namespace>` | Stop and remove deployed package |
 
-```shell
-kubectl logs -n <stress test namespace> <stress test pod name>
-# Note that we may define multiple containers (for example, sender and receiver)
-kubectl logs -n <stress test namespace> <stress test pod name> -c <container name>
-```
+### Additional Monitoring
 
-If stress test pod is in `Error` status, check logs from init container:
+After deployment, monitor telemetry and SDK metrics in the stress test resource group's Application Insights. SDK metrics are available through the
+[Azure OpenTelemetry Metrics plugin][azure_core_metrics_opentelemetry] dependency.
 
-```shell
-kubectl logs -n <stress test namespace> <stress test pod name> -c init-azure-deployer
-```
+Use the dashboards in the stress test resource group to monitor AKS pods and stress test status.
 
-If above command output is empty, there may have been startup failures:
-
-```shell
-kubectl describe pod -n <stress test namespace> <stress test pod name>
-```
-
-Stop and remove deployed package:
-
-```shell
-helm uninstall <stress test name> -n <stress test namespace>
-```
-### Monitoring
-
-After the stress test is deployed on the cluster, we can monitor the telemetry data on the application insights which is
-inside the stress test resource group.
-
-The SDK metrics can also be monitored on application insights as we have imported
-[Azure OpenTelemetry Metrics plugin][azure_core_metrics_opentelemetry] as project dependency.
-
-There are several dashboards within the stress test resource group that we can use to monitor the AKS pod and stress test status.
-
-If you want do the local test and enable application insights, you can follow the [steps][enable_application_insights] to set the java agent.
-Make sure you have added the JVM parameters when you start the test.
-
+For local runs, follow the [steps][enable_application_insights] to enable the Java agent for Application Insights, and start tests with the required JVM parameters.
 
 ### Logging
 
-We use [logback.xml][logback_xml] to configure the logging. By default, the stress test run on cluster will output
-`INFO` level log to the file share. The container console only save the `WARN` and `ERROR` level log.
+We use [logback.xml][logback_xml] to configure logging. By default, stress tests running on the cluster output
+`INFO` level logs to the file share. The container console only saves `WARN` and `ERROR` level logs.
 
 Follow the steps in [Stress Test File Share][stress_test_file_share] to find the file share logs.
-
 
 ### Configure Faults
 
@@ -113,34 +88,18 @@ Below is the current structure of project:
 └── README.md
 ```
 
-### Cluster Namespace 
-
-The cluster namespace is defined in `Chart.yaml`. The default value we set is `java-eh`.
-
-```yaml
-name: <stress test name>
-...
-annotations:
-  namespace: <stress test namespace>
-```
-
-For local deployment with script, if the namespace option is not specified, the value will be overridden by the shell username.
-
-```shell
-..\..\..\eng\common\scripts\stress-testing\deploy-stress-tests.ps1 -Namespace <stress test namespace>
-```
-
 ## Examples
 
-### Update EventSender
+### Configuring EventSender
 
 Change `SEND_TIMES` and `SEND_EVENTS` to the number of events you want to send.
 
-### Run EventProcessorWithOptions
+### Configuring EventProcessor for different receiver scenarios
 
-Modify receiver command in `job.yaml` to run stress test in different scenarios:
+Modify [`job.yaml`][job_yaml] to run stress test in different scenarios.
 
-Scenario 1: receiver does not checkpoint and not write to another new event hub.
+<details>
+<summary>Scenario: Receiving events without checkpointing</summary>
 
 ```yaml
     - name: receiver
@@ -153,10 +112,15 @@ Scenario 1: receiver does not checkpoint and not write to another new event hub.
               source $ENV_FILE &&
               java -javaagent:BOOT-INF/classes/applicationinsights-agent-3.4.1.jar \
               "org.springframework.boot.loader.JarLauncher" \
-              --TEST_CLASS=EventProcessorWithOptions --NEED_UPDATE_CHECKPOINT=false --NEED_SEND_EVENT_HUB=false
+              --TEST_CLASS=EventProcessor --ENABLE_CHECKPOINT=false
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 ```
-Scenario 2: receiver does checkpoint and not write to another new event hub.
+</details>
+
+<details>
+<summary>Scenario: Receiving and forwarding events to another Event Hub</summary>
+
+The EventProcessor receives events, checkpoints them, and then publishes them to another Event Hub, `eventHubBeta`.
 
 ```yaml
     - name: receiver
@@ -169,28 +133,12 @@ Scenario 2: receiver does checkpoint and not write to another new event hub.
           source $ENV_FILE &&
           java -javaagent:BOOT-INF/classes/applicationinsights-agent-3.4.1.jar \
           "org.springframework.boot.loader.JarLauncher" \
-          --TEST_CLASS=EventProcessorWithOptions --NEED_UPDATE_CHECKPOINT=true --NEED_SEND_EVENT_HUB=false
+          --TEST_CLASS=EventForwarder --FORWARD_EVENT_HUB_NAME=eventHubBeta
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 ```
-
-Scenario 3: receiver does checkpoint and write to another event hub.
-
-```yaml
-    - name: receiver
-      image: {{ .Values.image }}
-      imagePullPolicy: Always
-      command: ['sh', '-c']
-      args:
-        - |
-          set -a &&
-          source $ENV_FILE &&
-          java -javaagent:BOOT-INF/classes/applicationinsights-agent-3.4.1.jar \
-          "org.springframework.boot.loader.JarLauncher" \
-          --TEST_CLASS=EventProcessorWithOptions --NEED_UPDATE_CHECKPOINT=true --NEED_SEND_EVENT_HUB=true
-      {{- include "stress-test-addons.container-env" . | nindent 6 }}
-```
-
-Scenario 4: Four receiver does checkpoint and not write to another new event hub.
+</details>
+<details>
+<summary>Scenario: Receiving from multiple EventProcessors</summary>
 
 ```yaml
     - name: receiver1
@@ -203,7 +151,7 @@ Scenario 4: Four receiver does checkpoint and not write to another new event hub
           source $ENV_FILE &&
           java -javaagent:BOOT-INF/classes/applicationinsights-agent-3.4.1.jar \
           "org.springframework.boot.loader.JarLauncher" \
-          --TEST_CLASS=EventProcessorWithOptions --NEED_UPDATE_CHECKPOINT=true --NEED_SEND_EVENT_HUB=false
+          --TEST_CLASS=EventProcessor
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
     - name: receiver2
       image: {{ .Values.image }}
@@ -215,7 +163,7 @@ Scenario 4: Four receiver does checkpoint and not write to another new event hub
           source $ENV_FILE &&
           java -javaagent:BOOT-INF/classes/applicationinsights-agent-3.4.1.jar \
           "org.springframework.boot.loader.JarLauncher" \
-          --TEST_CLASS=EventProcessorWithOptions --NEED_UPDATE_CHECKPOINT=true --NEED_SEND_EVENT_HUB=false
+          --TEST_CLASS=EventProcessor
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
     - name: receiver3
       image: {{ .Values.image }}
@@ -227,7 +175,7 @@ Scenario 4: Four receiver does checkpoint and not write to another new event hub
           source $ENV_FILE &&
           java -javaagent:BOOT-INF/classes/applicationinsights-agent-3.4.1.jar \
           "org.springframework.boot.loader.JarLauncher" \
-          --TEST_CLASS=EventProcessorWithOptions --NEED_UPDATE_CHECKPOINT=true --NEED_SEND_EVENT_HUB=false
+          --TEST_CLASS=EventProcessor
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
     - name: receiver4
       image: {{ .Values.image }}
@@ -239,28 +187,23 @@ Scenario 4: Four receiver does checkpoint and not write to another new event hub
           source $ENV_FILE &&
           java -javaagent:BOOT-INF/classes/applicationinsights-agent-3.4.1.jar \
           "org.springframework.boot.loader.JarLauncher" \
-          --TEST_CLASS=EventProcessorWithOptions --NEED_UPDATE_CHECKPOINT=true --NEED_SEND_EVENT_HUB=false
+          --TEST_CLASS=EventProcessor
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 ```
+</details>
 
 ### Add New Test Scenario
 
-Add a new test class under `\scenarios`.
-
-Extend `EventHubsScenarios` and implement test logic in `run()` method.
-
-Configure new class as bean and use class name as its bean name.
-
-Update `args` field in `job.yaml` to execute the new test class.
-
-Build out jar package and redeploy to cluster.
+1. Add a new test class under the [`scenarios`][scenarios_folder] folder.
+1. Extend [`EventHubsScenario`][EventHubsScenario] and implement test logic in `run()` method.
+1. Configure new class as bean and use class name as its bean name.
+1. Update `args` field in [`templates/job.yaml`][job_yaml] to execute the new test class.
+1. Build out jar package and redeploy to cluster.
 
 ### Add New Scenario Option
 
-We use [Spring][spring_configuration] to inject environment variable or 
-command line arguments as the scenario options. 
-
-You can add new scenario option in [ScenarioOptions][ScenarioOptions] with below format: 
+We use [Spring][spring_configuration] to inject environment variables or
+command-line arguments as scenario options. You can add a new scenario option in [ScenarioOptions][ScenarioOptions] with the format below:
 
 ```java
 @Value("NEW_OPTION: default value")
@@ -271,7 +214,7 @@ public Type getNewOption() {
 }
 ```
 
-It is recommended to provide a default value for the new option, as it will not have any impact 
+It is recommended to provide a default value for the new option, as it will not have any impact
 on the existing job configuration.
 
 ## Troubleshooting
@@ -307,3 +250,6 @@ For details on contributing to this repository, see the [contributing guide](htt
 [stress_test_layout]: https://github.com/Azure/azure-sdk-tools/blob/main/tools/stress-cluster/chaos/README.md#layout
 [spring_configuration]: https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config
 [ScenarioOptions]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/util/ScenarioOptions.java
+[scenarios_folder]: https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/scenarios
+[EventHubsScenario]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/scenarios/EventHubsScenario.java
+[job_yaml]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/eventhubs/azure-messaging-eventhubs-stress/templates/job.yaml

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/scenarios-matrix.yaml
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/scenarios-matrix.yaml
@@ -1,6 +1,5 @@
 matrix:
   imageBuildDir: ..\..\..\
-  useV2: [ true, false ]
   scenarios:
     processor:
       senderTestClass: EventSender

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/scenarios-matrix.yaml
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/scenarios-matrix.yaml
@@ -1,5 +1,5 @@
 matrix:
-  imageBuildDir: ..\..\..\
+  imageBuildDir: .\
   scenarios:
     processor:
       senderTestClass: EventSender

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/scenarios/EventForwarder.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/scenarios/EventForwarder.java
@@ -4,6 +4,8 @@
 package com.azure.messaging.eventhubs.stress.scenarios;
 
 import com.azure.core.amqp.AmqpRetryOptions;
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.messaging.eventhubs.EventData;
 import com.azure.messaging.eventhubs.EventHubClientBuilder;
 import com.azure.messaging.eventhubs.EventHubProducerAsyncClient;
@@ -31,7 +33,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.azure.messaging.eventhubs.stress.util.TestUtils.blockingWait;
 import static com.azure.messaging.eventhubs.stress.util.TestUtils.createMessagePayload;
-import static com.azure.messaging.eventhubs.stress.util.TestUtils.getBuilder;
 import static com.azure.messaging.eventhubs.stress.util.TestUtils.getProcessorBuilder;
 
 /**
@@ -52,9 +53,6 @@ public class EventForwarder extends EventHubsScenario {
 
     @Value("${ENABLE_CHECKPOINT:true}")
     private boolean enableCheckpoint;
-
-    @Value("${FORWARD_EVENTHUBS_CONNECTION_STRING:#{null}}")
-    private String forwardConnectionString;
 
     @Value("${FORWARD_EVENT_HUB_NAME:#{null}}")
     private String forwardEventHubName;
@@ -105,10 +103,13 @@ public class EventForwarder extends EventHubsScenario {
     }
 
     private EventHubProducerAsyncClient getForwardProducer() {
-        // Gets the builder then overwrites the previously set values with new forwarder ones.
-        final EventHubClientBuilder builder = getBuilder(options).connectionString(forwardConnectionString)
-            .eventHubName(forwardEventHubName)
-            .retryOptions(new AmqpRetryOptions().setTryTimeout(Duration.ofSeconds(10)));
+        final TokenCredential tokenCredential = new DefaultAzureCredentialBuilder().build();
+        final EventHubClientBuilder builder = new EventHubClientBuilder()
+            .credential(options.getEventHubsFullyQualifiedNamespace(), forwardEventHubName,
+                tokenCredential)
+            .retryOptions(new AmqpRetryOptions().setTryTimeout(Duration.ofSeconds(10)))
+            .transportType(options.getAmqpTransportType())
+            .consumerGroup(options.getEventHubsConsumerGroup());
 
         return toClose(builder.buildAsyncProducerClient());
     }

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/util/ScenarioOptions.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/util/ScenarioOptions.java
@@ -47,9 +47,6 @@ public class ScenarioOptions {
     @Value("${IDLE_DURATION_MINUTES:0}")
     private int idleDurationInMinutes;
 
-    @Value("${USE_V2:false}")
-    private boolean useV2Stack;
-
     public String getTestClass() {
         return testClass;
     }
@@ -119,9 +116,5 @@ public class ScenarioOptions {
 
     public AmqpTransportType getAmqpTransportType() {
         return amqpTransportType;
-    }
-
-    public boolean useV2Stack() {
-        return useV2Stack;
     }
 }

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/util/TelemetryHelper.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/util/TelemetryHelper.java
@@ -89,13 +89,17 @@ public class TelemetryHelper {
      * Initializes telemetry helper: sets up Azure Monitor exporter, enables JVM metrics collection.
      */
     private static OpenTelemetry init() {
+        System.setProperty("otel.java.global-autoconfigure.enabled", "true");
+        
+        AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder = AutoConfiguredOpenTelemetrySdk.builder();
         String applicationInsightsConnectionString = System.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING");
         if (applicationInsightsConnectionString == null) {
-            return OpenTelemetry.noop();
+            System.setProperty("otel.traces.exporter", "none");
+            System.setProperty("otel.metrics.exporter", "none");
+            System.setProperty("otel.logs.exporter", "none");
+        } else {
+            AzureMonitorAutoConfigure.customize(sdkBuilder, applicationInsightsConnectionString);
         }
-        AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder = AutoConfiguredOpenTelemetrySdk.builder();
-
-        AzureMonitorAutoConfigure.customize(sdkBuilder, applicationInsightsConnectionString);
 
         String instanceId = System.getenv("CONTAINER_NAME");
         OpenTelemetry otel = sdkBuilder
@@ -124,7 +128,7 @@ public class TelemetryHelper {
         Cpu.registerObservers(otel);
         MemoryPools.registerObservers(otel);
         Threads.registerObservers(otel);
-        GarbageCollector.registerObservers(otel, false); // false disables the capture of the GC cause
+        GarbageCollector.registerObservers(otel, true);
         OpenTelemetryAppender.install(otel);
 
         return otel;

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/util/TelemetryHelper.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/util/TelemetryHelper.java
@@ -237,7 +237,6 @@ public class TelemetryHelper {
         span.setAttribute(AttributeKey.stringKey("eventHubName"), options.getEventHubsEventHubName());
         span.setAttribute(AttributeKey.stringKey("consumerGroupName"), options.getEventHubsConsumerGroup());
         span.setAttribute(AttributeKey.longKey("messageSize"), options.getMessageSize());
-        span.setAttribute(AttributeKey.booleanKey("useV2"), options.useV2Stack());
         span.setAttribute(AttributeKey.stringKey("hostname"), System.getenv().get("HOSTNAME"));
         span.setAttribute(AttributeKey.stringKey("jreVersion"), System.getProperty("java.version"));
         span.setAttribute(AttributeKey.stringKey("jreVendor"), System.getProperty("java.vendor"));

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/util/TestUtils.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/src/main/java/com/azure/messaging/eventhubs/stress/util/TestUtils.java
@@ -41,12 +41,6 @@ public final class TestUtils {
             .consumerGroup(options.getEventHubsConsumerGroup())
             .checkpointStore(new BlobCheckpointStore(getContainerClient(options)));
 
-        if (options.useV2Stack()) {
-            Configuration configuration
-                = new ConfigurationBuilder().putProperty("com.azure.messaging.eventhubs.v2", "true").build();
-
-            builder.configuration(configuration);
-        }
         return builder;
     }
 
@@ -67,13 +61,6 @@ public final class TestUtils {
             .eventHubName(options.getEventHubsEventHubName())
             .transportType(options.getAmqpTransportType())
             .consumerGroup(options.getEventHubsConsumerGroup());
-
-        if (options.useV2Stack()) {
-            Configuration configuration
-                = new ConfigurationBuilder().putProperty("com.azure.messaging.eventhubs.v2", "true").build();
-
-            builder.configuration(configuration);
-        }
 
         return builder;
     }

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/templates/job.yaml
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/templates/job.yaml
@@ -24,7 +24,6 @@ spec:
           export IDLE_DURATION_MINUTES={{ default 0 .Stress.idleDurationMinutes }}
           export CONTAINER_NAME=sender
           export DELAY_START_MINUTES=1
-          export USE_V2={{ default false .Stress.useV2 }}
           java \
           -Dotel.service.name={{ .Release.Name }}-{{ .Stress.BaseName }} \
           -Dotel.traces.sampler=traceidratio \
@@ -60,7 +59,6 @@ spec:
           export FORWARD_PARTITIONS_COUNT={{ default 32 .Stress.forwardPartitionsCount }}
           export IDLE_DURATION_MINUTES={{ default 0 .Stress.idleDurationMinutes }}
           export CONTAINER_NAME=receiver
-          export USE_V2={{ default false .Stress.useV2 }}
           java \
           -Dotel.service.name={{ .Release.Name }}-{{ .Stress.BaseName }} \
           -Dotel.traces.sampler=traceidratio \

--- a/sdk/eventhubs/azure-messaging-eventhubs-stress/templates/job.yaml
+++ b/sdk/eventhubs/azure-messaging-eventhubs-stress/templates/job.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     testName: "{{ .Release.Name }}"
 spec:
-  nodeSelector:
-    sku: chaosperf
   containers:
     - name: sender
       image: {{ .Stress.imageTag }}

--- a/sdk/servicebus/azure-messaging-servicebus-stress/Chart.yaml
+++ b/sdk/servicebus/azure-messaging-servicebus-stress/Chart.yaml
@@ -9,5 +9,5 @@ annotations:
 
 dependencies:
   - name: stress-test-addons
-    version: 0.2.0
-    repository: https://stresstestcharts.blob.core.windows.net/helm/
+    version: ~0.3.0
+    repository: "@stress-test-charts"

--- a/sdk/servicebus/azure-messaging-servicebus-stress/Dockerfile
+++ b/sdk/servicebus/azure-messaging-servicebus-stress/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/openjdk/jdk:21-mariner
 
 WORKDIR /app
 
-# Copy the jar files built by New-StressRun.ps1 to the container.
+# Copy the jar files built by New-StressTestRun.ps1 to the container.
 COPY ./target .
 
 RUN ls /app/azure-messaging-servicebus-stress* >/dev/null 2>&1 || (echo "ERROR: no file starting with azure-messaging-servicebus-stress was copied to /app." && exit 1)

--- a/sdk/servicebus/azure-messaging-servicebus-stress/Dockerfile
+++ b/sdk/servicebus/azure-messaging-servicebus-stress/Dockerfile
@@ -1,37 +1,44 @@
 ARG REGISTRY="azsdkengsys.azurecr.io"
-FROM ${REGISTRY}/java/jdk-mariner-mvn:jdk11-latest as builder
+FROM ${REGISTRY}/java/jdk-mariner-mvn:jdk11-latest AS builder
 
 RUN yum update -y
-RUN mkdir /stress-sb
-WORKDIR /stress-sb
 
-ADD ./.vscode /stress-sb/.vscode
-ADD ./sdk/tools /stress-sb/sdk/tools
-ADD ./sdk/parents /stress-sb/sdk/parents
-ADD ./sdk/core /stress-sb/sdk/core
-ADD ./sdk/serialization /stress-sb/sdk/serialization
-ADD ./sdk/servicebus /stress-sb/sdk/servicebus
-ADD ./eng /stress-sb/eng
+RUN mkdir /stress
+WORKDIR /stress
+
+ADD ./.vscode /stress/.vscode
+ADD ./sdk/tools /stress/sdk/tools
+ADD ./sdk/parents /stress/sdk/parents
+ADD ./sdk/appconfiguration-v2 /stress/sdk/appconfiguration-v2
+ADD ./sdk/core /stress/sdk/core
+ADD ./sdk/core-v2 /stress/sdk/core-v2
+ADD ./sdk/identity-v2 /stress/sdk/identity-v2
+ADD ./sdk/serialization /stress/sdk/serialization
+ADD ./sdk/servicebus /stress/sdk/servicebus
+ADD ./eng /stress/eng
 
 ARG SKIP_CHECKS="-Dcheckstyle.skip -Dgpg.skip -Dmaven.javadoc.skip -Drevapi.skip -Dspotbugs.skip -Djacoco.skip -DskipTests -Dcodesnippet.skip -Dspotless.skip -Denforcer.skip"
 
 RUN --mount=type=cache,target=/root/.m2 \
- mvn -f /stress-sb/sdk/tools/pom.xml clean install  ${SKIP_CHECKS} && \
- mvn -f /stress-sb/sdk/core/azure-core/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-sb/sdk/serialization/azure-xml/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-sb/sdk/core/azure-core-test/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-sb/sdk/core/azure-core-amqp/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-sb/sdk/core/azure-core-http-netty/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-sb/sdk/core/azure-core-metrics-opentelemetry/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-sb/sdk/servicebus/azure-messaging-servicebus/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress-sb/sdk/servicebus/azure-messaging-servicebus-stress/pom.xml clean install ${SKIP_CHECKS}
+ mvn -f /stress/sdk/core-v2/azure-core/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core-v2/azure-core-test/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/identity-v2/azure-identity/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/appconfiguration-v2/azure-data-appconfiguration/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/tools/pom.xml clean install  ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/tools/azure-openrewrite/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/serialization/azure-xml/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core-test/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core-amqp/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core-http-netty/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/core/azure-core-metrics-opentelemetry/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/servicebus/azure-messaging-servicebus/pom.xml clean install ${SKIP_CHECKS} && \
+ mvn -f /stress/sdk/servicebus/azure-messaging-servicebus-stress/pom.xml clean install ${SKIP_CHECKS}
 
 FROM mcr.microsoft.com/openjdk/jdk:21-mariner
 
-RUN yum update -y
-
 WORKDIR /app
-COPY --from=builder /stress-sb/sdk/servicebus/azure-messaging-servicebus-stress/target .
+COPY --from=builder /stress/sdk/servicebus/azure-messaging-servicebus-stress/target .
 
 # This is never executed (since job yaml overrides it)
 ENTRYPOINT ["bash"]

--- a/sdk/servicebus/azure-messaging-servicebus-stress/Dockerfile
+++ b/sdk/servicebus/azure-messaging-servicebus-stress/Dockerfile
@@ -1,44 +1,11 @@
-ARG REGISTRY="azsdkengsys.azurecr.io"
-FROM ${REGISTRY}/java/jdk-mariner-mvn:jdk11-latest AS builder
-
-RUN yum update -y
-
-RUN mkdir /stress
-WORKDIR /stress
-
-ADD ./.vscode /stress/.vscode
-ADD ./sdk/tools /stress/sdk/tools
-ADD ./sdk/parents /stress/sdk/parents
-ADD ./sdk/appconfiguration-v2 /stress/sdk/appconfiguration-v2
-ADD ./sdk/core /stress/sdk/core
-ADD ./sdk/core-v2 /stress/sdk/core-v2
-ADD ./sdk/identity-v2 /stress/sdk/identity-v2
-ADD ./sdk/serialization /stress/sdk/serialization
-ADD ./sdk/servicebus /stress/sdk/servicebus
-ADD ./eng /stress/eng
-
-ARG SKIP_CHECKS="-Dcheckstyle.skip -Dgpg.skip -Dmaven.javadoc.skip -Drevapi.skip -Dspotbugs.skip -Djacoco.skip -DskipTests -Dcodesnippet.skip -Dspotless.skip -Denforcer.skip"
-
-RUN --mount=type=cache,target=/root/.m2 \
- mvn -f /stress/sdk/core-v2/azure-core/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core-v2/azure-core-test/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/identity-v2/azure-identity/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/appconfiguration-v2/azure-data-appconfiguration/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/tools/pom.xml clean install  ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/tools/azure-openrewrite/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/serialization/azure-xml/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core-test/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core-amqp/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core-http-netty/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/core/azure-core-metrics-opentelemetry/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/servicebus/azure-messaging-servicebus/pom.xml clean install ${SKIP_CHECKS} && \
- mvn -f /stress/sdk/servicebus/azure-messaging-servicebus-stress/pom.xml clean install ${SKIP_CHECKS}
-
 FROM mcr.microsoft.com/openjdk/jdk:21-mariner
 
 WORKDIR /app
-COPY --from=builder /stress/sdk/servicebus/azure-messaging-servicebus-stress/target .
+
+# Copy the jar files built by New-StressRun.ps1 to the container.
+COPY ./target .
+
+RUN ls /app/azure-messaging-servicebus-stress* >/dev/null 2>&1 || (echo "ERROR: no file starting with azure-messaging-servicebus-stress was copied to /app." && exit 1)
 
 # This is never executed (since job yaml overrides it)
 ENTRYPOINT ["bash"]

--- a/sdk/servicebus/azure-messaging-servicebus-stress/New-StressTestRun.ps1
+++ b/sdk/servicebus/azure-messaging-servicebus-stress/New-StressTestRun.ps1
@@ -1,0 +1,65 @@
+<#
+.DESCRIPTION
+This script compiles the stress test module, optionally performs Azure login, and deploys 
+the Service Bus stress tests with the provided namespace and environment.
+
+.PARAMETER Namespace
+The namespace in AKS for the stress run.
+
+.PARAMETER Environment
+The stress deployment environment name. Defaults to "storage".
+
+.PARAMETER SkipCompile
+Skips the Maven compile/install step when specified.
+
+.PARAMETER SkipLogin
+Skips the Azure CLI login step when specified.
+
+.EXAMPLE
+./New-StressTestRun.ps1 -Namespace stress-test-namespace
+
+Builds the stress module, signs in to Azure, and deploys using the default environment.
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Namespace,
+
+    [Parameter()]
+    [string]$Environment = "storage",
+
+    [Parameter()]
+    [switch]$SkipCompile,
+
+    [Parameter()]
+    [switch]$SkipLogin
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($Environment)) {
+     throw "Environment is required"
+}
+
+$scriptDir = $PSScriptRoot
+Set-Location $scriptDir
+
+if ($SkipCompile) {
+    Write-Host "Skipping compile step"
+} else {
+    mvn clean install --% -am -pl com.azure:azure-messaging-servicebus-stress -Dcheckstyle.skip -Dgpg.skip -Dmaven.javadoc.skip -Drevapi.skip -Dspotbugs.skip -Djacoco.skip -Dmaven.test.skip -Dcodesnippet.skip -Dspotless.skip
+}
+
+if ($SkipLogin) {
+    Write-Host "Skipping login step"
+} else {
+    az login --scope https://management.core.windows.net//.default
+}
+
+try {
+    $resolvedDeployScript = Resolve-Path (Join-Path $PSScriptRoot "../../../eng/common/scripts/stress-testing/deploy-stress-tests.ps1")
+} catch {
+    throw "Unable to find deploy script relative to $PSScriptRoot"
+}
+
+$resolvedDeployScript = $resolvedDeployScript.Path
+& $resolvedDeployScript -Namespace $Namespace -Environment $Environment

--- a/sdk/servicebus/azure-messaging-servicebus-stress/README.md
+++ b/sdk/servicebus/azure-messaging-servicebus-stress/README.md
@@ -1,12 +1,12 @@
 # Azure Service Bus Stress test client library for Java
 
-Represents stress tests for Service Bus client.
+Contains stress tests for the Service Bus client.
 
 ## Getting started
 
-The stress tests for service bus client is developed from [azure-sdk-chaos][azure_sdk_chaos].
+The stress tests for the Service Bus client are developed from [azure-sdk-chaos][azure_sdk_chaos].
 
-To know how to develop a stress test project, you should first go through the [Azure SDK Stress Test Wiki][azure_sdk_stress_test].
+To learn how to develop a stress test project, first review the [Azure SDK Stress Test Wiki][azure_sdk_stress_test].
 
 ### Prerequisites
 
@@ -18,74 +18,50 @@ To know how to develop a stress test project, you should first go through the [A
 - [Azure CLI][azure_cli]
 - [Powershell 7.0+][powershell]
 
-### Deploy Stress Test
+### Deploying stress tests
 
-Cd into `azure-sdk-for-java` root folder and run command to deploy the package to cluster:
+1. In a terminal, navigate to the `azure-sdk-for-java` root folder
+2. Execute: `.\sdk\servicebus\azure-messaging-servicebus-stress\New-StressTestRun.ps1 -Namespace <stress test namespace>`
 
-```shell
-.\eng\common\scripts\stress-testing\deploy-stress-tests.ps1 -SearchDirectory .\sdk\servicebus\
-``` 
+> NOTE: The default environment for stress test deployments is "storage". This may change depending on EngSys resources.
 
-### Validate Status
+### Monitoring and validating stress tests
 
-Only the most frequently used commands are listed below. See [Deploying A Stress Test][deploy_stress_test] for more details.
+#### Azure portal
 
-List deployed packages:
+1. Navigate to: https://ms.portal.azure.com/#settings/directory
+2. Select the TME directory
+3. Choose the resource group
+4. Open the Azure Workbook named "Azure SDK Stress Testing - storage"
+5. Filter the "Namespace" by `<stress test namespace>` used to deploy the tests
 
-```shell
-helm list -n <stress test namespace>
-```
+Validate the events in the dashboard and examine "Container Logs" at the bottom of the dashboard.
 
-Get stress test pods and status:
+#### Command-line
 
-```shell
-kubectl get pods -n <stress test namespace>
-```
+See [Deploying A Stress Test][deploy_stress_test] for more commands.
 
-Get stress test pod logs:
+| Command | Description | 
+|--|--|
+| `helm list -n <stress test namespace>` | List deployed packages |
+| `kubectl get pods -n <stress test namespace>` | Get stress test pods and status |
+| `kubectl logs -n <stress test namespace> <stress test pod name>` | Get stress test pod logs |
+| `kubectl logs -n <stress test namespace> <stress test pod name> -c <container name>`| Get logs for a specific container (ex. "sender" and "receiver") |
+| `helm uninstall <stress test name> -n <stress test namespace>` | Stop and remove deployed package |
 
-```shell
-kubectl logs -n <stress test namespace> <stress test pod name>
-# Note that we may define multiple containers (for example, sender and receiver)
-kubectl logs -n <stress test namespace> <stress test pod name> -c <container name>
-```
+### Additional Monitoring
 
-If stress test pod is in `Error` status, check logs from init container:
+After deployment, monitor telemetry and SDK metrics in the stress test resource group's Application Insights. SDK metrics are available through the
+[Azure OpenTelemetry Metrics plugin][azure_core_metrics_opentelemetry] dependency.
 
-```shell
-kubectl logs -n <stress test namespace> <stress test pod name> -c init-azure-deployer
-```
+Use the dashboards in the stress test resource group to monitor AKS pods and stress test status.
 
-If above command output is empty, there may have been startup failures:
-
-```shell
-kubectl describe pod -n <stress test namespace> <stress test pod name>
-```
-
-Stop and remove deployed package:
-
-```shell
-helm uninstall <stress test name> -n <stress test namespace>
-```
-
-### Monitoring
-
-After the stress test is deployed on the cluster, we can monitor the telemetry data on the application insights which is 
-inside the stress test resource group.
-
-The SDK metrics can also be monitored on application insights as we have imported 
-[Azure OpenTelemetry Metrics plugin][azure_core_metrics_opentelemetry] as project dependency.
-
-There are several dashboards within the stress test resource group that we can use to monitor the AKS pod and stress test status.
-
-If you want do the local test and enable application insights, you can follow the [steps][enable_application_insights] to set the java agent.
-Make sure you have added the JVM parameters when you start the test.
-
+For local runs, follow the [steps][enable_application_insights] to enable the Java agent for Application Insights, and start tests with the required JVM parameters.
 
 ### Logging
 
-We use [logback.xml][logback_xml] to configure the logging. By default, the stress test run on cluster will output 
-`INFO` level log to the file share. The container console only save the `WARN` and `ERROR` level log.
+We use [logback.xml][logback_xml] to configure logging. By default, stress tests running on the cluster output
+`INFO` level logs to the file share. The container console only saves `WARN` and `ERROR` level logs.
 
 Follow the steps in [Stress Test File Share][stress_test_file_share] to find the file share logs.
 
@@ -97,9 +73,9 @@ See [Config Faults][config_faults] section for details.
 
 ### Project Structure
 
-See [Layout][stress_test_layout] section for details. 
+See the [Layout][stress_test_layout] section for details.
 
-Below is the current structure of project:
+Below is the current project structure:
 ```
 .
 ├── src/                           # Test code
@@ -107,53 +83,25 @@ Below is the current structure of project:
 ├── Chart.yaml                     # A YAML file containing information about the helm chart and its dependencies
 ├── scenarios-matrix.yaml          # A YAML file containing configuration and custom values for stress test(s)
 ├── Dockerfile                     # A Dockerfile for building the stress test image
-├── stress-test-resources.bicep    # An Azure Bicep for deploying stress test azure resources
+├── stress-test-resources.bicep    # An Azure Bicep file for deploying stress test Azure resources
 ├── pom.xml
 └── README.md
 ```
 
-### Cluster Namespace 
-The cluster namespace is defined in `Chart.yaml`. The default value we set is `java-sb`.
-
-```yaml
-name: <stress test name>
-...
-annotations:
-  namespace: <stress test namespace>
-```
-
-For local deployment with script, if the namespace option is not specified, the value will be overridden by the shell username.
-
-```shell
-..\..\..\eng\common\scripts\stress-testing\deploy-stress-tests.ps1 -Namespace <stress test namespace>
-```
-
 ## Examples
-
-### Test Queue/Topic
-
-You can switch to test Queue or Topic by providing the program argument `--SERVICEBUS_ENTITY_TYPE=QUEUE/TOPIC`. 
-
-If you haven't provided, the default value we are using is `QUEUE`.
 
 ### Add New Test Scenario
 
-Add a new test class under `\scenarios`.
-
-Extend `ServiceBusScenario` and implement test logic in `run()` method.
-
-Configure new class as bean and use class name as its bean name.
-
-Update `args` field in `job.yaml` to execute the new test class.
-
-Build out jar package and redeploy to cluster.
+1. Add a new test class under the [`scenarios`][scenarios_folder] folder.
+1. Extend [`ServiceBusScenario`][ServiceBusScenario] and implement test logic in `run()` method.
+1. Configure new class as bean and use class name as its bean name.
+1. Update `args` field in [`templates/job.yaml`][job_yaml] to execute the new test class.
+1. Build out jar package and redeploy to cluster.
 
 ### Add New Scenario Option
 
-We use [Spring][spring_configuration] to inject environment variable or
-command line arguments as the scenario options.
-
-You can add new scenario option in [ScenarioOptions][ScenarioOptions] with below format:
+We use [Spring][spring_configuration] to inject environment variables or
+command-line arguments as scenario options. You can add a new scenario option in [ScenarioOptions][ScenarioOptions] with the format below:
 
 ```java
 @Value("NEW_OPTION: default value")
@@ -168,6 +116,20 @@ It is recommended to provide a default value for the new option, as it will not 
 on the existing job configuration.
 
 ## Troubleshooting
+
+### ERROR: AADSTS500571: The guest user account is disabled.
+
+Verify that your account has access to the TME subscription.
+
+### Stress test pod has `Error` status
+
+There could have been an error while deploying the pod, such as logging into Azure or setting environment variables. Investigate the `init-azure-deployer` logs via Azure Workbook or the command line. On the command line:
+1. Execute `kubectl logs -n <stress test namespace> <stress test pod name> -c init-azure-deployer` to explore logs.
+2. If the logs are empty, there could have been startup failures. Execute `kubectl describe pod -n <stress test namespace> <stress test pod name>` to view additional pod details.
+
+### 0/x nodes are available: x node(s) didn't match Pod's node affinity/selector.
+
+The nodes probably do not have enough resources for the containers. A node pool of `Standard_D8ads_v6` had to be created to run the stress tests.
 
 ## Next steps
 
@@ -200,3 +162,6 @@ For details on contributing to this repository, see the [contributing guide](htt
 [stress_test_layout]: https://github.com/Azure/azure-sdk-tools/blob/main/tools/stress-cluster/chaos/README.md#layout
 [spring_configuration]: https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config
 [ScenarioOptions]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/servicebus/azure-messaging-servicebus-stress/src/main/java/com/azure/messaging/servicebus/stress/util/ScenarioOptions.java
+[scenarios_folder]: https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/servicebus/azure-messaging-servicebus-stress/src/main/java/com/azure/messaging/servicebus/stress/scenarios
+[ServiceBusScenario]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/servicebus/azure-messaging-servicebus-stress/src/main/java/com/azure/messaging/servicebus/stress/scenarios/ServiceBusScenario.java
+[job_yaml]: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/servicebus/azure-messaging-servicebus-stress/templates/job.yaml

--- a/sdk/servicebus/azure-messaging-servicebus-stress/scenarios-matrix.yaml
+++ b/sdk/servicebus/azure-messaging-servicebus-stress/scenarios-matrix.yaml
@@ -1,7 +1,7 @@
 matrix:
   scenarios:
     composite:
-      imageBuildDir: ..\..\..\
+      imageBuildDir: .\
       testDurationMin: 15
       senderTestClass: MessageSenderAsync
       senderConcurrency: 5
@@ -16,7 +16,7 @@ matrix:
       lockDurationInSec: 5
       messageSizeInBytes: 16
     happy-case:
-      imageBuildDir: ..\..\..\
+      imageBuildDir: .\
       testDurationMin: 15
       senderTestClass: MessageSenderAsync
       sendRate: 8000

--- a/sdk/servicebus/azure-messaging-servicebus-stress/src/main/java/com/azure/messaging/servicebus/stress/util/TelemetryHelper.java
+++ b/sdk/servicebus/azure-messaging-servicebus-stress/src/main/java/com/azure/messaging/servicebus/stress/util/TelemetryHelper.java
@@ -69,12 +69,15 @@ public class TelemetryHelper {
      * Initializes telemetry helper: sets up Azure Monitor exporter, enables JVM metrics collection.
      */
     private static OpenTelemetry init() {
+        System.setProperty("otel.java.global-autoconfigure.enabled", "true");
+
+        AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder = AutoConfiguredOpenTelemetrySdk.builder();
         String applicationInsightsConnectionString = System.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING");
         if (applicationInsightsConnectionString == null) {
-            return OpenTelemetry.noop();
-        }
-        AutoConfiguredOpenTelemetrySdkBuilder sdkBuilder = AutoConfiguredOpenTelemetrySdk.builder();
-        if (applicationInsightsConnectionString != null) {
+            System.setProperty("otel.traces.exporter", "none");
+            System.setProperty("otel.metrics.exporter", "none");
+            System.setProperty("otel.logs.exporter", "none");
+        } else {
             AzureMonitorAutoConfigure.customize(sdkBuilder, applicationInsightsConnectionString);
         }
 
@@ -105,7 +108,7 @@ public class TelemetryHelper {
         Cpu.registerObservers(otel);
         MemoryPools.registerObservers(otel);
         Threads.registerObservers(otel);
-        GarbageCollector.registerObservers(otel, false); // false disables the capture of the GC cause
+        GarbageCollector.registerObservers(otel, true);
         OpenTelemetryAppender.install(otel);
 
         return otel;


### PR DESCRIPTION
# Description

This updates the Event Hubs and Service Bus stress tests. 
- Removed the useV2Stack option
- Fixed the files required by EngSys' stress framework.
- Updated README
- Streamlined Docker container creation by having the assets built outside of the Dockerfile

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
