### PR TITLE
eng, remove code generation for swagger/autorest

### DIFF
--- a/eng/scripts/Compare-CurrentToCodegeneration.ps1
+++ b/eng/scripts/Compare-CurrentToCodegeneration.ps1
@@ -1,23 +1,23 @@
 <#
 .SYNOPSIS
-Runs code generation for either Swagger or TypeSpec, based on configuration, and compares the generated code against
+Runs code generation for TypeSpec, based on configuration, and compares the generated code against
 the state of the current codebase.
 
 .DESCRIPTION
-Runs code generation for either Swagger or TypeSpec, based on configuration, and compares the generated code against
+Runs code generation for TypeSpec, based on configuration, and compares the generated code against
 the state of the current codebase.
 
 If the regenerated code is different than the current codebase this will report the differences and exit with a failure
 status.
 
 .PARAMETER ServiceDirectories
-The service directories that will be searched for either 'Update-Codegeneration.ps1' or 'tsp-location.yaml' files to
+The service directories that will be searched for 'tsp-location.yaml' files to
 run code regeneration. If this parameter is not specified, the script will not check any directories and will exit
 with a success status.
 
 .PARAMETER RegenerationType
-The type of regeneration to perform. This can be 'All', 'Swagger', or 'TypeSpec'. If not specified, the script will use
-'All' as the default, which means it will run both Swagger and TypeSpec code generation.
+The type of regeneration to perform. This can be 'All', or 'TypeSpec'. If not specified, the script will use
+'All' as the default, which means it will run TypeSpec code generation.
 
 .PARAMETER Parallelization
 The number of parallel jobs to run. The default is the number of processors on the machine. If unspecified or
@@ -29,7 +29,7 @@ param(
   [string]$ServiceDirectories,
 
   [Parameter(Mandatory = $false)]
-  [ValidateSet('All', 'Swagger', 'TypeSpec')]
+  [ValidateSet('All', 'TypeSpec')]
   [string]$RegenerationType = 'All',
 
   [Parameter(Mandatory = $false)]
@@ -44,12 +44,12 @@ class GenerationInformation {
   [string]$LibraryFolder
 
   # The path to the script that will perform the code generation.
-  # This can be 'Update-Codegeneration.ps1' for Swagger or 'tsp-location.yaml' for TypeSpec.
+  # This can be 'tsp-location.yaml' for TypeSpec.
   [string]$ScriptPath
 
-  # The type of code generation this script performs, either 'Swagger' or 'TypeSpec'.
+  # The type of code generation this script performs, 'TypeSpec'.
   # This is used to determine actions to take based on the type of code generation.
-  [ValidateSet('Swagger', 'TypeSpec')]
+  [ValidateSet('TypeSpec')]
   [string]$Type
 
   GenerationInformation([string]$libraryFolder, [string]$scriptPath, [string]$type) {
@@ -66,12 +66,6 @@ function Find-GenerationInformation {
   )
 
   $path = Join-Path -Path $sdkFolder $LibraryFolder
-  if ($RegenerationType -eq 'Swagger' -or $RegenerationType -eq 'All') {
-    # Search for 'Update-Codegeneration.ps1' script in the specified service directory.
-    Get-ChildItem -Path $path -Filter "Update-Codegeneration.ps1" -Recurse | ForEach-Object {
-      $GenerationInformations.Add([GenerationInformation]::new($path, $_, 'Swagger')) | Out-Null
-    }
-  }
 
   if ($RegenerationType -eq 'TypeSpec' -or $RegenerationType -eq 'All') {
     if ($LibraryFolder.Contains("-v2")) {
@@ -139,18 +133,9 @@ foreach ($serviceDirectory in $orderedServiceDirectories) {
 }
 
 if ($generationInformations.Count -eq 0) {
-  $kind = $RegenerationType -eq 'All' ? 'Swagger or TypeSpec' : $RegenerationType
+  $kind = $RegenerationType -eq 'All' ? 'TypeSpec' : $RegenerationType
   Write-Host "No $kind generation files to regenerate in directories: $ServiceDirectories."
   exit 0
-}
-
-if ($RegenerationType -eq 'Swagger' -or $RegenerationType -eq 'All') {
-  # Ensure Autorest is installed.
-  $output = (& npm install -g autorest 2>&1)
-  if ($LASTEXITCODE -ne 0) {
-    Write-Error "Failed to install Autorest for Swagger regeneration.`n$output"
-    exit 1
-  }
 }
 
 if ($RegenerationType -eq 'TypeSpec' -or $RegenerationType -eq 'All') {
@@ -164,29 +149,8 @@ if ($RegenerationType -eq 'TypeSpec' -or $RegenerationType -eq 'All') {
 $generateScript = {
   $separatorBar = "======================================"
   $directory = $_.LibraryFolder
-  $updateCodegenScript = $_.ScriptPath
-
-  if ($_.Type -eq 'Swagger') {
-    # 6>&1 redirects Write-Host calls in the script to the output stream, so we can capture it.
-    # 2>&1 redirects stderr to stdout to suppress autorest deprecation messages that would fail the pipeline.
-    $generateOutput = (& $updateCodegenScript 2>&1 6>&1)
-
-    if ($LastExitCode -ne 0) {
-      Write-Host "$separatorBar`nError running Swagger regeneration $updateCodegenScript`n$([String]::Join("`n", $generateOutput))`n$separatorBar"
-      throw
-    } else {
-      # prevent warning related to EOL differences which triggers an exception for some reason
-      (& git -c core.safecrlf=false diff --ignore-space-at-eol --exit-code -- "$directory/*.java") | Out-Null
-
-      if ($LastExitCode -ne 0) {
-        $status = (git status -s "$directory" | Out-String)
-        Write-Host "$separatorBar`nThe following Swagger generated files in directoy $directory are out of date`n$status`n$separatorBar"
-        throw
-      } else {
-        Write-Host "$separatorBar`nSuccessfully ran Swagger regneration with no diff $updateCodegenScript`n$separatorBar"
-      }
-    }
-  } elseif ($_.Type -eq 'TypeSpec') {
+  
+  if ($_.Type -eq 'TypeSpec') {
     Push-Location $directory
     try {
       try {


### PR DESCRIPTION
Remove Swagger/AutoRest from Compare-CurrentToCodegeneration.ps1‎

I didn't remove the `All` option. Only remove the `Swagger`. So right now `All` == `TypeSpec`.

tested with storage build (should contain both Swagger and TypeSpec) and standby (only TypeSpec).

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
