### PR TITLE
Added auth and CFS step to partner release pipeline

### DIFF
--- a/eng/pipelines/partner-release.yml
+++ b/eng/pipelines/partner-release.yml
@@ -71,6 +71,11 @@ extends:
             displayName: 'Download Signed Artifacts'
             artifact: packages-signed
 
+          # Setup Maven mirror settings and authenticate with Azure Artifacts
+          - template: /eng/pipelines/templates/steps/maven-authenticate.yml
+            parameters:
+              SourceDirectory: $(Pipeline.Workspace)/azure-sdk-for-java
+
           # gpg-sign and create the flattened directory for ESRP bulk publish
           # Note: The maven release requires the files to be local GPG signed
           # Dev feed publishes use the gpg-sign-and-deply to do it in one step


### PR DESCRIPTION

Added a new step to the `partner-release.yml` pipeline to set up Maven mirror settings and authenticate with Azure Artifacts using the `maven-authenticate.yml` template. This occurs before GPG signing and artifact publishing steps, ensuring Maven has the necessary credentials and configuration for subsequent operations.