### PR TITLE
Remove pip install termcolor from spring pipelines for network isolation

### DIFF
--- a/sdk/spring/compatibility-tests.yml
+++ b/sdk/spring/compatibility-tests.yml
@@ -22,9 +22,6 @@ stages:
               GenerateVMJobs: true
           PreGenerationSteps:
             - script: |
-                python -m pip install termcolor
-              displayName: 'Install python module'
-            - script: |
                 python ./sdk/spring/scripts/compatibility_update_supported_version_matrix_json.py --target-version-prefix 4. --use-the-latest-version yes
               displayName: 'Update supported Spring versions'
   - stage: "NonLatestVersionsCompatibility"
@@ -44,9 +41,6 @@ stages:
                 - SPRING_CLOUD_AZURE_TEST_SUPPORTED_SPRING_BOOT_VERSION
               GenerateVMJobs: true
           PreGenerationSteps:
-            - script: |
-                python -m pip install termcolor
-              displayName: 'Install python module'
             - script: |
                 python ./sdk/spring/scripts/compatibility_update_supported_version_matrix_json.py --target-version-prefix 4. --use-the-latest-version no
               displayName: 'Update supported Spring versions'

--- a/sdk/spring/pipeline/compatibility-tests-job.yml
+++ b/sdk/spring/pipeline/compatibility-tests-job.yml
@@ -78,10 +78,6 @@ jobs:
           jdkVersionOption: $(JavaTestVersion)
           jdkArchitectureOption: 'x64'
           publishJUnitResults: false
-      - script: |
-          python -m pip install termcolor
-        displayName: 'Install python module'
-        condition: ne(variables['SPRING_CLOUD_AZURE_TEST_SUPPORTED_SPRING_BOOT_VERSION'], '')
       - bash: |
           echo "##vso[task.setVariable variable=SPRING_CLOUD_AZURE_TEST_SUPPORTED_SPRING_CLOUD_VERSION]$(python ./sdk/spring/scripts/compatibility_get_spring_cloud_version.py -b $(SPRING_CLOUD_AZURE_TEST_SUPPORTED_SPRING_BOOT_VERSION))"
         displayName: 'Set supported Spring version to environment variables'

--- a/sdk/spring/pipeline/monitor-tests-job.yml
+++ b/sdk/spring/pipeline/monitor-tests-job.yml
@@ -28,9 +28,6 @@ jobs:
             - '.vscode'
       - template: /eng/pipelines/templates/steps/maven-authenticate.yml
       - script: |
-          python -m pip install termcolor
-        displayName: 'Python module install'
-      - script: |
             python ./sdk/spring/scripts/spring_monitor_version_substitution.py -b $(TEST_SPRING_BOOT_VERSION)
         displayName: 'Replace Spring version'
       - task: Maven@4

--- a/sdk/spring/spring-cloud-azure-starter-monitor/tests.yml
+++ b/sdk/spring/spring-cloud-azure-starter-monitor/tests.yml
@@ -22,8 +22,5 @@ stages:
               GenerateVMJobs: true
           PreGenerationSteps:
             - script: |
-                python -m pip install termcolor
-              displayName: 'python module install'
-            - script: |
                 python ./sdk/spring/scripts/monitor_update_monitor_matrix_json.py
               displayName: 'update test version'


### PR DESCRIPTION
# Description

termcolor is only used in sdk/spring/scripts/log.py, which already falls back gracefully via try/except ImportError when termcolor is absent. Removing the install avoids external PyPI access under the upcoming CI network isolation policy (PyPI access failure).


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
