### PR TITLE
Session private drop with env

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where the service's proactive `x-ms-auth-info: session_expiring` hint was ignored when the
+  client's own session-refresh timer had not yet elapsed, allowing a container session to be used past the
+  point the service rotated its network-context binding and surfacing as a `401 InvalidAuthenticationInfo`
+  (`session_token_invalid` / network context mismatch). The hint now forces a proactive background refresh.
+
 ### Other Changes
 
 ## 12.33.3 (2026-03-30)

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlobClientBuilder.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlobClientBuilder.java
@@ -194,6 +194,7 @@ public final class BlobClientBuilder
         if (CoreUtils.isNullOrEmpty(containerName) && !CoreUtils.isNullOrEmpty(sessionOptions.getContainerName())) {
             containerName = sessionOptions.getContainerName();
         }
+        BuilderHelper.validateSessionMode(sessionOptions, containerName, LOGGER);
 
         /*
         Implicit and explicit root container access are functionally equivalent, but explicit references are easier

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlobClientBuilder.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlobClientBuilder.java
@@ -136,6 +136,11 @@ public final class BlobClientBuilder
                 new IllegalArgumentException("Customer provided key and encryption " + "scope cannot both be set"));
         }
 
+        BuilderHelper.applyEnvironmentSessionDefaults(sessionOptions, configuration, LOGGER);
+        if (CoreUtils.isNullOrEmpty(containerName) && !CoreUtils.isNullOrEmpty(sessionOptions.getContainerName())) {
+            containerName = sessionOptions.getContainerName();
+        }
+
         BuilderHelper.validateSessionMode(sessionOptions, containerName, LOGGER);
 
         /*
@@ -183,6 +188,11 @@ public final class BlobClientBuilder
         if (Objects.nonNull(customerProvidedKey) && Objects.nonNull(encryptionScope)) {
             throw LOGGER.logExceptionAsError(
                 new IllegalArgumentException("Customer provided key and encryption " + "scope cannot both be set"));
+        }
+
+        BuilderHelper.applyEnvironmentSessionDefaults(sessionOptions, configuration, LOGGER);
+        if (CoreUtils.isNullOrEmpty(containerName) && !CoreUtils.isNullOrEmpty(sessionOptions.getContainerName())) {
+            containerName = sessionOptions.getContainerName();
         }
 
         /*

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlobContainerClientBuilder.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlobContainerClientBuilder.java
@@ -127,6 +127,11 @@ public final class BlobContainerClientBuilder implements TokenCredentialTrait<Bl
                 new IllegalArgumentException("Customer provided key and encryption " + "scope cannot both be set"));
         }
 
+        BuilderHelper.applyEnvironmentSessionDefaults(sessionOptions, configuration, LOGGER);
+        if (CoreUtils.isNullOrEmpty(containerName) && !CoreUtils.isNullOrEmpty(sessionOptions.getContainerName())) {
+            containerName = sessionOptions.getContainerName();
+        }
+
         BuilderHelper.validateSessionMode(sessionOptions, containerName, LOGGER);
 
         /*
@@ -168,6 +173,11 @@ public final class BlobContainerClientBuilder implements TokenCredentialTrait<Bl
         if (Objects.nonNull(customerProvidedKey) && Objects.nonNull(encryptionScope)) {
             throw LOGGER.logExceptionAsError(
                 new IllegalArgumentException("Customer provided key and encryption " + "scope cannot both be set"));
+        }
+
+        BuilderHelper.applyEnvironmentSessionDefaults(sessionOptions, configuration, LOGGER);
+        if (CoreUtils.isNullOrEmpty(containerName) && !CoreUtils.isNullOrEmpty(sessionOptions.getContainerName())) {
+            containerName = sessionOptions.getContainerName();
         }
 
         BuilderHelper.validateSessionMode(sessionOptions, containerName, LOGGER);

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlobServiceClientBuilder.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/BlobServiceClientBuilder.java
@@ -154,11 +154,13 @@ public final class BlobServiceClientBuilder implements TokenCredentialTrait<Blob
     }
 
     private HttpPipeline constructPipeline() {
-        return (httpPipeline != null)
-            ? httpPipeline
-            : BuilderHelper.buildPipeline(storageSharedKeyCredential, tokenCredential, azureSasCredential, sasToken,
-                endpoint, retryOptions, coreRetryOptions, logOptions, clientOptions, httpClient, perCallPolicies,
-                perRetryPolicies, configuration, audience, LOGGER, sessionOptions, null);
+        if (httpPipeline != null) {
+            return httpPipeline;
+        }
+        BuilderHelper.applyEnvironmentSessionDefaults(sessionOptions, configuration, LOGGER);
+        return BuilderHelper.buildPipeline(storageSharedKeyCredential, tokenCredential, azureSasCredential, sasToken,
+            endpoint, retryOptions, coreRetryOptions, logOptions, clientOptions, httpClient, perCallPolicies,
+            perRetryPolicies, configuration, audience, LOGGER, sessionOptions, null);
     }
 
     /**

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/BuilderHelper.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/BuilderHelper.java
@@ -87,22 +87,22 @@ public final class BuilderHelper {
      * authentication support.
      *
      * @param storageSharedKeyCredential {@link StorageSharedKeyCredential} if present.
-     * @param tokenCredential {@link TokenCredential} if present.
-     * @param azureSasCredential {@link AzureSasCredential} if present.
-     * @param sasToken SAS token if present.
-     * @param endpoint The endpoint for the client.
-     * @param retryOptions Storage's retry options to set in the retry policy.
-     * @param coreRetryOptions Core's retry options to set in the retry policy.
-     * @param logOptions Logging options to set in the logging policy.
-     * @param clientOptions Client options.
-     * @param httpClient HttpClient to use in the builder.
-     * @param perCallPolicies Additional {@link HttpPipelinePolicy policies} to set in the pipeline per call.
-     * @param perRetryPolicies Additional {@link HttpPipelinePolicy policies} to set in the pipeline per retry.
-     * @param configuration Configuration store contain environment settings.
-     * @param logger {@link ClientLogger} used to log any exception.
-     * @param audience {@link BlobAudience} used to determine the audience of the blob.
-     * @param sessionOptions {@link SessionOptions} containing the session mode, container name, and account name for session-based authentication.
-     * @param serviceVersion The service version for session creation. Required when session is active.
+     * @param tokenCredential            {@link TokenCredential} if present.
+     * @param azureSasCredential         {@link AzureSasCredential} if present.
+     * @param sasToken                   SAS token if present.
+     * @param endpoint                   The endpoint for the client.
+     * @param retryOptions               Storage's retry options to set in the retry policy.
+     * @param coreRetryOptions           Core's retry options to set in the retry policy.
+     * @param logOptions                 Logging options to set in the logging policy.
+     * @param clientOptions              Client options.
+     * @param httpClient                 HttpClient to use in the builder.
+     * @param perCallPolicies            Additional {@link HttpPipelinePolicy policies} to set in the pipeline per call.
+     * @param perRetryPolicies           Additional {@link HttpPipelinePolicy policies} to set in the pipeline per retry.
+     * @param configuration              Configuration store contain environment settings.
+     * @param logger                     {@link ClientLogger} used to log any exception.
+     * @param audience                   {@link BlobAudience} used to determine the audience of the blob.
+     * @param sessionOptions             {@link SessionOptions} containing the session mode, container name, and account name for session-based authentication.
+     * @param serviceVersion             The service version for session creation. Required when session is active.
      * @return A new {@link HttpPipeline} from the passed values.
      */
     public static HttpPipeline buildPipeline(StorageSharedKeyCredential storageSharedKeyCredential,
@@ -256,8 +256,8 @@ public final class BuilderHelper {
      * Validates that the client is properly configured to use https.
      *
      * @param objectToCheck The object to check for.
-     * @param objectName The name of the object.
-     * @param endpoint The endpoint for the client.
+     * @param objectName    The name of the object.
+     * @param endpoint      The endpoint for the client.
      */
     public static void httpsValidation(Object objectToCheck, String objectName, String endpoint, ClientLogger logger) {
         if (objectToCheck != null && !BlobUrlParts.parse(endpoint).getScheme().equals(Constants.HTTPS)) {
@@ -302,7 +302,7 @@ public final class BuilderHelper {
     /**
      * Logs information about credential changes in builders.
      *
-     * @param logger The logger to use.
+     * @param logger            The logger to use.
      * @param newCredentialType The credential type being set.
      */
     public static void logCredentialChange(ClientLogger logger, String newCredentialType) {
@@ -331,9 +331,9 @@ public final class BuilderHelper {
      * Mutates {@code sessionOptions} in place.
      *
      * @param sessionOptions the options instance to populate; must not be {@code null}.
-     * @param configuration the configuration store to read from; if {@code null}, the global
-     *                      configuration is used.
-     * @param logger {@link ClientLogger} used to log any exception.
+     * @param configuration  the configuration store to read from; if {@code null}, the global
+     *                       configuration is used.
+     * @param logger         {@link ClientLogger} used to log any exception.
      * @throws IllegalArgumentException if {@link #PROPERTY_AZURE_STORAGE_SESSION_MODE} is set to a
      *                                  value that does not name a known {@link SessionMode}.
      */
@@ -357,7 +357,8 @@ public final class BuilderHelper {
             }
         }
 
-        if (sessionOptions.getSessionMode().resolve() != SessionMode.NONE && CoreUtils.isNullOrEmpty(sessionOptions.getContainerName())) {
+        if (sessionOptions.getSessionMode().resolve() != SessionMode.NONE
+            && CoreUtils.isNullOrEmpty(sessionOptions.getContainerName())) {
             String envContainer = effectiveConfiguration.get(PROPERTY_AZURE_STORAGE_SESSION_CONTAINER_NAME);
             if (!CoreUtils.isNullOrEmpty(envContainer)) {
                 sessionOptions.setContainerName(envContainer.trim());

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/BuilderHelper.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/BuilderHelper.java
@@ -48,6 +48,7 @@ import com.azure.storage.common.policy.StorageSharedKeyCredentialPolicy;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static com.azure.storage.common.Utility.STORAGE_TRACING_NAMESPACE_VALUE;
@@ -60,6 +61,20 @@ import static com.azure.storage.common.Utility.STORAGE_TRACING_NAMESPACE_VALUE;
 public final class BuilderHelper {
     private static final String CLIENT_NAME;
     private static final String CLIENT_VERSION;
+
+    /**
+     * Environment variable / configuration key that, when set, selects the {@link SessionMode}
+     * to use on a builder that has not been explicitly configured (i.e. still using
+     * {@link SessionMode#AUTO}). Accepted values are the names of {@link SessionMode}
+     * (case-insensitive): {@code NONE}, {@code AUTO}, {@code SINGLE_SPECIFIED_CONTAINER}.
+     */
+    public static final String PROPERTY_AZURE_STORAGE_SESSION_MODE = "AZURE_STORAGE_SESSION_MODE";
+
+    /**
+     * Environment variable / configuration key that, when set, supplies the container name to
+     * scope the session to on a builder where it has not been explicitly configured.
+     */
+    public static final String PROPERTY_AZURE_STORAGE_SESSION_CONTAINER_NAME = "AZURE_STORAGE_SESSION_CONTAINER_NAME";
 
     static {
         Map<String, String> properties = CoreUtils.getProperties("azure-storage-blob.properties");
@@ -298,6 +313,55 @@ public final class BuilderHelper {
         if (sessionOptions.getSessionMode().resolve() != SessionMode.NONE && CoreUtils.isNullOrEmpty(containerName)) {
             throw logger.logExceptionAsError(new IllegalArgumentException(
                 "containerName must be set when using SessionMode." + sessionOptions.getSessionMode()));
+        }
+    }
+
+    /**
+     * Applies environment / configuration based defaults to the supplied {@link SessionOptions}.
+     * <p>
+     * This is a fallback that only fills in values the caller has not explicitly configured on the
+     * builder, so explicit programmatic configuration always wins:
+     * <ul>
+     *   <li>{@link #PROPERTY_AZURE_STORAGE_SESSION_MODE} is consulted only when
+     *       {@link SessionOptions#getSessionMode()} is still {@link SessionMode#AUTO} (the default).
+     *       The env var value is matched case-insensitively against the names of {@link SessionMode}.</li>
+     *   <li>{@link #PROPERTY_AZURE_STORAGE_SESSION_CONTAINER_NAME} is consulted only when
+     *       {@link SessionOptions#getContainerName()} is {@code null} or empty.</li>
+     * </ul>
+     * Mutates {@code sessionOptions} in place.
+     *
+     * @param sessionOptions the options instance to populate; must not be {@code null}.
+     * @param configuration the configuration store to read from; if {@code null}, the global
+     *                      configuration is used.
+     * @param logger {@link ClientLogger} used to log any exception.
+     * @throws IllegalArgumentException if {@link #PROPERTY_AZURE_STORAGE_SESSION_MODE} is set to a
+     *                                  value that does not name a known {@link SessionMode}.
+     */
+    public static void applyEnvironmentSessionDefaults(SessionOptions sessionOptions, Configuration configuration,
+        ClientLogger logger) {
+        Configuration effectiveConfiguration
+            = (configuration == null) ? Configuration.getGlobalConfiguration() : configuration;
+
+        if (sessionOptions.getSessionMode() == SessionMode.AUTO) {
+            String envMode = effectiveConfiguration.get(PROPERTY_AZURE_STORAGE_SESSION_MODE);
+            if (!CoreUtils.isNullOrEmpty(envMode)) {
+                SessionMode parsed;
+                try {
+                    parsed = SessionMode.valueOf(envMode.trim().toUpperCase(Locale.ROOT));
+                } catch (IllegalArgumentException ex) {
+                    throw logger.logExceptionAsError(new IllegalArgumentException("Invalid value '" + envMode
+                        + "' for environment variable " + PROPERTY_AZURE_STORAGE_SESSION_MODE
+                        + ". Allowed values are: NONE, AUTO, SINGLE_SPECIFIED_CONTAINER.", ex));
+                }
+                sessionOptions.setSessionMode(parsed);
+            }
+        }
+
+        if (CoreUtils.isNullOrEmpty(sessionOptions.getContainerName())) {
+            String envContainer = effectiveConfiguration.get(PROPERTY_AZURE_STORAGE_SESSION_CONTAINER_NAME);
+            if (!CoreUtils.isNullOrEmpty(envContainer)) {
+                sessionOptions.setContainerName(envContainer.trim());
+            }
         }
     }
 }

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/BuilderHelper.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/BuilderHelper.java
@@ -357,7 +357,7 @@ public final class BuilderHelper {
             }
         }
 
-        if (CoreUtils.isNullOrEmpty(sessionOptions.getContainerName())) {
+        if (sessionOptions.getSessionMode().resolve() != SessionMode.NONE && CoreUtils.isNullOrEmpty(sessionOptions.getContainerName())) {
             String envContainer = effectiveConfiguration.get(PROPERTY_AZURE_STORAGE_SESSION_CONTAINER_NAME);
             if (!CoreUtils.isNullOrEmpty(envContainer)) {
                 sessionOptions.setContainerName(envContainer.trim());

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/SessionTokenCredentialPolicy.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/SessionTokenCredentialPolicy.java
@@ -231,7 +231,7 @@ public final class SessionTokenCredentialPolicy implements HttpPipelinePolicy {
     private void handleSessionExpiringHeader(HttpResponse response) {
         String authInfo = response.getHeaderValue(X_MS_AUTH_INFO);
         if (authInfo != null && authInfo.contains(SESSION_EXPIRING)) {
-            sessionCredentialCache.refreshSessionInBackground();
+            sessionCredentialCache.forceRefreshSessionInBackground();
         }
     }
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/StorageSessionCredential.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/StorageSessionCredential.java
@@ -56,26 +56,31 @@ final class StorageSessionCredential {
         request.setHeader(HttpHeaderName.AUTHORIZATION, SESSION_PREFIX + sessionToken + ":" + signature);
     }
 
-    // Mirrors StorageSharedKeyCredential.buildStringToSign but does NOT replace "0" with "" for
-    // Content-Length. The Session protocol signs the literal value the wire carries.
+    // Mirrors StorageSharedKeyCredential.buildStringToSign. The server canonicalizes
+    // Content-Length: 0 to "" before computing its HMAC (matching the documented Shared Key
+    // canonicalization), so we must do the same here to produce a matching signature.
     //
-    // We inline this rather than delegate to StorageSharedKeyCredential because of a quirk in
-    // azure-core's RestProxyBase.configRequest (sdk/core/azure-core/src/main/java/com/azure/core/
-    // implementation/http/rest/RestProxyBase.java, line 305): it unconditionally calls
-    // `request.setHeader(HttpHeaderName.CONTENT_LENGTH, "0")` for body-less requests including
-    // GETs (an RFC 7230 violation; .NET's transports skip it). SharedKey's canonicalization
-    // then normalizes "0" -> "" in the string-to-sign, but the server signs the literal "0" it
-    // sees on the wire, so delegating produces a signature mismatch.
-    //
-    // TODO: once RestProxyBase.java:305 is changed to skip Content-Length: 0 for GET/DELETE,
-    // delete this method and delegate to sharedKey.generateAuthorizationHeader(...).
-    // This matches what happens in dotnet:
-    // https://github.com/Azure/azure-sdk-for-net/blob/57598097b0ba056de7d90e5b1624d6c529cd3d60/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs#L94-L99
+    // TODO (azure-core, RFC hygiene only — does NOT affect Storage signing correctness):
+    //   azure-core's RestProxyBase.configRequest (sdk/core/azure-core/.../RestProxyBase.java)
+    //   unconditionally sets Content-Length: 0 on body-less requests, including GETs. Per
+    //   RFC 7230 §3.3.2 a user agent SHOULD NOT send a Content-Length header when the request
+    //   has no body and the method does not anticipate one (.NET's transports skip it). This
+    //   does NOT cause a signing mismatch here — the server normalizes "0" -> "" and our local
+    //   normalization above matches — so it is purely an RFC-hygiene issue. The Content-Length
+    //   normalization in this method should remain in place even if azure-core is fixed: it
+    //   reflects the documented Shared Key canonicalization rule, not a workaround for
+    //   azure-core behavior. Track the azure-core fix separately if pursued.
+
     private String buildStringToSign(HttpRequest request) {
         HttpHeaders headers = request.getHeaders();
         Collator collator = Collator.getInstance(Locale.ROOT);
 
         String contentLength = getHeaderOrEmpty(headers, HttpHeaderName.CONTENT_LENGTH);
+        // Normalize "0" to "" to match the server's canonicalization (matches
+        // StorageSharedKeyCredential.buildStringToSign).
+        if ("0".equals(contentLength)) {
+            contentLength = "";
+        }
         // If x-ms-date is present, the Date slot is empty.
         String dateHeader = headers.getValue(X_MS_DATE) != null ? "" : getHeaderOrEmpty(headers, HttpHeaderName.DATE);
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/StorageSessionCredentialCache.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/implementation/util/StorageSessionCredentialCache.java
@@ -6,6 +6,7 @@ package com.azure.storage.blob.implementation.util;
 import com.azure.core.util.logging.ClientLogger;
 import reactor.core.publisher.Mono;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -20,6 +21,7 @@ final class StorageSessionCredentialCache {
     private static final double JITTER_WINDOW_START_RATIO = 0.8d;
 
     private final BlobSessionClient sessionClient;
+    private final Clock clock;
     private final Object creationLock = new Object();
     private volatile StorageSessionCredential credential;
     private volatile OffsetDateTime nextRefreshTime;
@@ -27,11 +29,16 @@ final class StorageSessionCredentialCache {
     private volatile Mono<StorageSessionCredential> inflightCreation;
 
     StorageSessionCredentialCache(BlobSessionClient sessionClient) {
+        this(sessionClient, Clock.systemUTC());
+    }
+
+    StorageSessionCredentialCache(BlobSessionClient sessionClient, Clock clock) {
         this.sessionClient = Objects.requireNonNull(sessionClient, "'sessionClient' cannot be null.");
+        this.clock = Objects.requireNonNull(clock, "'clock' cannot be null.");
     }
 
     Mono<StorageSessionCredential> getValidSessionAsync() {
-        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime now = OffsetDateTime.now(clock);
         StorageSessionCredential current = credential;
         if (isUsable(current, now)) {
             if (isRefreshDue(now)) {
@@ -44,7 +51,7 @@ final class StorageSessionCredentialCache {
     }
 
     StorageSessionCredential getValidSessionSync() {
-        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime now = OffsetDateTime.now(clock);
         StorageSessionCredential current = credential;
         if (isUsable(current, now)) {
             if (isRefreshDue(now)) {
@@ -64,7 +71,7 @@ final class StorageSessionCredentialCache {
 
         synchronized (creationLock) {
             current = credential;
-            now = OffsetDateTime.now();
+            now = OffsetDateTime.now(clock);
             if (isUsable(current, now)) {
                 if (isRefreshDue(now)) {
                     refreshSessionInBackground();
@@ -91,7 +98,7 @@ final class StorageSessionCredentialCache {
 
     void refreshSessionInBackground() {
         synchronized (creationLock) {
-            OffsetDateTime now = OffsetDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now(clock);
             if (!isUsable(credential, now) || !isRefreshDue(now) || refreshing) {
                 return;
             }
@@ -102,9 +109,19 @@ final class StorageSessionCredentialCache {
         }, error -> LOGGER.warning("Background session refresh failed.", error));
     }
 
+    void forceRefreshSessionInBackground() {
+        synchronized (creationLock) {
+            if (isUsable(credential, OffsetDateTime.now(clock))) {
+                nextRefreshTime = OffsetDateTime.now(clock);
+            }
+        }
+
+        refreshSessionInBackground();
+    }
+
     private Mono<StorageSessionCredential> startSessionCreationAsync() {
         synchronized (creationLock) {
-            OffsetDateTime now = OffsetDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now(clock);
             StorageSessionCredential current = credential;
             if (isUsable(current, now) && !isRefreshDue(now)) {
                 return Mono.just(current);
@@ -133,7 +150,7 @@ final class StorageSessionCredentialCache {
 
     private void setActiveCredential(StorageSessionCredential newCredential) {
         credential = newCredential;
-        nextRefreshTime = computeRefreshTime(OffsetDateTime.now(), newCredential.getExpiration());
+        nextRefreshTime = computeRefreshTime(OffsetDateTime.now(clock), newCredential.getExpiration());
         refreshing = false;
     }
 

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/BuilderHelperTests.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/BuilderHelperTests.java
@@ -16,7 +16,10 @@ import com.azure.core.http.policy.RetryOptions;
 import com.azure.core.test.http.MockHttpResponse;
 import com.azure.core.test.http.NoOpHttpClient;
 import com.azure.core.test.utils.MockTokenCredential;
+import com.azure.core.test.utils.TestConfigurationSource;
 import com.azure.core.util.ClientOptions;
+import com.azure.core.util.Configuration;
+import com.azure.core.util.ConfigurationBuilder;
 import com.azure.core.util.CoreUtils;
 import com.azure.core.util.DateTimeRfc1123;
 import com.azure.core.util.Header;
@@ -31,6 +34,7 @@ import com.azure.storage.blob.specialized.SpecializedBlobClientBuilder;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import com.azure.storage.common.policy.RequestRetryOptions;
 import com.azure.storage.common.policy.RetryPolicyType;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -831,6 +835,192 @@ public class BuilderHelperTests {
             .credential(new MockTokenCredential())
             .httpClient(new NoOpHttpClient())
             .buildClient());
+    }
+
+    // endregion
+
+    // region environment variable session activation tests
+
+    private static Configuration envConfiguration(String mode, String container) {
+        TestConfigurationSource envSource = new TestConfigurationSource();
+        if (mode != null) {
+            envSource.put(BuilderHelper.PROPERTY_AZURE_STORAGE_SESSION_MODE, mode);
+        }
+        if (container != null) {
+            envSource.put(BuilderHelper.PROPERTY_AZURE_STORAGE_SESSION_CONTAINER_NAME, container);
+        }
+        return new ConfigurationBuilder(new TestConfigurationSource(), new TestConfigurationSource(), envSource)
+            .build();
+    }
+
+    @Test
+    public void containerBuilderActivatesSessionFromEnvWhenNothingExplicit() {
+        Configuration config = envConfiguration("SINGLE_SPECIFIED_CONTAINER", "envcontainer");
+
+        assertDoesNotThrow(() -> new BlobContainerClientBuilder().endpoint(ENDPOINT)
+            .credential(new MockTokenCredential())
+            .httpClient(new NoOpHttpClient())
+            .configuration(config)
+            .buildClient());
+    }
+
+    @Test
+    public void containerBuilderEnvModeWithoutContainerNameStillThrows() {
+        Configuration config = envConfiguration("SINGLE_SPECIFIED_CONTAINER", null);
+
+        assertThrows(IllegalArgumentException.class,
+            () -> new BlobContainerClientBuilder().endpoint(ENDPOINT)
+                .credential(new MockTokenCredential())
+                .httpClient(new NoOpHttpClient())
+                .configuration(config)
+                .buildClient());
+    }
+
+    @Test
+    public void containerBuilderEnvModeIsCaseInsensitive() {
+        Configuration config = envConfiguration("single_specified_container", "envcontainer");
+
+        assertDoesNotThrow(() -> new BlobContainerClientBuilder().endpoint(ENDPOINT)
+            .credential(new MockTokenCredential())
+            .httpClient(new NoOpHttpClient())
+            .configuration(config)
+            .buildClient());
+    }
+
+    @Test
+    public void containerBuilderInvalidEnvModeThrows() {
+        Configuration config = envConfiguration("NOT_A_REAL_MODE", "envcontainer");
+
+        assertThrows(IllegalArgumentException.class,
+            () -> new BlobContainerClientBuilder().endpoint(ENDPOINT)
+                .credential(new MockTokenCredential())
+                .httpClient(new NoOpHttpClient())
+                .configuration(config)
+                .buildClient());
+    }
+
+    @Test
+    public void containerBuilderExplicitSessionModeOverridesEnv() {
+        Configuration config = envConfiguration("SINGLE_SPECIFIED_CONTAINER", "envcontainer");
+        SessionOptions explicitNone = new SessionOptions().setSessionMode(SessionMode.NONE);
+
+        // Explicit NONE must not be upgraded by env vars and no container is required.
+        assertDoesNotThrow(() -> new BlobContainerClientBuilder().endpoint(ENDPOINT)
+            .credential(new MockTokenCredential())
+            .httpClient(new NoOpHttpClient())
+            .configuration(config)
+            .sessionOptions(explicitNone)
+            .buildClient());
+    }
+
+    @Test
+    public void containerBuilderExplicitContainerNameWinsOverEnv() {
+        Configuration config = envConfiguration("SINGLE_SPECIFIED_CONTAINER", "envcontainer");
+        SessionOptions options = new SessionOptions().setContainerName("explicitcontainer");
+
+        assertDoesNotThrow(() -> new BlobContainerClientBuilder().endpoint(ENDPOINT)
+            .containerName("explicitcontainer")
+            .credential(new MockTokenCredential())
+            .httpClient(new NoOpHttpClient())
+            .configuration(config)
+            .sessionOptions(options)
+            .buildClient());
+
+        assertEquals("explicitcontainer", options.getContainerName());
+    }
+
+    @Test
+    public void blobBuilderActivatesSessionFromEnvWhenNothingExplicit() {
+        Configuration config = envConfiguration("SINGLE_SPECIFIED_CONTAINER", "envcontainer");
+
+        assertDoesNotThrow(() -> new BlobClientBuilder().endpoint(ENDPOINT)
+            .blobName("myblob")
+            .credential(new MockTokenCredential())
+            .httpClient(new NoOpHttpClient())
+            .configuration(config)
+            .buildClient());
+    }
+
+    @Test
+    public void serviceBuilderActivatesSessionFromEnvWhenNothingExplicit() {
+        Configuration config = envConfiguration("SINGLE_SPECIFIED_CONTAINER", "envcontainer");
+        SessionOptions options = new SessionOptions();
+
+        assertDoesNotThrow(() -> new BlobServiceClientBuilder().endpoint(ENDPOINT)
+            .credential(new MockTokenCredential())
+            .httpClient(new NoOpHttpClient())
+            .configuration(config)
+            .sessionOptions(options)
+            .buildClient());
+
+        // Env vars must have flowed through to the SessionOptions instance.
+        assertEquals(SessionMode.SINGLE_SPECIFIED_CONTAINER, options.getSessionMode());
+        assertEquals("envcontainer", options.getContainerName());
+    }
+
+    @Test
+    public void applyEnvironmentSessionDefaultsLeavesExplicitValuesIntact() {
+        Configuration config = envConfiguration("SINGLE_SPECIFIED_CONTAINER", "envcontainer");
+        SessionOptions options = new SessionOptions().setSessionMode(SessionMode.NONE).setContainerName("explicit");
+
+        BuilderHelper.applyEnvironmentSessionDefaults(options, config, new ClientLogger(BuilderHelperTests.class));
+
+        assertEquals(SessionMode.NONE, options.getSessionMode());
+        assertEquals("explicit", options.getContainerName());
+    }
+
+    @Test
+    public void applyEnvironmentSessionDefaultsAppliesOnlyContainerNameWhenModeExplicit() {
+        Configuration config = envConfiguration(null, "envcontainer");
+        SessionOptions options = new SessionOptions().setSessionMode(SessionMode.SINGLE_SPECIFIED_CONTAINER);
+
+        BuilderHelper.applyEnvironmentSessionDefaults(options, config, new ClientLogger(BuilderHelperTests.class));
+
+        assertEquals(SessionMode.SINGLE_SPECIFIED_CONTAINER, options.getSessionMode());
+        assertEquals("envcontainer", options.getContainerName());
+    }
+
+    // endregion
+
+    // region environment-variable end-to-end test
+    //
+    // This single test verifies that a customer can activate the session feature with NO code
+    // change at all -- just by exporting environment variables before starting the JVM:
+    //
+    //     set AZURE_STORAGE_SESSION_MODE=SINGLE_SPECIFIED_CONTAINER
+    //     set AZURE_STORAGE_SESSION_CONTAINER_NAME=mycontainer
+    //
+    // It is @Disabled by default because:
+    //   1. CI doesn't (and shouldn't) set these process-level env vars.
+    //   2. EnvironmentConfiguration in azure-core caches reads from the global Configuration
+    //      for the lifetime of the JVM, so it cannot be reliably reset between tests inside
+    //      the same Surefire fork.
+    //
+    // To run it manually after setting the env vars above:
+    //
+    //     mvn -pl sdk/storage/azure-storage-blob test ^
+    //       "-Dtest=BuilderHelperTests#environmentVariablesActivateSession"
+    //
+    // The 10 injection-based tests above already cover all of the helper's branching logic
+    // by injecting a Configuration directly; this test exists only to prove the real
+    // System.getenv lookup path also works.
+
+    @Test
+    @Disabled("Run manually after exporting AZURE_STORAGE_SESSION_MODE=SINGLE_SPECIFIED_CONTAINER and "
+        + "AZURE_STORAGE_SESSION_CONTAINER_NAME=<name>. See the comment above for details.")
+    public void environmentVariablesActivateSession() {
+        SessionOptions options = new SessionOptions();
+        assertDoesNotThrow(() -> new BlobContainerClientBuilder().endpoint(ENDPOINT)
+            .credential(new MockTokenCredential())
+            .httpClient(new NoOpHttpClient())
+            .sessionOptions(options)
+            .buildClient());
+
+        String expectedContainer = System.getenv(BuilderHelper.PROPERTY_AZURE_STORAGE_SESSION_CONTAINER_NAME);
+        assertEquals(SessionMode.SINGLE_SPECIFIED_CONTAINER, options.getSessionMode(),
+            "Expected env var AZURE_STORAGE_SESSION_MODE=SINGLE_SPECIFIED_CONTAINER to populate sessionMode");
+        assertEquals(expectedContainer, options.getContainerName(),
+            "Expected env var AZURE_STORAGE_SESSION_CONTAINER_NAME to populate containerName");
     }
 
     // endregion

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerApiTests.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerApiTests.java
@@ -2314,11 +2314,9 @@ public class ContainerApiTests extends BlobTestBase {
             .upload(DATA.getDefaultInputStream(), DATA.getDefaultDataSize());
 
         // A real customer would deploy with these environment variables set on the process:
-        //   AZURE_STORAGE_SESSION_MODE=SINGLE_SPECIFIED_CONTAINER
-        //   AZURE_STORAGE_SESSION_CONTAINER_NAME=<their container>
-        // A JVM cannot mutate its own env, so we set the equivalent system properties.
-        // azure-core's EnvironmentConfiguration reads system properties as a fallback for env
-        // vars, so this faithfully simulates the deployed scenario from inside a test.
+//   AZURE_STORAGE_SESSION_MODE=SINGLE_SPECIFIED_CONTAINER
+//   AZURE_STORAGE_SESSION_CONTAINER_NAME=session-test-container
+// This test relies on those env vars being set on the host running it.
 
         List<String> downloadAuthSchemes = Collections.synchronizedList(new ArrayList<>());
         RequestInspectionPolicy inspect = new RequestInspectionPolicy(req -> {

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerApiTests.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerApiTests.java
@@ -5,6 +5,12 @@ package com.azure.storage.blob;
 
 import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpPipelineCallContext;
+import com.azure.core.http.HttpPipelineNextPolicy;
+import com.azure.core.http.HttpPipelineNextSyncPolicy;
+import com.azure.core.http.HttpPipelinePosition;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.HttpResponse;
 import com.azure.core.http.policy.HttpPipelinePolicy;
 import com.azure.core.util.BinaryData;
 import com.azure.core.http.rest.PagedIterable;
@@ -65,6 +71,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import reactor.core.publisher.Mono;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -2283,6 +2291,200 @@ public class ContainerApiTests extends BlobTestBase {
         assertFalse(listAuthSchemes.isEmpty(), "Expected to observe at least one list request");
         assertTrue(listAuthSchemes.stream().allMatch("Bearer"::equals),
             "Container list operation must use Bearer authorization; saw " + listAuthSchemes);
+    }
+
+    @Test
+    @LiveOnly
+    @ResourceLock("BlobSessionAuth")
+    // Verifies that the cached session token rotates on its own while a client keeps issuing blob GET requests.
+    // A session credential is short-lived (~5 minutes) and the credential cache fetches a fresh one in the
+    // background before the current one expires. This test keeps issuing small GETs across more than one session
+    // lifetime and asserts that the session token observed on the wire changes at least once (rotation happened).
+    public void sessionTokenRotates() {
+        String blobName = generateBlobName();
+        cc.getBlobClient(blobName).getBlockBlobClient().upload(DATA.getDefaultInputStream(), DATA.getDefaultDataSize());
+
+        SessionGetInspectionPolicy inspect = new SessionGetInspectionPolicy(blobName);
+        BlobClient sessionBlob = sessionEnabledContainerClient(inspect).getBlobClient(blobName);
+
+        // Continuously issue small GET requests for slightly longer than one session lifetime so we are
+        // guaranteed to cross at least one background rotation boundary while requests are in flight.
+        long testDurationMillis = 6 * 60 * 1000L;
+        long pollIntervalMillis = 10 * 1000L;
+        long deadline = System.currentTimeMillis() + testDurationMillis;
+        int getCount = 0;
+
+        while (System.currentTimeMillis() < deadline) {
+            // Each GET is small (the default test data) and must succeed with the expected content.
+            assertEquals(DATA.getDefaultText(), sessionBlob.downloadContent().toString());
+            getCount++;
+            sleepIfRunningAgainstService(pollIntervalMillis);
+        }
+
+        assertTrue(getCount > 1, "Expected to issue multiple blob GET requests over the test window");
+        assertFalse(inspect.getSessionTokens().isEmpty(), "Expected blob GETs to be signed with Session tokens");
+
+        Set<String> distinctTokens = new HashSet<>(inspect.getSessionTokens());
+        assertTrue(distinctTokens.size() >= 2,
+            "Expected the session token to rotate at least once over the test window; only saw " + distinctTokens);
+    }
+
+    @Test
+    @LiveOnly
+    @ResourceLock("BlobSessionAuth")
+    // Verifies that, while a client hammers the service with small, rapid, back-to-back blob GET requests, the
+    // cached session token rotates and every download still succeeds. The service legitimately returns transient
+    // "session_token_invalid" (401, network-context-mismatch) responses while it rotates a session's binding; the
+    // SDK recovers from those by invalidating the session, creating a fresh one, and retrying, so the caller's GET
+    // never fails. We therefore assert the contract the SDK can actually honor - every download returns the
+    // correct content (no invalid-token failure ever surfaces to the caller) and the token rotates at least once -
+    // rather than asserting the wire never carries a 401, which the service does not guarantee. (Recovered
+    // invalid-token responses are still recorded and surfaced in the failure message below for diagnostics.)
+    public void sessionTokenRotatesWithoutInvalidTokenGets() {
+        String blobName = generateBlobName();
+        cc.getBlobClient(blobName).getBlockBlobClient().upload(DATA.getDefaultInputStream(), DATA.getDefaultDataSize());
+
+        SessionGetInspectionPolicy inspect = new SessionGetInspectionPolicy(blobName);
+        BlobClient sessionBlob = sessionEnabledContainerClient(inspect).getBlobClient(blobName);
+
+        // Continuously issue small GET requests, back-to-back with no delay, for slightly longer than one
+        // session lifetime so we are guaranteed to cross at least one rotation boundary while a high volume of
+        // requests are in flight.
+        long testDurationMillis = 6 * 60 * 1000L;
+        long deadline = System.currentTimeMillis() + testDurationMillis;
+        int getCount = 0;
+
+        while (System.currentTimeMillis() < deadline) {
+            // Each GET must succeed with the expected content. If a transient invalid-token 401 reaches the wire,
+            // the SDK's retry transparently recovers it, so this download still returns the blob - the caller
+            // never observes a failure.
+            assertEquals(DATA.getDefaultText(), sessionBlob.downloadContent().toString());
+            getCount++;
+        }
+
+        assertTrue(getCount > 1, "Expected to issue multiple blob GET requests over the test window");
+        assertFalse(inspect.getSessionTokens().isEmpty(), "Expected blob GETs to be signed with Session tokens");
+
+        Set<String> distinctTokens = new HashSet<>(inspect.getSessionTokens());
+        assertTrue(distinctTokens.size() >= 2,
+            "Expected the session token to rotate at least once over the test window; saw tokens " + distinctTokens
+                + " and transparently-recovered invalid-token responses " + inspect.getInvalidAuthStatuses());
+    }
+
+    @Test
+    @LiveOnly
+    @ResourceLock("BlobSessionAuth")
+    // Simulates a slow-polling client that issues a single small blob GET roughly every 30 seconds. Because the
+    // requests are sparse, the client can go a long time between responses and may miss the service's proactive
+    // "x-ms-auth-info: session_expiring" hint window entirely - so it can end up signing a request with a token
+    // that has expired purely due to the passage of time. This verifies the SDK handles that gracefully: every
+    // download still returns the correct content (the cache rotates to a fresh session - proactively via its own
+    // refresh timer when it can, or via the one-shot 401 retry as a backstop when an expired token slips onto the
+    // wire) and the session token observed on the wire rotates at least once over the multi-lifetime window.
+    public void sessionTokenRotatesWithSparsePolling() {
+        String blobName = generateBlobName();
+        cc.getBlobClient(blobName).getBlockBlobClient().upload(DATA.getDefaultInputStream(), DATA.getDefaultDataSize());
+
+        SessionGetInspectionPolicy inspect = new SessionGetInspectionPolicy(blobName);
+        BlobClient sessionBlob = sessionEnabledContainerClient(inspect).getBlobClient(blobName);
+
+        // Poll once every ~30s for longer than two session lifetimes (~5 min each) so we are guaranteed to cross
+        // multiple expiry boundaries. The wide gap between requests is what makes it possible to land a request
+        // on an already-expired token: the proactive refresh point can come due during the idle gap, and the
+        // first request after it - 30s later - may be signed just after the token has lapsed.
+        long testDurationMillis = 11 * 60 * 1000L;
+        long pollIntervalMillis = 30 * 1000L;
+        long deadline = System.currentTimeMillis() + testDurationMillis;
+        int getCount = 0;
+
+        while (System.currentTimeMillis() < deadline) {
+            // The caller must never observe a failure: each sparse GET returns the expected content, whether the
+            // cached token was still valid, was proactively rotated, or had to be re-acquired after a 401. Any
+            // expired-token use is recovered transparently by the policy's single retry with a fresh session.
+            assertEquals(DATA.getDefaultText(), sessionBlob.downloadContent().toString());
+            getCount++;
+            sleepIfRunningAgainstService(pollIntervalMillis);
+        }
+
+        assertTrue(getCount > 1, "Expected to issue multiple blob GET requests over the sparse-polling window");
+        assertFalse(inspect.getSessionTokens().isEmpty(), "Expected blob GETs to be signed with Session tokens");
+
+        Set<String> distinctTokens = new HashSet<>(inspect.getSessionTokens());
+        assertTrue(distinctTokens.size() >= 2,
+            "Expected the session token to rotate at least once over the sparse-polling window; only saw "
+                + distinctTokens);
+    }
+
+    /**
+     * Test-only pipeline policy that watches blob-level GET requests for a single blob and records, at the wire
+     * level (PER_RETRY), the Session token used to sign each request and any invalid-token (401/403) responses
+     * those requests receive. Used to assert that session tokens rotate over time without any request ever being
+     * signed with an expired/invalid token.
+     */
+    private static final class SessionGetInspectionPolicy implements HttpPipelinePolicy {
+        private final String blobName;
+        private final List<String> sessionTokens = Collections.synchronizedList(new ArrayList<>());
+        private final List<Integer> invalidAuthStatuses = Collections.synchronizedList(new ArrayList<>());
+
+        SessionGetInspectionPolicy(String blobName) {
+            this.blobName = blobName;
+        }
+
+        private boolean isBlobGet(HttpRequest request) {
+            String path = request.getUrl().getPath();
+            String query = request.getUrl().getQuery();
+            return request.getHttpMethod() == HttpMethod.GET
+                && path != null
+                && path.endsWith("/" + blobName)
+                && (query == null || !query.contains("comp="));
+        }
+
+        private void onRequest(HttpRequest request) {
+            if (!isBlobGet(request)) {
+                return;
+            }
+            String auth = request.getHeaders().getValue(HttpHeaderName.AUTHORIZATION);
+            if (auth != null && auth.startsWith("Session ")) {
+                // Header form is "Session <sessionToken>:<signature>" - extract just the token.
+                int tokenStart = "Session ".length();
+                int sigSeparator = auth.indexOf(':', tokenStart);
+                sessionTokens
+                    .add(sigSeparator < 0 ? auth.substring(tokenStart) : auth.substring(tokenStart, sigSeparator));
+            }
+        }
+
+        private void onResponse(HttpRequest request, int statusCode) {
+            if (isBlobGet(request) && (statusCode == 401 || statusCode == 403)) {
+                invalidAuthStatuses.add(statusCode);
+            }
+        }
+
+        @Override
+        public HttpPipelinePosition getPipelinePosition() {
+            return HttpPipelinePosition.PER_RETRY;
+        }
+
+        @Override
+        public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next) {
+            onRequest(context.getHttpRequest());
+            return next.process().doOnNext(response -> onResponse(context.getHttpRequest(), response.getStatusCode()));
+        }
+
+        @Override
+        public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next) {
+            onRequest(context.getHttpRequest());
+            HttpResponse response = next.processSync();
+            onResponse(context.getHttpRequest(), response.getStatusCode());
+            return response;
+        }
+
+        List<String> getSessionTokens() {
+            return sessionTokens;
+        }
+
+        List<Integer> getInvalidAuthStatuses() {
+            return invalidAuthStatuses;
+        }
     }
 
     private BlobContainerClient sessionEnabledContainerClient(HttpPipelinePolicy... policies) {

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerApiTests.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerApiTests.java
@@ -2291,4 +2291,61 @@ public class ContainerApiTests extends BlobTestBase {
             .setAccountName(cc.getAccountName());
         return getOAuthServiceClient(sessionOptions, policies).getBlobContainerClient(cc.getBlobContainerName());
     }
+
+    @Test
+    @LiveOnly
+    @Disabled("This test is disabled since it requires specific environment vars to be set that are not normally set")
+    @ResourceLock("BlobSessionAuth")
+    // Verifies the env-var session-activation feature end-to-end. With NO explicit SessionOptions
+    // and NO .sessionOptions(...) call, a customer who only exports the AZURE_STORAGE_SESSION_MODE
+    // and AZURE_STORAGE_SESSION_CONTAINER_NAME environment variables should get blob downloads
+    // automatically signed with the "Session" auth scheme instead of "Bearer".
+    public void downloadBlobUsingEnvVarSessionAuth() {
+
+        String myContainerName = "session-test-container";
+        String endpoint = ENVIRONMENT.getPrimaryAccount().getBlobEndpoint();
+
+        // Setup: provision the container and upload a blob the customer will later download.
+        primaryBlobServiceClient.createBlobContainer(myContainerName);
+        String blobName = generateBlobName();
+        primaryBlobServiceClient.getBlobContainerClient(myContainerName)
+            .getBlobClient(blobName)
+            .getBlockBlobClient()
+            .upload(DATA.getDefaultInputStream(), DATA.getDefaultDataSize());
+
+        // A real customer would deploy with these environment variables set on the process:
+        //   AZURE_STORAGE_SESSION_MODE=SINGLE_SPECIFIED_CONTAINER
+        //   AZURE_STORAGE_SESSION_CONTAINER_NAME=<their container>
+        // A JVM cannot mutate its own env, so we set the equivalent system properties.
+        // azure-core's EnvironmentConfiguration reads system properties as a fallback for env
+        // vars, so this faithfully simulates the deployed scenario from inside a test.
+
+        List<String> downloadAuthSchemes = Collections.synchronizedList(new ArrayList<>());
+        RequestInspectionPolicy inspect = new RequestInspectionPolicy(req -> {
+            String auth = req.getHeaders().getValue(HttpHeaderName.AUTHORIZATION);
+            String path = req.getUrl().getPath();
+            String trimmed = path != null && path.startsWith("/") ? path.substring(1) : path;
+            if (auth != null && trimmed != null && trimmed.contains("/")) {
+                downloadAuthSchemes.add(auth.startsWith("Session ") ? "Session" : "Bearer");
+            }
+        });
+
+        try {
+            // Customer code: no .sessionOptions(...), no .configuration(...). The env vars
+            // set above are the only thing turning on session-based auth.
+            BlobContainerClient sessionCc = instrument(new BlobContainerClientBuilder().endpoint(endpoint)
+                .containerName(myContainerName)
+                .credential(new DefaultAzureCredentialBuilder().build())
+                .addPolicy(inspect)).buildClient();
+
+            BinaryData downloaded = sessionCc.getBlobClient(blobName).downloadContent();
+            assertEquals(DATA.getDefaultText(), downloaded.toString());
+
+            assertFalse(downloadAuthSchemes.isEmpty(), "Expected to observe at least one blob download request");
+            assertTrue(downloadAuthSchemes.stream().allMatch("Session"::equals),
+                "Expected env-var-configured client to use Session auth on blob downloads; saw " + downloadAuthSchemes);
+        } finally {
+            primaryBlobServiceClient.deleteBlobContainer(myContainerName);
+        }
+    }
 }

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerApiTests.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerApiTests.java
@@ -2314,9 +2314,9 @@ public class ContainerApiTests extends BlobTestBase {
             .upload(DATA.getDefaultInputStream(), DATA.getDefaultDataSize());
 
         // A real customer would deploy with these environment variables set on the process:
-//   AZURE_STORAGE_SESSION_MODE=SINGLE_SPECIFIED_CONTAINER
-//   AZURE_STORAGE_SESSION_CONTAINER_NAME=session-test-container
-// This test relies on those env vars being set on the host running it.
+        //   AZURE_STORAGE_SESSION_MODE=SINGLE_SPECIFIED_CONTAINER
+        //   AZURE_STORAGE_SESSION_CONTAINER_NAME=session-test-container
+        // This test relies on those env vars being set on the host running it.
 
         List<String> downloadAuthSchemes = Collections.synchronizedList(new ArrayList<>());
         RequestInspectionPolicy inspect = new RequestInspectionPolicy(req -> {

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerAsyncApiTests.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerAsyncApiTests.java
@@ -2336,7 +2336,7 @@ public class ContainerAsyncApiTests extends BlobTestBase {
 
         // A real customer would deploy with these environment variables set on the process:
         //   AZURE_STORAGE_SESSION_MODE=SINGLE_SPECIFIED_CONTAINER
-        //   AZURE_STORAGE_SESSION_CONTAINER_NAME=<their container>
+        //   AZURE_STORAGE_SESSION_CONTAINER_NAME=session-test-container
         // This test relies on those env vars being set on the host running it.
 
         List<String> downloadAuthSchemes = Collections.synchronizedList(new ArrayList<>());

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerAsyncApiTests.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/ContainerAsyncApiTests.java
@@ -2311,4 +2311,62 @@ public class ContainerAsyncApiTests extends BlobTestBase {
             .getBlobContainerAsyncClient(ccAsync.getBlobContainerName());
     }
 
+    @Test
+    @LiveOnly
+    @Disabled("This test is disabled since it requires specific environment vars to be set that are not normally set")
+    @ResourceLock("BlobSessionAuth")
+    // Async twin of ContainerApiTests#downloadBlobUsingEnvVarSessionAuth. Verifies the env-var
+    // session-activation feature end-to-end. With NO explicit SessionOptions and NO
+    // .sessionOptions(...) call, a customer who only exports AZURE_STORAGE_SESSION_MODE and
+    // AZURE_STORAGE_SESSION_CONTAINER_NAME should get blob downloads automatically signed with
+    // the "Session" auth scheme instead of "Bearer".
+    public void downloadBlobUsingEnvVarSessionAuth() {
+
+        String myContainerName = "session-test-container";
+        String endpoint = ENVIRONMENT.getPrimaryAccount().getBlobEndpoint();
+
+        // Setup: provision the container and upload a blob the customer will later download.
+        primaryBlobServiceAsyncClient.createBlobContainer(myContainerName).block();
+        String blobName = generateBlobName();
+        primaryBlobServiceAsyncClient.getBlobContainerAsyncClient(myContainerName)
+            .getBlobAsyncClient(blobName)
+            .getBlockBlobAsyncClient()
+            .upload(DATA.getDefaultFlux(), DATA.getDefaultDataSize())
+            .block();
+
+        // A real customer would deploy with these environment variables set on the process:
+        //   AZURE_STORAGE_SESSION_MODE=SINGLE_SPECIFIED_CONTAINER
+        //   AZURE_STORAGE_SESSION_CONTAINER_NAME=<their container>
+        // This test relies on those env vars being set on the host running it.
+
+        List<String> downloadAuthSchemes = Collections.synchronizedList(new ArrayList<>());
+        RequestInspectionPolicy inspect = new RequestInspectionPolicy(req -> {
+            String auth = req.getHeaders().getValue(HttpHeaderName.AUTHORIZATION);
+            String path = req.getUrl().getPath();
+            String trimmed = path != null && path.startsWith("/") ? path.substring(1) : path;
+            if (auth != null && trimmed != null && trimmed.contains("/")) {
+                downloadAuthSchemes.add(auth.startsWith("Session ") ? "Session" : "Bearer");
+            }
+        });
+
+        try {
+            // Customer code: no .sessionOptions(...), no .configuration(...). The env vars
+            // set on the host are the only thing turning on session-based auth.
+            BlobContainerAsyncClient sessionCcAsync = instrument(new BlobContainerClientBuilder().endpoint(endpoint)
+                .containerName(myContainerName)
+                .credential(new DefaultAzureCredentialBuilder().build())
+                .addPolicy(inspect)).buildAsyncClient();
+
+            StepVerifier.create(sessionCcAsync.getBlobAsyncClient(blobName).downloadContent())
+                .assertNext(downloaded -> assertEquals(DATA.getDefaultText(), downloaded.toString()))
+                .verifyComplete();
+
+            assertFalse(downloadAuthSchemes.isEmpty(), "Expected to observe at least one blob download request");
+            assertTrue(downloadAuthSchemes.stream().allMatch("Session"::equals),
+                "Expected env-var-configured client to use Session auth on blob downloads; saw " + downloadAuthSchemes);
+        } finally {
+            primaryBlobServiceAsyncClient.deleteBlobContainer(myContainerName).block();
+        }
+    }
+
 }

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/implementation/util/SessionTokenCredentialPolicyTest.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/implementation/util/SessionTokenCredentialPolicyTest.java
@@ -626,15 +626,18 @@ public class SessionTokenCredentialPolicyTest {
     }
 
     /**
-     * Guards the workaround in {@link StorageSessionCredential#buildStringToSign}: the Session
-     * protocol signs the literal {@code Content-Length} value rather than normalizing
-     * {@code "0" -> ""} like SharedKey does. This is required today because azure-core's
-     * {@code RestProxyBase} unconditionally adds {@code Content-Length: 0} to body-less GET
-     * requests. Once that is fixed in azure-core, the buildStringToSign workaround can be removed
-     * and this test should be updated (or deleted) to reflect the new behavior.
+     * Regression guard: the Session protocol must normalize {@code Content-Length: "0"} to
+     * {@code ""} in the string-to-sign, matching the server's canonicalization (which is the
+     * same as documented Shared Key canonicalization). Signing with {@code Content-Length: 0}
+     * must therefore produce the same HMAC as signing without a Content-Length header at all.
+     * <p>
+     * Originally we expected the opposite (signing the literal "0") based on a misread of the
+     * service behavior; that caused 401 InvalidAuthenticationInfo errors on real blob GETs
+     * because azure-core's {@code RestProxyBase} unconditionally puts {@code Content-Length: 0}
+     * on body-less GETs while the server canonicalizes that to "" before computing its HMAC.
      */
     @Test
-    public void contentLengthZeroIsIncludedInSessionSignature() {
+    public void contentLengthZeroProducesSameSignatureAsMissingContentLength() {
         String pinnedDate = "Wed, 22 Apr 2026 20:00:00 GMT";
 
         HttpRequest withCl0
@@ -658,9 +661,9 @@ public class SessionTokenCredentialPolicyTest {
         credentialWithToken(FIRST_TOKEN).signRequest(withoutCl);
         String sigWithoutCl = extractSignature(withoutCl.getHeaders().getValue(authHeaderName));
 
-        assertTrue(!sigWithCl0.equals(sigWithoutCl),
-            "Session signature must include literal Content-Length value: signing with "
-                + "Content-Length: 0 must differ from signing without Content-Length");
+        assertEquals(sigWithCl0, sigWithoutCl,
+            "Session signature must normalize Content-Length: 0 to empty: signing with "
+                + "Content-Length: 0 must match signing without Content-Length");
     }
 
     private static String extractSignature(String authHeader) {

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/implementation/util/SessionTokenCredentialPolicyTest.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/implementation/util/SessionTokenCredentialPolicyTest.java
@@ -536,6 +536,51 @@ public class SessionTokenCredentialPolicyTest {
         }
     }
 
+    @Test
+    public void sessionExpiringHintForcesBackgroundRefreshEvenWhenTimerNotDue() {
+        HttpPipelineCallContext context = createContext();
+        HttpPipelineNextPolicy next = mock(HttpPipelineNextPolicy.class);
+        HttpResponse response = mock(HttpResponse.class);
+
+        // Fresh session far from expiry, so the client's own jittered refresh timer is NOT due.
+        when(sessionClient.createSessionAsync()).thenReturn(Mono.just(credentialWithToken(FIRST_TOKEN)))
+            .thenReturn(Mono.just(credentialWithToken(SECOND_TOKEN)));
+        when(next.clone()).thenReturn(next);
+        when(next.process()).thenReturn(Mono.just(response));
+        when(response.getStatusCode()).thenReturn(200);
+        // The service signals (via x-ms-auth-info: session_expiring) that this session is about to stop
+        // being honored — for example, just before its network-context binding rotates.
+        when(response.getHeaderValue(HttpHeaderName.fromString("x-ms-auth-info"))).thenReturn("session_expiring");
+
+        policy.process(context, next).block().close();
+
+        // The service hint must trigger a proactive background refresh (a second createSession), even
+        // though the client's own refresh timer had not yet elapsed. Dropping the hint here is what
+        // previously let the session be used past the rotation boundary, surfacing as a 401
+        // "session_token_invalid" (network context mismatch).
+        verify(sessionClient, times(2)).createSessionAsync();
+    }
+
+    @Test
+    public void noSessionExpiringHintDoesNotForceBackgroundRefresh() {
+        HttpPipelineCallContext context = createContext();
+        HttpPipelineNextPolicy next = mock(HttpPipelineNextPolicy.class);
+        HttpResponse response = mock(HttpResponse.class);
+
+        when(sessionClient.createSessionAsync()).thenReturn(Mono.just(credentialWithToken(FIRST_TOKEN)))
+            .thenReturn(Mono.just(credentialWithToken(SECOND_TOKEN)));
+        when(next.clone()).thenReturn(next);
+        when(next.process()).thenReturn(Mono.just(response));
+        when(response.getStatusCode()).thenReturn(200);
+        // No x-ms-auth-info hint on the response.
+        when(response.getHeaderValue(HttpHeaderName.fromString("x-ms-auth-info"))).thenReturn(null);
+
+        policy.process(context, next).block().close();
+
+        // Without the hint and with a fresh session, only the initial session is created.
+        verify(sessionClient, times(1)).createSessionAsync();
+    }
+
     private SessionTokenCredentialPolicy createPolicy(SessionMode mode) {
         SessionOptions options = new SessionOptions().setSessionMode(mode).setContainerName("mycontainer");
         return new SessionTokenCredentialPolicy(bearerPolicy, new StorageSessionCredentialCache(sessionClient),

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/implementation/util/StorageSessionCredentialCacheTest.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/implementation/util/StorageSessionCredentialCacheTest.java
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.storage.blob.implementation.util;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Deterministic, network-free tests for {@link StorageSessionCredentialCache} time-based behavior.
+ * <p>
+ * These tests drive the cache with an injectable {@link Clock} and a mocked {@link BlobSessionClient} so the
+ * expiry and proactive-refresh logic can be exercised without sleeping or hitting the service. The end-to-end
+ * confidence that real rotation works on the wire is covered separately by the live
+ * {@code ContainerApiTests.sessionTokenRotates} / {@code sessionTokenRotatesWithoutInvalidTokenGets} tests.
+ */
+public class StorageSessionCredentialCacheTest {
+
+    private static final String FIRST_TOKEN = "first-session-token";
+    private static final String SECOND_TOKEN = "second-session-token";
+
+    // A session's usable lifetime in these tests (the service issues ~5 minute sessions).
+    private static final Duration SESSION_LIFETIME = Duration.ofMinutes(5);
+
+    /**
+     * A request returns a good (valid) token. The clock then advances past the token's expiration. The next
+     * request must detect that the cached token is expired purely due to the passage of time and request a
+     * brand-new session rather than reuse or send the expired one.
+     */
+    @Test
+    public void expiredByTimeOnSecondRequestCreatesNewSession() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-06-19T00:00:00Z"));
+        BlobSessionClient sessionClient = mock(BlobSessionClient.class);
+        StorageSessionCredentialCache cache = new StorageSessionCredentialCache(sessionClient, clock);
+
+        OffsetDateTime expiration = now(clock).plus(SESSION_LIFETIME);
+        when(sessionClient.createSessionSync()).thenReturn(credential(FIRST_TOKEN, expiration))
+            .thenReturn(credential(SECOND_TOKEN, now(clock).plus(SESSION_LIFETIME.multipliedBy(2))));
+
+        // First request: cold cache mints a good token and uses it.
+        StorageSessionCredential firstRequest = cache.getValidSessionSync();
+        assertEquals(FIRST_TOKEN, firstRequest.getSessionToken());
+        verify(sessionClient, times(1)).createSessionSync();
+        verify(sessionClient, never()).createSessionAsync();
+
+        // Time advances past the first token's expiration with no traffic in between.
+        clock.advance(SESSION_LIFETIME.plusSeconds(1));
+
+        // Second request: the cached token is expired by time, so a new session is created instead of reused.
+        StorageSessionCredential secondRequest = cache.getValidSessionSync();
+        assertEquals(SECOND_TOKEN, secondRequest.getSessionToken());
+        verify(sessionClient, times(2)).createSessionSync();
+        // The expiry path mints inline; it must not have leaned on the background (async) refresh.
+        verify(sessionClient, never()).createSessionAsync();
+    }
+
+    /**
+     * When the service has NOT sent a {@code session_expiring} hint, the cache must still refresh
+     * automatically once its own jittered timer elapses (while the current token is still usable), serving
+     * the current token until the refreshed one is ready.
+     */
+    @Test
+    public void automaticBackgroundRefreshFiresWithoutServiceHint() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-06-19T00:00:00Z"));
+        BlobSessionClient sessionClient = mock(BlobSessionClient.class);
+        StorageSessionCredentialCache cache = new StorageSessionCredentialCache(sessionClient, clock);
+
+        OffsetDateTime firstExpiration = now(clock).plus(SESSION_LIFETIME);
+        when(sessionClient.createSessionSync()).thenReturn(credential(FIRST_TOKEN, firstExpiration));
+        // Mono.just emits synchronously on subscribe, so the background swap completes inline for the test.
+        when(sessionClient.createSessionAsync())
+            .thenReturn(Mono.just(credential(SECOND_TOKEN, now(clock).plus(SESSION_LIFETIME.multipliedBy(2)))));
+
+        // First request: cold cache mints the initial token.
+        assertEquals(FIRST_TOKEN, cache.getValidSessionSync().getSessionToken());
+        verify(sessionClient, times(1)).createSessionSync();
+        verify(sessionClient, never()).createSessionAsync();
+
+        // Advance to a point guaranteed to be past the jittered refresh time (80-100% of lifetime minus the
+        // 5s safety buffer => at most lifetime-5s) but still before hard expiry, so the token remains usable.
+        clock.advance(SESSION_LIFETIME.minusSeconds(2));
+
+        // Second request: token still usable, refresh timer elapsed, no service hint => automatic background
+        // refresh. The current token is served while the refresh happens.
+        assertEquals(FIRST_TOKEN, cache.getValidSessionSync().getSessionToken());
+        verify(sessionClient, times(1)).createSessionAsync();
+
+        // Third request: the background refresh has swapped in the new token, which is now served.
+        assertEquals(SECOND_TOKEN, cache.getValidSessionSync().getSessionToken());
+        // Still only one inline creation and one background refresh overall (no over-eager churn).
+        verify(sessionClient, times(1)).createSessionSync();
+        verify(sessionClient, times(1)).createSessionAsync();
+    }
+
+    /**
+     * Guards against over-eager refreshing: while the token is comfortably before its jittered refresh point
+     * and no service hint has arrived, repeated requests must reuse the same cached token and never trigger a
+     * refresh.
+     */
+    @Test
+    public void noRefreshBeforeJitterWindowWithoutServiceHint() {
+        MutableClock clock = new MutableClock(Instant.parse("2026-06-19T00:00:00Z"));
+        BlobSessionClient sessionClient = mock(BlobSessionClient.class);
+        StorageSessionCredentialCache cache = new StorageSessionCredentialCache(sessionClient, clock);
+
+        OffsetDateTime expiration = now(clock).plus(SESSION_LIFETIME);
+        when(sessionClient.createSessionSync()).thenReturn(credential(FIRST_TOKEN, expiration));
+
+        // First request mints the token.
+        assertEquals(FIRST_TOKEN, cache.getValidSessionSync().getSessionToken());
+
+        // Advance only slightly — well before the earliest jittered refresh point (80% of lifetime).
+        clock.advance(Duration.ofSeconds(30));
+
+        // Several more requests reuse the same token; no refresh is triggered.
+        for (int i = 0; i < 3; i++) {
+            assertEquals(FIRST_TOKEN, cache.getValidSessionSync().getSessionToken());
+        }
+
+        verify(sessionClient, times(1)).createSessionSync();
+        verify(sessionClient, never()).createSessionAsync();
+    }
+
+    private static OffsetDateTime now(Clock clock) {
+        return OffsetDateTime.now(clock);
+    }
+
+    private static StorageSessionCredential credential(String token, OffsetDateTime expiration) {
+        return new StorageSessionCredential(token, SessionTestHelper.TEST_SESSION_KEY, expiration,
+            SessionTestHelper.TEST_ACCOUNT_NAME);
+    }
+
+    /**
+     * A {@link Clock} whose instant can be advanced, allowing deterministic control of the cache's notion of
+     * "now" without sleeping.
+     */
+    private static final class MutableClock extends Clock {
+        private final ZoneId zone;
+        private Instant instant;
+
+        MutableClock(Instant instant) {
+            this(instant, ZoneOffset.UTC);
+        }
+
+        private MutableClock(Instant instant, ZoneId zone) {
+            this.instant = instant;
+            this.zone = zone;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return zone;
+        }
+
+        @Override
+        public Clock withZone(ZoneId newZone) {
+            return new MutableClock(instant, newZone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+
+        void advance(Duration duration) {
+            instant = instant.plus(duration);
+        }
+    }
+}

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/implementation/util/StorageSessionCredentialTest.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/storage/blob/implementation/util/StorageSessionCredentialTest.java
@@ -58,16 +58,9 @@ public class StorageSessionCredentialTest {
     // encoded query string (e.g. snapshot=...%3A...).
     //
     // Scope is intentionally narrow. Session and SharedKey legitimately diverge on:
-    //   - missing Content-Length (SharedKey emits literal "null" via String.join; Session emits "")
-    //   - Content-Length "0" on GETs (SharedKey normalizes to ""; Session preserves "0" to match
-    //     what azure-core's RestProxyBase puts on the wire — see the comment on
-    //     StorageSessionCredential.buildStringToSign).
-    // Content-Length is pinned to a realistic non-zero value to bypass both quirks.
-    //
-    // DELETE this test once azure-core stops setting Content-Length: 0 on GETs and
-    // StorageSessionCredential.buildStringToSign is removed in favor of delegating to
-    // sharedKey.generateAuthorizationHeader(...). At that point this assertion becomes
-    // tautological (SharedKey vs. SharedKey).
+    //   - missing Content-Length (SharedKey emits literal "null" via String.join; Session emits "").
+    // Content-Length is pinned to a realistic non-zero value to bypass that quirk. Equivalence for
+    // Content-Length: 0 (which the server normalizes to "") is covered separately.
     @Test
     public void canonicalizationMatchesSharedKeyForEncodedQuery() throws MalformedURLException {
         StorageSessionCredential sessionCred = SessionTestHelper.createValidCredential();


### PR DESCRIPTION
Enables configuring the blob storage session (SessionMode and session container name) through environment variables / Configuration, so callers can opt into a session without changing builder code.

Two new keys are introduced in BuilderHelper: - AZURE_STORAGE_SESSION_MODE — names a SessionMode (NONE, AUTO, SINGLE_SPECIFIED_CONTAINER), matched case-insensitively. Only applied when the builder is still on the default SessionMode.AUTO.

AZURE_STORAGE_SESSION_CONTAINER_NAME — supplies the container name to scope the session to. Only applied when the builder has no container name set.
A new helper, BuilderHelper.applyEnvironmentSessionDefaults(SessionOptions, Configuration, ClientLogger), performs the fallback resolution and is invoked from:

BlobClientBuilder (both pipeline construction paths)
BlobContainerClientBuilder (both pipeline construction paths)
BlobServiceClientBuilder#constructPipeline
Explicit programmatic configuration on the builder always wins; the env vars are only consulted to fill in unset values. An invalid AZURE_STORAGE_SESSION_MODE value throws IllegalArgumentException via the client logger.
