### PR TITLE
Revapi suppressions

### DIFF
--- a/eng/lintingconfigs/revapi/track2/revapi.json
+++ b/eng/lintingconfigs/revapi/track2/revapi.json
@@ -2007,7 +2007,7 @@
             "matcher": "regex",
             "match": "method .* com\\.azure\\.ai\\.agents\\.Agents(Async)?Client::createAgentVersion\\(.*\\)"
           },
-          "justification": "Breaking change in beta operation: createAgentVersion is retained on AgentsClient/AgentsAsyncClient but the overload taking AgentDefinitionOptInKeys was removed. The opt-in key is now sent implicitly, so users are no longer meant to pass opt-in keys directly. The AgentBlueprintReference capability is preserved via a new overload that drops the opt-in key."
+          "justification": "Breaking change in beta operation: the createAgentVersion overload taking AgentDefinitionOptInKeys (and AgentBlueprintReference) was removed from AgentsClient/AgentsAsyncClient. The opt-in key is now sent implicitly, so users are no longer meant to pass opt-in keys directly; callers that need to set a blueprint reference should supply the blueprint reference via the CreateAgentVersionInput model instead."
         },
         {
           "ignore": true,

--- a/eng/lintingconfigs/revapi/track2/revapi.json
+++ b/eng/lintingconfigs/revapi/track2/revapi.json
@@ -1963,6 +1963,105 @@
           "code": "java.method.returnTypeChanged",
           "old": "method double com.azure.ai.projects.models.ModelSamplingParams::getTopP()",
           "justification": "Breaking change in beta operation: return type changed from primitive double to boxed Double to support optional values."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": {
+            "matcher": "regex",
+            "match": "class com\\.azure\\.ai\\.agents\\.(AgentSessionFiles|MemoryStores|Toolboxes)(Async)?Client"
+          },
+          "justification": "Beta operations were moved out of the main agents client into dedicated beta clients: the AgentSessionFiles, MemoryStores and Toolboxes sub-clients are removed and their operations now live on BetaAgentsClient/BetaAgentsAsyncClient, BetaMemoryStoresClient/BetaMemoryStoresAsyncClient and BetaToolboxesClient/BetaToolboxesAsyncClient."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": {
+            "matcher": "regex",
+            "match": "method com\\.azure\\.ai\\.agents\\.(AgentSessionFiles|MemoryStores|Toolboxes)(Async)?Client com\\.azure\\.ai\\.agents\\.AgentsClientBuilder::build(AgentSessionFiles|MemoryStores|Toolboxes)(Async)?Client\\(\\)"
+          },
+          "justification": "Beta operations were moved into dedicated beta clients: the AgentsClientBuilder factory methods for the AgentSessionFiles, MemoryStores and Toolboxes sub-clients are removed and replaced by buildBetaAgentsClient/buildBetaMemoryStoresClient/buildBetaToolboxesClient (and their async variants)."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": {
+            "matcher": "regex",
+            "match": "method .* com\\.azure\\.ai\\.agents\\.Agents(Async)?Client::(createSession|getSession|listSessions|deleteSession|stopSession|getSessionLogStream|cancelOptimizationJob|createOptimizationJob|deleteOptimizationJob|getOptimizationJob|listOptimizationJobs|getOptimizationCandidate|listOptimizationCandidates|promoteOptimizationCandidate|createAgentVersionFromCode|updateAgentDetails|updateAgentFromCode|downloadAgentCode)\\w*\\(.*\\)"
+          },
+          "justification": "Beta operations were moved out of AgentsClient/AgentsAsyncClient into the dedicated beta clients: session, optimization-job/candidate and agent-version/code operations were removed from the main client and now live on BetaAgentsClient/BetaAgentsAsyncClient."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.numberOfParametersChanged",
+          "old": {
+            "matcher": "regex",
+            "match": "method .* com\\.azure\\.ai\\.agents\\.Agents(Async)?Client::createAgentVersion\\(.*\\)"
+          },
+          "justification": "Breaking change in beta operation: createAgentVersion is retained on AgentsClient/AgentsAsyncClient but the AgentDefinitionOptInKeys parameter was dropped from its signature. The opt-in key is now sent implicitly, so users are no longer meant to pass opt-in keys directly."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": {
+            "matcher": "regex",
+            "match": "method .* com\\.azure\\.ai\\.agents\\.Agents(Async)?Client::createAgentVersion\\(.*\\)"
+          },
+          "justification": "Breaking change in beta operation: createAgentVersion is retained on AgentsClient/AgentsAsyncClient but the overload taking AgentDefinitionOptInKeys was removed. The opt-in key is now sent implicitly, so users are no longer meant to pass opt-in keys directly. The AgentBlueprintReference capability is preserved via a new overload that drops the opt-in key."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": {
+            "matcher": "regex",
+            "match": "enum com\\.azure\\.ai\\.agents\\.models\\.(AgentDefinitionOptInKeys|FoundryFeaturesOptInKeys)"
+          },
+          "justification": "Breaking change in beta operation: the AgentDefinitionOptInKeys and FoundryFeaturesOptInKeys opt-in enums were removed from the public models package and relocated to implementation.models (made internal). The opt-in key is now sent implicitly, so users are no longer meant to use the opt-in keys directly."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": "class com.azure.ai.agents.models.OptimizationCandidatePagedResult",
+          "justification": "Breaking change in beta operation: OptimizationCandidatePagedResult was removed; listOptimizationCandidates now returns standard PagedIterable<OptimizationCandidate> instead of a custom paged-result wrapper."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": {
+            "matcher": "regex",
+            "match": "class com\\.azure\\.ai\\.projects\\.(DataGenerationJobs|EvaluationTaxonomies|Evaluators|Insights|Models|RedTeams|Routines|Schedules|Skills)(Async)?Client"
+          },
+          "justification": "Beta operations were moved out of the AI Projects client into dedicated beta clients: these sub-clients are removed and their operations now live on the matching BetaEvaluationTaxonomies/BetaEvaluators/BetaInsights/BetaModels/BetaRedTeams/BetaRoutines/BetaSchedules/BetaSkills clients (data generation job operations moved onto BetaDatasetsClient)."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": {
+            "matcher": "regex",
+            "match": "method com\\.azure\\.ai\\.projects\\.\\w+ com\\.azure\\.ai\\.projects\\.AIProjectClientBuilder::build(DataGenerationJobs|EvaluationTaxonomies|Evaluators|Insights|Models|RedTeams|Routines|Schedules|Skills)(Async)?Client\\(\\)"
+          },
+          "justification": "Beta operations were moved into dedicated beta clients: the AIProjectClientBuilder factory methods for these sub-clients are removed and replaced by the corresponding buildBeta*Client factory methods (and their async variants)."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": "enum com.azure.ai.projects.models.FoundryFeaturesOptInKeys",
+          "justification": "Breaking change in beta operation: the FoundryFeaturesOptInKeys opt-in enum was removed from the public models package and relocated to implementation.models (made internal). The opt-in key is now sent implicitly, so users are no longer meant to use the opt-in keys directly."
+        },
+        {
+          "ignore": true,
+          "code": "java.class.removed",
+          "old": "class com.azure.ai.projects.models.Skill",
+          "justification": "Breaking change in beta operation: the Skill model was removed and replaced by the restructured SkillDetails/SkillVersion (and related) models."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": {
+            "matcher": "regex",
+            "match": "method .* com\\.azure\\.ai\\.projects\\.EvaluationRules(Async)?Client::createOrUpdateEvaluationRule\\(.*FoundryFeaturesOptInKeys\\)"
+          },
+          "justification": "Breaking change in beta operation: EvaluationRulesClient/EvaluationRulesAsyncClient are retained; only the overload of createOrUpdateEvaluationRule that took FoundryFeaturesOptInKeys was removed. The opt-in key is now sent implicitly, so users are no longer meant to pass opt-in keys directly."
         }
       ]
     }

--- a/eng/lintingconfigs/revapi/track2/revapi.json
+++ b/eng/lintingconfigs/revapi/track2/revapi.json
@@ -2062,6 +2062,18 @@
             "match": "method .* com\\.azure\\.ai\\.projects\\.EvaluationRules(Async)?Client::createOrUpdateEvaluationRule\\(.*FoundryFeaturesOptInKeys\\)"
           },
           "justification": "Breaking change in beta operation: EvaluationRulesClient/EvaluationRulesAsyncClient are retained; only the overload of createOrUpdateEvaluationRule that took FoundryFeaturesOptInKeys was removed. The opt-in key is now sent implicitly, so users are no longer meant to pass opt-in keys directly."
+        },
+        {
+          "regex": true,
+          "code": "java\\..*",
+          "old": ".*com\\.azure\\.ai\\.agents\\.Beta\\w*(Async)?Client.*",
+          "justification": "Breaking changes are accepted on the azure-ai-agents beta clients (Beta*Client/Beta*AsyncClient, e.g. BetaAgentsClient, BetaMemoryStoresClient, BetaToolboxesClient). These clients expose preview operations whose API surface is allowed to change until the operations are promoted to a stable client."
+        },
+        {
+          "regex": true,
+          "code": "java\\..*",
+          "old": ".*com\\.azure\\.ai\\.projects\\.Beta\\w*(Async)?Client.*",
+          "justification": "Breaking changes are accepted on the azure-ai-projects beta clients (Beta*Client/Beta*AsyncClient, e.g. BetaDatasetsClient, BetaEvaluatorsClient, BetaModelsClient, BetaRedTeamsClient, BetaSchedulesClient, BetaSkillsClient). These clients expose preview operations whose API surface is allowed to change until the operations are promoted to a stable client."
         }
       ]
     }

--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/AgentsAsyncClient.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/AgentsAsyncClient.java
@@ -1938,45 +1938,6 @@ public final class AgentsAsyncClient {
      * - Must start and end with alphanumeric characters,
      * - Can contain hyphens in the middle
      * - Must not exceed 63 characters.
-     * @param definition The agent definition. This can be a workflow, hosted agent, or a simple agent definition.
-     * @param metadata Set of 16 key-value pairs that can be attached to an object. This can be
-     * useful for storing additional information about the object in a structured
-     * format, and querying for objects via API or the dashboard.
-     *
-     * Keys are strings with a maximum length of 64 characters. Values are strings
-     * with a maximum length of 512 characters.
-     * @param description A human-readable description of the agent.
-     * @param blueprintReference The blueprint reference to associate with the new agent version.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response body on successful completion of {@link Mono}.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public Mono<AgentVersionDetails> createAgentVersion(String agentName, AgentDefinition definition,
-        Map<String, String> metadata, String description, AgentBlueprintReference blueprintReference) {
-        // Generated convenience method for createAgentVersionWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        CreateAgentVersionRequest createAgentVersionRequestObj
-            = new CreateAgentVersionRequest(definition).setMetadata(metadata)
-                .setDescription(description)
-                .setBlueprintReference(blueprintReference);
-        BinaryData createAgentVersionRequest = BinaryData.fromObject(createAgentVersionRequestObj);
-        return createAgentVersionWithResponse(agentName, createAgentVersionRequest, requestOptions)
-            .flatMap(FluxUtil::toMono)
-            .map(protocolMethodData -> protocolMethodData.toObject(AgentVersionDetails.class));
-    }
-
-    /**
-     * Create a new agent version.
-     *
-     * @param agentName The unique name that identifies the agent. Name can be used to retrieve/update/delete the agent.
-     * - Must start and end with alphanumeric characters,
-     * - Can contain hyphens in the middle
-     * - Must not exceed 63 characters.
      * @param createAgentVersionInput The request body for creating an agent version, which includes the agent
      * definition and optional metadata.
      * @throws IllegalArgumentException thrown if parameters fail the validation.

--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/AgentsAsyncClient.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/AgentsAsyncClient.java
@@ -1938,6 +1938,45 @@ public final class AgentsAsyncClient {
      * - Must start and end with alphanumeric characters,
      * - Can contain hyphens in the middle
      * - Must not exceed 63 characters.
+     * @param definition The agent definition. This can be a workflow, hosted agent, or a simple agent definition.
+     * @param metadata Set of 16 key-value pairs that can be attached to an object. This can be
+     * useful for storing additional information about the object in a structured
+     * format, and querying for objects via API or the dashboard.
+     *
+     * Keys are strings with a maximum length of 64 characters. Values are strings
+     * with a maximum length of 512 characters.
+     * @param description A human-readable description of the agent.
+     * @param blueprintReference The blueprint reference to associate with the new agent version.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response body on successful completion of {@link Mono}.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<AgentVersionDetails> createAgentVersion(String agentName, AgentDefinition definition,
+        Map<String, String> metadata, String description, AgentBlueprintReference blueprintReference) {
+        // Generated convenience method for createAgentVersionWithResponse
+        RequestOptions requestOptions = new RequestOptions();
+        CreateAgentVersionRequest createAgentVersionRequestObj
+            = new CreateAgentVersionRequest(definition).setMetadata(metadata)
+                .setDescription(description)
+                .setBlueprintReference(blueprintReference);
+        BinaryData createAgentVersionRequest = BinaryData.fromObject(createAgentVersionRequestObj);
+        return createAgentVersionWithResponse(agentName, createAgentVersionRequest, requestOptions)
+            .flatMap(FluxUtil::toMono)
+            .map(protocolMethodData -> protocolMethodData.toObject(AgentVersionDetails.class));
+    }
+
+    /**
+     * Create a new agent version.
+     *
+     * @param agentName The unique name that identifies the agent. Name can be used to retrieve/update/delete the agent.
+     * - Must start and end with alphanumeric characters,
+     * - Can contain hyphens in the middle
+     * - Must not exceed 63 characters.
      * @param createAgentVersionInput The request body for creating an agent version, which includes the agent
      * definition and optional metadata.
      * @throws IllegalArgumentException thrown if parameters fail the validation.

--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/AgentsClient.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/AgentsClient.java
@@ -1855,44 +1855,6 @@ public final class AgentsClient {
      * - Must start and end with alphanumeric characters,
      * - Can contain hyphens in the middle
      * - Must not exceed 63 characters.
-     * @param definition The agent definition. This can be a workflow, hosted agent, or a simple agent definition.
-     * @param metadata Set of 16 key-value pairs that can be attached to an object. This can be
-     * useful for storing additional information about the object in a structured
-     * format, and querying for objects via API or the dashboard.
-     *
-     * Keys are strings with a maximum length of 64 characters. Values are strings
-     * with a maximum length of 512 characters.
-     * @param description A human-readable description of the agent.
-     * @param blueprintReference The blueprint reference to associate with the new agent version.
-     * @throws IllegalArgumentException thrown if parameters fail the validation.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
-     * @return the response.
-     */
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    public AgentVersionDetails createAgentVersion(String agentName, AgentDefinition definition,
-        Map<String, String> metadata, String description, AgentBlueprintReference blueprintReference) {
-        // Generated convenience method for createAgentVersionWithResponse
-        RequestOptions requestOptions = new RequestOptions();
-        CreateAgentVersionRequest createAgentVersionRequestObj
-            = new CreateAgentVersionRequest(definition).setMetadata(metadata)
-                .setDescription(description)
-                .setBlueprintReference(blueprintReference);
-        BinaryData createAgentVersionRequest = BinaryData.fromObject(createAgentVersionRequestObj);
-        return createAgentVersionWithResponse(agentName, createAgentVersionRequest, requestOptions).getValue()
-            .toObject(AgentVersionDetails.class);
-    }
-
-    /**
-     * Create a new agent version.
-     *
-     * @param agentName The unique name that identifies the agent. Name can be used to retrieve/update/delete the agent.
-     * - Must start and end with alphanumeric characters,
-     * - Can contain hyphens in the middle
-     * - Must not exceed 63 characters.
      * @param createAgentVersionInput The request body for creating an agent version, which includes the agent
      * definition and optional metadata.
      * @throws IllegalArgumentException thrown if parameters fail the validation.

--- a/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/AgentsClient.java
+++ b/sdk/ai/azure-ai-agents/src/main/java/com/azure/ai/agents/AgentsClient.java
@@ -1855,6 +1855,44 @@ public final class AgentsClient {
      * - Must start and end with alphanumeric characters,
      * - Can contain hyphens in the middle
      * - Must not exceed 63 characters.
+     * @param definition The agent definition. This can be a workflow, hosted agent, or a simple agent definition.
+     * @param metadata Set of 16 key-value pairs that can be attached to an object. This can be
+     * useful for storing additional information about the object in a structured
+     * format, and querying for objects via API or the dashboard.
+     *
+     * Keys are strings with a maximum length of 64 characters. Values are strings
+     * with a maximum length of 512 characters.
+     * @param description A human-readable description of the agent.
+     * @param blueprintReference The blueprint reference to associate with the new agent version.
+     * @throws IllegalArgumentException thrown if parameters fail the validation.
+     * @throws HttpResponseException thrown if the request is rejected by server.
+     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
+     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
+     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
+     * @throws RuntimeException all other wrapped checked exceptions if the request fails to be sent.
+     * @return the response.
+     */
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public AgentVersionDetails createAgentVersion(String agentName, AgentDefinition definition,
+        Map<String, String> metadata, String description, AgentBlueprintReference blueprintReference) {
+        // Generated convenience method for createAgentVersionWithResponse
+        RequestOptions requestOptions = new RequestOptions();
+        CreateAgentVersionRequest createAgentVersionRequestObj
+            = new CreateAgentVersionRequest(definition).setMetadata(metadata)
+                .setDescription(description)
+                .setBlueprintReference(blueprintReference);
+        BinaryData createAgentVersionRequest = BinaryData.fromObject(createAgentVersionRequestObj);
+        return createAgentVersionWithResponse(agentName, createAgentVersionRequest, requestOptions).getValue()
+            .toObject(AgentVersionDetails.class);
+    }
+
+    /**
+     * Create a new agent version.
+     *
+     * @param agentName The unique name that identifies the agent. Name can be used to retrieve/update/delete the agent.
+     * - Must start and end with alphanumeric characters,
+     * - Can contain hyphens in the middle
+     * - Must not exceed 63 characters.
      * @param createAgentVersionInput The request body for creating an agent version, which includes the agent
      * definition and optional metadata.
      * @throws IllegalArgumentException thrown if parameters fail the validation.


### PR DESCRIPTION
This pull request updates the API review configuration in `eng/lintingconfigs/revapi/track2/revapi.json` to reflect recent refactoring and breaking changes in the beta operations for the Azure AI Agents and AI Projects Java SDKs. The main focus is on ignoring intentional breaking changes due to the migration of beta operations from general clients to dedicated beta clients, and on handling changes to opt-in keys and model structures.

**Beta client migration and breaking changes:**

* Added ignore rules for the removal of `AgentSessionFiles`, `MemoryStores`, and `Toolboxes` (and their async variants) sub-clients from the main agents client, as these operations now reside on dedicated beta clients (`BetaAgentsClient`, `BetaMemoryStoresClient`, `BetaToolboxesClient`, etc.).
* Added ignore rules for the removal of related factory methods from `AgentsClientBuilder` and `AIProjectClientBuilder`, replaced by new `buildBeta*Client` methods.
* Added ignore rules for the removal of various beta operations from `AgentsClient`/`AgentsAsyncClient`, which are now available on the new beta clients.
* Added ignore rules for the removal of beta sub-clients from the AI Projects client, with their operations now moved to corresponding beta clients (e.g., `BetaEvalu