### PR TITLE
Docs: change default package source override to Dev feed

### DIFF
--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -166,7 +166,6 @@ jobs:
             filePath: eng/common/scripts/Update-DocsMsPackages.ps1
             arguments: >-
               -DocRepoLocation $(DocRepoLocation)
-              -PackageSourceOverride 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1'
           displayName: Update Docs Onboarding for Daily docs
 
         - task: Powershell@2

--- a/eng/scripts/docs/Docs-Onboarding.ps1
+++ b/eng/scripts/docs/Docs-Onboarding.ps1
@@ -19,7 +19,7 @@ function Set-java-DocsPackageOnboarding($moniker, $metadata, $docRepoLocation, $
         Write-Error "No appropriate index for moniker $moniker"
     }
 
-    $packageDownloadUrl = 'https://repo1.maven.org/maven2'
+    $packageDownloadUrl = 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1'
     if ($PackageSourceOverride) {
         $packageDownloadUrl = $PackageSourceOverride
     }


### PR DESCRIPTION
Generates the onboarding file with the dev feed as the default URL. 

DEPENDS ON [migration of non-CFS packages](https://github.com/MicrosoftDocs/azure-docs-sdk-java/pull/2653) to use

```
"packageDownloadUrl": "https://repo1.maven.org/maven2"
``` 

in their metadata JSONs if the package does not exist in the Dev Feed (i.e. mostly legacy or packages that ship outside of the Azure SDK EngSys)