### PR TITLE
Stabilize Azure Monitor autoconfigure QuickPulse coordinator tests

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-autoconfigure/src/test/java/com/azure/monitor/opentelemetry/autoconfigure/implementation/quickpulse/QuickPulseCoordinatorTest.java
+++ b/sdk/monitor/azure-monitor-opentelemetry-autoconfigure/src/test/java/com/azure/monitor/opentelemetry/autoconfigure/implementation/quickpulse/QuickPulseCoordinatorTest.java
@@ -18,6 +18,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 class QuickPulseCoordinatorTest {
+    private static final long VERIFY_TIMEOUT_MILLIS = 10000;
+    private static final long THREAD_JOIN_TIMEOUT_MILLIS = 10000;
+
     private static final HttpHeaderName QPS_STATUS_HEADER = HttpHeaderName.fromString("x-ms-qps-subscribed");
     private static final HttpHeaderName QPS_SERVICE_POLLING_INTERVAL_HINT
         = HttpHeaderName.fromString("x-ms-qps-service-polling-interval-hint");
@@ -50,17 +53,17 @@ class QuickPulseCoordinatorTest {
         thread.setDaemon(true);
         thread.start();
 
-        Thread.sleep(1000);
-        coordinator.stop();
-
-        thread.join();
+        try {
+            Mockito.verify(mockPingSender, Mockito.timeout(VERIFY_TIMEOUT_MILLIS).atLeastOnce()).ping(null);
+        } finally {
+            stopAndJoin(coordinator, thread);
+        }
 
         Mockito.verify(mockFetcher, Mockito.never()).prepareQuickPulseDataForSend();
 
         Mockito.verify(mockSender, Mockito.never()).startSending();
         Mockito.verify(mockSender, Mockito.never()).getQuickPulseStatus();
 
-        Mockito.verify(mockPingSender, Mockito.atLeast(1)).ping(null);
         // make sure QP_IS_OFF after ping
         assertThat(collector.getQuickPulseStatus()).isEqualTo(QuickPulseStatus.QP_IS_OFF);
     }
@@ -96,12 +99,12 @@ class QuickPulseCoordinatorTest {
         thread.setDaemon(true);
         thread.start();
 
-        Thread.sleep(1000);
-        coordinator.stop();
-
-        thread.join();
-
-        Mockito.verify(mockFetcher, Mockito.atLeast(1)).prepareQuickPulseDataForSend();
+        try {
+            Mockito.verify(mockFetcher, Mockito.timeout(VERIFY_TIMEOUT_MILLIS).atLeastOnce())
+                .prepareQuickPulseDataForSend();
+        } finally {
+            stopAndJoin(coordinator, thread);
+        }
 
         Mockito.verify(mockSender, Mockito.times(1)).startSending();
         Mockito.verify(mockSender, Mockito.times(1)).getQuickPulseStatus();
@@ -109,6 +112,12 @@ class QuickPulseCoordinatorTest {
         Mockito.verify(mockPingSender, Mockito.atLeast(1)).ping(null);
         // Make sure QP_IS_OFF after one post and ping
         assertThat(collector.getQuickPulseStatus()).isEqualTo(QuickPulseStatus.QP_IS_OFF);
+    }
+
+    private static void stopAndJoin(QuickPulseCoordinator coordinator, Thread thread) throws InterruptedException {
+        coordinator.stop();
+        thread.join(THREAD_JOIN_TIMEOUT_MILLIS);
+        assertThat(thread.isAlive()).isFalse();
     }
 
     @Disabled("sporadically failing on CI")


### PR DESCRIPTION
## Summary

Stabilizes `QuickPulseCoordinatorTest` in `azure-monitor-opentelemetry-autoconfigure` by replacing fixed sleeps with Mockito timeout-based waits for the expected coordinator interactions.

## Problem

The `java - monitor` pipeline repeatedly failed in the Windows Java 25 test leg with zero interactions recorded on QuickPulse mocks:

- `quickPulsePingSender.ping(null)` was not invoked
- `quickPulseDataFetcher.prepareQuickPulseDataForSend()` was not invoked

The test started the coordinator on a background thread, slept for one second, then stopped the coordinator. On Azure DevOps hosted agents, the coordinator thread could be scheduled late enough that the test stopped it before it entered the run loop.

## Fix

The test now:

- Waits for the expected mock interaction using `Mockito.timeout(...)`
- Stops the coordinator in a `finally` block
- Uses a bounded thread join and asserts the coordinator thread exits

This removes the scheduling assumption while preserving the behavior being tested.

## Verification

Ran locally with JDK 25 and Maven 3.9.16:

```text
QuickPulseCoordinatorTest#testOnlyPings+testOnePingAndThenOnePost: PASS
QuickPulseCoordinatorTest full class: PASS
QuickPulseCoordinatorTest repeated 5 times: PASS