### PR TITLE
Added CFSClean3 policy

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -42,7 +42,7 @@ extends:
       skipBuildTagsForGitHubPullRequests: true
       # Set network isolation policy to Permissive, CFSClean which our pipeline are currently compliant with.
       # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/cloudbuild/security/1espt-network-isolation#shared-policies-for-common-use-cases
-      networkIsolationPolicy: Permissive, CFSClean
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean3
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'java - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,7 +40,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      # Set network isolation policy to Permissive, CFSClean which our pipeline are currently compliant with.
+      # Set network isolation policy to Permissive, CFSClean, CFSClean3 which our pipelines are currently compliant with.
       # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/cloudbuild/security/1espt-network-isolation#shared-policies-for-common-use-cases
       networkIsolationPolicy: Permissive, CFSClean, CFSClean3
     sdl:

--- a/eng/repo-docs/docms/daily.update.setting.xml
+++ b/eng/repo-docs/docms/daily.update.setting.xml
@@ -6,7 +6,7 @@
             <id>azure-sdk-for-java</id>
             <name>Azure Artifacts Maven Mirror</name>
             <url>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1</url>
-            <mirrorOf>external:*,!confluent,!repository.spring.milestone,!docs-public-packages</mirrorOf>
+            <mirrorOf>external:*,!repository.spring.milestone,!docs-public-packages</mirrorOf>
         </mirror>
     </mirrors>
     <profiles>

--- a/eng/settings.xml
+++ b/eng/settings.xml
@@ -7,7 +7,7 @@
       <id>azure-sdk-for-java</id>
       <name>Azure Artifacts Maven Mirror</name>
       <url>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1</url>
-      <mirrorOf>external:*,!confluent,!repository.spring.milestone</mirrorOf>
+      <mirrorOf>external:*,!repository.spring.milestone</mirrorOf>
     </mirror>
   </mirrors>
 </settings>


### PR DESCRIPTION
This pull request makes updates to the build pipeline configuration and Maven mirror settings to improve network isolation policies and adjust repository mirroring rules. The most important changes are summarized below:

**Build Pipeline Configuration:**

* Updated the `networkIsolationPolicy` in `1es-redirect.yml` to include `CFSClean3`, enhancing compliance with network isolation requirements.

**Maven Mirror Settings:**

* Removed the exclusion for the `confluent` repository from the `mirrorOf` attribute in both `eng/settings.xml` and `eng/repo-docs/docms/daily.update.setting.xml`. 