### PR TITLE
Cosmos: add cold-start metadata cache hedging (Java port of dotnet #5923)

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingStrategyTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingStrategyTest.java
@@ -248,6 +248,37 @@ public class MetadataHedgingStrategyTest {
     }
 
     @Test(groups = "unit", timeOut = TIMEOUT)
+    public void executeAsync_fastPrimaryWinDoesNotLeakLateHedge() throws InterruptedException {
+        // Regression: the hedge timer must be cancelled when the primary wins before the
+        // threshold. With a hot/cached hedge pipeline the detached timer would dispatch a
+        // spurious hedge ~threshold after the operation already returned.
+        long thresholdMs = 200;
+        MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, thresholdMs);
+
+        AtomicInteger hedgeCalls = new AtomicInteger();
+        RxDocumentServiceResponse primaryOk = okResponse();
+        Function<RxDocumentServiceRequest, Mono<RxDocumentServiceResponse>> sender = req -> {
+            RegionalRoutingContext routed = req.requestContext.regionalRoutingContextToRoute;
+            if (routed != null && routed.equals(this.west)) {
+                hedgeCalls.incrementAndGet();
+                return Mono.just(okResponse());
+            }
+            return Mono.just(primaryOk);
+        };
+
+        StepVerifier.create(strategy.executeAsync(collectionReadRequest(), sender, coldStartContext()))
+            .assertNext(result -> {
+                assertThat(result.isHedgeFired()).isFalse();
+                assertThat(result.getResponse()).isSameAs(primaryOk);
+            })
+            .verifyComplete();
+
+        // Wait well past the threshold; a leaked timer would have fired the hedge by now.
+        Thread.sleep(thresholdMs * 4);
+        assertThat(hedgeCalls.get()).isZero();
+    }
+
+    @Test(groups = "unit", timeOut = TIMEOUT)
     public void executeAsync_hedgeWinsWhenPrimaryRegionalFailure() {
         MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, 2000);
 

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingStrategyTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingStrategyTest.java
@@ -1,0 +1,345 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.metadatahedging;
+
+import com.azure.cosmos.implementation.ForbiddenException;
+import com.azure.cosmos.implementation.GlobalEndpointManager;
+import com.azure.cosmos.implementation.HttpConstants;
+import com.azure.cosmos.implementation.NotFoundException;
+import com.azure.cosmos.implementation.OperationType;
+import com.azure.cosmos.implementation.ResourceType;
+import com.azure.cosmos.implementation.RxDocumentServiceRequest;
+import com.azure.cosmos.implementation.RxDocumentServiceResponse;
+import com.azure.cosmos.implementation.ServiceUnavailableException;
+import com.azure.cosmos.implementation.apachecommons.collections.list.UnmodifiableList;
+import com.azure.cosmos.implementation.http.HttpHeaders;
+import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static com.azure.cosmos.implementation.TestUtils.mockDiagnosticsClientContext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class MetadataHedgingStrategyTest {
+
+    private static final int TIMEOUT = 10_000;
+
+    private GlobalEndpointManager globalEndpointManager;
+    private RegionalRoutingContext east;
+    private RegionalRoutingContext west;
+
+    @BeforeMethod(groups = "unit")
+    public void before() {
+        this.east = new RegionalRoutingContext(URI.create("https://east.example.com"));
+        this.west = new RegionalRoutingContext(URI.create("https://west.example.com"));
+        this.globalEndpointManager = Mockito.mock(GlobalEndpointManager.class);
+
+        Mockito.when(this.globalEndpointManager.getReadEndpoints())
+            .thenReturn(new UnmodifiableList<>(Arrays.asList(this.east, this.west)));
+        Mockito.when(this.globalEndpointManager.getApplicableReadRegionalRoutingContexts(any(RxDocumentServiceRequest.class)))
+            .thenReturn(new UnmodifiableList<>(Arrays.asList(this.east, this.west)));
+        Mockito.when(this.globalEndpointManager.resolveServiceEndpoint(any())).thenReturn(this.east);
+        Mockito.when(this.globalEndpointManager.getRegionName(eq(this.east.getGatewayRegionalEndpoint()), any(), anyBoolean()))
+            .thenReturn("East");
+        Mockito.when(this.globalEndpointManager.getRegionName(eq(this.west.getGatewayRegionalEndpoint()), any(), anyBoolean()))
+            .thenReturn("West");
+    }
+
+    // ---------- resolveOptIn ----------
+
+    @Test(groups = "unit")
+    public void resolveOptIn_nullFollowsPpaf() {
+        assertThat(MetadataHedgingStrategy.resolveOptIn(null, true)).isTrue();
+        assertThat(MetadataHedgingStrategy.resolveOptIn(null, false)).isFalse();
+    }
+
+    @Test(groups = "unit")
+    public void resolveOptIn_explicitWins() {
+        assertThat(MetadataHedgingStrategy.resolveOptIn(Boolean.TRUE, false)).isTrue();
+        assertThat(MetadataHedgingStrategy.resolveOptIn(Boolean.FALSE, true)).isFalse();
+    }
+
+    // ---------- createIfEnabled ----------
+
+    @Test(groups = "unit")
+    public void createIfEnabled_explicitFalseReturnsNull() {
+        assertThat(MetadataHedgingStrategy.createIfEnabled(Boolean.FALSE, this.globalEndpointManager, () -> true)).isNull();
+    }
+
+    @Test(groups = "unit")
+    public void createIfEnabled_nullOrTrueReturnsStrategy() {
+        assertThat(MetadataHedgingStrategy.createIfEnabled(null, this.globalEndpointManager, () -> false)).isNotNull();
+        assertThat(MetadataHedgingStrategy.createIfEnabled(Boolean.TRUE, this.globalEndpointManager, () -> false)).isNotNull();
+    }
+
+    // ---------- isRegionalFailure(status, subStatus) ----------
+
+    @Test(groups = "unit")
+    public void isRegionalFailure_statusOverlay() {
+        assertThat(MetadataHedgingStrategy.isRegionalFailure(HttpConstants.StatusCodes.SERVICE_UNAVAILABLE, 0)).isTrue();
+        assertThat(MetadataHedgingStrategy.isRegionalFailure(HttpConstants.StatusCodes.INTERNAL_SERVER_ERROR, 0)).isTrue();
+        assertThat(MetadataHedgingStrategy.isRegionalFailure(
+            HttpConstants.StatusCodes.GONE, HttpConstants.SubStatusCodes.LEASE_NOT_FOUND)).isTrue();
+        assertThat(MetadataHedgingStrategy.isRegionalFailure(HttpConstants.StatusCodes.GONE, 0)).isFalse();
+        assertThat(MetadataHedgingStrategy.isRegionalFailure(
+            HttpConstants.StatusCodes.FORBIDDEN, HttpConstants.SubStatusCodes.DATABASE_ACCOUNT_NOTFOUND)).isTrue();
+        assertThat(MetadataHedgingStrategy.isRegionalFailure(HttpConstants.StatusCodes.FORBIDDEN, 0)).isFalse();
+        assertThat(MetadataHedgingStrategy.isRegionalFailure(HttpConstants.StatusCodes.NOTFOUND, 0)).isFalse();
+    }
+
+    // ---------- isRegionalFailure(Throwable) ----------
+
+    @Test(groups = "unit")
+    public void isRegionalFailure_throwable() {
+        assertThat(MetadataHedgingStrategy.isRegionalFailure((Throwable) null)).isFalse();
+        assertThat(MetadataHedgingStrategy.isRegionalFailure(serviceUnavailable())).isTrue();
+        assertThat(MetadataHedgingStrategy.isRegionalFailure(new NotFoundException())).isFalse();
+    }
+
+    // ---------- isAcceptableWinner(response, branch) ----------
+
+    @Test(groups = "unit")
+    public void isAcceptableWinner_response() {
+        assertThat(MetadataHedgingStrategy.isAcceptableWinner(okResponse(), HedgeBranch.PRIMARY)).isTrue();
+        assertThat(MetadataHedgingStrategy.isAcceptableWinner(okResponse(), HedgeBranch.HEDGE)).isTrue();
+        assertThat(MetadataHedgingStrategy.isAcceptableWinner(
+            responseWithStatus(HttpConstants.StatusCodes.SERVICE_UNAVAILABLE), HedgeBranch.PRIMARY)).isFalse();
+        // Hedge-branch 401 / 403 overlay
+        assertThat(MetadataHedgingStrategy.isAcceptableWinner(
+            responseWithStatus(HttpConstants.StatusCodes.UNAUTHORIZED), HedgeBranch.HEDGE)).isFalse();
+        assertThat(MetadataHedgingStrategy.isAcceptableWinner(
+            responseWithStatus(HttpConstants.StatusCodes.FORBIDDEN), HedgeBranch.HEDGE)).isFalse();
+        assertThat(MetadataHedgingStrategy.isAcceptableWinner((RxDocumentServiceResponse) null, HedgeBranch.PRIMARY)).isFalse();
+    }
+
+    // ---------- isAcceptableWinner(throwable, branch) ----------
+
+    @Test(groups = "unit")
+    public void isAcceptableWinner_throwable() {
+        assertThat(MetadataHedgingStrategy.isAcceptableWinner(serviceUnavailable(), HedgeBranch.PRIMARY)).isFalse();
+        assertThat(MetadataHedgingStrategy.isAcceptableWinner(serviceUnavailable(), HedgeBranch.HEDGE)).isFalse();
+        // Non-regional terminal error is an acceptable winner so the retry path classifies it.
+        assertThat(MetadataHedgingStrategy.isAcceptableWinner(new NotFoundException(), HedgeBranch.PRIMARY)).isTrue();
+        // Hedge-branch 403 is rejected even though it is not a regional failure.
+        assertThat(MetadataHedgingStrategy.isAcceptableWinner(forbidden(), HedgeBranch.HEDGE)).isFalse();
+        assertThat(MetadataHedgingStrategy.isAcceptableWinner(forbidden(), HedgeBranch.PRIMARY)).isTrue();
+    }
+
+    // ---------- evaluateEligibility ----------
+
+    @Test(groups = "unit")
+    public void eligibility_eligibleColdStartCollectionRead() {
+        MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, 1000);
+        MetadataHedgingContext ctx = coldStartContext();
+        MetadataHedgeEligibility eligibility = strategy.evaluateEligibility(collectionReadRequest(), ctx);
+        assertThat(eligibility.isEligible()).isTrue();
+    }
+
+    @Test(groups = "unit")
+    public void eligibility_notColdStart() {
+        MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, 1000);
+        MetadataHedgingContext ctx = new MetadataHedgingContext();
+        ctx.setColdStart(false);
+        assertThat(strategy.evaluateEligibility(collectionReadRequest(), ctx).getSkipReason())
+            .isEqualTo(MetadataHedgeSkipReason.NOT_COLD_START);
+    }
+
+    @Test(groups = "unit")
+    public void eligibility_unsupportedResource() {
+        MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, 1000);
+        RxDocumentServiceRequest documentRead = RxDocumentServiceRequest.create(
+            mockDiagnosticsClientContext(), OperationType.Read, ResourceType.Document, "/dbs/db/colls/col/docs/d", new HashMap<>());
+        assertThat(strategy.evaluateEligibility(documentRead, coldStartContext()).getSkipReason())
+            .isEqualTo(MetadataHedgeSkipReason.RESOURCE_TYPE_NOT_SUPPORTED);
+    }
+
+    @Test(groups = "unit")
+    public void eligibility_partitionKeyRangeNotFirstPage() {
+        MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, 1000);
+        MetadataHedgingContext ctx = coldStartContext();
+        ctx.setFirstReadFeedPage(false);
+        RxDocumentServiceRequest pkRangeRead = RxDocumentServiceRequest.create(
+            mockDiagnosticsClientContext(), OperationType.ReadFeed, ResourceType.PartitionKeyRange, "/dbs/db/colls/col/pkranges", new HashMap<>());
+        assertThat(strategy.evaluateEligibility(pkRangeRead, ctx).getSkipReason())
+            .isEqualTo(MetadataHedgeSkipReason.NOT_FIRST_READ_FEED_PAGE);
+    }
+
+    @Test(groups = "unit")
+    public void eligibility_singleRegion() {
+        Mockito.when(this.globalEndpointManager.getReadEndpoints())
+            .thenReturn(new UnmodifiableList<>(Collections.singletonList(this.east)));
+        MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, 1000);
+        assertThat(strategy.evaluateEligibility(collectionReadRequest(), coldStartContext()).getSkipReason())
+            .isEqualTo(MetadataHedgeSkipReason.SINGLE_REGION);
+    }
+
+    @Test(groups = "unit")
+    public void eligibility_excludedRegionLeavesNoTarget() {
+        Mockito.when(this.globalEndpointManager.getApplicableReadRegionalRoutingContexts(any(RxDocumentServiceRequest.class)))
+            .thenReturn(new UnmodifiableList<>(Collections.singletonList(this.east)));
+        MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, 1000);
+        assertThat(strategy.evaluateEligibility(collectionReadRequest(), coldStartContext()).getSkipReason())
+            .isEqualTo(MetadataHedgeSkipReason.EXCLUDED_REGION_LEAVES_NO_TARGET);
+    }
+
+    @Test(groups = "unit")
+    public void eligibility_ppafDisabledWithNullOptIn() {
+        MetadataHedgingStrategy strategy = strategy(null, () -> false, 1000);
+        assertThat(strategy.evaluateEligibility(collectionReadRequest(), coldStartContext()).getSkipReason())
+            .isEqualTo(MetadataHedgeSkipReason.PPAF_DISABLED);
+    }
+
+    // ---------- executeAsync ----------
+
+    @Test(groups = "unit", timeOut = TIMEOUT)
+    public void executeAsync_ineligibleFallsBackToPrimaryOnly() {
+        Mockito.when(this.globalEndpointManager.getReadEndpoints())
+            .thenReturn(new UnmodifiableList<>(Collections.singletonList(this.east)));
+        MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, 1000);
+
+        RxDocumentServiceResponse ok = okResponse();
+        AtomicInteger calls = new AtomicInteger();
+        Function<RxDocumentServiceRequest, Mono<RxDocumentServiceResponse>> sender = req -> {
+            calls.incrementAndGet();
+            return Mono.just(ok);
+        };
+
+        StepVerifier.create(strategy.executeAsync(collectionReadRequest(), sender, coldStartContext()))
+            .assertNext(result -> {
+                assertThat(result.isHedgeFired()).isFalse();
+                assertThat(result.getResponse()).isSameAs(ok);
+                assertThat(result.getDiagnostics().getTotalAttempts()).isEqualTo(1);
+            })
+            .verifyComplete();
+
+        assertThat(calls.get()).isEqualTo(1);
+    }
+
+    @Test(groups = "unit", timeOut = TIMEOUT)
+    public void executeAsync_primaryWinsNoHedge() {
+        MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, 2000);
+
+        RxDocumentServiceResponse ok = okResponse();
+        Function<RxDocumentServiceRequest, Mono<RxDocumentServiceResponse>> sender = req -> Mono.just(ok);
+
+        StepVerifier.create(strategy.executeAsync(collectionReadRequest(), sender, coldStartContext()))
+            .assertNext(result -> {
+                assertThat(result.isHedgeFired()).isFalse();
+                assertThat(result.getResponse()).isSameAs(ok);
+                assertThat(result.getWinningRegion()).isEqualTo("East");
+            })
+            .verifyComplete();
+    }
+
+    @Test(groups = "unit", timeOut = TIMEOUT)
+    public void executeAsync_hedgeWinsWhenPrimaryRegionalFailure() {
+        MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, 2000);
+
+        RxDocumentServiceResponse hedgeOk = okResponse();
+        Function<RxDocumentServiceRequest, Mono<RxDocumentServiceResponse>> sender = req -> {
+            RegionalRoutingContext routed = req.requestContext.regionalRoutingContextToRoute;
+            if (routed != null && routed.equals(this.west)) {
+                return Mono.just(hedgeOk);
+            }
+            return Mono.error(serviceUnavailable());
+        };
+
+        StepVerifier.create(strategy.executeAsync(collectionReadRequest(), sender, coldStartContext()))
+            .assertNext(result -> {
+                assertThat(result.isHedgeFired()).isTrue();
+                assertThat(result.getResponse()).isSameAs(hedgeOk);
+                assertThat(result.getWinningRegion()).isEqualTo("West");
+                assertThat(result.getDiagnostics().getTotalAttempts()).isEqualTo(2);
+            })
+            .verifyComplete();
+    }
+
+    @Test(groups = "unit", timeOut = TIMEOUT)
+    public void executeAsync_budgetExhaustedFallsBackToPrimaryOnly() {
+        MetadataHedgingStrategy strategy = strategy(Boolean.TRUE, () -> true, 2000, 1);
+
+        // Occupy the single permit with a hanging primary so the budget is exhausted.
+        Disposable hanging = strategy
+            .executeAsync(collectionReadRequest(), req -> Mono.never(), coldStartContext())
+            .subscribe();
+
+        try {
+            assertThat(strategy.getAvailableBudget()).isEqualTo(0);
+
+            RxDocumentServiceResponse ok = okResponse();
+            StepVerifier.create(strategy.executeAsync(collectionReadRequest(), req -> Mono.just(ok), coldStartContext()))
+                .assertNext(result -> {
+                    assertThat(result.isHedgeFired()).isFalse();
+                    assertThat(result.getResponse()).isSameAs(ok);
+                    assertThat(result.getDiagnostics().getSkipReason())
+                        .isEqualTo(MetadataHedgeSkipReason.BUDGET_EXHAUSTED);
+                })
+                .verifyComplete();
+        } finally {
+            hanging.dispose();
+        }
+    }
+
+    // ---------- helpers ----------
+
+    private MetadataHedgingStrategy strategy(Boolean optIn, java.util.function.BooleanSupplier ppaf, long thresholdMs) {
+        return strategy(optIn, ppaf, thresholdMs, MetadataHedgingStrategy.DEFAULT_PER_CLIENT_CONCURRENCY_BUDGET);
+    }
+
+    private MetadataHedgingStrategy strategy(Boolean optIn, java.util.function.BooleanSupplier ppaf, long thresholdMs, int budget) {
+        return new MetadataHedgingStrategy(
+            this.globalEndpointManager,
+            () -> false,
+            ppaf,
+            optIn,
+            Duration.ofMillis(thresholdMs),
+            budget);
+    }
+
+    private static MetadataHedgingContext coldStartContext() {
+        MetadataHedgingContext ctx = new MetadataHedgingContext();
+        ctx.setColdStart(true);
+        return ctx;
+    }
+
+    private static RxDocumentServiceRequest collectionReadRequest() {
+        return RxDocumentServiceRequest.create(
+            mockDiagnosticsClientContext(), OperationType.Read, ResourceType.DocumentCollection, "/dbs/db/colls/col", new HashMap<>());
+    }
+
+    private static RxDocumentServiceResponse okResponse() {
+        return responseWithStatus(HttpConstants.StatusCodes.OK);
+    }
+
+    private static RxDocumentServiceResponse responseWithStatus(int statusCode) {
+        RxDocumentServiceResponse response = Mockito.mock(RxDocumentServiceResponse.class);
+        Mockito.when(response.getStatusCode()).thenReturn(statusCode);
+        Mockito.when(response.getResponseHeaders()).thenReturn(new HashMap<>());
+        return response;
+    }
+
+    private static ServiceUnavailableException serviceUnavailable() {
+        return new ServiceUnavailableException("metadata hedge test", new HttpHeaders(), null, 0);
+    }
+
+    private static ForbiddenException forbidden() {
+        return new ForbiddenException("metadata hedge test", new HttpHeaders(), null);
+    }
+}
+

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/Configs.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/Configs.java
@@ -55,6 +55,12 @@ public class Configs {
     private static final String THINCLIENT_ENABLED = "COSMOS.THINCLIENT_ENABLED";
     private static final String THINCLIENT_ENABLED_VARIABLE = "COSMOS_THINCLIENT_ENABLED";
 
+    // Tri-state opt-in / kill-switch for cold-start metadata cache hedging. When unset (null),
+    // cold-start metadata hedging follows the account's PPAF state. "true" forces it on even when
+    // PPAF is disabled; "false" suppresses it regardless of PPAF.
+    private static final String METADATA_HEDGING_FOR_COLD_START_ENABLED = "COSMOS.METADATA_HEDGING_FOR_COLD_START_ENABLED";
+    private static final String METADATA_HEDGING_FOR_COLD_START_ENABLED_VARIABLE = "COSMOS_METADATA_HEDGING_FOR_COLD_START_ENABLED";
+
     private static final boolean DEFAULT_NETTY_HTTP_CLIENT_METRICS_ENABLED = false;
     private static final String NETTY_HTTP_CLIENT_METRICS_ENABLED = "COSMOS.NETTY_HTTP_CLIENT_METRICS_ENABLED";
     private static final String NETTY_HTTP_CLIENT_METRICS_ENABLED_VARIABLE = "COSMOS_NETTY_HTTP_CLIENT_METRICS_ENABLED";
@@ -583,6 +589,25 @@ public class Configs {
         }
 
         return DEFAULT_THINCLIENT_ENABLED;
+    }
+
+    /**
+     * Resolves the tri-state cold-start metadata hedging opt-in.
+     *
+     * @return {@code null} when unset (follow PPAF), otherwise the explicit {@link Boolean} value.
+     */
+    public static Boolean getMetadataHedgingForColdStartEnabled() {
+        String valueFromSystemProperty = System.getProperty(METADATA_HEDGING_FOR_COLD_START_ENABLED);
+        if (valueFromSystemProperty != null && !valueFromSystemProperty.isEmpty()) {
+            return Boolean.parseBoolean(valueFromSystemProperty);
+        }
+
+        String valueFromEnvVariable = System.getenv(METADATA_HEDGING_FOR_COLD_START_ENABLED_VARIABLE);
+        if (valueFromEnvVariable != null && !valueFromEnvVariable.isEmpty()) {
+            return Boolean.parseBoolean(valueFromEnvVariable);
+        }
+
+        return null;
     }
 
     public static boolean isNettyHttpClientMetricsEnabled() {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxDocumentClientImpl.java
@@ -31,6 +31,7 @@ import com.azure.cosmos.implementation.batch.ServerBatchRequest;
 import com.azure.cosmos.implementation.batch.SinglePartitionKeyServerBatchRequest;
 import com.azure.cosmos.implementation.caches.AsyncCache;
 import com.azure.cosmos.implementation.caches.RxClientCollectionCache;
+import com.azure.cosmos.implementation.metadatahedging.MetadataHedgingStrategy;
 import com.azure.cosmos.implementation.caches.RxCollectionCache;
 import com.azure.cosmos.implementation.caches.RxPartitionKeyRangeCache;
 import com.azure.cosmos.implementation.clienttelemetry.ClientTelemetry;
@@ -282,6 +283,7 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
     private final GlobalEndpointManager globalEndpointManager;
     private final GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker globalPartitionEndpointManagerForPerPartitionCircuitBreaker;
     private final GlobalPartitionEndpointManagerForPerPartitionAutomaticFailover globalPartitionEndpointManagerForPerPartitionAutomaticFailover;
+    private MetadataHedgingStrategy metadataHedgingStrategy;
     private final RetryPolicy retryPolicy;
     private HttpClient reactorHttpClient;
     private Function<HttpClient, HttpClient> httpClientInterceptor;
@@ -895,6 +897,12 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
             DatabaseAccount databaseAccountSnapshot = this.initializeGatewayConfigurationReader();
             this.resetSessionContainerIfNeeded(databaseAccountSnapshot);
 
+            this.metadataHedgingStrategy = MetadataHedgingStrategy.createIfEnabled(
+                Configs.getMetadataHedgingForColdStartEnabled(),
+                this.globalEndpointManager,
+                () -> this.globalPartitionEndpointManagerForPerPartitionAutomaticFailover != null
+                    && this.globalPartitionEndpointManagerForPerPartitionAutomaticFailover.isPerPartitionAutomaticFailoverEnabled());
+
             if (metadataCachesSnapshot != null) {
                 AsyncCache<String, DocumentCollection> nameCache = metadataCachesSnapshot.getCollectionInfoByNameCache();
                 AsyncCache<String, DocumentCollection> idCache = metadataCachesSnapshot.getCollectionInfoByIdCache();
@@ -905,7 +913,9 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
                         this,
                         this.retryPolicy,
                         nameCache,
-                        idCache
+                        idCache,
+                        this.globalEndpointManager,
+                        this.metadataHedgingStrategy
                     );
                 } else {
                     // Cache data could not be deserialized (e.g., old format); fall back to fresh fetch
@@ -913,14 +923,18 @@ public class RxDocumentClientImpl implements AsyncDocumentClient, IAuthorization
                         this.sessionContainer,
                         this.gatewayProxy,
                         this,
-                        this.retryPolicy);
+                        this.retryPolicy,
+                        this.globalEndpointManager,
+                        this.metadataHedgingStrategy);
                 }
             } else {
                 this.collectionCache = new RxClientCollectionCache(this,
                     this.sessionContainer,
                     this.gatewayProxy,
                     this,
-                    this.retryPolicy);
+                    this.retryPolicy,
+                    this.globalEndpointManager,
+                    this.metadataHedgingStrategy);
             }
             this.resetSessionTokenRetryPolicy = new ResetSessionTokenRetryPolicyFactory(this.sessionContainer, this.collectionCache, this.retryPolicy);
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/RxClientCollectionCache.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/RxClientCollectionCache.java
@@ -103,24 +103,25 @@ public class RxClientCollectionCache extends RxCollectionCache {
         this.metadataHedgingStrategy = metadataHedgingStrategy;
     }
 
-    protected Mono<DocumentCollection> getByRidAsync(MetadataDiagnosticsContext metaDataDiagnosticsContext, String collectionRid, Map<String, Object> properties) {
+    protected Mono<DocumentCollection> getByRidAsync(MetadataDiagnosticsContext metaDataDiagnosticsContext, String collectionRid, Map<String, Object> properties, boolean isColdStart) {
         DocumentClientRetryPolicy retryPolicyInstance = new ClearingSessionContainerClientRetryPolicy(this.sessionContainer, this.retryPolicy.getRequestPolicy(null));
         return ObservableHelper.inlineIfPossible(
-                () -> this.readCollectionAsync(metaDataDiagnosticsContext, PathsHelper.generatePath(ResourceType.DocumentCollection, collectionRid, false), retryPolicyInstance, properties)
+                () -> this.readCollectionAsync(metaDataDiagnosticsContext, PathsHelper.generatePath(ResourceType.DocumentCollection, collectionRid, false), retryPolicyInstance, properties, isColdStart)
                 , retryPolicyInstance);
     }
 
-    protected Mono<DocumentCollection> getByNameAsync(MetadataDiagnosticsContext metaDataDiagnosticsContext, String resourceAddress, Map<String, Object> properties) {
+    protected Mono<DocumentCollection> getByNameAsync(MetadataDiagnosticsContext metaDataDiagnosticsContext, String resourceAddress, Map<String, Object> properties, boolean isColdStart) {
         DocumentClientRetryPolicy retryPolicyInstance = new ClearingSessionContainerClientRetryPolicy(this.sessionContainer, this.retryPolicy.getRequestPolicy(null));
         return ObservableHelper.inlineIfPossible(
-                () -> this.readCollectionAsync(metaDataDiagnosticsContext, resourceAddress, retryPolicyInstance, properties),
+                () -> this.readCollectionAsync(metaDataDiagnosticsContext, resourceAddress, retryPolicyInstance, properties, isColdStart),
                 retryPolicyInstance);
     }
 
     private Mono<DocumentCollection> readCollectionAsync(MetadataDiagnosticsContext metaDataDiagnosticsContext,
                                                          String collectionLink,
                                                          DocumentClientRetryPolicy retryPolicyInstance,
-                                                         Map<String, Object> properties) {
+                                                         Map<String, Object> properties,
+                                                         boolean isColdStart) {
 
         String path = Utils.joinPath(collectionLink, null);
         RxDocumentServiceRequest request = RxDocumentServiceRequest.create(this.diagnosticsClientContext,
@@ -167,8 +168,9 @@ public class RxClientCollectionCache extends RxCollectionCache {
 
         Instant addressCallStartTime = Instant.now();
         Mono<RxDocumentServiceResponse> responseObs;
-        if (this.metadataHedgingStrategy != null) {
-            // Cold-start metadata cache population: getByName/getByRid only execute on a cache miss.
+        if (this.metadataHedgingStrategy != null && isColdStart) {
+            // Only cold-start metadata cache population (first read on a cache miss) hedges.
+            // Forced refresh paths pass isColdStart=false and fall through to the direct send.
             MetadataHedgingContext hedgeContext = new MetadataHedgingContext();
             hedgeContext.setColdStart(true);
             responseObs = this.metadataHedgingStrategy

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/RxClientCollectionCache.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/RxClientCollectionCache.java
@@ -8,6 +8,7 @@ import com.azure.cosmos.implementation.ClearingSessionContainerClientRetryPolicy
 import com.azure.cosmos.implementation.DiagnosticsClientContext;
 import com.azure.cosmos.implementation.DocumentClientRetryPolicy;
 import com.azure.cosmos.implementation.DocumentCollection;
+import com.azure.cosmos.implementation.GlobalEndpointManager;
 import com.azure.cosmos.implementation.HttpConstants;
 import com.azure.cosmos.implementation.IAuthorizationTokenProvider;
 import com.azure.cosmos.implementation.IRetryPolicyFactory;
@@ -22,6 +23,8 @@ import com.azure.cosmos.implementation.RxDocumentServiceRequest;
 import com.azure.cosmos.implementation.RxDocumentServiceResponse;
 import com.azure.cosmos.implementation.RxStoreModel;
 import com.azure.cosmos.implementation.Utils;
+import com.azure.cosmos.implementation.metadatahedging.MetadataHedgingContext;
+import com.azure.cosmos.implementation.metadatahedging.MetadataHedgingStrategy;
 import reactor.core.publisher.Mono;
 
 import java.io.UnsupportedEncodingException;
@@ -29,6 +32,7 @@ import java.net.URLEncoder;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Caches collection information.
@@ -42,6 +46,8 @@ public class RxClientCollectionCache extends RxCollectionCache {
     private final IAuthorizationTokenProvider tokenProvider;
     private final IRetryPolicyFactory retryPolicy;
     private final ISessionContainer sessionContainer;
+    private final GlobalEndpointManager globalEndpointManager;
+    private final MetadataHedgingStrategy metadataHedgingStrategy;
 
     public RxClientCollectionCache(DiagnosticsClientContext diagnosticsClientContext,
                                    ISessionContainer sessionContainer,
@@ -49,12 +55,27 @@ public class RxClientCollectionCache extends RxCollectionCache {
                                    IAuthorizationTokenProvider tokenProvider,
                                    IRetryPolicyFactory retryPolicy,
                                    AsyncCache<String, DocumentCollection> collectionInfoByNameCache, AsyncCache<String, DocumentCollection> collectionInfoByIdCache) {
+        this(diagnosticsClientContext, sessionContainer, storeModel, tokenProvider, retryPolicy,
+            collectionInfoByNameCache, collectionInfoByIdCache, null, null);
+    }
+
+    public RxClientCollectionCache(DiagnosticsClientContext diagnosticsClientContext,
+                                   ISessionContainer sessionContainer,
+                                   RxStoreModel storeModel,
+                                   IAuthorizationTokenProvider tokenProvider,
+                                   IRetryPolicyFactory retryPolicy,
+                                   AsyncCache<String, DocumentCollection> collectionInfoByNameCache,
+                                   AsyncCache<String, DocumentCollection> collectionInfoByIdCache,
+                                   GlobalEndpointManager globalEndpointManager,
+                                   MetadataHedgingStrategy metadataHedgingStrategy) {
         super(collectionInfoByNameCache, collectionInfoByIdCache);
         this.diagnosticsClientContext = diagnosticsClientContext;
         this.storeModel = storeModel;
         this.tokenProvider = tokenProvider;
         this.retryPolicy = retryPolicy;
         this.sessionContainer = sessionContainer;
+        this.globalEndpointManager = globalEndpointManager;
+        this.metadataHedgingStrategy = metadataHedgingStrategy;
     }
 
     public RxClientCollectionCache(DiagnosticsClientContext diagnosticsClientContext,
@@ -62,11 +83,24 @@ public class RxClientCollectionCache extends RxCollectionCache {
                                    RxStoreModel storeModel,
                                    IAuthorizationTokenProvider tokenProvider,
                                    IRetryPolicyFactory retryPolicy) {
+        this(diagnosticsClientContext, sessionContainer, storeModel, tokenProvider, retryPolicy,
+            (GlobalEndpointManager) null, (MetadataHedgingStrategy) null);
+    }
+
+    public RxClientCollectionCache(DiagnosticsClientContext diagnosticsClientContext,
+                                   ISessionContainer sessionContainer,
+                                   RxStoreModel storeModel,
+                                   IAuthorizationTokenProvider tokenProvider,
+                                   IRetryPolicyFactory retryPolicy,
+                                   GlobalEndpointManager globalEndpointManager,
+                                   MetadataHedgingStrategy metadataHedgingStrategy) {
         this.diagnosticsClientContext = diagnosticsClientContext;
         this.storeModel = storeModel;
         this.tokenProvider = tokenProvider;
         this.retryPolicy = retryPolicy;
         this.sessionContainer = sessionContainer;
+        this.globalEndpointManager = globalEndpointManager;
+        this.metadataHedgingStrategy = metadataHedgingStrategy;
     }
 
     protected Mono<DocumentCollection> getByRidAsync(MetadataDiagnosticsContext metaDataDiagnosticsContext, String collectionRid, Map<String, Object> properties) {
@@ -119,14 +153,29 @@ public class RxClientCollectionCache extends RxCollectionCache {
             retryPolicyInstance.onBeforeSendRequest(request);
         }
 
+        // Region-targeted sender shared by the primary-only path and the metadata hedge branches.
+        // The hedging strategy routes each cloned request to its target region before this runs.
+        final boolean isAadToken = tokenProvider.getAuthorizationTokenType() == AuthorizationTokenType.AadToken;
+        Function<RxDocumentServiceRequest, Mono<RxDocumentServiceResponse>> sender = serviceRequest -> {
+            if (isAadToken) {
+                return tokenProvider
+                    .populateAuthorizationHeader(serviceRequest)
+                    .flatMap(this.storeModel::processMessage);
+            }
+            return this.storeModel.processMessage(serviceRequest);
+        };
+
         Instant addressCallStartTime = Instant.now();
         Mono<RxDocumentServiceResponse> responseObs;
-        if (tokenProvider.getAuthorizationTokenType() != AuthorizationTokenType.AadToken) {
-            responseObs = this.storeModel.processMessage(request);
+        if (this.metadataHedgingStrategy != null) {
+            // Cold-start metadata cache population: getByName/getByRid only execute on a cache miss.
+            MetadataHedgingContext hedgeContext = new MetadataHedgingContext();
+            hedgeContext.setColdStart(true);
+            responseObs = this.metadataHedgingStrategy
+                .executeAsync(request, sender, hedgeContext)
+                .map(hedgeResult -> hedgeResult.getResponse());
         } else {
-            responseObs = tokenProvider
-                .populateAuthorizationHeader(request)
-                .flatMap(serviceRequest -> this.storeModel.processMessage(serviceRequest));
+            responseObs = sender.apply(request);
         }
 
         return responseObs.map(response -> {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/RxCollectionCache.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/caches/RxCollectionCache.java
@@ -124,15 +124,15 @@ public abstract class RxCollectionCache {
             this.collectionInfoByNameCache.refresh(
                     resourceFullName,
                     () -> {
-                        Mono<DocumentCollection> collectionObs = this.getByNameAsync(metaDataDiagnosticsContext, resourceFullName, properties);
+                        Mono<DocumentCollection> collectionObs = this.getByNameAsync(metaDataDiagnosticsContext, resourceFullName, properties, false);
                         return collectionObs.doOnSuccess(collection -> this.collectionInfoByIdCache.set(collection.getResourceId(), collection));
                     });
         }
     }
 
-    protected abstract Mono<DocumentCollection> getByRidAsync(MetadataDiagnosticsContext metaDataDiagnosticsContext, String collectionRid, Map<String, Object> properties);
+    protected abstract Mono<DocumentCollection> getByRidAsync(MetadataDiagnosticsContext metaDataDiagnosticsContext, String collectionRid, Map<String, Object> properties, boolean isColdStart);
 
-    protected abstract Mono<DocumentCollection> getByNameAsync(MetadataDiagnosticsContext metaDataDiagnosticsContext, String resourceAddress, Map<String, Object> properties);
+    protected abstract Mono<DocumentCollection> getByNameAsync(MetadataDiagnosticsContext metaDataDiagnosticsContext, String resourceAddress, Map<String, Object> properties, boolean isColdStart);
 
     private Mono<Utils.ValueHolder<DocumentCollection>> resolveByPartitionKeyRangeIdentityAsync(MetadataDiagnosticsContext metaDataDiagnosticsContext,
                                                                                                 PartitionKeyRangeIdentity partitionKeyRangeIdentity,
@@ -166,7 +166,7 @@ public abstract class RxCollectionCache {
         Mono<DocumentCollection> async = this.collectionInfoByIdCache.getAsync(
             collectionResourceId,
             null,
-            () -> this.getByRidAsync(metaDataDiagnosticsContext, collectionResourceId, properties));
+            () -> this.getByRidAsync(metaDataDiagnosticsContext, collectionResourceId, properties, true));
         return async.map(Utils.ValueHolder::new);
     }
 
@@ -190,7 +190,7 @@ public abstract class RxCollectionCache {
             obsoleteValue,
             () -> {
                 Mono<DocumentCollection> collectionObs = this.getByNameAsync(
-                    metaDataDiagnosticsContext, resourceFullName, properties)
+                    metaDataDiagnosticsContext, resourceFullName, properties, obsoleteValue == null)
                     .onErrorMap(throwable -> {
 
                         if (throwable instanceof CosmosException) {
@@ -242,7 +242,7 @@ public abstract class RxCollectionCache {
                     resourceFullName,
                     obsoleteValue,
                     () -> {
-                        Mono<DocumentCollection> collectionObs = this.getByNameAsync(metaDataDiagnosticsContext, resourceFullName, request.properties);
+                        Mono<DocumentCollection> collectionObs = this.getByNameAsync(metaDataDiagnosticsContext, resourceFullName, request.properties, false);
                         return collectionObs.doOnSuccess(collection -> {
                             this.collectionInfoByIdCache.set(collection.getResourceId(), collection);
                         });

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/HedgeBranch.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/HedgeBranch.java
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.metadatahedging;
+
+/**
+ * Identifies the branch (primary or hedge) that produced a candidate metadata-hedge winner.
+ * Used to compose the per-branch overlay in
+ * {@link MetadataHedgingStrategy#isAcceptableWinner}.
+ * <p>
+ * Java port of the .NET {@code MetadataHedgingStrategy.HedgeBranch} enum
+ * (Azure/azure-cosmos-dotnet-v3#5923).
+ */
+public enum HedgeBranch {
+    PRIMARY,
+    HEDGE
+}

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgeDiagnostics.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgeDiagnostics.java
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.metadatahedging;
+
+/**
+ * Diagnostic record describing the outcome of a single
+ * {@link MetadataHedgingStrategy#executeAsync} invocation. Attached to the request trace for
+ * supportability.
+ * <p>
+ * Java port of the .NET {@code MetadataHedgingStrategy.MetadataHedgeDiagnostics}
+ * (Azure/azure-cosmos-dotnet-v3#5923, design &sect;9).
+ */
+public final class MetadataHedgeDiagnostics {
+
+    private volatile boolean eligible;
+    private volatile MetadataHedgeSkipReason skipReason = MetadataHedgeSkipReason.NONE;
+    private final String resourceType;
+    private volatile String primaryRegion;
+    private volatile String hedgeRegion;
+    private final double thresholdMs;
+    private volatile Double hedgeFiredElapsedMs;
+    private volatile String winningRegion;
+    private volatile int totalAttempts;
+    private volatile boolean hedgeFired;
+    private volatile String hedgeOutcome;
+
+    public MetadataHedgeDiagnostics(String resourceType, double thresholdMs) {
+        this.resourceType = resourceType;
+        this.thresholdMs = thresholdMs;
+    }
+
+    public boolean isEligible() {
+        return this.eligible;
+    }
+
+    public void setEligible(boolean eligible) {
+        this.eligible = eligible;
+    }
+
+    public MetadataHedgeSkipReason getSkipReason() {
+        return this.skipReason;
+    }
+
+    public void setSkipReason(MetadataHedgeSkipReason skipReason) {
+        this.skipReason = skipReason;
+    }
+
+    public String getResourceType() {
+        return this.resourceType;
+    }
+
+    public String getPrimaryRegion() {
+        return this.primaryRegion;
+    }
+
+    public void setPrimaryRegion(String primaryRegion) {
+        this.primaryRegion = primaryRegion;
+    }
+
+    public String getHedgeRegion() {
+        return this.hedgeRegion;
+    }
+
+    public void setHedgeRegion(String hedgeRegion) {
+        this.hedgeRegion = hedgeRegion;
+    }
+
+    public double getThresholdMs() {
+        return this.thresholdMs;
+    }
+
+    public Double getHedgeFiredElapsedMs() {
+        return this.hedgeFiredElapsedMs;
+    }
+
+    public void setHedgeFiredElapsedMs(Double hedgeFiredElapsedMs) {
+        this.hedgeFiredElapsedMs = hedgeFiredElapsedMs;
+    }
+
+    public String getWinningRegion() {
+        return this.winningRegion;
+    }
+
+    public void setWinningRegion(String winningRegion) {
+        this.winningRegion = winningRegion;
+    }
+
+    public int getTotalAttempts() {
+        return this.totalAttempts;
+    }
+
+    public void setTotalAttempts(int totalAttempts) {
+        this.totalAttempts = totalAttempts;
+    }
+
+    public boolean isHedgeFired() {
+        return this.hedgeFired;
+    }
+
+    public void setHedgeFired(boolean hedgeFired) {
+        this.hedgeFired = hedgeFired;
+    }
+
+    public String getHedgeOutcome() {
+        return this.hedgeOutcome;
+    }
+
+    public void setHedgeOutcome(String hedgeOutcome) {
+        this.hedgeOutcome = hedgeOutcome;
+    }
+
+    @Override
+    public String toString() {
+        return "MetadataHedgeDiagnostics{"
+            + "eligible=" + this.eligible
+            + ", skipReason=" + this.skipReason
+            + ", resourceType='" + this.resourceType + '\''
+            + ", primaryRegion='" + this.primaryRegion + '\''
+            + ", hedgeRegion='" + this.hedgeRegion + '\''
+            + ", thresholdMs=" + this.thresholdMs
+            + ", hedgeFiredElapsedMs=" + this.hedgeFiredElapsedMs
+            + ", winningRegion='" + this.winningRegion + '\''
+            + ", totalAttempts=" + this.totalAttempts
+            + ", hedgeFired=" + this.hedgeFired
+            + ", hedgeOutcome='" + this.hedgeOutcome + '\''
+            + '}';
+    }
+}

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgeEligibility.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgeEligibility.java
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.metadatahedging;
+
+/**
+ * Output of {@link MetadataHedgingStrategy#evaluateEligibility}.
+ * <p>
+ * Java port of the .NET {@code MetadataHedgingStrategy.MetadataHedgeEligibility}
+ * (Azure/azure-cosmos-dotnet-v3#5923).
+ */
+public final class MetadataHedgeEligibility {
+
+    private final boolean isEligible;
+    private final MetadataHedgeSkipReason skipReason;
+
+    private MetadataHedgeEligibility(boolean isEligible, MetadataHedgeSkipReason skipReason) {
+        this.isEligible = isEligible;
+        this.skipReason = skipReason;
+    }
+
+    public boolean isEligible() {
+        return this.isEligible;
+    }
+
+    public MetadataHedgeSkipReason getSkipReason() {
+        return this.skipReason;
+    }
+
+    public static MetadataHedgeEligibility eligible() {
+        return new MetadataHedgeEligibility(true, MetadataHedgeSkipReason.NONE);
+    }
+
+    public static MetadataHedgeEligibility skip(MetadataHedgeSkipReason reason) {
+        return new MetadataHedgeEligibility(false, reason);
+    }
+}

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgeSkipReason.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgeSkipReason.java
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.metadatahedging;
+
+/**
+ * Reason a metadata hedge was not dispatched. Recorded in {@link MetadataHedgeDiagnostics}
+ * for supportability.
+ * <p>
+ * Java port of the .NET {@code MetadataHedgingStrategy.MetadataHedgeSkipReason} enum
+ * (Azure/azure-cosmos-dotnet-v3#5923).
+ */
+public enum MetadataHedgeSkipReason {
+    NONE,
+    OPT_IN_DISABLED,
+    PPAF_DISABLED,
+    GATEWAY_KILL_SWITCH_ON,
+    SINGLE_REGION,
+    NOT_COLD_START,
+    RESOURCE_TYPE_NOT_SUPPORTED,
+    NOT_FIRST_READ_FEED_PAGE,
+    BUDGET_EXHAUSTED,
+    ALREADY_HEDGED_THIS_OPERATION,
+    EXCLUDED_REGION_LEAVES_NO_TARGET
+}

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingContext.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingContext.java
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.metadatahedging;
+
+import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Per-logical-operation context shared between {@link MetadataHedgingStrategy} and the
+ * metadata retry path. Carries the cold-start signal, the dedupe set of attempted endpoints,
+ * the winning endpoint, the "hedged this operation" latch, and the first-page flag for
+ * partition-key-range pagination.
+ * <p>
+ * Java port of the .NET {@code MetadataHedgingStrategy.MetadataHedgingContext}
+ * (Azure/azure-cosmos-dotnet-v3#5923, design &sect;5.2 / &sect;6.1).
+ */
+public final class MetadataHedgingContext {
+
+    private volatile boolean isColdStart;
+    private volatile boolean isFirstReadFeedPage = true;
+    private final ConcurrentHashMap<String, Byte> attemptedEndpoints = new ConcurrentHashMap<>();
+    private final AtomicReference<RegionalRoutingContext> winningEndpoint = new AtomicReference<>(null);
+    private final AtomicBoolean hasHedgedThisOperation = new AtomicBoolean(false);
+
+    public boolean isColdStart() {
+        return this.isColdStart;
+    }
+
+    public void setColdStart(boolean coldStart) {
+        this.isColdStart = coldStart;
+    }
+
+    public boolean isFirstReadFeedPage() {
+        return this.isFirstReadFeedPage;
+    }
+
+    public void setFirstReadFeedPage(boolean firstReadFeedPage) {
+        this.isFirstReadFeedPage = firstReadFeedPage;
+    }
+
+    /**
+     * Dedupe set of endpoint URIs that have already been attempted on this operation. Keyed on
+     * the absolute URI string so a metadata retry can skip a region the hedge already used.
+     */
+    public ConcurrentHashMap<String, Byte> getAttemptedEndpoints() {
+        return this.attemptedEndpoints;
+    }
+
+    public RegionalRoutingContext getWinningEndpoint() {
+        return this.winningEndpoint.get();
+    }
+
+    public boolean hasHedgedThisOperation() {
+        return this.hasHedgedThisOperation.get();
+    }
+
+    /**
+     * Single-publication of the winning endpoint. Late loser continuations that try to
+     * re-publish observe a non-null existing value and leave it intact.
+     */
+    public void recordWinner(RegionalRoutingContext endpoint) {
+        this.winningEndpoint.compareAndSet(null, endpoint);
+    }
+
+    /**
+     * Returns {@code true} if this caller is the first to mark the operation as having
+     * dispatched a hedge. Subsequent callers observe {@code false} and skip.
+     */
+    public boolean tryMarkHedgedThisOperation() {
+        return this.hasHedgedThisOperation.compareAndSet(false, true);
+    }
+}

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingResult.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingResult.java
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.metadatahedging;
+
+import com.azure.cosmos.implementation.RxDocumentServiceResponse;
+import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
+
+/**
+ * Result of {@link MetadataHedgingStrategy#executeAsync}.
+ * <p>
+ * Java port of the .NET {@code MetadataHedgingStrategy.MetadataHedgingResult}
+ * (Azure/azure-cosmos-dotnet-v3#5923).
+ */
+public final class MetadataHedgingResult {
+
+    private final RxDocumentServiceResponse response;
+    private final RegionalRoutingContext winningEndpoint;
+    private final String winningRegion;
+    private final boolean hedgeFired;
+    private final MetadataHedgeDiagnostics diagnostics;
+
+    public MetadataHedgingResult(
+        RxDocumentServiceResponse response,
+        RegionalRoutingContext winningEndpoint,
+        String winningRegion,
+        boolean hedgeFired,
+        MetadataHedgeDiagnostics diagnostics) {
+        this.response = response;
+        this.winningEndpoint = winningEndpoint;
+        this.winningRegion = winningRegion;
+        this.hedgeFired = hedgeFired;
+        this.diagnostics = diagnostics;
+    }
+
+    public RxDocumentServiceResponse getResponse() {
+        return this.response;
+    }
+
+    public RegionalRoutingContext getWinningEndpoint() {
+        return this.winningEndpoint;
+    }
+
+    public String getWinningRegion() {
+        return this.winningRegion;
+    }
+
+    public boolean isHedgeFired() {
+        return this.hedgeFired;
+    }
+
+    public MetadataHedgeDiagnostics getDiagnostics() {
+        return this.diagnostics;
+    }
+}

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingStrategy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingStrategy.java
@@ -1,0 +1,560 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.metadatahedging;
+
+import com.azure.cosmos.CosmosException;
+import com.azure.cosmos.implementation.GlobalEndpointManager;
+import com.azure.cosmos.implementation.HttpConstants;
+import com.azure.cosmos.implementation.OperationType;
+import com.azure.cosmos.implementation.ResourceType;
+import com.azure.cosmos.implementation.RxDocumentServiceRequest;
+import com.azure.cosmos.implementation.RxDocumentServiceResponse;
+import com.azure.cosmos.implementation.Utils;
+import com.azure.cosmos.implementation.directconnectivity.WebExceptionUtility;
+import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+
+/**
+ * Bounded cross-region hedging for cold-start metadata cache population. One instance per
+ * client. Consumed by {@code RxClientCollectionCache} (and, in a later phase,
+ * {@code RxPartitionKeyRangeCache}) for cold-start metadata cache reads.
+ * <p>
+ * Java (Project Reactor) port of the .NET {@code MetadataHedgingStrategy}
+ * (Azure/azure-cosmos-dotnet-v3#5923). The orchestration races a primary regional read against
+ * a hedge dispatched after a fixed SDK-derived threshold, returning the first acceptable winner
+ * and cancelling the loser. When ineligible (single region, not a cold start, opt-in disabled,
+ * budget exhausted, ...) the read collapses to a primary-only send with identical behaviour to
+ * the non-hedged path.
+ */
+public final class MetadataHedgingStrategy {
+
+    private static final Logger logger = LoggerFactory.getLogger(MetadataHedgingStrategy.class);
+
+    /**
+     * Per-client concurrency budget for in-flight metadata hedges (design &sect;5.11).
+     * Not customer-configurable.
+     */
+    public static final int DEFAULT_PER_CLIENT_CONCURRENCY_BUDGET = 8;
+
+    /**
+     * Added to the first-attempt timeout to derive the fixed hedge threshold (today
+     * 1&nbsp;s + 500&nbsp;ms = 1.5&nbsp;s). Not customer-configurable. See design &sect;5.1 / &sect;5.9.
+     */
+    public static final Duration DEFAULT_THRESHOLD = Duration.ofMillis(1500);
+
+    private final GlobalEndpointManager globalEndpointManager;
+    private final BooleanSupplier isHedgingDisabledByGateway;
+    private final BooleanSupplier isPpafEnabled;
+    private final Boolean customerOptIn;
+    private final Duration threshold;
+    private final Semaphore hedgeBudget;
+    private final int perClientConcurrencyBudget;
+
+    public MetadataHedgingStrategy(
+        GlobalEndpointManager globalEndpointManager,
+        BooleanSupplier isHedgingDisabledByGateway,
+        BooleanSupplier isPpafEnabled,
+        Boolean customerOptIn,
+        Duration threshold,
+        int perClientConcurrencyBudget) {
+
+        if (globalEndpointManager == null) {
+            throw new NullPointerException("globalEndpointManager");
+        }
+        if (threshold == null || threshold.isZero() || threshold.isNegative()) {
+            throw new IllegalArgumentException("threshold must be a positive duration");
+        }
+
+        this.globalEndpointManager = globalEndpointManager;
+        this.isHedgingDisabledByGateway = isHedgingDisabledByGateway != null ? isHedgingDisabledByGateway : () -> false;
+        this.isPpafEnabled = isPpafEnabled != null ? isPpafEnabled : () -> false;
+        this.customerOptIn = customerOptIn;
+        this.threshold = threshold;
+        this.perClientConcurrencyBudget = Math.max(1, perClientConcurrencyBudget);
+        this.hedgeBudget = new Semaphore(this.perClientConcurrencyBudget);
+    }
+
+    public Duration getThreshold() {
+        return this.threshold;
+    }
+
+    public int getPerClientConcurrencyBudget() {
+        return this.perClientConcurrencyBudget;
+    }
+
+    public int getAvailableBudget() {
+        return this.hedgeBudget.availablePermits();
+    }
+
+    /**
+     * Resolves the tri-state opt-in to a concrete {@code boolean}. When the customer leaves the
+     * property {@code null}, cold-start metadata hedging follows the account's PPAF state. An
+     * explicit {@code true} enables hedging even when PPAF is disabled, and an explicit
+     * {@code false} disables it regardless of PPAF.
+     */
+    public static boolean resolveOptIn(Boolean customerOptIn, boolean isPpafEnabled) {
+        return customerOptIn != null ? customerOptIn : isPpafEnabled;
+    }
+
+    /**
+     * Builds the strategy from the customer-supplied tri-state opt-in. Returns {@code null} only
+     * when the customer explicitly disabled hedging ({@code false}). When the property is
+     * {@code true} or left {@code null} the strategy is created and the per-request eligibility
+     * check resolves the effective opt-in against the live PPAF state. The Gateway kill-switch is
+     * hard-wired to {@code false} in Phase 1; see design &sect;5.1.
+     */
+    public static MetadataHedgingStrategy createIfEnabled(
+        Boolean enableMetadataHedgingForColdStart,
+        GlobalEndpointManager globalEndpointManager,
+        BooleanSupplier isPpafEnabled) {
+
+        if (Boolean.FALSE.equals(enableMetadataHedgingForColdStart)) {
+            return null;
+        }
+
+        return new MetadataHedgingStrategy(
+            globalEndpointManager,
+            () -> false,
+            isPpafEnabled,
+            enableMetadataHedgingForColdStart,
+            DEFAULT_THRESHOLD,
+            DEFAULT_PER_CLIENT_CONCURRENCY_BUDGET);
+    }
+
+    /**
+     * Evaluate hedging eligibility for a single send attempt. Does NOT touch the concurrency
+     * semaphore.
+     */
+    public MetadataHedgeEligibility evaluateEligibility(
+        RxDocumentServiceRequest request,
+        MetadataHedgingContext hedgeContext) {
+
+        if (request == null) {
+            throw new NullPointerException("request");
+        }
+        if (hedgeContext == null) {
+            throw new NullPointerException("hedgeContext");
+        }
+
+        // A live strategy is only constructed when hedging is enabled (see createIfEnabled), so
+        // customerOptIn is never false here in production -- defense-in-depth for direct construction.
+        if (Boolean.FALSE.equals(this.customerOptIn)) {
+            return MetadataHedgeEligibility.skip(MetadataHedgeSkipReason.OPT_IN_DISABLED);
+        }
+
+        if (this.isHedgingDisabledByGateway.getAsBoolean()) {
+            return MetadataHedgeEligibility.skip(MetadataHedgeSkipReason.GATEWAY_KILL_SWITCH_ON);
+        }
+
+        // When the customer leaves the opt-in null, cold-start metadata hedging follows the live
+        // PPAF state. An explicit opt-in of true bypasses this gate.
+        if (!resolveOptIn(this.customerOptIn, this.isPpafEnabled.getAsBoolean())) {
+            return MetadataHedgeEligibility.skip(MetadataHedgeSkipReason.PPAF_DISABLED);
+        }
+
+        if (!hedgeContext.isColdStart()) {
+            return MetadataHedgeEligibility.skip(MetadataHedgeSkipReason.NOT_COLD_START);
+        }
+
+        if (hedgeContext.hasHedgedThisOperation()) {
+            return MetadataHedgeEligibility.skip(MetadataHedgeSkipReason.ALREADY_HEDGED_THIS_OPERATION);
+        }
+
+        if (!isSupportedResource(request)) {
+            return MetadataHedgeEligibility.skip(MetadataHedgeSkipReason.RESOURCE_TYPE_NOT_SUPPORTED);
+        }
+
+        if (request.getResourceType() == ResourceType.PartitionKeyRange && !hedgeContext.isFirstReadFeedPage()) {
+            return MetadataHedgeEligibility.skip(MetadataHedgeSkipReason.NOT_FIRST_READ_FEED_PAGE);
+        }
+
+        List<RegionalRoutingContext> readEndpoints = this.globalEndpointManager.getReadEndpoints();
+        if (readEndpoints == null || readEndpoints.size() <= 1) {
+            return MetadataHedgeEligibility.skip(MetadataHedgeSkipReason.SINGLE_REGION);
+        }
+
+        List<RegionalRoutingContext> applicable =
+            this.globalEndpointManager.getApplicableReadRegionalRoutingContexts(request);
+        if (applicable == null || applicable.size() <= 1) {
+            return MetadataHedgeEligibility.skip(MetadataHedgeSkipReason.EXCLUDED_REGION_LEAVES_NO_TARGET);
+        }
+
+        return MetadataHedgeEligibility.eligible();
+    }
+
+    /**
+     * Execute a single metadata send with optional cross-region hedging. The strategy clones the
+     * request per branch and routes each clone to its target region before delegating to the
+     * supplied sender (which performs the actual store-model dispatch).
+     */
+    public Mono<MetadataHedgingResult> executeAsync(
+        RxDocumentServiceRequest request,
+        Function<RxDocumentServiceRequest, Mono<RxDocumentServiceResponse>> sender,
+        MetadataHedgingContext hedgeContext) {
+
+        if (request == null) {
+            return Mono.error(new NullPointerException("request"));
+        }
+        if (sender == null) {
+            return Mono.error(new NullPointerException("sender"));
+        }
+        if (hedgeContext == null) {
+            return Mono.error(new NullPointerException("hedgeContext"));
+        }
+
+        return Mono.defer(() -> {
+            MetadataHedgeDiagnostics diag =
+                new MetadataHedgeDiagnostics(request.getResourceType().toString(), this.threshold.toMillis());
+
+            MetadataHedgeEligibility eligibility = this.evaluateEligibility(request, hedgeContext);
+            diag.setEligible(eligibility.isEligible());
+            diag.setSkipReason(eligibility.getSkipReason());
+
+            RegionalRoutingContext primaryEndpoint = this.primaryEndpoint(request);
+            diag.setPrimaryRegion(this.safeGetRegion(primaryEndpoint));
+
+            if (!eligibility.isEligible()) {
+                logger.debug("Metadata hedge skipped (reason: {}, resourceType: {})",
+                    diag.getSkipReason(), diag.getResourceType());
+                return this.primaryOnly(request, primaryEndpoint, sender, hedgeContext, diag);
+            }
+
+            // Non-blocking concurrency budget check (equivalent to Wait(TimeSpan.Zero)).
+            if (!this.hedgeBudget.tryAcquire()) {
+                diag.setEligible(false);
+                diag.setSkipReason(MetadataHedgeSkipReason.BUDGET_EXHAUSTED);
+                logger.debug("Metadata hedge skipped (budget exhausted, resourceType: {})", diag.getResourceType());
+                return this.primaryOnly(request, primaryEndpoint, sender, hedgeContext, diag);
+            }
+
+            RegionalRoutingContext hedgeEndpoint = this.resolveHedgeEndpoint(request, primaryEndpoint);
+            if (hedgeEndpoint == null) {
+                this.hedgeBudget.release();
+                diag.setEligible(false);
+                diag.setSkipReason(MetadataHedgeSkipReason.SINGLE_REGION);
+                return this.primaryOnly(request, primaryEndpoint, sender, hedgeContext, diag);
+            }
+
+            diag.setHedgeRegion(this.safeGetRegion(hedgeEndpoint));
+            if (primaryEndpoint != null) {
+                hedgeContext.getAttemptedEndpoints().putIfAbsent(endpointKey(primaryEndpoint), (byte) 0);
+            }
+
+            AtomicBoolean budgetReleased = new AtomicBoolean(false);
+            return this.raceWithHedge(request, sender, hedgeContext, diag, primaryEndpoint, hedgeEndpoint)
+                .doFinally(signalType -> {
+                    if (budgetReleased.compareAndSet(false, true)) {
+                        this.hedgeBudget.release();
+                    }
+                });
+        });
+    }
+
+    private Mono<MetadataHedgingResult> raceWithHedge(
+        RxDocumentServiceRequest request,
+        Function<RxDocumentServiceRequest, Mono<RxDocumentServiceResponse>> sender,
+        MetadataHedgingContext hedgeContext,
+        MetadataHedgeDiagnostics diag,
+        RegionalRoutingContext primaryEndpoint,
+        RegionalRoutingContext hedgeEndpoint) {
+
+        long startNanos = System.nanoTime();
+
+        Mono<HedgeOutcome> primaryOutcome =
+            this.sendOutcome(sender, request, primaryEndpoint, HedgeBranch.PRIMARY).cache();
+
+        // Fire the hedge when the threshold elapses OR when the primary settles as a regional
+        // failure before the threshold (fail-fast hedging).
+        Mono<Long> timerArm = Mono.delay(this.threshold).thenReturn(0L);
+        Mono<Long> primaryFaultArm = primaryOutcome.flatMap(outcome ->
+            outcome.isAcceptable() ? Mono.never() : Mono.just(0L));
+        Mono<Long> hedgeTrigger = Mono.firstWithSignal(timerArm, primaryFaultArm);
+
+        Mono<HedgeOutcome> hedgeOutcome = hedgeTrigger.flatMap(ignored -> {
+            hedgeContext.getAttemptedEndpoints().putIfAbsent(endpointKey(hedgeEndpoint), (byte) 0);
+            hedgeContext.tryMarkHedgedThisOperation();
+            diag.setHedgeFired(true);
+            diag.setHedgeFiredElapsedMs((System.nanoTime() - startNanos) / 1_000_000.0);
+            logger.debug("Metadata hedge fired (primary: {}, hedge: {}, elapsedMs: {})",
+                diag.getPrimaryRegion(), diag.getHedgeRegion(), diag.getHedgeFiredElapsedMs());
+            return this.sendOutcome(sender, request, hedgeEndpoint, HedgeBranch.HEDGE);
+        }).cache();
+
+        Mono<HedgeOutcome> winner = Flux.merge(primaryOutcome, hedgeOutcome)
+            .filter(HedgeOutcome::isAcceptable)
+            .next()
+            // Neither branch produced an acceptable winner: prefer the primary's outcome so the
+            // metadata retry path classifies the failure normally (design &sect;10).
+            .switchIfEmpty(primaryOutcome);
+
+        return winner.flatMap(outcome -> {
+            diag.setTotalAttempts(diag.isHedgeFired() ? 2 : 1);
+            String winningRegion =
+                outcome.getBranch() == HedgeBranch.PRIMARY ? diag.getPrimaryRegion() : diag.getHedgeRegion();
+            diag.setWinningRegion(winningRegion);
+            if (outcome.getBranch() == HedgeBranch.HEDGE) {
+                diag.setHedgeOutcome("Won");
+            }
+            hedgeContext.recordWinner(outcome.getEndpoint());
+
+            if (outcome.getError() != null) {
+                return Mono.error(outcome.getError());
+            }
+
+            return Mono.just(new MetadataHedgingResult(
+                outcome.getResponse(),
+                outcome.getEndpoint(),
+                winningRegion,
+                diag.isHedgeFired(),
+                diag));
+        });
+    }
+
+    private Mono<MetadataHedgingResult> primaryOnly(
+        RxDocumentServiceRequest request,
+        RegionalRoutingContext primaryEndpoint,
+        Function<RxDocumentServiceRequest, Mono<RxDocumentServiceResponse>> sender,
+        MetadataHedgingContext hedgeContext,
+        MetadataHedgeDiagnostics diag) {
+
+        return this.sendOutcome(sender, request, primaryEndpoint, HedgeBranch.PRIMARY)
+            .flatMap(outcome -> {
+                diag.setTotalAttempts(1);
+                diag.setWinningRegion(diag.getPrimaryRegion());
+                hedgeContext.recordWinner(primaryEndpoint);
+                if (outcome.getError() != null) {
+                    return Mono.error(outcome.getError());
+                }
+                return Mono.just(new MetadataHedgingResult(
+                    outcome.getResponse(), primaryEndpoint, diag.getPrimaryRegion(), false, diag));
+            });
+    }
+
+    private Mono<HedgeOutcome> sendOutcome(
+        Function<RxDocumentServiceRequest, Mono<RxDocumentServiceResponse>> sender,
+        RxDocumentServiceRequest request,
+        RegionalRoutingContext targetEndpoint,
+        HedgeBranch branch) {
+
+        return Mono.defer(() -> {
+            // Clone per branch. The primary and hedge sends run concurrently; sharing one request
+            // would let one branch overwrite the other's target region. clone() produces an
+            // independent requestContext.
+            RxDocumentServiceRequest branchRequest = request.clone();
+            if (targetEndpoint != null) {
+                branchRequest.requestContext.routeToLocation(targetEndpoint);
+            }
+            return sender.apply(branchRequest);
+        })
+            .map(response -> new HedgeOutcome(branch, targetEndpoint, response, null, isAcceptableWinner(response, branch)))
+            .onErrorResume(error -> Mono.just(
+                new HedgeOutcome(branch, targetEndpoint, null, error, isAcceptableWinner(error, branch))));
+    }
+
+    private RegionalRoutingContext primaryEndpoint(RxDocumentServiceRequest request) {
+        if (request.requestContext != null && request.requestContext.regionalRoutingContextToRoute != null) {
+            return request.requestContext.regionalRoutingContextToRoute;
+        }
+        return this.globalEndpointManager.resolveServiceEndpoint(request);
+    }
+
+    private RegionalRoutingContext resolveHedgeEndpoint(
+        RxDocumentServiceRequest request,
+        RegionalRoutingContext primaryEndpoint) {
+
+        List<RegionalRoutingContext> applicable =
+            this.globalEndpointManager.getApplicableReadRegionalRoutingContexts(request);
+        if (applicable == null) {
+            return null;
+        }
+
+        for (RegionalRoutingContext candidate : applicable) {
+            if (candidate != null && !candidate.equals(primaryEndpoint)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private String safeGetRegion(RegionalRoutingContext endpoint) {
+        if (endpoint == null || endpoint.getGatewayRegionalEndpoint() == null) {
+            return null;
+        }
+        try {
+            return this.globalEndpointManager.getRegionName(
+                endpoint.getGatewayRegionalEndpoint(), OperationType.Read, false);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String endpointKey(RegionalRoutingContext endpoint) {
+        URI uri = endpoint.getGatewayRegionalEndpoint();
+        return uri != null ? uri.toString() : endpoint.toString();
+    }
+
+    private static boolean isSupportedResource(RxDocumentServiceRequest request) {
+        return (request.getResourceType() == ResourceType.DocumentCollection
+            && request.getOperationType() == OperationType.Read)
+            || (request.getResourceType() == ResourceType.PartitionKeyRange
+            && request.getOperationType() == OperationType.ReadFeed);
+    }
+
+    /**
+     * Per-branch acceptable-winner predicate for a successful response. A 401 / plain 403 from the
+     * hedge branch is rejected (design &sect;5.13).
+     */
+    public static boolean isAcceptableWinner(RxDocumentServiceResponse response, HedgeBranch branch) {
+        if (response == null) {
+            return false;
+        }
+
+        if (isRegionalFailure(response.getStatusCode(), getSubStatusCode(response))) {
+            return false;
+        }
+
+        if (branch == HedgeBranch.HEDGE
+            && (response.getStatusCode() == HttpConstants.StatusCodes.UNAUTHORIZED
+            || response.getStatusCode() == HttpConstants.StatusCodes.FORBIDDEN)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Per-branch acceptable-winner predicate for a terminal error. A regional failure is not an
+     * acceptable winner (let the other branch win); a hedge-branch 401 / plain 403 is rejected.
+     * Any other terminal error is an acceptable winner so the metadata retry path classifies it.
+     */
+    public static boolean isAcceptableWinner(Throwable error, HedgeBranch branch) {
+        if (error == null) {
+            return false;
+        }
+
+        if (isRegionalFailure(error)) {
+            return false;
+        }
+
+        CosmosException cosmosException = Utils.as(error, CosmosException.class);
+        if (branch == HedgeBranch.HEDGE && cosmosException != null
+            && (cosmosException.getStatusCode() == HttpConstants.StatusCodes.UNAUTHORIZED
+            || cosmosException.getStatusCode() == HttpConstants.StatusCodes.FORBIDDEN)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns {@code true} iff the throwable represents a regional failure that should advance a
+     * metadata retry/hedge to a different preferred location. Single source of truth shared by the
+     * metadata retry path and the cold-start metadata hedging strategy (design &sect;5.7.2).
+     */
+    public static boolean isRegionalFailure(Throwable error) {
+        if (error == null) {
+            return false;
+        }
+
+        if (error instanceof Exception && WebExceptionUtility.isNetworkFailure((Exception) error)) {
+            return true;
+        }
+
+        CosmosException cosmosException = Utils.as(error, CosmosException.class);
+        if (cosmosException == null) {
+            return false;
+        }
+
+        return isRegionalFailure(cosmosException.getStatusCode(), cosmosException.getSubStatusCode());
+    }
+
+    /**
+     * Status/sub-status overlay of {@link #isRegionalFailure(Throwable)}: 503 / 500, 410 +
+     * LeaseNotFound, 403 + DatabaseAccountNotFound.
+     */
+    public static boolean isRegionalFailure(int statusCode, int subStatusCode) {
+        switch (statusCode) {
+            case HttpConstants.StatusCodes.SERVICE_UNAVAILABLE:
+            case HttpConstants.StatusCodes.INTERNAL_SERVER_ERROR:
+                return true;
+            case HttpConstants.StatusCodes.GONE:
+                return subStatusCode == HttpConstants.SubStatusCodes.LEASE_NOT_FOUND;
+            case HttpConstants.StatusCodes.FORBIDDEN:
+                return subStatusCode == HttpConstants.SubStatusCodes.DATABASE_ACCOUNT_NOTFOUND;
+            default:
+                return false;
+        }
+    }
+
+    private static int getSubStatusCode(RxDocumentServiceResponse response) {
+        if (response.getResponseHeaders() == null) {
+            return HttpConstants.SubStatusCodes.UNKNOWN;
+        }
+        String subStatus = response.getResponseHeaders().get(HttpConstants.HttpHeaders.SUB_STATUS);
+        if (subStatus == null) {
+            return HttpConstants.SubStatusCodes.UNKNOWN;
+        }
+        try {
+            return Integer.parseInt(subStatus);
+        } catch (NumberFormatException e) {
+            return HttpConstants.SubStatusCodes.UNKNOWN;
+        }
+    }
+
+    /**
+     * Captured outcome of one branch (primary or hedge): either a successful response or a
+     * terminal error, plus whether it qualifies as an acceptable winner.
+     */
+    private static final class HedgeOutcome {
+        private final HedgeBranch branch;
+        private final RegionalRoutingContext endpoint;
+        private final RxDocumentServiceResponse response;
+        private final Throwable error;
+        private final boolean acceptable;
+
+        HedgeOutcome(
+            HedgeBranch branch,
+            RegionalRoutingContext endpoint,
+            RxDocumentServiceResponse response,
+            Throwable error,
+            boolean acceptable) {
+            this.branch = branch;
+            this.endpoint = endpoint;
+            this.response = response;
+            this.error = error;
+            this.acceptable = acceptable;
+        }
+
+        HedgeBranch getBranch() {
+            return this.branch;
+        }
+
+        RegionalRoutingContext getEndpoint() {
+            return this.endpoint;
+        }
+
+        RxDocumentServiceResponse getResponse() {
+            return this.response;
+        }
+
+        Throwable getError() {
+            return this.error;
+        }
+
+        boolean isAcceptable() {
+            return this.acceptable;
+        }
+    }
+}

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingStrategy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/metadatahedging/MetadataHedgingStrategy.java
@@ -239,26 +239,38 @@ public final class MetadataHedgingStrategy {
                 return this.primaryOnly(request, primaryEndpoint, sender, hedgeContext, diag);
             }
 
-            RegionalRoutingContext hedgeEndpoint = this.resolveHedgeEndpoint(request, primaryEndpoint);
-            if (hedgeEndpoint == null) {
-                this.hedgeBudget.release();
-                diag.setEligible(false);
-                diag.setSkipReason(MetadataHedgeSkipReason.SINGLE_REGION);
-                return this.primaryOnly(request, primaryEndpoint, sender, hedgeContext, diag);
-            }
-
-            diag.setHedgeRegion(this.safeGetRegion(hedgeEndpoint));
-            if (primaryEndpoint != null) {
-                hedgeContext.getAttemptedEndpoints().putIfAbsent(endpointKey(primaryEndpoint), (byte) 0);
-            }
-
+            // From here a permit is held. The single AtomicBoolean guard guarantees the permit is
+            // released exactly once across every exit path: the no-hedge-endpoint fast-return, the
+            // race pipeline's doFinally (success / error / cancel), and an assembly-time throw.
             AtomicBoolean budgetReleased = new AtomicBoolean(false);
-            return this.raceWithHedge(request, sender, hedgeContext, diag, primaryEndpoint, hedgeEndpoint)
-                .doFinally(signalType -> {
+            try {
+                RegionalRoutingContext hedgeEndpoint = this.resolveHedgeEndpoint(request, primaryEndpoint);
+                if (hedgeEndpoint == null) {
                     if (budgetReleased.compareAndSet(false, true)) {
                         this.hedgeBudget.release();
                     }
-                });
+                    diag.setEligible(false);
+                    diag.setSkipReason(MetadataHedgeSkipReason.SINGLE_REGION);
+                    return this.primaryOnly(request, primaryEndpoint, sender, hedgeContext, diag);
+                }
+
+                diag.setHedgeRegion(this.safeGetRegion(hedgeEndpoint));
+                if (primaryEndpoint != null) {
+                    hedgeContext.getAttemptedEndpoints().putIfAbsent(endpointKey(primaryEndpoint), (byte) 0);
+                }
+
+                return this.raceWithHedge(request, sender, hedgeContext, diag, primaryEndpoint, hedgeEndpoint)
+                    .doFinally(signalType -> {
+                        if (budgetReleased.compareAndSet(false, true)) {
+                            this.hedgeBudget.release();
+                        }
+                    });
+            } catch (Throwable assemblyError) {
+                if (budgetReleased.compareAndSet(false, true)) {
+                    this.hedgeBudget.release();
+                }
+                throw assemblyError;
+            }
         });
     }
 
@@ -272,6 +284,11 @@ public final class MetadataHedgingStrategy {
 
         long startNanos = System.nanoTime();
 
+        // primaryOutcome is cached because it has three consumers (the merge, the primary-fault
+        // arm that fires the hedge early, and the switchIfEmpty fallback) and must be sent exactly
+        // once. A consequence is that when the hedge wins, the primary loser drains in the
+        // background rather than being cancelled -- this mirrors the .NET design's loser drain and
+        // is harmless for a body-less metadata GET.
         Mono<HedgeOutcome> primaryOutcome =
             this.sendOutcome(sender, request, primaryEndpoint, HedgeBranch.PRIMARY).cache();
 
@@ -290,7 +307,13 @@ public final class MetadataHedgingStrategy {
             logger.debug("Metadata hedge fired (primary: {}, hedge: {}, elapsedMs: {})",
                 diag.getPrimaryRegion(), diag.getHedgeRegion(), diag.getHedgeFiredElapsedMs());
             return this.sendOutcome(sender, request, hedgeEndpoint, HedgeBranch.HEDGE);
-        }).cache();
+        });
+        // NOTE: hedgeOutcome is intentionally NOT cached. It has a single consumer (the merge
+        // below), so when the primary wins acceptably before the threshold, Flux.merge cancels
+        // this subscription and the cancellation propagates into hedgeTrigger -- cancelling the
+        // pending Mono.delay timer so the hedge is never dispatched. Caching would make the timer
+        // hot and detach it from downstream cancellation, letting a spurious hedge fire ~threshold
+        // after the primary already won (extra cross-region load + post-completion diag writes).
 
         Mono<HedgeOutcome> winner = Flux.merge(primaryOutcome, hedgeOutcome)
             .filter(HedgeOutcome::isAcceptable)


### PR DESCRIPTION
## Summary

Ports cold-start **metadata cache hedging** from the .NET Cosmos SDK (Azure/azure-cosmos-dotnet-v3#5923) to the Java SDK, adapted to the reactive (Project Reactor) model.

On cold-start metadata cache population (Collection read), the SDK now proactively dispatches a hedged cross-region request when the primary region hasn't responded within an SDK-derived threshold, reducing cold-start tail latency during regional brown-outs / PPAF failover.

## What's included

New package `com.azure.cosmos.implementation.metadatahedging`:
- **`MetadataHedgingStrategy`** (one per client): `executeAsync` races a primary regional read against a hedge dispatched after a fixed threshold (1.5s = first-attempt + 500ms), returns the first *acceptable* winner and cancels the loser. Non-blocking per-client `Semaphore` budget; fail-fast hedging when the primary returns a regional failure before the threshold; shared failure classification (`isRegionalFailure`, `isAcceptableWinner` with the hedge-branch 401/403 overlay).
- Supporting types: `MetadataHedgingContext`, `MetadataHedgingResult`, `MetadataHedgeDiagnostics`, `MetadataHedgeEligibility`, `MetadataHedgeSkipReason`, `HedgeBranch`.

Wiring & config:
- **`Configs.getMetadataHedgingForColdStartEnabled()`** — tri-state opt-in (`null`=follow PPAF, `true`=force on, `false`=off) via `COSMOS.METADATA_HEDGING_FOR_COLD_START_ENABLED` system property / env var. **Default behavior is unchanged** (the strategy is only constructed when PPAF is enabled or the customer explicitly opts in).
- **`RxClientCollectionCache`** — injects GlobalEndpointManager + strategy (backward-compatible constructors); cold-start Collection reads route through the strategy with a region-targeted sender that handles both master-key and AAD auth per cloned branch.
- **`RxDocumentClientImpl`** — builds the strategy via `createIfEnabled`, resolving PPAF state from the per-partition automatic-failover manager.

## Testing

- `azure-cosmos` compiles; **checkstyle and spotbugs both pass** (not disabled).
- New `MetadataHedgingStrategyTest`: **19/19 unit tests pass** covering opt-in resolution, `createIfEnabled`, regional-failure / acceptable-winner classification, all eligibility skip reasons, and `executeAsync` race paths (ineligible→primary-only, primary-wins-no-hedge, hedge-wins-on-primary-regional-failure, budget-exhausted fallback).

## Scope notes

Phase-1 scope mirrors the .NET phased rollout. Deferred follow-ups: PartitionKeyRangeCache hedging (Java path goes through the full `readPartitionKeyRanges` query pipeline, not a direct store-model call), OpenTelemetry metrics, and the Gateway kill-switch account flag (hard-wired `false` in .NET Phase 1 too).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>