### PR TITLE
Add CODEOWNERS entry for .github/skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -975,6 +975,7 @@
 /.github/CODEOWNERS                                                @Azure/azure-sdk-eng @Azure/azure-java-sdk
 /.github/workflows/                                                @Azure/azure-sdk-eng
 /.github/copilot-instructions.md                                   @samvaity @praveenkuttappan @maririos
+/.github/skills/                                                   @Azure/azsdk-cli
 /.config/1espt/                                                    @benbp @mikeharder
 /eng/tools/mcp/                                                    @weidongxu-microsoft @haolingdong-msft @XiaofeiCao @samvaity @praveenkuttappan @maririos @Azure/azure-sdk-eng
 


### PR DESCRIPTION
Adds a CODEOWNERS entry that assigns ownership of skill definitions under `.github/skills/` to the `@azure/azsdk-cli` team.

The entry is grouped with the other `/.github/` entries in the Eng Sys section, following the file's existing alignment and section conventions.

```
/.github/skills/                                                   @Azure/azsdk-cli
```