### PR TITLE
Remove Spring Milestone repository

### DIFF
--- a/eng/repo-docs/docms/daily.update.setting.xml
+++ b/eng/repo-docs/docms/daily.update.setting.xml
@@ -6,7 +6,7 @@
             <id>azure-sdk-for-java</id>
             <name>Azure Artifacts Maven Mirror</name>
             <url>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1</url>
-            <mirrorOf>external:*,!repository.spring.milestone,!docs-public-packages</mirrorOf>
+            <mirrorOf>external:*,!docs-public-packages</mirrorOf>
         </mirror>
     </mirrors>
     <profiles>

--- a/eng/settings.xml
+++ b/eng/settings.xml
@@ -7,7 +7,7 @@
       <id>azure-sdk-for-java</id>
       <name>Azure Artifacts Maven Mirror</name>
       <url>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-java/maven/v1</url>
-      <mirrorOf>external:*,!repository.spring.milestone</mirrorOf>
+      <mirrorOf>external:*</mirrorOf>
     </mirror>
   </mirrors>
 </settings>

--- a/sdk/parents/azure-client-sdk-parent-v2/pom.xml
+++ b/sdk/parents/azure-client-sdk-parent-v2/pom.xml
@@ -1511,31 +1511,6 @@
       </build>
     </profile>
 
-    <!-- Used when Reactor had milestone releases to the Spring Milestone repository. -->
-    <!-- If Reactor milestones are needed again in the future, and they're being released -->
-    <!-- to the Spring Milestone repository uncomment the XML below. -->
-    <profile>
-      <id>external-dependency-version-overrides</id>
-      <activation>
-        <property>
-          <name>env.VERSION_OVERRIDE_TESTS</name>
-        </property>
-      </activation>
-      <repositories>
-        <repository>
-          <id>repository.spring.milestone</id>
-          <name>Spring Milestone Repository</name>
-          <url>https://repo.spring.io/milestone</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-        </repository>
-      </repositories>
-    </profile>
-
     <profile>
       <id>test-module-base-compile</id>
       <activation>

--- a/sdk/parents/azure-client-sdk-parent/pom.xml
+++ b/sdk/parents/azure-client-sdk-parent/pom.xml
@@ -1657,31 +1657,6 @@
       </build>
     </profile>
 
-    <!-- Used when Reactor had milestone releases to the Spring Milestone repository. -->
-    <!-- If Reactor milestones are needed again in the future, and they're being released -->
-    <!-- to the Spring Milestone repository uncomment the XML below. -->
-    <profile>
-      <id>external-dependency-version-overrides</id>
-      <activation>
-        <property>
-          <name>env.VERSION_OVERRIDE_TESTS</name>
-        </property>
-      </activation>
-      <repositories>
-        <repository>
-          <id>repository.spring.milestone</id>
-          <name>Spring Milestone Repository</name>
-          <url>https://repo.spring.io/milestone</url>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-        </repository>
-      </repositories>
-    </profile>
-
     <profile>
       <id>test-module-base-compile</id>
       <activation>


### PR DESCRIPTION
# Description

- Remove Spring Milestone repository
- This repository won't be used anymore, and Azure DevOps pipeline will not enable network access. 
- Related PR: https://github.com/Azure/azure-sdk-for-java/pull/49481

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
