### PR TITLE
Honor access token type in bearer auth policy

### DIFF
--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/policy/BearerTokenAuthenticationPolicy.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/policy/BearerTokenAuthenticationPolicy.java
@@ -210,7 +210,7 @@ public class BearerTokenAuthenticationPolicy implements HttpPipelinePolicy {
     private Mono<Void> setAuthorizationHeaderHelper(HttpPipelineCallContext context,
         TokenRequestContext tokenRequestContext, boolean checkToForceFetchToken) {
         return cache.getToken(tokenRequestContext, checkToForceFetchToken).flatMap(token -> {
-            setAuthorizationHeader(context.getHttpRequest().getHeaders(), token.getToken());
+            setAuthorizationHeader(context.getHttpRequest().getHeaders(), token);
             return Mono.empty();
         });
     }
@@ -218,11 +218,12 @@ public class BearerTokenAuthenticationPolicy implements HttpPipelinePolicy {
     private void setAuthorizationHeaderHelperSync(HttpPipelineCallContext context,
         TokenRequestContext tokenRequestContext, boolean checkToForceFetchToken) {
         AccessToken token = cache.getTokenSync(tokenRequestContext, checkToForceFetchToken);
-        setAuthorizationHeader(context.getHttpRequest().getHeaders(), token.getToken());
+        setAuthorizationHeader(context.getHttpRequest().getHeaders(), token);
     }
 
-    private static void setAuthorizationHeader(HttpHeaders headers, String token) {
-        headers.set(HttpHeaderName.AUTHORIZATION, BEARER + " " + token);
+    private static void setAuthorizationHeader(HttpHeaders headers, AccessToken token) {
+        String tokenType = CoreUtils.isNullOrEmpty(token.getTokenType()) ? BEARER : token.getTokenType();
+        headers.set(HttpHeaderName.AUTHORIZATION, tokenType + " " + token.getToken());
     }
 
     private TokenRequestContext getTokenRequestContextForCaeChallenge(HttpResponse response) {

--- a/sdk/core/azure-core/src/test/java/com/azure/core/http/policy/BearerTokenAuthenticationPolicyTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/http/policy/BearerTokenAuthenticationPolicyTests.java
@@ -16,6 +16,7 @@ import com.azure.core.http.HttpResponse;
 import com.azure.core.http.MockHttpResponse;
 import com.azure.core.implementation.http.policy.AuthorizationChallengeParser;
 import com.azure.core.util.Context;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -31,6 +32,45 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BearerTokenAuthenticationPolicyTests {
+
+    @Test
+    public void usesAccessTokenTypeInAuthorizationHeader() {
+        TokenCredential credential
+            = request -> Mono.just(new AccessToken("token", OffsetDateTime.now().plusHours(2), null, "Pop"));
+        BearerTokenAuthenticationPolicy policy = new BearerTokenAuthenticationPolicy(credential, "scope");
+        AtomicReference<String> authorizationHeader = new AtomicReference<>();
+        HttpClient client = request -> {
+            authorizationHeader.set(request.getHeaders().getValue(HttpHeaderName.AUTHORIZATION));
+            return Mono.just(new MockHttpResponse(request, 200));
+        };
+
+        HttpPipeline pipeline = new HttpPipelineBuilder().policies(policy).httpClient(client).build();
+
+        StepVerifier.create(pipeline.send(new HttpRequest(HttpMethod.GET, "https://localhost")))
+            .assertNext(response -> assertEquals(200, response.getStatusCode()))
+            .verifyComplete();
+        assertEquals("Pop token", authorizationHeader.get());
+    }
+
+    @Test
+    public void usesAccessTokenTypeInAuthorizationHeaderSync() {
+        TokenCredential credential
+            = request -> Mono.just(new AccessToken("token", OffsetDateTime.now().plusHours(2), null, "Pop"));
+        BearerTokenAuthenticationPolicy policy = new BearerTokenAuthenticationPolicy(credential, "scope");
+        AtomicReference<String> authorizationHeader = new AtomicReference<>();
+        HttpClient client = request -> {
+            authorizationHeader.set(request.getHeaders().getValue(HttpHeaderName.AUTHORIZATION));
+            return Mono.just(new MockHttpResponse(request, 200));
+        };
+
+        HttpPipeline pipeline = new HttpPipelineBuilder().policies(policy).httpClient(client).build();
+
+        try (HttpResponse response
+            = pipeline.sendSync(new HttpRequest(HttpMethod.GET, "https://localhost"), Context.NONE)) {
+            assertEquals(200, response.getStatusCode());
+        }
+        assertEquals("Pop token", authorizationHeader.get());
+    }
 
     @ParameterizedTest
     @MethodSource("caeTestArguments")


### PR DESCRIPTION
Updates BearerTokenAuthenticationPolicy to use AccessToken.getTokenType() when setting the Authorization header. This is a Core prerequisite for PoP/MSI token binding flows while preserving Bearer as the default.\n\nValidation:\n- mvn -pl sdk/core/azure-core -Dtest=BearerTokenAuthenticationPolicyTests test -DskipCheckStyle=true -DskipRevapi=true -Dgpg.skip=true -q