### PR TITLE
Use authenticated npmrc

### DIFF
--- a/eng/automation/generation.yml
+++ b/eng/automation/generation.yml
@@ -34,16 +34,24 @@ steps:
     inputs:
       versionSpec: '$(NodeVersion)'
 
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(Agent.TempDirectory)/release/.npmrc
+
   - bash: |
       npm install -g autorest
     displayName: 'Install autorest'
     condition: ${{ eq(parameters.RELEASE_TYPE, 'Swagger') }}
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/release/.npmrc"
 
   - bash: |
       npm ci
     workingDirectory: $(Build.SourcesDirectory)/eng/common/tsp-client
     displayName: 'Install tsp-client'
     condition: ${{ eq(parameters.RELEASE_TYPE, 'TypeSpec') }}
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/release/.npmrc"
 
   # - template: /eng/common/testproxy/test-proxy-tool.yml
   #   parameters:

--- a/eng/automation/generation.yml
+++ b/eng/automation/generation.yml
@@ -35,23 +35,17 @@ steps:
       versionSpec: '$(NodeVersion)'
 
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-    parameters:
-      npmrcPath: $(Agent.TempDirectory)/release/.npmrc
 
   - bash: |
       npm install -g autorest
     displayName: 'Install autorest'
     condition: ${{ eq(parameters.RELEASE_TYPE, 'Swagger') }}
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/release/.npmrc"
 
   - bash: |
       npm ci
     workingDirectory: $(Build.SourcesDirectory)/eng/common/tsp-client
     displayName: 'Install tsp-client'
     condition: ${{ eq(parameters.RELEASE_TYPE, 'TypeSpec') }}
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/release/.npmrc"
 
   # - template: /eng/common/testproxy/test-proxy-tool.yml
   #   parameters:


### PR DESCRIPTION
This pull request updates the `eng/automation/generation.yml` pipeline to improve authentication for npm operations by ensuring a properly configured `.npmrc` file is used during package installation steps. The main focus is on securely handling npm credentials during the pipeline execution.

**Pipeline authentication improvements:**

* Added a step to create an authenticated `.npmrc` file using the `/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml` template, specifying the path as `$(Agent.TempDirectory)/release/.npmrc`.
* Updated npm-related steps (`autorest` installation and `tsp-client` installation) to use the authenticated `.npmrc` by setting the `npm_config_userconfig` environment variable.