### PR TITLE
Support no-op for PR pipeline

### DIFF
--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -9,7 +9,9 @@ pr:
     - pipelinev3*
   paths:
     include:
-    - "*"
+      - "*"
+    exclude:
+      - .github/skills/**
 
 parameters:
   - name: Service

--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -15,6 +15,9 @@ parameters:
   - name: Service
     type: string
     default: auto
+  - name: SkipPrValidation
+    type: boolean
+    default: false
   # Switch to canary to test canary 1es branch. 1es template validation will set this parameter
   # to canary on run.
   - name: oneESTemplateTag
@@ -28,6 +31,7 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     oneESTemplateTag: ${{ parameters.oneESTemplateTag }}
+    SkipPrValidation: ${{ parameters.SkipPrValidation }}
     # Short term hack to get 1es canary validation working until we can fix manual runs with 'auto'
     ${{ if and(eq(parameters.oneESTemplateTag, 'canary'), eq(parameters.Service, 'auto')) }}:
       ServiceDirectory: template

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -100,63 +100,63 @@ extends:
                 - pwsh: Write-Host "PR validation skipped because SkipPrValidation was set to true for a manual run."
                   displayName: Skip PR validation
 
-      - ${{ if not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))) }}:
-        - stage: Build
-          variables:
-            - template: /eng/pipelines/templates/variables/globals.yml
-            - template: /eng/pipelines/templates/variables/image.yml
-            # Convert artifact parameter objects to json and set them as variables to be used in
-            # pipeline jobs/stages. By setting these as a variable once we save thousands of lines
-            # of yaml in extreme cases. This helps us stay under the devops max yaml size limits.
-            - name: ArtifactsJson
-              value: '${{ convertToJson(parameters.Artifacts) }}'
-            - name: AdditionalModulesJson
-              value: '${{ convertToJson(parameters.AdditionalModules) }}'
-          jobs:
-            - template: /eng/pipelines/templates/jobs/ci.yml
-              parameters:
-                ServiceDirectory: ${{ parameters.ServiceDirectory }}
-                TestPipeline: ${{ parameters.TestPipeline }}
-                SDKType: ${{ parameters.SDKType }}
-                Artifacts: ${{ parameters.Artifacts }}
-                ExcludePaths: ${{parameters.ExcludePaths}}
-                TimeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
-                ReleaseArtifacts:
-                  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'Manual')) }}:
-                      - ${{ each artifact in parameters.Artifacts }}:
-                          - ${{ if ne(artifact.releaseInBatch, 'false') }}:
-                              - ${{ artifact }}
-                  - ${{ else }}:
-                    - ${{ parameters.Artifacts }}
-                MatrixConfigs:
-                  - ${{ each config in parameters.MatrixConfigs }}:
-                    - ${{ config }}
-                  - ${{ each config in parameters.AdditionalMatrixConfigs }}:
-                    - ${{ config }}
-                MatrixFilters:
-                  - ${{ each filter in parameters.MatrixFilters }}:
-                    - ${{ filter }}
-                  # Skip TestFromSource jobs for SDKType data
-                  - ${{ if eq(parameters.SDKType, 'data') }}:
-                    - TestFromSource=^(?!true).*
-                MatrixReplace:
-                  - ${{ each replacement in parameters.MatrixReplace }}:
-                    - ${{ replacement }}
+      - stage: Build
+        condition: not(and(eq(${{ parameters.SkipPrValidation }}, true), eq(variables['Build.Reason'], 'Manual')))
+        variables:
+          - template: /eng/pipelines/templates/variables/globals.yml
+          - template: /eng/pipelines/templates/variables/image.yml
+          # Convert artifact parameter objects to json and set them as variables to be used in
+          # pipeline jobs/stages. By setting these as a variable once we save thousands of lines
+          # of yaml in extreme cases. This helps us stay under the devops max yaml size limits.
+          - name: ArtifactsJson
+            value: '${{ convertToJson(parameters.Artifacts) }}'
+          - name: AdditionalModulesJson
+            value: '${{ convertToJson(parameters.AdditionalModules) }}'
+        jobs:
+          - template: /eng/pipelines/templates/jobs/ci.yml
+            parameters:
+              ServiceDirectory: ${{ parameters.ServiceDirectory }}
+              TestPipeline: ${{ parameters.TestPipeline }}
+              SDKType: ${{ parameters.SDKType }}
+              Artifacts: ${{ parameters.Artifacts }}
+              ExcludePaths: ${{parameters.ExcludePaths}}
+              TimeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
+              ReleaseArtifacts:
+                - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'Manual')) }}:
+                    - ${{ each artifact in parameters.Artifacts }}:
+                        - ${{ if ne(artifact.releaseInBatch, 'false') }}:
+                            - ${{ artifact }}
+                - ${{ else }}:
+                  - ${{ parameters.Artifacts }}
+              MatrixConfigs:
+                - ${{ each config in parameters.MatrixConfigs }}:
+                  - ${{ config }}
+                - ${{ each config in parameters.AdditionalMatrixConfigs }}:
+                  - ${{ config }}
+              MatrixFilters:
+                - ${{ each filter in parameters.MatrixFilters }}:
+                  - ${{ filter }}
+                # Skip TestFromSource jobs for SDKType data
+                - ${{ if eq(parameters.SDKType, 'data') }}:
+                  - TestFromSource=^(?!true).*
+              MatrixReplace:
+                - ${{ each replacement in parameters.MatrixReplace }}:
+                  - ${{ replacement }}
 
-                  - AZURE_TEST.*=.*/
-                  - ${{ if eq(parameters.SDKType, 'data') }}:
-                    - JavaTestVersion=(.*1)\.\d{2}(.*)/$1.11$2
-                PreBuildSteps: ${{ parameters.PreBuildSteps }}
-                EnvVars: ${{ parameters.EnvVars }}
-                AdditionalLintingOptions: ${{ parameters.AdditionalLintingOptions }}
-                ${{ if eq(parameters.SDKType, 'data') }}:
-                  TestGoals: 'verify'
-                  TestOptions: '-am'
-                  JavaBuildVersion: '1.11'
-                ${{ else }}:
-                  JavaBuildVersion: ${{ parameters.JavaBuildVersion }}
-                BuildParallelization: ${{ parameters.BuildParallelization }}
-                TestParallelization: ${{ parameters.TestParallelization }}
+                - AZURE_TEST.*=.*/
+                - ${{ if eq(parameters.SDKType, 'data') }}:
+                  - JavaTestVersion=(.*1)\.\d{2}(.*)/$1.11$2
+              PreBuildSteps: ${{ parameters.PreBuildSteps }}
+              EnvVars: ${{ parameters.EnvVars }}
+              AdditionalLintingOptions: ${{ parameters.AdditionalLintingOptions }}
+              ${{ if eq(parameters.SDKType, 'data') }}:
+                TestGoals: 'verify'
+                TestOptions: '-am'
+                JavaBuildVersion: '1.11'
+              ${{ else }}:
+                JavaBuildVersion: ${{ parameters.JavaBuildVersion }}
+              BuildParallelization: ${{ parameters.BuildParallelization }}
+              TestParallelization: ${{ parameters.TestParallelization }}
 
       - ${{ if and(not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))), gt(length(parameters.AdditionalStagesAfterBuild), 0)) }}:
           - ${{ parameters.AdditionalStagesAfterBuild }}

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -82,7 +82,7 @@ extends:
   parameters:
     oneESTemplateTag: ${{ parameters.oneESTemplateTag }}
     stages:
-      - ${{ if eq(parameters.SkipPrValidation, true) }}:
+      - ${{ if and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual')) }}:
         - stage: NoOp
           displayName: No-op
           variables:
@@ -97,10 +97,10 @@ extends:
                 os: linux
               steps:
                 - checkout: none
-                - pwsh: Write-Host "PR validation skipped because SkipPrValidation was set to true."
+                - pwsh: Write-Host "PR validation skipped because SkipPrValidation was set to true for a manual run."
                   displayName: Skip PR validation
 
-      - ${{ if ne(parameters.SkipPrValidation, true) }}:
+      - ${{ if not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))) }}:
         - stage: Build
           variables:
             - template: /eng/pipelines/templates/variables/globals.yml
@@ -158,15 +158,15 @@ extends:
                 BuildParallelization: ${{ parameters.BuildParallelization }}
                 TestParallelization: ${{ parameters.TestParallelization }}
 
-      - ${{ if and(ne(parameters.SkipPrValidation, true), parameters.AdditionalStagesAfterBuild) }}:
+      - ${{ if and(not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))), gt(length(parameters.AdditionalStagesAfterBuild), 0)) }}:
           - ${{ parameters.AdditionalStagesAfterBuild }}
 
-      - ${{ if and(ne(parameters.SkipPrValidation, true), eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'],'IndividualCI')) }}:
+      - ${{ if and(not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))), eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'],'IndividualCI')) }}:
           - ${{ parameters.LiveTestStages }}
 
       # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
       # The tests-weekly check needs to be done so we don't create signing/release tasks for manual weekly-test runs
-      - ${{if and(ne(parameters.SkipPrValidation, true), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), not(contains(variables['Build.DefinitionName'], 'tests-weekly'))) }}:
+      - ${{if and(not(and(eq(parameters.SkipPrValidation, true), eq(variables['Build.Reason'], 'Manual'))), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), not(contains(variables['Build.DefinitionName'], 'tests-weekly'))) }}:
           - template: archetype-java-release-batch.yml
             parameters:
               DependsOn:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -14,6 +14,9 @@ parameters:
   - name: ServiceDirectory
     type: string
     default: not-specified
+  - name: SkipPrValidation
+    type: boolean
+    default: false
   - name: ExcludePaths
     type: object
     default: []
@@ -79,72 +82,91 @@ extends:
   parameters:
     oneESTemplateTag: ${{ parameters.oneESTemplateTag }}
     stages:
-      - stage: Build
-        variables:
-          - template: /eng/pipelines/templates/variables/globals.yml
-          - template: /eng/pipelines/templates/variables/image.yml
-          # Convert artifact parameter objects to json and set them as variables to be used in
-          # pipeline jobs/stages. By setting these as a variable once we save thousands of lines
-          # of yaml in extreme cases. This helps us stay under the devops max yaml size limits.
-          - name: ArtifactsJson
-            value: '${{ convertToJson(parameters.Artifacts) }}'
-          - name: AdditionalModulesJson
-            value: '${{ convertToJson(parameters.AdditionalModules) }}'
-        jobs:
-          - template: /eng/pipelines/templates/jobs/ci.yml
-            parameters:
-              ServiceDirectory: ${{ parameters.ServiceDirectory }}
-              TestPipeline: ${{ parameters.TestPipeline }}
-              SDKType: ${{ parameters.SDKType }}
-              Artifacts: ${{ parameters.Artifacts }}
-              ExcludePaths: ${{parameters.ExcludePaths}}
-              TimeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
-              ReleaseArtifacts:
-                - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'Manual')) }}:
-                    - ${{ each artifact in parameters.Artifacts }}:
-                        - ${{ if ne(artifact.releaseInBatch, 'false') }}:
-                            - ${{ artifact }}
-                - ${{ else }}:
-                  - ${{ parameters.Artifacts }}
-              MatrixConfigs:
-                - ${{ each config in parameters.MatrixConfigs }}:
-                  - ${{ config }}
-                - ${{ each config in parameters.AdditionalMatrixConfigs }}:
-                  - ${{ config }}
-              MatrixFilters:
-                - ${{ each filter in parameters.MatrixFilters }}:
-                  - ${{ filter }}
-                # Skip TestFromSource jobs for SDKType data
-                - ${{ if eq(parameters.SDKType, 'data') }}:
-                  - TestFromSource=^(?!true).*
-              MatrixReplace:
-                - ${{ each replacement in parameters.MatrixReplace }}:
-                  - ${{ replacement }}
+      - ${{ if eq(parameters.SkipPrValidation, true) }}:
+        - stage: NoOp
+          displayName: No-op
+          variables:
+            - template: /eng/pipelines/templates/variables/globals.yml
+            - template: /eng/pipelines/templates/variables/image.yml
+          jobs:
+            - job: NoOp
+              displayName: No-op
+              pool:
+                name: $(LINUXPOOL)
+                image: $(LINUXVMIMAGE)
+                os: linux
+              steps:
+                - checkout: none
+                - pwsh: Write-Host "PR validation skipped because SkipPrValidation was set to true."
+                  displayName: Skip PR validation
 
-                - AZURE_TEST.*=.*/
-                - ${{ if eq(parameters.SDKType, 'data') }}:
-                  - JavaTestVersion=(.*1)\.\d{2}(.*)/$1.11$2
-              PreBuildSteps: ${{ parameters.PreBuildSteps }}
-              EnvVars: ${{ parameters.EnvVars }}
-              AdditionalLintingOptions: ${{ parameters.AdditionalLintingOptions }}
-              ${{ if eq(parameters.SDKType, 'data') }}:
-                TestGoals: 'verify'
-                TestOptions: '-am'
-                JavaBuildVersion: '1.11'
-              ${{ else }}:
-                JavaBuildVersion: ${{ parameters.JavaBuildVersion }}
-              BuildParallelization: ${{ parameters.BuildParallelization }}
-              TestParallelization: ${{ parameters.TestParallelization }}
+      - ${{ if ne(parameters.SkipPrValidation, true) }}:
+        - stage: Build
+          variables:
+            - template: /eng/pipelines/templates/variables/globals.yml
+            - template: /eng/pipelines/templates/variables/image.yml
+            # Convert artifact parameter objects to json and set them as variables to be used in
+            # pipeline jobs/stages. By setting these as a variable once we save thousands of lines
+            # of yaml in extreme cases. This helps us stay under the devops max yaml size limits.
+            - name: ArtifactsJson
+              value: '${{ convertToJson(parameters.Artifacts) }}'
+            - name: AdditionalModulesJson
+              value: '${{ convertToJson(parameters.AdditionalModules) }}'
+          jobs:
+            - template: /eng/pipelines/templates/jobs/ci.yml
+              parameters:
+                ServiceDirectory: ${{ parameters.ServiceDirectory }}
+                TestPipeline: ${{ parameters.TestPipeline }}
+                SDKType: ${{ parameters.SDKType }}
+                Artifacts: ${{ parameters.Artifacts }}
+                ExcludePaths: ${{parameters.ExcludePaths}}
+                TimeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
+                ReleaseArtifacts:
+                  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'Manual')) }}:
+                      - ${{ each artifact in parameters.Artifacts }}:
+                          - ${{ if ne(artifact.releaseInBatch, 'false') }}:
+                              - ${{ artifact }}
+                  - ${{ else }}:
+                    - ${{ parameters.Artifacts }}
+                MatrixConfigs:
+                  - ${{ each config in parameters.MatrixConfigs }}:
+                    - ${{ config }}
+                  - ${{ each config in parameters.AdditionalMatrixConfigs }}:
+                    - ${{ config }}
+                MatrixFilters:
+                  - ${{ each filter in parameters.MatrixFilters }}:
+                    - ${{ filter }}
+                  # Skip TestFromSource jobs for SDKType data
+                  - ${{ if eq(parameters.SDKType, 'data') }}:
+                    - TestFromSource=^(?!true).*
+                MatrixReplace:
+                  - ${{ each replacement in parameters.MatrixReplace }}:
+                    - ${{ replacement }}
 
-      - ${{ if parameters.AdditionalStagesAfterBuild }}:
+                  - AZURE_TEST.*=.*/
+                  - ${{ if eq(parameters.SDKType, 'data') }}:
+                    - JavaTestVersion=(.*1)\.\d{2}(.*)/$1.11$2
+                PreBuildSteps: ${{ parameters.PreBuildSteps }}
+                EnvVars: ${{ parameters.EnvVars }}
+                AdditionalLintingOptions: ${{ parameters.AdditionalLintingOptions }}
+                ${{ if eq(parameters.SDKType, 'data') }}:
+                  TestGoals: 'verify'
+                  TestOptions: '-am'
+                  JavaBuildVersion: '1.11'
+                ${{ else }}:
+                  JavaBuildVersion: ${{ parameters.JavaBuildVersion }}
+                BuildParallelization: ${{ parameters.BuildParallelization }}
+                TestParallelization: ${{ parameters.TestParallelization }}
+
+      - ${{ if and(ne(parameters.SkipPrValidation, true), parameters.AdditionalStagesAfterBuild) }}:
           - ${{ parameters.AdditionalStagesAfterBuild }}
 
-      - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'],'IndividualCI')) }}:
+      - ${{ if and(ne(parameters.SkipPrValidation, true), eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'],'IndividualCI')) }}:
           - ${{ parameters.LiveTestStages }}
 
       # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
       # The tests-weekly check needs to be done so we don't create signing/release tasks for manual weekly-test runs
-      - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), not(contains(variables['Build.DefinitionName'], 'tests-weekly'))) }}:
+      - ${{if and(ne(parameters.SkipPrValidation, true), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), not(contains(variables['Build.DefinitionName'], 'tests-weekly'))) }}:
           - template: archetype-java-release-batch.yml
             parameters:
               DependsOn:


### PR DESCRIPTION
This pull request introduces a new mechanism to optionally skip pull request (PR) validation in the Azure Pipelines configuration. It does so by adding a `SkipPrValidation` parameter to relevant pipeline templates and updating the pipeline logic to perform a no-op stage when skipping is enabled. This provides more flexibility in controlling PR validation runs, especially for scenarios like common skills sync or manual overrides.

Key changes include:

**Pipeline parameterization and control:**

* Added a new boolean parameter `SkipPrValidation` (default: `false`) to both `eng/pipelines/pullrequest.yml` and `eng/pipelines/templates/stages/archetype-sdk-client.yml`, allowing users to control whether PR validation should be skipped.
* Updated parameter passing so that `SkipPrValidation` is propagated from the top-level pipeline to the archetype template.

**Conditional pipeline execution:**

* Modified the pipeline stages to conditionally execute either a no-op stage (when `SkipPrValidation` is `true`) or the normal build and test stages (when `SkipPrValidation` is `false`). The no-op stage logs a message indicating PR validation was skipped.
* Updated conditions for executing additional stages (`AdditionalStagesAfterBuild`, `LiveTestStages`, and release stages) to ensure they are only run if PR validation is not skipped.