### PR TITLE
Feature/cfp throughput bucket support

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/changefeed/epkversion/FeedRangeThroughputControlConfigManagerTests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/changefeed/epkversion/FeedRangeThroughputControlConfigManagerTests.java
@@ -66,4 +66,36 @@ public class FeedRangeThroughputControlConfigManagerTests {
         assertThat(pkRangeThroughputControlConfig.getTargetThroughputThreshold()).isEqualTo(throughputControlGroupConfig.getTargetThroughputThreshold()/allLeases.size());
         assertThat(pkRangeThroughputControlConfig.getPriorityLevel()).isEqualTo(throughputControlGroupConfig.getPriorityLevel());
     }
+
+    @Test(groups = "unit")
+    public void getOrCreateThroughputControlConfigForFeedRange_withThroughputBucket() {
+
+        ThroughputControlGroupConfig throughputControlGroupConfig =
+            new ThroughputControlGroupConfigBuilder()
+                .groupName("test-" + UUID.randomUUID())
+                .priorityLevel(PriorityLevel.LOW)
+                .throughputBucket(2)
+                .build();
+
+        ChangeFeedContextClient documentClientMock = Mockito.mock(ChangeFeedContextClient.class);
+        CosmosAsyncContainer containerMock = Mockito.mock(CosmosAsyncContainer.class);
+        Mockito.doReturn(containerMock).when(documentClientMock).getContainerClient();
+        Mockito.doNothing().when(containerMock).enableServerThroughputControlGroup(Mockito.any());
+
+        FeedRangeThroughputControlConfigManager throughputControlConfigManager =
+            new FeedRangeThroughputControlConfigManager(throughputControlGroupConfig, documentClientMock);
+
+        FeedRangeEpkImpl feedRangeEpk = new FeedRangeEpkImpl(new Range<>("AA", "CC", true, false));
+
+        ThroughputControlGroupConfig pkRangeThroughputControlConfig =
+            throughputControlConfigManager.getOrCreateThroughputControlConfigForFeedRange(feedRangeEpk).block();
+
+        assertThat(pkRangeThroughputControlConfig).isNotNull();
+        assertThat(pkRangeThroughputControlConfig.getGroupName()).isEqualTo(throughputControlGroupConfig.getGroupName());
+        assertThat(pkRangeThroughputControlConfig.getPriorityLevel()).isEqualTo(throughputControlGroupConfig.getPriorityLevel());
+        assertThat(pkRangeThroughputControlConfig.getThroughputBucket()).isEqualTo(2);
+
+        Mockito.verify(containerMock, Mockito.times(1)).enableServerThroughputControlGroup(throughputControlGroupConfig);
+        Mockito.verify(containerMock, Mockito.never()).enableLocalThroughputControlGroup(Mockito.any());
+    }
 }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/changefeed/pkversion/FeedRangeThroughputControlConfigManagerTests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/changefeed/pkversion/FeedRangeThroughputControlConfigManagerTests.java
@@ -48,4 +48,35 @@ public class FeedRangeThroughputControlConfigManagerTests {
         assertThat(pkRangeThroughputControlConfig.getTargetThroughputThreshold()).isEqualTo(throughputControlGroupConfig.getTargetThroughputThreshold());
         assertThat(pkRangeThroughputControlConfig.getPriorityLevel()).isEqualTo(throughputControlGroupConfig.getPriorityLevel());
     }
+
+    @Test(groups = "unit")
+    public void getThroughputControlConfigForFeedRange_withThroughputBucket() {
+
+        ThroughputControlGroupConfig throughputControlGroupConfig =
+            new ThroughputControlGroupConfigBuilder()
+                .groupName("test-" + UUID.randomUUID())
+                .priorityLevel(PriorityLevel.LOW)
+                .throughputBucket(2)
+                .build();
+
+        ChangeFeedContextClient documentClientMock = Mockito.mock(ChangeFeedContextClient.class);
+        CosmosAsyncContainer containerMock = Mockito.mock(CosmosAsyncContainer.class);
+        Mockito.doReturn(containerMock).when(documentClientMock).getContainerClient();
+        Mockito.doNothing().when(containerMock).enableServerThroughputControlGroup(Mockito.any());
+
+        FeedRangeThroughputControlConfigManager throughputControlConfigManager =
+            new FeedRangeThroughputControlConfigManager(throughputControlGroupConfig, documentClientMock);
+
+        FeedRange feedRange = new FeedRangePartitionKeyRangeImpl("1");
+        ThroughputControlGroupConfig pkRangeThroughputControlConfig =
+            throughputControlConfigManager.getThroughputControlConfigForFeedRange(feedRange);
+
+        assertThat(pkRangeThroughputControlConfig).isNotNull();
+        assertThat(pkRangeThroughputControlConfig.getGroupName()).isEqualTo(throughputControlGroupConfig.getGroupName());
+        assertThat(pkRangeThroughputControlConfig.getPriorityLevel()).isEqualTo(throughputControlGroupConfig.getPriorityLevel());
+        assertThat(pkRangeThroughputControlConfig.getThroughputBucket()).isEqualTo(2);
+
+        Mockito.verify(containerMock, Mockito.times(1)).enableServerThroughputControlGroup(throughputControlGroupConfig);
+        Mockito.verify(containerMock, Mockito.never()).enableLocalThroughputControlGroup(Mockito.any());
+    }
 }

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.82.0-beta.1 (Unreleased)
 
 #### Features Added
+* Added throughput bucket support for Change Feed Processor feed polling throughput control. - See [Issue 49487](https://github.com/Azure/azure-sdk-for-java/issues/49487)
 
 #### Breaking Changes
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/epkversion/FeedRangeThroughputControlConfigManager.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/epkversion/FeedRangeThroughputControlConfigManager.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -34,6 +35,7 @@ public class FeedRangeThroughputControlConfigManager {
     private final AtomicReference<List<FeedRangeEpkImpl>> leaseTokens; // epk leases
     private final Map<PartitionKeyRange, List<FeedRange>> pkRangeToFeedRangeMap;
     private final Map<FeedRange, ThroughputControlGroupConfig> feedRangeToThroughputControlGroupConfigMap;
+    private final AtomicBoolean throughputControlGroupEnabled;
 
     public FeedRangeThroughputControlConfigManager(
         ThroughputControlGroupConfig throughputControlGroupConfig,
@@ -47,6 +49,7 @@ public class FeedRangeThroughputControlConfigManager {
         this.leaseTokens = new AtomicReference<>();
         this.pkRangeToFeedRangeMap = new ConcurrentHashMap<>();
         this.feedRangeToThroughputControlGroupConfigMap = new ConcurrentHashMap<>();
+        this.throughputControlGroupEnabled = new AtomicBoolean(false);
     }
 
     /**
@@ -88,6 +91,14 @@ public class FeedRangeThroughputControlConfigManager {
 
     public Mono<ThroughputControlGroupConfig> getOrCreateThroughputControlConfigForFeedRange(FeedRangeEpkImpl feedRange) {
         checkNotNull(feedRange, "Argument 'feedRange' can not be null");
+
+        if (this.throughputControlGroupConfig.getThroughputBucket() != null) {
+            if (this.throughputControlGroupEnabled.compareAndSet(false, true)) {
+                this.documentClient.getContainerClient().enableServerThroughputControlGroup(this.throughputControlGroupConfig);
+            }
+            return Mono.just(this.throughputControlGroupConfig);
+        }
+
         ThroughputControlGroupConfig throughputControlGroupConfigForFeedRange =
             this.feedRangeToThroughputControlGroupConfigMap.get(feedRange);
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/pkversion/FeedRangeThroughputControlConfigManager.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/changefeed/pkversion/FeedRangeThroughputControlConfigManager.java
@@ -41,7 +41,11 @@ public class FeedRangeThroughputControlConfigManager {
         // Note: if global throughput control be added in future, then we will need to create one group per pkRange
 
         if (this.throughputControlGroupEnabled.compareAndSet(false, true)) {
-            this.documentClient.getContainerClient().enableLocalThroughputControlGroup(this.throughputControlGroupConfig);
+            if (this.throughputControlGroupConfig.getThroughputBucket() != null) {
+                this.documentClient.getContainerClient().enableServerThroughputControlGroup(this.throughputControlGroupConfig);
+            } else {
+                this.documentClient.getContainerClient().enableLocalThroughputControlGroup(this.throughputControlGroupConfig);
+            }
         }
 
         return this.throughputControlGroupConfig;

--- a/sdk/storage/azure-storage-common/CHANGELOG.md
+++ b/sdk/storage/azure-storage-common/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed an async retry hang that could occur when draining a retryable response body after the response was closed.
 
 ### Other Changes
 

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/RequestRetryPolicy.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/RequestRetryPolicy.java
@@ -174,17 +174,17 @@ public final class RequestRetryPolicy implements HttpPipelinePolicy {
                 int newPrimaryTry = getNewPrimaryTry(considerSecondary, primaryTry, tryingPrimary);
 
                 Flux<ByteBuffer> responseBody = response.getBody();
-                final boolean retryConsiderSecondary = newConsiderSecondary;
-                final HttpResponse retryResponse = response;
+                final boolean consideredSecondaryForRetry = newConsiderSecondary;
 
                 if (responseBody == null) {
-                    retryResponse.close();
-                    return attemptAsync(context, next, originalRequest, retryConsiderSecondary, newPrimaryTry,
+                    response.close();
+                    return attemptAsync(context, next, originalRequest, consideredSecondaryForRetry, newPrimaryTry,
                         attempt + 1, suppressed);
                 } else {
                     return responseBody.ignoreElements()
-                        .doFinally(ignored -> retryResponse.close())
-                        .then(Mono.defer(() -> attemptAsync(context, next, originalRequest, retryConsiderSecondary,
+                        .doFinally(ignored -> response.close())
+                        .onErrorResume(drainError -> Mono.empty())
+                        .then(Mono.defer(() -> attemptAsync(context, next, originalRequest, consideredSecondaryForRetry,
                             newPrimaryTry, attempt + 1, suppressed)));
                 }
 

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/RequestRetryPolicy.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/RequestRetryPolicy.java
@@ -174,13 +174,14 @@ public final class RequestRetryPolicy implements HttpPipelinePolicy {
                 int newPrimaryTry = getNewPrimaryTry(considerSecondary, primaryTry, tryingPrimary);
 
                 Flux<ByteBuffer> responseBody = response.getBody();
-                response.close();
 
                 if (responseBody == null) {
+                    response.close();
                     return attemptAsync(context, next, originalRequest, newConsiderSecondary, newPrimaryTry,
                         attempt + 1, suppressed);
                 } else {
                     return responseBody.ignoreElements()
+                        .doFinally(ignored -> response.close())
                         .then(attemptAsync(context, next, originalRequest, newConsiderSecondary, newPrimaryTry,
                             attempt + 1, suppressed));
                 }

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/RequestRetryPolicy.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/RequestRetryPolicy.java
@@ -181,9 +181,13 @@ public final class RequestRetryPolicy implements HttpPipelinePolicy {
                         attempt + 1, suppressed);
                 } else {
                     return responseBody.ignoreElements()
-                        .doFinally(ignored -> response.close())
-                        .then(attemptAsync(context, next, originalRequest, newConsiderSecondary, newPrimaryTry,
-                            attempt + 1, suppressed));
+                        .doOnError(e -> response.close())
+                        .doOnCancel(response::close)
+                        .then(Mono.defer(() -> {
+                            response.close();
+                            return attemptAsync(context, next, originalRequest, newConsiderSecondary, newPrimaryTry,
+                                attempt + 1, suppressed);
+                        }));
                 }
 
             }

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/RequestRetryPolicy.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/RequestRetryPolicy.java
@@ -174,18 +174,20 @@ public final class RequestRetryPolicy implements HttpPipelinePolicy {
                 int newPrimaryTry = getNewPrimaryTry(considerSecondary, primaryTry, tryingPrimary);
 
                 Flux<ByteBuffer> responseBody = response.getBody();
+                final boolean retryConsiderSecondary = newConsiderSecondary;
+                final HttpResponse retryResponse = response;
 
                 if (responseBody == null) {
-                    response.close();
-                    return attemptAsync(context, next, originalRequest, newConsiderSecondary, newPrimaryTry,
+                    retryResponse.close();
+                    return attemptAsync(context, next, originalRequest, retryConsiderSecondary, newPrimaryTry,
                         attempt + 1, suppressed);
                 } else {
                     return responseBody.ignoreElements()
-                        .doOnError(e -> response.close())
-                        .doOnCancel(response::close)
+                        .doOnError(e -> retryResponse.close())
+                        .doOnCancel(retryResponse::close)
                         .then(Mono.defer(() -> {
-                            response.close();
-                            return attemptAsync(context, next, originalRequest, newConsiderSecondary, newPrimaryTry,
+                            retryResponse.close();
+                            return attemptAsync(context, next, originalRequest, retryConsiderSecondary, newPrimaryTry,
                                 attempt + 1, suppressed);
                         }));
                 }

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/RequestRetryPolicy.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/storage/common/policy/RequestRetryPolicy.java
@@ -183,13 +183,9 @@ public final class RequestRetryPolicy implements HttpPipelinePolicy {
                         attempt + 1, suppressed);
                 } else {
                     return responseBody.ignoreElements()
-                        .doOnError(e -> retryResponse.close())
-                        .doOnCancel(retryResponse::close)
-                        .then(Mono.defer(() -> {
-                            retryResponse.close();
-                            return attemptAsync(context, next, originalRequest, retryConsiderSecondary, newPrimaryTry,
-                                attempt + 1, suppressed);
-                        }));
+                        .doFinally(ignored -> retryResponse.close())
+                        .then(Mono.defer(() -> attemptAsync(context, next, originalRequest, retryConsiderSecondary,
+                            newPrimaryTry, attempt + 1, suppressed)));
                 }
 
             }

--- a/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/RequestRetryPolicyTest.java
+++ b/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/RequestRetryPolicyTest.java
@@ -183,7 +183,8 @@ public class RequestRetryPolicyTest {
 
         StepVerifier.create(sendRequest(pipeline))
             .expectNextMatches(response -> response.getStatusCode() == 200)
-            .verifyComplete();
+            .expectComplete()
+            .verify(Duration.ofSeconds(5));
         assertEquals(2, requestCount.get());
     }
 

--- a/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/RequestRetryPolicyTest.java
+++ b/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/RequestRetryPolicyTest.java
@@ -22,11 +22,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -144,6 +148,43 @@ public class RequestRetryPolicyTest {
         SyncAsyncExtension.execute(() -> sendRequestSync(pipeline), () -> sendRequest(pipeline));
 
         assertEquals(3, closeCalls.get());
+    }
+
+    @Test
+    public void retryDrainsBodyBeforeClosingAsync() {
+        AtomicInteger requestCount = new AtomicInteger();
+        AtomicBoolean firstResponseClosed = new AtomicBoolean();
+
+        final HttpPipeline pipeline = new HttpPipelineBuilder().policies(new RequestRetryPolicy(retryTestOptions))
+            .httpClient(new NoOpHttpClient() {
+                @Override
+                public Mono<HttpResponse> send(HttpRequest request) {
+                    if (requestCount.incrementAndGet() == 1) {
+                        return Mono.just(new MockHttpResponse(request, 500) {
+                            @Override
+                            public Flux<ByteBuffer> getBody() {
+                                return Flux.defer(() -> firstResponseClosed.get()
+                                    ? Flux.never()
+                                    : Flux.just(ByteBuffer.wrap(new byte[0])));
+                            }
+
+                            @Override
+                            public void close() {
+                                firstResponseClosed.set(true);
+                                super.close();
+                            }
+                        });
+                    }
+
+                    return Mono.just(new MockHttpResponse(request, 200));
+                }
+            })
+            .build();
+
+        StepVerifier.create(sendRequest(pipeline))
+            .expectNextMatches(response -> response.getStatusCode() == 200)
+            .verifyComplete();
+        assertEquals(2, requestCount.get());
     }
 
     @SyncAsyncTest

--- a/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/RequestRetryPolicyTest.java
+++ b/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/RequestRetryPolicyTest.java
@@ -185,7 +185,8 @@ public class RequestRetryPolicyTest {
             .expectNextMatches(response -> response.getStatusCode() == 200)
             .expectComplete()
             .verify(Duration.ofSeconds(5));
-        assertEquals(2, requestCount.get());
+assertEquals(2, requestCount.get());
+Assertions.assertTrue(firstResponseClosed.get(), "Retryable response should be closed after draining the body.");
     }
 
     @SyncAsyncTest

--- a/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/RequestRetryPolicyTest.java
+++ b/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/RequestRetryPolicyTest.java
@@ -185,8 +185,9 @@ public class RequestRetryPolicyTest {
             .expectNextMatches(response -> response.getStatusCode() == 200)
             .expectComplete()
             .verify(Duration.ofSeconds(5));
-assertEquals(2, requestCount.get());
-Assertions.assertTrue(firstResponseClosed.get(), "Retryable response should be closed after draining the body.");
+        assertEquals(2, requestCount.get());
+        Assertions.assertTrue(firstResponseClosed.get(),
+            "Retryable response should be closed after draining the body.");
     }
 
     @SyncAsyncTest

--- a/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/RequestRetryPolicyTest.java
+++ b/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/policy/RequestRetryPolicyTest.java
@@ -42,6 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class RequestRetryPolicyTest {
     static RequestRetryOptions retryTestOptions
         = new RequestRetryOptions(RetryPolicyType.EXPONENTIAL, 4, 2, 100L, 1000L, "SecondaryHost");
+    private static final RequestRetryOptions FAST_RETRY_OPTIONS
+        = new RequestRetryOptions(RetryPolicyType.FIXED, 4, (Integer) null, 1L, 5L, null);
 
     @SyncAsyncTest
     public void requestRetryPolicySuccessMaxRetries() {
@@ -155,7 +157,7 @@ public class RequestRetryPolicyTest {
         AtomicInteger requestCount = new AtomicInteger();
         AtomicBoolean firstResponseClosed = new AtomicBoolean();
 
-        final HttpPipeline pipeline = new HttpPipelineBuilder().policies(new RequestRetryPolicy(retryTestOptions))
+        final HttpPipeline pipeline = new HttpPipelineBuilder().policies(new RequestRetryPolicy(FAST_RETRY_OPTIONS))
             .httpClient(new NoOpHttpClient() {
                 @Override
                 public Mono<HttpResponse> send(HttpRequest request) {
@@ -184,7 +186,84 @@ public class RequestRetryPolicyTest {
         StepVerifier.create(sendRequest(pipeline))
             .expectNextMatches(response -> response.getStatusCode() == 200)
             .expectComplete()
-            .verify(Duration.ofSeconds(5));
+            .verify(Duration.ofSeconds(1));
+        assertEquals(2, requestCount.get());
+        Assertions.assertTrue(firstResponseClosed.get(),
+            "Retryable response should be closed after draining the body.");
+    }
+
+    @Test
+    public void retryContinuesWhenDrainingBodyFailsAsync() {
+        AtomicInteger requestCount = new AtomicInteger();
+        AtomicBoolean firstResponseClosed = new AtomicBoolean();
+
+        final HttpPipeline pipeline = new HttpPipelineBuilder().policies(new RequestRetryPolicy(FAST_RETRY_OPTIONS))
+            .httpClient(new NoOpHttpClient() {
+                @Override
+                public Mono<HttpResponse> send(HttpRequest request) {
+                    if (requestCount.incrementAndGet() == 1) {
+                        return Mono.just(new MockHttpResponse(request, 500) {
+                            @Override
+                            public Flux<ByteBuffer> getBody() {
+                                return Flux.error(new IllegalStateException("Body was discarded after close."));
+                            }
+
+                            @Override
+                            public void close() {
+                                firstResponseClosed.set(true);
+                                super.close();
+                            }
+                        });
+                    }
+
+                    return Mono.just(new MockHttpResponse(request, 200));
+                }
+            })
+            .build();
+
+        StepVerifier.create(sendRequest(pipeline))
+            .expectNextMatches(response -> response.getStatusCode() == 200)
+            .expectComplete()
+            .verify(Duration.ofSeconds(1));
+        assertEquals(2, requestCount.get());
+        Assertions.assertTrue(firstResponseClosed.get(), "Retryable response should be closed after a drain error.");
+    }
+
+    @Test
+    public void retryAfter500StillRetriesWhenDrainingClosedBodyErrors() {
+        AtomicInteger requestCount = new AtomicInteger();
+        AtomicBoolean firstResponseClosed = new AtomicBoolean();
+
+        final HttpPipeline pipeline = new HttpPipelineBuilder().policies(new RequestRetryPolicy(FAST_RETRY_OPTIONS))
+            .httpClient(new NoOpHttpClient() {
+                @Override
+                public Mono<HttpResponse> send(HttpRequest request) {
+                    if (requestCount.incrementAndGet() == 1) {
+                        return Mono.just(new MockHttpResponse(request, 500) {
+                            @Override
+                            public Flux<ByteBuffer> getBody() {
+                                return Flux.defer(() -> firstResponseClosed.get()
+                                    ? Flux.error(new IllegalStateException("Body was discarded after close."))
+                                    : Flux.just(ByteBuffer.wrap(new byte[0])));
+                            }
+
+                            @Override
+                            public void close() {
+                                firstResponseClosed.set(true);
+                                super.close();
+                            }
+                        });
+                    }
+
+                    return Mono.just(new MockHttpResponse(request, 200));
+                }
+            })
+            .build();
+
+        StepVerifier.create(sendRequest(pipeline))
+            .expectNextMatches(response -> response.getStatusCode() == 200)
+            .expectComplete()
+            .verify(Duration.ofSeconds(1));
         assertEquals(2, requestCount.get());
         Assertions.assertTrue(firstResponseClosed.get(),
             "Retryable response should be closed after draining the body.");


### PR DESCRIPTION
# Description

Adds throughput bucket support for Change Feed Processor feed polling throughput control in Azure Cosmos DB.

When a CFP feed poll throughput control config includes `throughputBucket`, CFP now enables server-side throughput control for the configured group instead of only using local/client-side throughput control. This is implemented for both PK-range and EPK-range CFP paths.

Also adds unit coverage for both CFP paths and updates the Cosmos changelog.

Fixes #49487

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.