### PR TITLE
Narrow PR pipeline skill path exclusion

### DIFF
--- a/eng/pipelines/pullrequest.yml
+++ b/eng/pipelines/pullrequest.yml
@@ -11,7 +11,7 @@ pr:
     include:
       - "*"
     exclude:
-      - .github/skills/**
+      - .github/skills/azsdk-common-*/**
 
 parameters:
   - name: Service


### PR DESCRIPTION
## Summary
- Narrow the PR pipeline path exclusion from all skills to common Azure SDK skill folders only.