### PR TITLE
Prepare azure-messaging-servicebus 7.18.0-beta.2 for release

### DIFF
--- a/sdk/servicebus/azure-messaging-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-messaging-servicebus/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Release History
 
-## 7.18.0-beta.2 (Unreleased)
+## 7.18.0-beta.2 (2026-06-22)
 
 ### Features Added
 
 - Added `drainTimeout(Duration)` to `ServiceBusProcessorClientBuilder` and `ServiceBusSessionProcessorClientBuilder` to configure the maximum wait time for in-flight message handlers during processor shutdown. Defaults to 30 seconds.
-
-### Breaking Changes
 
 ### Bugs Fixed
 

--- a/sdk/servicebus/azure-messaging-servicebus/README.md
+++ b/sdk/servicebus/azure-messaging-servicebus/README.md
@@ -70,7 +70,7 @@ add the direct dependency to your project as follows.
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-messaging-servicebus</artifactId>
-    <version>7.17.13</version>
+    <version>7.18.0-beta.2</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})


### PR DESCRIPTION
Release-prep PR for `azure-messaging-servicebus` **7.18.0-beta.2**.

Produced by `eng/common/scripts/Prepare-Release.ps1`:

- CHANGELOG: `## 7.18.0-beta.2 (Unreleased)` to `## 7.18.0-beta.2 (2026-06-22)` (also trims the empty `### Breaking Changes` section).
- README: dependency snippet version `7.17.13` to `7.18.0-beta.2`.

The DevOps release work item [22249](https://dev.azure.com/azure-sdk/Release/_workitems/edit/22249/) is set to `In Release` (Beta).

Stamping the release date lets the changelog pass `verify-changelog -ForRelease` at publish. Once this merges, `azure-messaging-servicebus` 7.18.0-beta.2 is ready for the `java - servicebus` release pipeline run.

### What 7.18.0-beta.2 ships

- **Features Added:** `drainTimeout(Duration)` on the processor builders for graceful shutdown ([#48192](https://github.com/Azure/azure-sdk-for-java/pull/48192)).
- **Bugs Fixed:** `ServiceBusProcessorClient.close()` now drains in-flight handlers before disposing the receiver ([#45716](https://github.com/Azure/azure-sdk-for-java/issues/45716)).
- **Other Changes:** `com.microsoft:max-message-batch-size` AMQP vendor-property support in `createMessageBatch` ([#48214](https://github.com/Azure/azure-sdk-for-java/pull/48214)).
