### PR TITLE
chore: add @j7nw4r to Service Bus CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -457,15 +457,15 @@
 # ServiceOwners:                                                   @kuanlu95 @mattgotteiner
 
 # PRLabel: %Service Bus
-/sdk/servicebus/                                                   @EldertGrootenboer @skarri-microsoft @Azure/azure-java-sdk
+/sdk/servicebus/                                                   @EldertGrootenboer @skarri-microsoft @j7nw4r @Azure/azure-java-sdk
 
 # PRLabel: %Service Bus %Track 1
-/sdk/servicebus/microsoft-azure-servicebus/                        @EldertGrootenboer @skarri-microsoft @vinaysurya @Azure/azure-java-sdk
+/sdk/servicebus/microsoft-azure-servicebus/                        @EldertGrootenboer @skarri-microsoft @j7nw4r @vinaysurya @Azure/azure-java-sdk
 
 # ServiceLabel: %Service Bus
-# ServiceOwners:                                                   @EldertGrootenboer @skarri-microsoft
+# ServiceOwners:                                                   @EldertGrootenboer @skarri-microsoft @j7nw4r
 
-# AzureSdkOwners:                                                  @EldertGrootenboer @skarri-microsoft
+# AzureSdkOwners:                                                  @EldertGrootenboer @skarri-microsoft @j7nw4r
 # ServiceLabel: %Service Bus %Track 1
 
 # PRLabel: %Speech Transcription


### PR DESCRIPTION
## Summary

Adds @j7nw4r to the Service Bus CODEOWNERS entries, matching the existing @skarri-microsoft ownership.

## Motivation

@j7nw4r is taking on Service Bus maintenance alongside the current owners and should appear on the same review-routing and owner-metadata entries as @skarri-microsoft for the Service Bus paths. @skarri-microsoft is already listed on each of these lines; this brings @j7nw4r to the same set so Service Bus pull requests and ownership tooling route to both.

## Changes

Add @j7nw4r next to @skarri-microsoft on the four Service Bus lines in `.github/CODEOWNERS`: the `/sdk/servicebus/` path rule, the `/sdk/servicebus/microsoft-azure-servicebus/` path rule, and the `# ServiceOwners` and `# AzureSdkOwners` metadata comments.