### PR TITLE
Storage - [Content Validation] Make synchronous stageBlock request body replayable on retry

### DIFF
--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/specialized/BlockBlobClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/specialized/BlockBlobClient.java
@@ -41,11 +41,14 @@ import com.azure.storage.blob.options.BlockBlobStageBlockOptions;
 import com.azure.storage.common.implementation.Constants;
 import com.azure.storage.common.implementation.StorageImplUtils;
 import com.azure.storage.common.implementation.StorageSeekableByteChannel;
+import com.azure.storage.common.Utility;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.time.Duration;
 import java.util.List;
@@ -783,10 +786,14 @@ public final class BlockBlobClient extends BlobClientBase {
         String leaseId, Duration timeout, Context context) {
         StorageImplUtils.assertNotNull("data", data);
 
-        Mono<Response<Void>> response = client.stageBlockWithResponseInternal(
-            new BlockBlobStageBlockOptions(base64BlockId, BinaryData.fromStream(data, length)).setContentMd5(contentMd5)
-                .setLeaseId(leaseId),
-            context);
+        Flux<ByteBuffer> dataFlux
+            = Utility.convertStreamToByteBuffer(data, length, BlobAsyncClient.BLOB_DEFAULT_UPLOAD_BLOCK_SIZE, true);
+
+        Mono<Response<Void>> response = BinaryData.fromFlux(dataFlux, length, false)
+            .flatMap(binaryData -> client.stageBlockWithResponseInternal(
+                new BlockBlobStageBlockOptions(base64BlockId, binaryData).setContentMd5(contentMd5)
+                    .setLeaseId(leaseId),
+                context));
         return blockWithOptionalTimeout(response, timeout);
     }
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/specialized/BlockBlobClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/storage/blob/specialized/BlockBlobClient.java
@@ -791,8 +791,7 @@ public final class BlockBlobClient extends BlobClientBase {
 
         Mono<Response<Void>> response = BinaryData.fromFlux(dataFlux, length, false)
             .flatMap(binaryData -> client.stageBlockWithResponseInternal(
-                new BlockBlobStageBlockOptions(base64BlockId, binaryData).setContentMd5(contentMd5)
-                    .setLeaseId(leaseId),
+                new BlockBlobStageBlockOptions(base64BlockId, binaryData).setContentMd5(contentMd5).setLeaseId(leaseId),
                 context));
         return blockWithOptionalTimeout(response, timeout);
     }


### PR DESCRIPTION
Updates the synchronous `BlockBlobClient.stageBlockWithResponse(String, InputStream, long, byte[], String, Duration, Context)` so the staged-block request body can be re-sent when the HTTP pipeline retries a request.

Previously the caller's InputStream was wrapped directly via BinaryData.fromStream(data, length). A BinaryData created from a raw stream is not replayable (BinaryData.isReplayable() returns false), so once the stream was consumed it could not be re-read.