### PR TITLE
[EventGrid] Set release date for azure-messaging-eventgrid-systemevents 1.1.0-beta.1

### DIFF
--- a/sdk/eventgrid/azure-messaging-eventgrid-systemevents/CHANGELOG.md
+++ b/sdk/eventgrid/azure-messaging-eventgrid-systemevents/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Updated system events with the latest Event Grid system event definitions, adding Virtual Machine Scale Set lifecycle hook events and Azure Communication Services chat retention-policy support.
 
 ## 1.0.0 (2025-06-26)
 

--- a/sdk/eventgrid/azure-messaging-eventgrid-systemevents/CHANGELOG.md
+++ b/sdk/eventgrid/azure-messaging-eventgrid-systemevents/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Updated system events with the latest Event Grid system event definitions, adding Virtual Machine Scale Set lifecycle hook events and Azure Communication Services chat retention-policy support.
+- Updated system event models to the latest Event Grid system events definitions.
 
 ## 1.0.0 (2025-06-26)
 

--- a/sdk/eventgrid/azure-messaging-eventgrid-systemevents/CHANGELOG.md
+++ b/sdk/eventgrid/azure-messaging-eventgrid-systemevents/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
+## 1.1.0-beta.1 (2026-06-25)
 
 ### Features Added
 


### PR DESCRIPTION
Sets the release date for `azure-messaging-eventgrid-systemevents` **1.1.0-beta.1** so the release pipeline's `Verify-ChangeLogEntry` check passes (it requires a `yyyy-MM-dd` date and rejects `(Unreleased)`).

Scope: only `azure-messaging-eventgrid-systemevents` (the other EventGrid libraries are left untouched).

### Change
- CHANGELOG.md: `## 1.1.0-beta.1 (Unreleased)` -> `## 1.1.0-beta.1 (2026-06-25)`