### PR TITLE
Fix DLQ reason and description not transmitted in ServiceBus binder

### DIFF
--- a/sdk/spring/spring-cloud-azure-stream-binder-servicebus/src/main/java/com/azure/spring/cloud/stream/binder/servicebus/implementation/ServiceBusMessageChannelBinder.java
+++ b/sdk/spring/spring-cloud-azure-stream-binder-servicebus/src/main/java/com/azure/spring/cloud/stream/binder/servicebus/implementation/ServiceBusMessageChannelBinder.java
@@ -227,7 +227,6 @@ public class ServiceBusMessageChannelBinder extends
             .getHeaders()
             .get(ServiceBusMessageHeaders.RECEIVED_MESSAGE_CONTEXT);
         if (messageContext != null) {
-            messageContext.deadLetter();
             DeadLetterOptions options = new DeadLetterOptions();
             options.setDeadLetterReason(deadLetterReason);
             options.setDeadLetterErrorDescription(deadLetterErrorDescription);

--- a/sdk/spring/spring-cloud-azure-stream-binder-servicebus/src/test/java/com/azure/spring/cloud/stream/binder/servicebus/implementation/ServiceBusMessageChannelBinderTest.java
+++ b/sdk/spring/spring-cloud-azure-stream-binder-servicebus/src/test/java/com/azure/spring/cloud/stream/binder/servicebus/implementation/ServiceBusMessageChannelBinderTest.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -105,6 +106,7 @@ class ServiceBusMessageChannelBinderTest {
         ErrorMessage msg = new ErrorMessage(new RuntimeException(description), originalMessage);
         handler.handleMessage(msg);
         verify(messageContext).deadLetter(captor.capture());
+        verify(messageContext, never()).deadLetter();
         assertEquals("exception-message", captor.getValue().getDeadLetterReason());
         assertEquals(description, captor.getValue().getDeadLetterErrorDescription());
     }


### PR DESCRIPTION
## Summary

- Remove the redundant no-arg `messageContext.deadLetter()` call in `ServiceBusMessageChannelBinder.deadLetter()` that settles the message before the parameterized `deadLetter(options)` can set the DLQ reason and error description
- This is a one-line deletion fix — the no-arg call was left over from PR #41172 which addressed the original issue #40951

## Root Cause

```java
// Before (bug): line 230 settles the message immediately without reason/description
messageContext.deadLetter();          // ← settles message, no reason
messageContext.deadLetter(options);   // ← ignored, message already settled

// After (fix): only the parameterized call remains
messageContext.deadLetter(options);   // ← settles with reason and description
```

## Test Plan

- [ ] Verified the code change by reviewing the `deadLetter` method logic
- [ ] The fix aligns with the approach suggested by the issue reporter and confirmed by @dreyinger

Fixes #41883

🤖 Generated with [Claude Code](https://claude.com/claude-code)