### PR TITLE
Fix DLQ reason and description not transmitted in ServiceBus binder

### DIFF
--- a/sdk/spring/CHANGELOG.md
+++ b/sdk/spring/CHANGELOG.md
@@ -93,6 +93,14 @@ This section includes changes in `spring-cloud-azure-docker-compose` module.
 
 - Upgrade to Jackson 3 to align with Spring Boot 4 ([#49538](https://github.com/Azure/azure-sdk-for-java/issues/49538)).
 
+### Spring Cloud Azure Stream Binder Service Bus
+
+This section includes changes in `spring-cloud-azure-stream-binder-servicebus` module.
+
+#### Bugs Fixed
+
+- Fixed a regression where dead-letter reason and error description were not transmitted because a no-arg `deadLetter()` call settled the message before `deadLetter(options)` was invoked ([#41883](https://github.com/Azure/azure-sdk-for-java/issues/41883)).
+
 ## 6.4.0 (2026-06-01)
 - This release is compatible with Spring Boot 3.5.0-3.5.14. (Note: 3.5.x (x>14) should be supported, but they aren't tested with this release.)
 - This release is compatible with Spring Cloud 2025.0.0-2025.0.2. (Note: 2025.0.x (x>2) should be supported, but they aren't tested with this release.)

--- a/sdk/spring/spring-cloud-azure-stream-binder-servicebus/src/main/java/com/azure/spring/cloud/stream/binder/servicebus/implementation/ServiceBusMessageChannelBinder.java
+++ b/sdk/spring/spring-cloud-azure-stream-binder-servicebus/src/main/java/com/azure/spring/cloud/stream/binder/servicebus/implementation/ServiceBusMessageChannelBinder.java
@@ -227,7 +227,6 @@ public class ServiceBusMessageChannelBinder extends
             .getHeaders()
             .get(ServiceBusMessageHeaders.RECEIVED_MESSAGE_CONTEXT);
         if (messageContext != null) {
-            messageContext.deadLetter();
             DeadLetterOptions options = new DeadLetterOptions();
             options.setDeadLetterReason(deadLetterReason);
             options.setDeadLetterErrorDescription(deadLetterErrorDescription);

--- a/sdk/spring/spring-cloud-azure-stream-binder-servicebus/src/test/java/com/azure/spring/cloud/stream/binder/servicebus/implementation/ServiceBusMessageChannelBinderTest.java
+++ b/sdk/spring/spring-cloud-azure-stream-binder-servicebus/src/test/java/com/azure/spring/cloud/stream/binder/servicebus/implementation/ServiceBusMessageChannelBinderTest.java
@@ -34,7 +34,9 @@ import java.util.HashMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class ServiceBusMessageChannelBinderTest {
@@ -104,9 +106,11 @@ class ServiceBusMessageChannelBinderTest {
         String description = "testDescription";
         ErrorMessage msg = new ErrorMessage(new RuntimeException(description), originalMessage);
         handler.handleMessage(msg);
+        verify(messageContext, never()).deadLetter();
         verify(messageContext).deadLetter(captor.capture());
         assertEquals("exception-message", captor.getValue().getDeadLetterReason());
         assertEquals(description, captor.getValue().getDeadLetterErrorDescription());
+        verifyNoMoreInteractions(messageContext);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Remove the redundant no-arg `messageContext.deadLetter()` call in `ServiceBusMessageChannelBinder.deadLetter(...)`.
- Keep only `messageContext.deadLetter(options)` so the dead-letter reason and error description are applied correctly.
- Strengthen regression test to verify the no-arg overload is never invoked.

## Root Cause
The no-arg `deadLetter()` settled the message before the parameterized `deadLetter(options)` call executed, so DLQ reason/description were not transmitted.

## Changes
- `ServiceBusMessageChannelBinder`: deleted the no-arg dead-letter call.
- `ServiceBusMessageChannelBinderTest`: added `verify(messageContext, never()).deadLetter()`.

## Verification
- Ran:
  - `mvn -pl sdk/spring/spring-cloud-azure-stream-binder-servicebus -Dtest=ServiceBusMessageChannelBinderTest test -DskipITs`
- Result:
  - `BUILD SUCCESS`
  - `Tests run: 3, Failures: 0, Errors: 0`

Fixes #41883