### PR TITLE
Add CFSClean2 to 1ES network isolation policy

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -40,9 +40,9 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      # Set network isolation policy to Permissive, CFSClean, CFSClean3 which our pipelines are currently compliant with.
+      # Set network isolation policy to Permissive, CFSClean, CFSClean2, CFSClean3 which our pipelines are currently compliant with.
       # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-build/cloudbuild/security/1espt-network-isolation#shared-policies-for-common-use-cases
-      networkIsolationPolicy: Permissive, CFSClean, CFSClean3
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2, CFSClean3
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'java - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:


### PR DESCRIPTION
I've worked with service teams addressing the violations for CFSClean2.

## Summary
- Adds CFSClean2 to the 1ES pipeline network isolation policy allowlist.
- Updates the adjacent comment to match the configured policy list.

