### PR TITLE
Remove link verification from ci job

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -393,15 +393,6 @@ jobs:
             ServiceDirectory: ${{ parameters.ServiceDirectory }}
             TestPipeline: ${{ parameters.TestPipeline }}
 
-      - template: /eng/common/pipelines/templates/steps/verify-links.yml
-        parameters:
-          ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-            Directory: ''
-            Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-          ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-            Directory: sdk/${{ parameters.ServiceDirectory }}
-          CheckLinkGuidance: $true
-
       - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
         # NOTE: The PRServiceDirectories string is used in the two Code Generation steps below and
         # the verify samples


### PR DESCRIPTION
This pull request removes the link verification step from the CI pipeline configuration. Specifically, it deletes the inclusion of the `verify-links.yml` template, which previously checked for valid links in markdown files as part of the build process.

* CI pipeline simplification:
  * Removed the `verify-links.yml` step from the `ci.yml` pipeline, so link verification will no longer run during CI builds.