### PR TITLE
Add configurability to AadB2cAuthorizationRequestResolver

### DIFF
--- a/sdk/spring/CHANGELOG.md
+++ b/sdk/spring/CHANGELOG.md
@@ -8,6 +8,8 @@ This section includes changes in `spring-cloud-azure-autoconfigure` module.
 
 #### Features Added
 
+- Added support for constructing `AadB2cAuthorizationRequestResolver` with a custom `authorizationRequestBaseUri`, aligning Azure AD B2C authorization request resolution with the configurability already available for AAD. ([#49674](https://github.com/Azure/azure-sdk-for-java/pull/49674))
+
 #### Breaking Changes
 
 #### Bugs Fixed

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
@@ -34,11 +34,9 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
 
     private static final String AAD_B2C_USER_AGENT = "spring-boot-starter";
 
-    private static final String MATCHER_PATTERN = String.format("%s/{%s}", REQUEST_BASE_URI, REGISTRATION_ID_NAME);
-
-    private static final PathPatternRequestMatcher REQUEST_MATCHER = PathPatternRequestMatcher.withDefaults().matcher(MATCHER_PATTERN);
-
     private final OAuth2AuthorizationRequestResolver delegateResolver;
+
+    private final PathPatternRequestMatcher requestMatcher;
 
     private final String passwordResetUserFlow;
 
@@ -52,7 +50,22 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
      */
     public AadB2cAuthorizationRequestResolver(ClientRegistrationRepository repository,
                                               AadB2cProperties properties) {
-        this(properties, new DefaultOAuth2AuthorizationRequestResolver(repository, REQUEST_BASE_URI));
+        this(REQUEST_BASE_URI, repository, properties);
+    }
+
+    /**
+     * Creates a new instance of {@link AadB2cAuthorizationRequestResolver}.
+     *
+     * @param authorizationRequestBaseUri the base URI used to resolve authorization requests
+     * @param repository the client registration repository
+     * @param properties the AAD B2C properties
+     */
+    public AadB2cAuthorizationRequestResolver(String authorizationRequestBaseUri,
+                                              ClientRegistrationRepository repository,
+                                              AadB2cProperties properties) {
+        this(properties,
+            new DefaultOAuth2AuthorizationRequestResolver(repository, authorizationRequestBaseUri),
+            createRequestMatcher(authorizationRequestBaseUri));
     }
 
     /**
@@ -63,9 +76,16 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
      */
     public AadB2cAuthorizationRequestResolver(AadB2cProperties properties,
                                               OAuth2AuthorizationRequestResolver delegateResolver) {
+        this(properties, delegateResolver, createRequestMatcher(REQUEST_BASE_URI));
+    }
+
+    private AadB2cAuthorizationRequestResolver(AadB2cProperties properties,
+                                               OAuth2AuthorizationRequestResolver delegateResolver,
+                                               PathPatternRequestMatcher requestMatcher) {
         this.properties = properties;
         this.passwordResetUserFlow = this.properties.getPasswordReset();
         this.delegateResolver = delegateResolver;
+        this.requestMatcher = requestMatcher;
     }
 
     /**
@@ -97,7 +117,7 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
             return getB2cAuthorizationRequest(authRequest, passwordResetUserFlow);
         }
 
-        if (StringUtils.hasText(registrationId) && REQUEST_MATCHER.matches(request)) {
+        if (StringUtils.hasText(registrationId) && requestMatcher.matches(request)) {
             return getB2cAuthorizationRequest(delegateResolver.resolve(request), registrationId);
         }
 
@@ -129,11 +149,16 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
     }
 
     private String getRegistrationId(HttpServletRequest request) {
-        if (REQUEST_MATCHER.matches(request)) {
-            return REQUEST_MATCHER.matcher(request).getVariables().get(REGISTRATION_ID_NAME);
+        if (requestMatcher.matches(request)) {
+            return requestMatcher.matcher(request).getVariables().get(REGISTRATION_ID_NAME);
         }
 
         return null;
+    }
+
+    private static PathPatternRequestMatcher createRequestMatcher(String authorizationRequestBaseUri) {
+        String matcherPattern = String.format("%s/{%s}", authorizationRequestBaseUri, REGISTRATION_ID_NAME);
+        return PathPatternRequestMatcher.withDefaults().matcher(matcherPattern);
     }
 
     // Handle the forgot password of sign-up-or-in page cannot redirect user to password-reset page.

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
@@ -176,9 +176,8 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
         if (!normalizedBaseUri.startsWith("/")) {
             normalizedBaseUri = "/" + normalizedBaseUri;
         }
-        if (normalizedBaseUri.endsWith("/")) {
-            normalizedBaseUri = normalizedBaseUri.substring(0, normalizedBaseUri.length() - 1);
-        }
+        // Remove all trailing slashes to handle multiple trailing slashes and ensure idempotent normalization
+        normalizedBaseUri = normalizedBaseUri.replaceAll("/+$", "");
 
         String matcherPattern = String.format("%s/{%s}", normalizedBaseUri, REGISTRATION_ID_NAME);
         return PathPatternRequestMatcher.withDefaults().matcher(matcherPattern);

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
@@ -76,7 +76,20 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
      */
     public AadB2cAuthorizationRequestResolver(AadB2cProperties properties,
                                               OAuth2AuthorizationRequestResolver delegateResolver) {
-        this(properties, delegateResolver, createRequestMatcher(REQUEST_BASE_URI));
+        this(properties, delegateResolver, REQUEST_BASE_URI);
+    }
+
+    /**
+     * Creates a new instance of {@link AadB2cAuthorizationRequestResolver}.
+     *
+     * @param properties the AAD B2C properties.
+     * @param delegateResolver the delegate resolver.
+     * @param authorizationRequestBaseUri the base URI used to resolve authorization requests.
+     */
+    public AadB2cAuthorizationRequestResolver(AadB2cProperties properties,
+                                              OAuth2AuthorizationRequestResolver delegateResolver,
+                                              String authorizationRequestBaseUri) {
+        this(properties, delegateResolver, createRequestMatcher(authorizationRequestBaseUri));
     }
 
     private AadB2cAuthorizationRequestResolver(AadB2cProperties properties,
@@ -157,7 +170,17 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
     }
 
     private static PathPatternRequestMatcher createRequestMatcher(String authorizationRequestBaseUri) {
-        String matcherPattern = String.format("%s/{%s}", authorizationRequestBaseUri, REGISTRATION_ID_NAME);
+        Assert.hasText(authorizationRequestBaseUri, "authorizationRequestBaseUri must contain text.");
+        
+        String normalizedBaseUri = authorizationRequestBaseUri;
+        if (!normalizedBaseUri.startsWith("/")) {
+            normalizedBaseUri = "/" + normalizedBaseUri;
+        }
+        if (normalizedBaseUri.endsWith("/")) {
+            normalizedBaseUri = normalizedBaseUri.substring(0, normalizedBaseUri.length() - 1);
+        }
+        
+        String matcherPattern = String.format("%s/{%s}", normalizedBaseUri, REGISTRATION_ID_NAME);
         return PathPatternRequestMatcher.withDefaults().matcher(matcherPattern);
     }
 

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
@@ -63,7 +63,8 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
     public AadB2cAuthorizationRequestResolver(String authorizationRequestBaseUri,
                                               ClientRegistrationRepository repository,
                                               AadB2cProperties properties) {
-        this(properties, new DefaultOAuth2AuthorizationRequestResolver(repository, normalizeBaseUri(authorizationRequestBaseUri)), createRequestMatcher(normalizeBaseUri(authorizationRequestBaseUri)));
+        this(authorizationRequestBaseUri, properties,
+            new DefaultOAuth2AuthorizationRequestResolver(repository, normalizeBaseUri(authorizationRequestBaseUri)));
     }
 
     /**
@@ -170,12 +171,14 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
     private static String normalizeBaseUri(String authorizationRequestBaseUri) {
         Assert.hasText(authorizationRequestBaseUri, "authorizationRequestBaseUri must contain text.");
 
-        String normalizedBaseUri = authorizationRequestBaseUri;
+        String normalizedBaseUri = authorizationRequestBaseUri.trim();
         if (!normalizedBaseUri.startsWith("/")) {
             normalizedBaseUri = "/" + normalizedBaseUri;
         }
         // Remove all trailing slashes to handle multiple trailing slashes and ensure idempotent normalization
         normalizedBaseUri = normalizedBaseUri.replaceAll("/+$", "");
+        // Ensure result is not empty (e.g., from inputs like "/" or " / ")
+        Assert.hasText(normalizedBaseUri, "authorizationRequestBaseUri must normalize to a non-empty value.");
         return normalizedBaseUri;
     }
 

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
@@ -92,19 +92,6 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
         this(properties, delegateResolver, createRequestMatcher(authorizationRequestBaseUri));
     }
 
-    /**
-     * Creates a new instance of {@link AadB2cAuthorizationRequestResolver}.
-     *
-     * @param properties the AAD B2C properties.
-     * @param delegateResolver the delegate resolver.
-     * @param authorizationRequestBaseUri the base URI used to resolve authorization requests.
-     */
-    public AadB2cAuthorizationRequestResolver(AadB2cProperties properties,
-                                              OAuth2AuthorizationRequestResolver delegateResolver,
-                                              String authorizationRequestBaseUri) {
-        this(properties, delegateResolver, createRequestMatcher(authorizationRequestBaseUri));
-    }
-
     private AadB2cAuthorizationRequestResolver(AadB2cProperties properties,
                                                OAuth2AuthorizationRequestResolver delegateResolver,
                                                PathPatternRequestMatcher requestMatcher) {

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
@@ -76,7 +76,20 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
      */
     public AadB2cAuthorizationRequestResolver(AadB2cProperties properties,
                                               OAuth2AuthorizationRequestResolver delegateResolver) {
-        this(properties, delegateResolver, REQUEST_BASE_URI);
+        this(REQUEST_BASE_URI, properties, delegateResolver);
+    }
+
+    /**
+     * Creates a new instance of {@link AadB2cAuthorizationRequestResolver}.
+     *
+     * @param authorizationRequestBaseUri the base URI used to resolve authorization requests
+     * @param properties the AAD B2C properties.
+     * @param delegateResolver the delegate resolver.
+     */
+    public AadB2cAuthorizationRequestResolver(String authorizationRequestBaseUri,
+                                              AadB2cProperties properties,
+                                              OAuth2AuthorizationRequestResolver delegateResolver) {
+        this(properties, delegateResolver, createRequestMatcher(authorizationRequestBaseUri));
     }
 
     /**

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
@@ -131,7 +131,7 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
         }
 
         if (StringUtils.hasText(registrationId) && requestMatcher.matches(request)) {
-            return getB2cAuthorizationRequest(delegateResolver.resolve(request), registrationId);
+            return getB2cAuthorizationRequest(delegateResolver.resolve(request, registrationId), registrationId);
         }
 
         // Return null may not be the good practice, but we need to align with oauth2.client.web
@@ -171,7 +171,7 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
 
     private static PathPatternRequestMatcher createRequestMatcher(String authorizationRequestBaseUri) {
         Assert.hasText(authorizationRequestBaseUri, "authorizationRequestBaseUri must contain text.");
-        
+
         String normalizedBaseUri = authorizationRequestBaseUri;
         if (!normalizedBaseUri.startsWith("/")) {
             normalizedBaseUri = "/" + normalizedBaseUri;
@@ -179,7 +179,7 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
         if (normalizedBaseUri.endsWith("/")) {
             normalizedBaseUri = normalizedBaseUri.substring(0, normalizedBaseUri.length() - 1);
         }
-        
+
         String matcherPattern = String.format("%s/{%s}", normalizedBaseUri, REGISTRATION_ID_NAME);
         return PathPatternRequestMatcher.withDefaults().matcher(matcherPattern);
     }

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolver.java
@@ -63,9 +63,7 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
     public AadB2cAuthorizationRequestResolver(String authorizationRequestBaseUri,
                                               ClientRegistrationRepository repository,
                                               AadB2cProperties properties) {
-        this(properties,
-            new DefaultOAuth2AuthorizationRequestResolver(repository, authorizationRequestBaseUri),
-            createRequestMatcher(authorizationRequestBaseUri));
+        this(properties, new DefaultOAuth2AuthorizationRequestResolver(repository, normalizeBaseUri(authorizationRequestBaseUri)), createRequestMatcher(normalizeBaseUri(authorizationRequestBaseUri)));
     }
 
     /**
@@ -89,7 +87,7 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
     public AadB2cAuthorizationRequestResolver(String authorizationRequestBaseUri,
                                               AadB2cProperties properties,
                                               OAuth2AuthorizationRequestResolver delegateResolver) {
-        this(properties, delegateResolver, createRequestMatcher(authorizationRequestBaseUri));
+        this(properties, delegateResolver, createRequestMatcher(normalizeBaseUri(authorizationRequestBaseUri)));
     }
 
     private AadB2cAuthorizationRequestResolver(AadB2cProperties properties,
@@ -169,7 +167,7 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
         return null;
     }
 
-    private static PathPatternRequestMatcher createRequestMatcher(String authorizationRequestBaseUri) {
+    private static String normalizeBaseUri(String authorizationRequestBaseUri) {
         Assert.hasText(authorizationRequestBaseUri, "authorizationRequestBaseUri must contain text.");
 
         String normalizedBaseUri = authorizationRequestBaseUri;
@@ -178,8 +176,13 @@ public class AadB2cAuthorizationRequestResolver implements OAuth2AuthorizationRe
         }
         // Remove all trailing slashes to handle multiple trailing slashes and ensure idempotent normalization
         normalizedBaseUri = normalizedBaseUri.replaceAll("/+$", "");
+        return normalizedBaseUri;
+    }
 
-        String matcherPattern = String.format("%s/{%s}", normalizedBaseUri, REGISTRATION_ID_NAME);
+    private static PathPatternRequestMatcher createRequestMatcher(String authorizationRequestBaseUri) {
+        // The URI should already be normalized by the caller; validate it has text
+        Assert.hasText(authorizationRequestBaseUri, "authorizationRequestBaseUri must contain text.");
+        String matcherPattern = String.format("%s/{%s}", authorizationRequestBaseUri, REGISTRATION_ID_NAME);
         return PathPatternRequestMatcher.withDefaults().matcher(matcherPattern);
     }
 

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolverTests.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolverTests.java
@@ -118,6 +118,40 @@ class AadB2cAuthorizationRequestResolverTests {
             resolved.getAdditionalParameters().get("x-client-SKU"));
     }
 
+    @Test
+    void testBaseUriNormalizationWithoutLeadingSlash() {
+        // Base URI without leading '/' should be normalized to include it
+        final String baseUriWithoutLeadingSlash = "oauth2/authorization";
+        final String registrationId = AadB2cConstants.TEST_SIGN_UP_OR_IN_NAME;
+        final AadB2cAuthorizationRequestResolver resolver = new AadB2cAuthorizationRequestResolver(
+            baseUriWithoutLeadingSlash,
+            new InMemoryClientRegistrationRepository(createClientRegistration(registrationId)),
+            new AadB2cProperties());
+
+        // Request with leading '/' should match
+        HttpServletRequest request = getHttpServletRequest("/oauth2/authorization/" + registrationId);
+        final org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest resolved =
+            resolver.resolve(request);
+        Assertions.assertNotNull(resolved);
+    }
+
+    @Test
+    void testBaseUriNormalizationWithMultipleTrailingSlashes() {
+        // Base URI with multiple trailing slashes should be normalized
+        final String baseUriWithTrailingSlashes = "/oauth2/authorization///";
+        final String registrationId = AadB2cConstants.TEST_SIGN_UP_OR_IN_NAME;
+        final AadB2cAuthorizationRequestResolver resolver = new AadB2cAuthorizationRequestResolver(
+            baseUriWithTrailingSlashes,
+            new InMemoryClientRegistrationRepository(createClientRegistration(registrationId)),
+            new AadB2cProperties());
+
+        // Request should match against normalized path
+        HttpServletRequest request = getHttpServletRequest("/oauth2/authorization/" + registrationId);
+        final org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest resolved =
+            resolver.resolve(request);
+        Assertions.assertNotNull(resolved);
+    }
+
     private ClientRegistration createClientRegistration(String registrationId) {
         return ClientRegistration.withRegistrationId(registrationId)
             .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolverTests.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolverTests.java
@@ -4,6 +4,7 @@ package com.azure.spring.cloud.autoconfigure.implementation.aadb2c.security;
 
 import com.azure.spring.cloud.autoconfigure.implementation.aadb2c.AadB2cConstants;
 import com.azure.spring.cloud.autoconfigure.implementation.aadb2c.configuration.AadB2cAutoConfiguration;
+import com.azure.spring.cloud.autoconfigure.implementation.aadb2c.configuration.properties.AadB2cProperties;
 import com.azure.spring.cloud.autoconfigure.implementation.aadb2c.configuration.WebOAuth2ClientTestApp;
 import com.azure.spring.cloud.autoconfigure.implementation.context.AzureGlobalPropertiesAutoConfiguration;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,6 +18,9 @@ import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 import org.springframework.util.Assert;
 
@@ -88,5 +92,41 @@ class AadB2cAuthorizationRequestResolverTests {
                     AuthorizationGrantType.AUTHORIZATION_CODE);
                 Assertions.assertTrue(resolver.resolve(request).getScopes().containsAll(Arrays.asList("openid", AadB2cConstants.TEST_CLIENT_ID)));
             });
+    }
+
+    @Test
+    void testCustomAuthorizationRequestBaseUri() {
+        final String customAuthorizationRequestBaseUri = "/login/oauth2/authorization";
+        final String registrationId = AadB2cConstants.TEST_SIGN_UP_OR_IN_NAME;
+        final AadB2cAuthorizationRequestResolver resolver = new AadB2cAuthorizationRequestResolver(
+            customAuthorizationRequestBaseUri,
+            new InMemoryClientRegistrationRepository(createClientRegistration(registrationId)),
+            new AadB2cProperties());
+
+        HttpServletRequest defaultRequest = getHttpServletRequest("/oauth2/authorization/" + registrationId);
+        HttpServletRequest customRequest = getHttpServletRequest(customAuthorizationRequestBaseUri + "/" + registrationId);
+
+        Assertions.assertNull(resolver.resolve(defaultRequest));
+        Assertions.assertNull(resolver.resolve(defaultRequest, registrationId));
+
+        Assertions.assertNotNull(resolver.resolve(customRequest));
+        Assertions.assertNotNull(resolver.resolve(customRequest, registrationId));
+        Assertions.assertEquals(registrationId, resolver.resolve(customRequest).getAdditionalParameters().get("p"));
+        Assertions.assertEquals("spring-boot-starter",
+            resolver.resolve(customRequest).getAdditionalParameters().get("x-client-SKU"));
+    }
+
+    private ClientRegistration createClientRegistration(String registrationId) {
+        return ClientRegistration.withRegistrationId(registrationId)
+            .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("{baseUrl}/{action}/oauth2/code/{registrationId}")
+            .scope("openid")
+            .authorizationUri("https://faketenant.b2clogin.com/oauth2/v2.0/authorize")
+            .tokenUri("https://faketenant.b2clogin.com/oauth2/v2.0/token")
+            .clientName("b2c")
+            .clientId(AadB2cConstants.TEST_CLIENT_ID)
+            .clientSecret(AadB2cConstants.TEST_CLIENT_SECRET)
+            .build();
     }
 }

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolverTests.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/aadb2c/security/AadB2cAuthorizationRequestResolverTests.java
@@ -109,11 +109,13 @@ class AadB2cAuthorizationRequestResolverTests {
         Assertions.assertNull(resolver.resolve(defaultRequest));
         Assertions.assertNull(resolver.resolve(defaultRequest, registrationId));
 
-        Assertions.assertNotNull(resolver.resolve(customRequest));
+        final org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest resolved =
+            resolver.resolve(customRequest);
+        Assertions.assertNotNull(resolved);
         Assertions.assertNotNull(resolver.resolve(customRequest, registrationId));
-        Assertions.assertEquals(registrationId, resolver.resolve(customRequest).getAdditionalParameters().get("p"));
+        Assertions.assertEquals(registrationId, resolved.getAdditionalParameters().get("p"));
         Assertions.assertEquals("spring-boot-starter",
-            resolver.resolve(customRequest).getAdditionalParameters().get("x-client-SKU"));
+            resolved.getAdditionalParameters().get("x-client-SKU"));
     }
 
     private ClientRegistration createClientRegistration(String registrationId) {


### PR DESCRIPTION
## Summary
- add an `authorizationRequestBaseUri` constructor overload to `AadB2cAuthorizationRequestResolver`
- make B2C authorization request matching instance-specific so custom base URIs are honored
- add focused tests covering custom authorization request base URI behavior

## Why
This aligns the B2C resolver with the existing configurability already available in `AadOAuth2AuthorizationRequestResolver` and addresses the gap reported in #42881.

## How to verify
- Run `mvn -pl sdk/spring/spring-cloud-azure-autoconfigure -Dtest=AadB2cAuthorizationRequestResolverTests test`

## Notes
- This change is intentionally scoped to the resolver layer and does not add a new higher-level B2C configuration surface.
