### PR TITLE
Fixes ReadManyByPK bug in Spark connector resulting in duplicates a  possibly missing first record

### DIFF
--- a/sdk/cosmos/azure-cosmos-spark_3-3_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-3_2-12/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bugs Fixed
 * Added a defensive guard in bounded change feed reads (with `endLsn`) that fails the Spark task with `IllegalStateException` when the underlying paginator stops before the latest continuation token has advanced to `endLsn`. - See [PR 49393](https://github.com/Azure/azure-sdk-for-java/pull/49393)
+* Fixed an issue in the `readManyByPartitionKeys` API in the Spark connector which could result in duplicates and missing the first record. - See [PR 49694](https://github.com/Azure/azure-sdk-for-java/pull/49694)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos-spark_3-4_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-4_2-12/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bugs Fixed
 * Added a defensive guard in bounded change feed reads (with `endLsn`) that fails the Spark task with `IllegalStateException` when the underlying paginator stops before the latest continuation token has advanced to `endLsn`. - See [PR 49393](https://github.com/Azure/azure-sdk-for-java/pull/49393)
+* Fixed an issue in the `readManyByPartitionKeys` API in the Spark connector which could result in duplicates and missing the first record. - See [PR 49694](https://github.com/Azure/azure-sdk-for-java/pull/49694)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-12/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-12/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bugs Fixed
 * Added a defensive guard in bounded change feed reads (with `endLsn`) that fails the Spark task with `IllegalStateException` when the underlying paginator stops before the latest continuation token has advanced to `endLsn`. - See [PR 49393](https://github.com/Azure/azure-sdk-for-java/pull/49393)
+* Fixed an issue in the `readManyByPartitionKeys` API in the Spark connector which could result in duplicates and missing the first record. - See [PR 49694](https://github.com/Azure/azure-sdk-for-java/pull/49694)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos-spark_3-5_2-13/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_3-5_2-13/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bugs Fixed
 * Added a defensive guard in bounded change feed reads (with `endLsn`) that fails the Spark task with `IllegalStateException` when the underlying paginator stops before the latest continuation token has advanced to `endLsn`. - See [PR 49393](https://github.com/Azure/azure-sdk-for-java/pull/49393)
+* Fixed an issue in the `readManyByPartitionKeys` API in the Spark connector which could result in duplicates and missing the first record. - See [PR 49694](https://github.com/Azure/azure-sdk-for-java/pull/49694)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/CosmosReadManyByPartitionKeyReader.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/CosmosReadManyByPartitionKeyReader.scala
@@ -165,13 +165,13 @@ private[spark] object CosmosReadManyByPartitionKeyReader {
 
   private[spark] trait CloseableIterator[+T] extends Iterator[T] with AutoCloseable
 
-  private[spark] def closeOnTaskCompletion[T](iterator: CloseableIterator[T], taskContext: TaskContext): Iterator[T] = {
+  private[spark] def closeOnTaskCompletion[T](sourceIterator: CloseableIterator[T], taskContext: TaskContext): Iterator[T] = {
     new Iterator[T] {
       private val isClosed = new AtomicBoolean(false)
 
       private def closeIterator(): Unit = {
         if (isClosed.compareAndSet(false, true)) {
-          iterator.close()
+          sourceIterator.close()
         }
       }
 
@@ -181,7 +181,7 @@ private[spark] object CosmosReadManyByPartitionKeyReader {
 
       override def hasNext: Boolean = {
         try {
-          val hasMore = !isClosed.get() && iterator.hasNext
+          val hasMore = !isClosed.get() && sourceIterator.hasNext
           if (!hasMore) {
             closeIterator()
           }
@@ -196,7 +196,7 @@ private[spark] object CosmosReadManyByPartitionKeyReader {
 
       override def next(): T = {
         try {
-          iterator.next()
+          sourceIterator.next()
         } catch {
           case error: Throwable =>
             closeIterator()

--- a/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/CosmosReadManyByPartitionKeyReader.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/CosmosReadManyByPartitionKeyReader.scala
@@ -153,47 +153,57 @@ private[spark] class CosmosReadManyByPartitionKeyReader(
             taskContext,
             pkIterator)
 
-          new Iterator[Row] {
-            private val isClosed = new AtomicBoolean(false)
-
-            private def closeReader(): Unit = {
-              if (isClosed.compareAndSet(false, true)) {
-                reader.close()
-              }
-            }
-
-            if (taskContext != null) {
-              taskContext.addTaskCompletionListener[Unit](_ => closeReader())
-            }
-
-            override def hasNext: Boolean = {
-              try {
-                val hasMore = reader.next()
-                if (!hasMore) {
-                  closeReader()
-                }
-                hasMore
-              } catch {
-                case error: Throwable =>
-                  closeReader()
-                  throw error
-              }
-            }
-
-            override def next(): Row = {
-              try {
-                reader.getCurrentRow()
-              } catch {
-                case error: Throwable =>
-                  closeReader()
-                  throw error
-              }
-            }
-          }
+          CosmosReadManyByPartitionKeyReader.closeOnTaskCompletion(reader.rowIterator, taskContext)
         },
         preservesPartitioning = true
       ),
       schema)
+  }
+}
+
+private[spark] object CosmosReadManyByPartitionKeyReader {
+
+  private[spark] trait CloseableIterator[+T] extends Iterator[T] with AutoCloseable
+
+  private[spark] def closeOnTaskCompletion[T](iterator: CloseableIterator[T], taskContext: TaskContext): Iterator[T] = {
+    new Iterator[T] {
+      private val isClosed = new AtomicBoolean(false)
+
+      private def closeIterator(): Unit = {
+        if (isClosed.compareAndSet(false, true)) {
+          iterator.close()
+        }
+      }
+
+      if (taskContext != null) {
+        taskContext.addTaskCompletionListener[Unit](_ => closeIterator())
+      }
+
+      override def hasNext: Boolean = {
+        try {
+          val hasMore = !isClosed.get() && iterator.hasNext
+          if (!hasMore) {
+            closeIterator()
+          }
+
+          hasMore
+        } catch {
+          case error: Throwable =>
+            closeIterator()
+            throw error
+        }
+      }
+
+      override def next(): T = {
+        try {
+          iterator.next()
+        } catch {
+          case error: Throwable =>
+            closeIterator()
+            throw error
+        }
+      }
+    }
   }
 }
 

--- a/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/ItemsPartitionReaderWithReadManyByPartitionKey.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/src/main/scala/com/azure/cosmos/spark/ItemsPartitionReaderWithReadManyByPartitionKey.scala
@@ -186,11 +186,7 @@ private[spark] case class ItemsPartitionReaderWithReadManyByPartitionKey
 
   readManyOptionsImpl.setCosmosEndToEndOperationLatencyPolicyConfig(endToEndTimeoutPolicy)
 
-  private trait CloseableSparkRowItemIterator {
-    def hasNext: Boolean
-    def next(): SparkRowItem
-    def close(): Unit
-  }
+  private trait CloseableSparkRowItemIterator extends CosmosReadManyByPartitionKeyReader.CloseableIterator[SparkRowItem]
 
   private object EmptySparkRowItemIterator extends CloseableSparkRowItemIterator {
     override def hasNext: Boolean = false
@@ -285,6 +281,16 @@ private[spark] case class ItemsPartitionReaderWithReadManyByPartitionKey
   }
 
   private var currentRow: Option[Row] = None
+
+  def rowIterator: CosmosReadManyByPartitionKeyReader.CloseableIterator[Row] = {
+    new CosmosReadManyByPartitionKeyReader.CloseableIterator[Row] {
+      override def hasNext: Boolean = getOrCreateIterator.hasNext
+
+      override def next(): Row = getOrCreateIterator.next().row
+
+      override def close(): Unit = ItemsPartitionReaderWithReadManyByPartitionKey.this.close()
+    }
+  }
 
   override def next(): Boolean = {
     val hasMore = getOrCreateIterator.hasNext

--- a/sdk/cosmos/azure-cosmos-spark_3/src/test/scala/com/azure/cosmos/spark/SparkE2EReadManyByPartitionKeyReproITest.scala
+++ b/sdk/cosmos/azure-cosmos-spark_3/src/test/scala/com/azure/cosmos/spark/SparkE2EReadManyByPartitionKeyReproITest.scala
@@ -1,0 +1,203 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.spark
+
+import com.azure.cosmos.implementation.{TestConfigurations, Utils}
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+
+import java.util.UUID
+import scala.collection.mutable.ListBuffer
+
+// scalastyle:off underscore.import
+import scala.collection.JavaConverters._
+// scalastyle:on underscore.import
+
+/**
+ * Repro-only suite for the customer-reported defects in
+ * `CosmosItemsDataSource.readManyByPartitionKeys` (see the LSEG bi-temporal workflow report):
+ *   1. the FIRST record of a partition is skipped, and
+ *   2. the remaining records are DUPLICATED (the backend query is executed twice).
+ *
+ * Both stem from the `Iterator[Row]` returned by
+ * [[CosmosReadManyByPartitionKeyReader.readManyByPartitionKeys]] violating the Scala/Java
+ * iterator contract: its `hasNext` calls `reader.next()` (which ADVANCES the underlying reader)
+ * instead of being idempotent.
+ *
+ * These tests intentionally assert the CORRECT behavior so they FAIL against the current
+ * (buggy) code and clearly print each symptom. They are expected to pass once the reader is
+ * fixed. No production code is changed by this suite.
+ */
+class SparkE2EReadManyByPartitionKeyReproITest
+  extends IntegrationSpec
+    with Spark
+    with AutoCleanableCosmosContainersWithPkAsPartitionKey {
+
+  private val pkProperty = "pk"
+
+  // scalastyle:off multiple.string.literals
+  // scalastyle:off magic.number
+
+  private val recordCount = 5
+
+  private def readSchema: StructType = StructType(Seq(
+    StructField("id", StringType, nullable = false),
+    StructField(pkProperty, StringType, nullable = false)
+  ))
+
+  private def readConfig: Map[String, String] = Map(
+    "spark.cosmos.accountEndpoint" -> TestConfigurations.HOST,
+    "spark.cosmos.accountKey" -> TestConfigurations.MASTER_KEY,
+    "spark.cosmos.database" -> cosmosDatabase,
+    "spark.cosmos.container" -> cosmosContainersWithPkAsPartitionKey,
+    "spark.cosmos.read.inferSchema.enabled" -> "false",
+    "spark.cosmos.applicationName" -> "ReadManyByPKRepro"
+  )
+
+  /**
+   * Inserts `recordCount` documents, each with a distinct partition-key value and exactly one
+   * item per logical partition (mirroring the customer's "one current record per instrument"
+   * bi-temporal scenario). Returns the expected (id -> pk) pairs.
+   */
+  private def seedRecords(): Seq[(String, String)] = {
+    val container = cosmosClient.getDatabase(cosmosDatabase).getContainer(cosmosContainersWithPkAsPartitionKey)
+    val records = (1 to recordCount).map { i =>
+      (s"id-$i-${UUID.randomUUID()}", s"pk-$i-${UUID.randomUUID()}")
+    }
+    records.foreach { case (id, pk) =>
+      val node = Utils.getSimpleObjectMapper.createObjectNode()
+      node.put("id", id)
+      node.put(pkProperty, pk)
+      container.createItem(node).block()
+    }
+    // give the emulator a moment so a subsequent read-many reliably sees all writes
+    Thread.sleep(500)
+    records
+  }
+
+  /**
+   * Builds the single-partition "keys" DataFrame that drives readManyByPartitionKeys.
+   * Coalescing to a single partition forces every record to flow through ONE reader so the
+   * within-partition symptoms (missing first / duplicates) are crisp and deterministic.
+   */
+  private def buildKeysDataFrame(pkValues: Seq[String]) = {
+    val rows = pkValues.map(pk => Row(pk)).asJava
+    val pkSchema = StructType(Seq(StructField(pkProperty, StringType, nullable = false)))
+    spark.createDataFrame(rows, pkSchema).coalesce(1)
+  }
+
+  it should "return each record exactly once (DUPLICATE-records repro)" in {
+    val expected = seedRecords()
+    val expectedIds = expected.map(_._1).toSet
+
+    val keysDf = buildKeysDataFrame(expected.map(_._2))
+    val resultDf = CosmosItemsDataSource.readManyByPartitionKeys(keysDf, readConfig.asJava, readSchema)
+
+    // Drive the reader's iterator with two sequential drains. queryExecution.toRdd exposes the
+    // bare RDDScanExec InternalRow iterator, which delegates hasNext 1:1 to the connector's
+    // buggy iterator (no codegen buffering in between). The second drain reproduces exactly
+    // what Spark's cache/columnar-batch builder does when it peeks hasNext again after the
+    // first batch is complete: because hasNext calls reader.next() after the reader was already
+    // exhausted+closed, the reader re-creates its inner iterator and RE-EXECUTES the whole
+    // query -> every record is emitted a second time.
+    val actualIds: Array[String] = resultDf.queryExecution.toRdd.mapPartitions(rowIter => {
+      val buf = ListBuffer[String]()
+      while (rowIter.hasNext) buf += rowIter.next().getUTF8String(0).toString // first drain
+      while (rowIter.hasNext) buf += rowIter.next().getUTF8String(0).toString // peek-after-exhaustion -> re-executes query
+      buf.iterator
+    }).collect()
+
+    val duplicatedIds = actualIds.groupBy(identity).filter(_._2.size > 1).keys.toList.sorted
+
+    println(s"[DUPLICATE-repro] expected distinct records = ${expectedIds.size}")
+    println(s"[DUPLICATE-repro] total rows returned        = ${actualIds.size}")
+    println(s"[DUPLICATE-repro] duplicated ids             = $duplicatedIds")
+
+    withClue(
+      s"Expected exactly ${expectedIds.size} rows (each record once) but got ${actualIds.length}. " +
+        s"Duplicated ids: $duplicatedIds. This confirms readManyByPartitionKeys returns duplicate " +
+        s"records (the backend query is executed twice) - reproduces the customer report. ") {
+      duplicatedIds shouldBe empty
+      actualIds.length shouldEqual expectedIds.size
+    }
+  }
+
+  it should "return the first record and not skip it (MISSING-FIRST-record repro)" in {
+    val expected = seedRecords()
+    val expectedIds = expected.map(_._1).toSet
+
+    val keysDf = buildKeysDataFrame(expected.map(_._2))
+
+    // A single hasNext "peek" before iterating (as Spark does when it checks a partition for
+    // emptiness / primes a columnar batch) advances the underlying reader past the first record.
+    // Because next() only returns the CURRENT row (it never re-reads the skipped one), the first
+    // record is lost. Whole-stage codegen is disabled here so the peek hits the connector's buggy
+    // iterator directly rather than a BufferedRowIterator that would buffer (and thus hide) the
+    // skipped row - which is exactly what happens on engines/paths that don't buffer the scan.
+    val priorWholeStageCodegen = spark.conf.get("spark.sql.codegen.wholeStage")
+    spark.conf.set("spark.sql.codegen.wholeStage", "false")
+    val actualIds: Set[String] = try {
+      val resultDf = CosmosItemsDataSource.readManyByPartitionKeys(keysDf, readConfig.asJava, readSchema)
+      resultDf.queryExecution.toRdd.mapPartitions(rowIter => {
+        val buf = ListBuffer[String]()
+        if (rowIter.hasNext) {
+          // intentional peek: mirrors Spark peeking hasNext before the consume loop
+        }
+        while (rowIter.hasNext) buf += rowIter.next().getUTF8String(0).toString
+        buf.iterator
+      }).collect().toSet
+    } finally {
+      spark.conf.set("spark.sql.codegen.wholeStage", priorWholeStageCodegen)
+    }
+
+    val missingIds = (expectedIds -- actualIds).toList.sorted
+
+    println(s"[MISSING-FIRST-repro] expected records = ${expectedIds.size}")
+    println(s"[MISSING-FIRST-repro] returned records = ${actualIds.size}")
+    println(s"[MISSING-FIRST-repro] missing ids      = $missingIds")
+
+    withClue(
+      s"Expected all ${expectedIds.size} records but ${missingIds.size} were missing: $missingIds. " +
+        s"This confirms readManyByPartitionKeys skips the first record of a partition after a " +
+        s"single hasNext peek - reproduces the customer report. ") {
+      missingIds shouldBe empty
+      actualIds shouldEqual expectedIds
+    }
+  }
+
+  it should "return the correct multiset via .cache() (end-to-end customer scenario repro)" in {
+    val expected = seedRecords()
+    val expectedIds = expected.map(_._1).toList.sorted
+
+    val keysDf = buildKeysDataFrame(expected.map(_._2))
+    val resultDf = CosmosItemsDataSource.readManyByPartitionKeys(keysDf, readConfig.asJava, readSchema)
+
+    // Faithful reproduction of the customer's notebook: read-many, cache, then materialize.
+    // Caching builds columnar batches, whose iterator peeks hasNext before/after each batch and
+    // therefore triggers BOTH symptoms at once (skipped first record + re-executed query).
+    val cached = resultDf.cache()
+    val collected = cached.collect()
+
+    val actualIds = collected.map(_.getAs[String]("id")).toList.sorted
+    val duplicatedIds = actualIds.groupBy(identity).filter(_._2.size > 1).keys.toList.sorted
+    val missingIds = (expectedIds.toSet -- actualIds.toSet).toList.sorted
+
+    println(s"[CACHE-repro] expected records  = ${expectedIds.size} -> $expectedIds")
+    println(s"[CACHE-repro] returned rows      = ${actualIds.size} -> $actualIds")
+    println(s"[CACHE-repro] duplicated ids     = $duplicatedIds")
+    println(s"[CACHE-repro] missing ids        = $missingIds")
+
+    withClue(
+      s"Expected exactly the ${expectedIds.size} seeded records via .cache() but got " +
+        s"${actualIds.size} rows (missing: $missingIds, duplicated: $duplicatedIds). " +
+        s"Reproduces the customer's notebook result. ") {
+      missingIds shouldBe empty
+      duplicatedIds shouldBe empty
+      actualIds shouldEqual expectedIds
+    }
+  }
+
+  // scalastyle:on multiple.string.literals
+  // scalastyle:on magic.number
+}

--- a/sdk/cosmos/azure-cosmos-spark_4-0_2-13/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_4-0_2-13/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bugs Fixed
 * Added a defensive guard in bounded change feed reads (with `endLsn`) that fails the Spark task with `IllegalStateException` when the underlying paginator stops before the latest continuation token has advanced to `endLsn`. - See [PR 49393](https://github.com/Azure/azure-sdk-for-java/pull/49393)
+* Fixed an issue in the `readManyByPartitionKeys` API in the Spark connector which could result in duplicates and missing the first record. - See [PR 49694](https://github.com/Azure/azure-sdk-for-java/pull/49694)
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos-spark_4-1_2-13/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos-spark_4-1_2-13/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bugs Fixed
 * Added a defensive guard in bounded change feed reads (with `endLsn`) that fails the Spark task with `IllegalStateException` when the underlying paginator stops before the latest continuation token has advanced to `endLsn`. - See [PR 49393](https://github.com/Azure/azure-sdk-for-java/pull/49393)
+* Fixed an issue in the `readManyByPartitionKeys` API in the Spark connector which could result in duplicates and missing the first record. - See [PR 49694](https://github.com/Azure/azure-sdk-for-java/pull/49694)
 
 #### Other Changes
 


### PR DESCRIPTION
# Description
This PR adds tests to reproduce the failure symptoms (duplicate records being returned and first record missing when a peek happeend) and fixes the root cause.

**After validation**
| Test | Before fix | After fix |
|---|---|---|
| DUPLICATE-records | 10 rows (each ×2) | 5 rows, no duplicates |
| MISSING-FIRST-record | 4 rows (id-1 dropped) | 5 rows, none missing |
| .cache() customer scenario | 10 rows | 5 rows, correct |

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
