### PR TITLE
Storage - STG104 File Share Mock Retry Test Adjustment

### DIFF
--- a/sdk/storage/azure-storage-file-share/pom.xml
+++ b/sdk/storage/azure-storage-file-share/pom.xml
@@ -37,6 +37,7 @@
     <!-- Configures the Java 9+ run to perform the required module exports, opens, and reads that are necessary for testing but shouldn't be part of the module-info. -->
     <javaModulesSurefireArgLine>
       --add-exports com.azure.core/com.azure.core.implementation.http=ALL-UNNAMED
+      --add-exports com.azure.storage.common/com.azure.storage.common.implementation.contentvalidation=ALL-UNNAMED
       --add-exports com.azure.storage.common/com.azure.storage.common.implementation.credentials=ALL-UNNAMED
       --add-opens com.azure.storage.common/com.azure.storage.common.implementation=ALL-UNNAMED
       --add-opens com.azure.storage.file.share/com.azure.storage.file.share=ALL-UNNAMED

--- a/sdk/storage/azure-storage-file-share/src/test/java/com/azure/storage/file/share/FileApiTests.java
+++ b/sdk/storage/azure-storage-file-share/src/test/java/com/azure/storage/file/share/FileApiTests.java
@@ -676,7 +676,7 @@ class FileApiTests extends FileShareTestBase {
         }
         outFile.deleteOnExit();
 
-        MockPartialResponsePolicy policy = new MockPartialResponsePolicy(5);
+        MockPartialResponsePolicy policy = new MockPartialResponsePolicy(5, 1);
 
         // Create a ShareFileClient for download using the custom pipeline
         ShareFileClient downloadClient
@@ -724,7 +724,7 @@ class FileApiTests extends FileShareTestBase {
         }
         outFile.deleteOnExit();
 
-        MockPartialResponsePolicy policy = new MockPartialResponsePolicy(6);
+        MockPartialResponsePolicy policy = new MockPartialResponsePolicy(6, 1);
 
         // Create a ShareFileClient for download using the custom pipeline
         ShareFileClient downloadClient

--- a/sdk/storage/azure-storage-file-share/src/test/java/com/azure/storage/file/share/FileAsyncApiTests.java
+++ b/sdk/storage/azure-storage-file-share/src/test/java/com/azure/storage/file/share/FileAsyncApiTests.java
@@ -646,7 +646,7 @@ public class FileAsyncApiTests extends FileShareTestBase {
         }
         outFile.deleteOnExit();
 
-        MockPartialResponsePolicy policy = new MockPartialResponsePolicy(5);
+        MockPartialResponsePolicy policy = new MockPartialResponsePolicy(5, 1);
 
         // Create a ShareFileAsyncClient for download using the custom pipeline
         ShareFileAsyncClient downloadClient = getFileAsyncClient(ENVIRONMENT.getPrimaryAccount().getCredential(),
@@ -696,7 +696,7 @@ public class FileAsyncApiTests extends FileShareTestBase {
         }
         outFile.deleteOnExit();
 
-        MockPartialResponsePolicy policy = new MockPartialResponsePolicy(6);
+        MockPartialResponsePolicy policy = new MockPartialResponsePolicy(6, 1);
 
         // Create a ShareFileAsyncClient for download using the custom pipeline
         ShareFileAsyncClient downloadClient = getFileAsyncClient(ENVIRONMENT.getPrimaryAccount().getCredential(),


### PR DESCRIPTION
## Overview

Updates Azure Files Share partial download retry tests to align with changes in `MockPartialResponsePolicy` and test module requirements.

## Changes Made

### Test Updates

Updated partial download test scenarios in both sync and async test suites to use the new `MockPartialResponsePolicy` constructor signature:

```java
new MockPartialResponsePolicy(<failureCount>, 1)
```

Affected tests:

- `FileApiTests#downloadToFileWithPartialDownloads`
- `FileApiTests#downloadToFileRetryExhausted`
- `FileAsyncApiTests#downloadToFileWithPartialDownloads`
- `FileAsyncApiTests#downloadToFileRetryExhausted`

### Module Configuration

Added the following export to the test JVM arguments:

```text
--add-exports com.azure.storage.common/com.azure.storage.common.implementation.contentvalidation=ALL-UNNAMED
```

This enables the test runtime to access the internal `contentvalidation` package required by the updated mock policy implementation.

## Motivation

Recent changes to `MockPartialResponsePolicy` introduced an additional constructor parameter and dependencies on classes within the `contentvalidation` package. This update keeps the File Share download retry tests compatible with the latest storage-common test infrastructure.