### PR TITLE
Serialize Instant fields as ISO-8601 strings (#49715)

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/CosmosItemSerializerUnitTests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/CosmosItemSerializerUnitTests.java
@@ -12,6 +12,7 @@ import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -196,5 +197,45 @@ public class CosmosItemSerializerUnitTests {
         public int defaultValueProperty = 0;
         public String nullValueProperty = null;
         public String emptyValueProperty = "";
+    }
+
+    @Test(groups = { "unit" })
+    public void defaultSerializerWritesInstantAsIso8601String() {
+        ObjectMapper mapper = Utils.getDocumentObjectMapper(Configs.getItemSerializationInclusionMode());
+        CosmosItemSerializer serializer = new DefaultCosmosItemSerializer(mapper);
+
+        Instant createdAt = Instant.parse("2023-07-22T09:46:40.123456789Z");
+        PojoItemWithInstant item = new PojoItemWithInstant();
+        item.createdAt = createdAt;
+
+        Map<String, Object> jsonMap = serializer.serialize(item);
+        ByteBuffer buffer = Utils.serializeJsonToByteBuffer(serializer, jsonMap, null, false);
+        String json = new String(buffer.array(), 0, buffer.limit(), StandardCharsets.UTF_8);
+
+        logger.info("Actual: {}", json);
+        assertThat(json).isEqualTo(
+            "{\"id\":\"SomeId\",\"createdAt\":\"" + createdAt + "\"}");
+    }
+
+    @Test(groups = { "unit" })
+    public void defaultSerializerRoundTripsInstant() {
+        ObjectMapper mapper = Utils.getDocumentObjectMapper(Configs.getItemSerializationInclusionMode());
+        CosmosItemSerializer serializer = new DefaultCosmosItemSerializer(mapper);
+
+        Instant createdAt = Instant.parse("2023-07-22T09:46:40.123456789Z");
+        PojoItemWithInstant item = new PojoItemWithInstant();
+        item.createdAt = createdAt;
+
+        Map<String, Object> jsonMap = serializer.serialize(item);
+        PojoItemWithInstant deserialized = serializer.deserialize(jsonMap, PojoItemWithInstant.class);
+
+        assertThat(deserialized.id).isEqualTo(item.id);
+        assertThat(deserialized.createdAt).isEqualTo(createdAt);
+    }
+
+    private static class PojoItemWithInstant
+    {
+        public String id = "SomeId";
+        public Instant createdAt;
     }
 }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/UtilsTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/UtilsTest.java
@@ -9,9 +9,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.testng.annotations.Test;
@@ -164,5 +166,38 @@ public class UtilsTest {
                 .getDefaultPropertyInclusion())
             .isEqualTo(
                 JsonInclude.Value.construct(JsonInclude.Include.NON_DEFAULT, JsonInclude.Include.NON_DEFAULT));
+    }
+    
+    @Test(groups = { "unit" })
+    public void documentObjectMapperDoesNotWriteDatesAsTimestamps() {
+        assertThat(
+            Utils.getSimpleObjectMapper()
+                .getSerializationConfig()
+                .isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS))
+            .isFalse();
+
+        assertThat(
+            Utils.getDocumentObjectMapper(null)
+                .getSerializationConfig()
+                .isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS))
+            .isFalse();
+
+        assertThat(
+            Utils.getDocumentObjectMapper("Always")
+                .getSerializationConfig()
+                .isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS))
+            .isFalse();
+    }
+
+    @Test(groups = { "unit" })
+    public void instantSerializesAsIso8601String() throws Exception {
+        Instant instant = Instant.parse("2023-07-22T09:46:40.123456789Z");
+
+        String json = Utils.getSimpleObjectMapper().writeValueAsString(instant);
+
+        assertThat(json).isEqualTo("\"" + instant.toString() + "\"");
+
+        Instant roundTripped = Utils.getSimpleObjectMapper().readValue(json, Instant.class);
+        assertThat(roundTripped).isEqualTo(instant);
     }
 }

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Features Added
 
 #### Breaking Changes
+* Fixed `java.time.Instant` (and other `java.time` types handled by `JavaTimeModule`) serializing as a numeric epoch timestamp instead of an ISO-8601 string when using the default `CosmosItemSerializer`. Items previously written with epoch-numeric date fields will now be written with ISO-8601 string values going forward; reading previously-stored epoch-numeric values back into `Instant` fields continues to work unaffected. - See PR [49720](https://github.com/Azure/azure-sdk-for-java/pull/49720).
 
 #### Bugs Fixed
 * Unified request-level consistency override behavior across transports: invalid attempts to upgrade the request consistency level above the account default are now silently ignored instead of returning `BadRequest` in some gateway paths. - See PR [49606](https://github.com/Azure/azure-sdk-for-java/pull/49606).

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/Utils.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/Utils.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
@@ -152,6 +153,7 @@ public class Utils {
         tryToLoadJacksonPerformanceLibrary(objectMapper);
 
         objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
         return objectMapper;
     }


### PR DESCRIPTION
# Description

  Fixes java.time.Instant fields (and other java.time types handled by Jackson's JavaTimeModule, e.g. LocalDateTime) serializing as a numeric 
  epoch timestamp instead of an ISO-8601 string when written through the default CosmosItemSerializer (#49715)

  Root cause: Utils.createAndInitializeObjectMapper() (com.azure.cosmos.implementation.Utils) registers Jackson's JavaTimeModule but never
  disables SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, which defaults to true on a plain ObjectMapper. Since this is the single factory
  backing Utils.getSimpleObjectMapper() / Utils.getDocumentObjectMapper(...) — which CosmosItemSerializer.DEFAULT_SERIALIZER uses for every item
  read/write on both CosmosContainer and CosmosAsyncContainer — every Instant field was silently written as a number (e.g.
  1690019200.123456789) instead of a quoted ISO-8601 string (e.g. "2023-07-22T09:46:40.123456789Z").

  Fix: explicitly configure SerializationFeature.WRITE_DATES_AS_TIMESTAMPS = false alongside the JavaTimeModule registration.

  Compatibility: this only changes the write format going forward. Jackson's InstantDeserializer recognizes a numeric JSON token as epoch time
  independent of this flag, so existing items already stored with epoch-numeric date fields continue to deserialize correctly into Instant — no
  data migration needed. It's flagged as a breaking change because any downstream consumer (non-Java SDKs, raw JSON tooling, dashboards) that
  was relying on the old numeric wire format will now see a string instead.


# All SDK Contribution checklist:
  - [] The pull request does not introduce [breaking changes] - This is behaviour changing but non breaking for existing data, happy to discuss this. 
  - [x] CHANGELOG is updated for new features, bug fixes or other significant changes.
  - [x] I have read the contribution guidelines.

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
