### PR TITLE
test: cover implementation bridge accessor initialization

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ImplementationBridgeHelpersTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ImplementationBridgeHelpersTest.java
@@ -14,6 +14,9 @@ import org.testng.annotations.Test;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
@@ -30,18 +33,16 @@ import static org.assertj.core.api.Assertions.fail;
 public class ImplementationBridgeHelpersTest {
 
     private static final Logger logger = LoggerFactory.getLogger(ImplementationBridgeHelpers.class);
+    private static final String HELPER_CLASS_SUFFIX = "Helper";
+    private static final Class<?>[] DECLARED_CLASSES = ImplementationBridgeHelpers.class.getDeclaredClasses();
 
     @Test(groups = { "unit" })
     public void accessorInitialization() {
 
-        String helperClassSuffix = "Helper";
-
-        Class<?>[] declaredClasses = ImplementationBridgeHelpers.class.getDeclaredClasses();
-
         try {
-            for (Class<?> declaredClass : declaredClasses) {
+            for (Class<?> declaredClass : DECLARED_CLASSES) {
 
-                if (declaredClass.getSimpleName().endsWith(helperClassSuffix)) {
+                if (declaredClass.getSimpleName().endsWith(HELPER_CLASS_SUFFIX)) {
 
                     Field[] fields = declaredClass.getDeclaredFields();
                     boolean isAccessorReset = false;
@@ -72,11 +73,9 @@ public class ImplementationBridgeHelpersTest {
             ModelBridgeInternal.initializeAllAccessors();
             UtilBridgeInternal.initializeAllAccessors();
 
-            declaredClasses = ImplementationBridgeHelpers.class.getDeclaredClasses();
+            for (Class<?> declaredClass : DECLARED_CLASSES) {
 
-            for (Class<?> declaredClass : declaredClasses) {
-
-                if (declaredClass.getSimpleName().endsWith(helperClassSuffix)) {
+                if (declaredClass.getSimpleName().endsWith(HELPER_CLASS_SUFFIX)) {
 
                     logger.info("Helper class name : {}", declaredClass.getSimpleName());
 
@@ -706,5 +705,110 @@ public class ImplementationBridgeHelpersTest {
                 + "Use 'private static XxxAccessor xxx() { return getXxxAccessor(); }' instead.\n"
                 + "Violations:\n" + String.join("\n", violations))
             .isEmpty();
+    }
+
+    @Test(groups = { "unit" })
+    public void accessorInitializationFromAccessorGetter() throws ReflectiveOperationException {
+        int accessorGetterCount = 0;
+
+        for (Class<?> declaredClass : DECLARED_CLASSES) {
+            if (declaredClass.getSimpleName().endsWith(HELPER_CLASS_SUFFIX)) {
+                boolean helperAccessorGetterInvoked = false;
+
+                for (Method method : declaredClass.getDeclaredMethods()) {
+                    if (isAccessorGetter(method)) {
+                        resetAccessorReferences();
+                        assertThat(method.invoke(null)).isNotNull();
+
+                        helperAccessorGetterInvoked = true;
+                        accessorGetterCount++;
+                    }
+                }
+
+                assertThat(helperAccessorGetterInvoked).isTrue();
+            }
+        }
+
+        assertThat(accessorGetterCount).isGreaterThan(0);
+    }
+
+    @Test(groups = { "unit" })
+    public void accessorSettersKeepExistingAccessor() throws ReflectiveOperationException {
+        int accessorSetterCount = 0;
+
+        for (Class<?> declaredClass : DECLARED_CLASSES) {
+            if (declaredClass.getSimpleName().endsWith(HELPER_CLASS_SUFFIX)) {
+                boolean helperAccessorSetterInvoked = false;
+
+                for (Method method : declaredClass.getDeclaredMethods()) {
+                    if (isAccessorSetter(method)) {
+                        Method getter = findAccessorGetter(declaredClass, method.getParameterTypes()[0]);
+                        Object firstAccessor = proxyAccessor(method.getParameterTypes()[0]);
+                        Object secondAccessor = proxyAccessor(method.getParameterTypes()[0]);
+
+                        resetAccessorReferences();
+                        method.invoke(null, firstAccessor);
+                        method.invoke(null, secondAccessor);
+
+                        assertThat(getter.invoke(null)).isSameAs(firstAccessor);
+                        helperAccessorSetterInvoked = true;
+                        accessorSetterCount++;
+                    }
+                }
+
+                assertThat(helperAccessorSetterInvoked).isTrue();
+            }
+        }
+
+        assertThat(accessorSetterCount).isGreaterThan(0);
+    }
+
+    private static boolean isAccessorGetter(Method method) {
+        return Modifier.isStatic(method.getModifiers())
+            && method.getParameterCount() == 0
+            && method.getName().startsWith("get")
+            && method.getReturnType().getSimpleName().endsWith("Accessor");
+    }
+
+    private static boolean isAccessorSetter(Method method) {
+        return Modifier.isStatic(method.getModifiers())
+            && method.getParameterCount() == 1
+            && method.getName().startsWith("set")
+            && method.getParameterTypes()[0].getSimpleName().endsWith("Accessor");
+    }
+
+    private static Method findAccessorGetter(Class<?> declaredClass, Class<?> accessorType) {
+        for (Method method : declaredClass.getDeclaredMethods()) {
+            if (isAccessorGetter(method) && method.getReturnType().equals(accessorType)) {
+                return method;
+            }
+        }
+
+        throw new AssertionError("No accessor getter found for " + accessorType.getName());
+    }
+
+    private static Object proxyAccessor(Class<?> accessorType) {
+        return Proxy.newProxyInstance(
+            accessorType.getClassLoader(),
+            new Class<?>[] { accessorType },
+            (proxy, method, args) -> null);
+    }
+
+    private static void resetAccessorReferences() throws IllegalAccessException {
+        for (Class<?> declaredClass : DECLARED_CLASSES) {
+            if (declaredClass.getSimpleName().endsWith(HELPER_CLASS_SUFFIX)) {
+                for (Field field : declaredClass.getDeclaredFields()) {
+                    if (field.getName().contains("accessor")) {
+                        field.setAccessible(true);
+                        ((AtomicReference<?>) FieldUtils.readStaticField(field)).set(null);
+                    }
+
+                    if (field.getName().contains("ClassLoaded")) {
+                        field.setAccessible(true);
+                        ((AtomicBoolean) FieldUtils.readStaticField(field)).set(false);
+                    }
+                }
+            }
+        }
     }
 }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ImplementationBridgeHelpersTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/ImplementationBridgeHelpersTest.java
@@ -736,28 +736,32 @@ public class ImplementationBridgeHelpersTest {
     public void accessorSettersKeepExistingAccessor() throws ReflectiveOperationException {
         int accessorSetterCount = 0;
 
-        for (Class<?> declaredClass : DECLARED_CLASSES) {
-            if (declaredClass.getSimpleName().endsWith(HELPER_CLASS_SUFFIX)) {
-                boolean helperAccessorSetterInvoked = false;
+        try {
+            for (Class<?> declaredClass : DECLARED_CLASSES) {
+                if (declaredClass.getSimpleName().endsWith(HELPER_CLASS_SUFFIX)) {
+                    boolean helperAccessorSetterInvoked = false;
 
-                for (Method method : declaredClass.getDeclaredMethods()) {
-                    if (isAccessorSetter(method)) {
-                        Method getter = findAccessorGetter(declaredClass, method.getParameterTypes()[0]);
-                        Object firstAccessor = proxyAccessor(method.getParameterTypes()[0]);
-                        Object secondAccessor = proxyAccessor(method.getParameterTypes()[0]);
+                    for (Method method : declaredClass.getDeclaredMethods()) {
+                        if (isAccessorSetter(method)) {
+                            Method getter = findAccessorGetter(declaredClass, method.getParameterTypes()[0]);
+                            Object firstAccessor = proxyAccessor(method.getParameterTypes()[0]);
+                            Object secondAccessor = proxyAccessor(method.getParameterTypes()[0]);
 
-                        resetAccessorReferences();
-                        method.invoke(null, firstAccessor);
-                        method.invoke(null, secondAccessor);
+                            resetAccessorReferences();
+                            method.invoke(null, firstAccessor);
+                            method.invoke(null, secondAccessor);
 
-                        assertThat(getter.invoke(null)).isSameAs(firstAccessor);
-                        helperAccessorSetterInvoked = true;
-                        accessorSetterCount++;
+                            assertThat(getter.invoke(null)).isSameAs(firstAccessor);
+                            helperAccessorSetterInvoked = true;
+                            accessorSetterCount++;
+                        }
                     }
-                }
 
-                assertThat(helperAccessorSetterInvoked).isTrue();
+                    assertThat(helperAccessorSetterInvoked).isTrue();
+                }
             }
+        } finally {
+            restoreAccessorReferences();
         }
 
         assertThat(accessorSetterCount).isGreaterThan(0);
@@ -792,6 +796,11 @@ public class ImplementationBridgeHelpersTest {
             accessorType.getClassLoader(),
             new Class<?>[] { accessorType },
             (proxy, method, args) -> null);
+    }
+
+    private static void restoreAccessorReferences() throws IllegalAccessException {
+        resetAccessorReferences();
+        ImplementationBridgeHelpers.initializeAllAccessors();
     }
 
     private static void resetAccessorReferences() throws IllegalAccessException {


### PR DESCRIPTION
# Description

Hi,

This PR adds focused unit coverage for `ImplementationBridgeHelpers`.

It covers accessor initialization behavior across the helper classes, including the [CosmosClientBuilder accessor path](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ImplementationBridgeHelpers.java#L123-L143) and the [bulk execution thresholds accessor path](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ImplementationBridgeHelpers.java#L737-L757).

The tests check lazy getter initialization after cached accessor state is cleared, and that a second setter call does not replace an accessor that was already installed. Line coverage for `ImplementationBridgeHelpers` increases by 31%.

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
