### PR TITLE
mgmt, prepare azure-resourcemanager 2.63.0 release

### DIFF
--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -276,7 +276,7 @@ com.azure.spring:spring-cloud-azure-stream-binder-servicebus-core;7.3.0;7.4.0-be
 com.azure.spring:spring-cloud-azure-stream-binder-servicebus;7.3.0;7.4.0-beta.1
 com.azure.spring:spring-cloud-azure-testcontainers;7.3.0;7.4.0-beta.1
 com.azure:azure-spring-data-cosmos;7.3.0;7.4.0-beta.1
-com.azure.resourcemanager:azure-resourcemanager;2.62.0;2.63.0-beta.1
+com.azure.resourcemanager:azure-resourcemanager;2.62.0;2.63.0
 com.azure.resourcemanager:azure-resourcemanager-appplatform;2.51.0;2.52.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-appservice;2.55.3;2.56.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-authorization;2.53.10;2.54.0-beta.2

--- a/sdk/resourcemanager/azure-resourcemanager-perf/pom.xml
+++ b/sdk/resourcemanager/azure-resourcemanager-perf/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>
       <artifactId>azure-resourcemanager</artifactId>
-      <version>2.63.0-beta.1</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
+      <version>2.63.0</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
     </dependency>
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>

--- a/sdk/resourcemanager/azure-resourcemanager-samples/pom.xml
+++ b/sdk/resourcemanager/azure-resourcemanager-samples/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>
       <artifactId>azure-resourcemanager</artifactId>
-      <version>2.63.0-beta.1</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
+      <version>2.63.0</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
     </dependency>
     <dependency>
       <groupId>com.azure.resourcemanager</groupId>

--- a/sdk/resourcemanager/azure-resourcemanager/CHANGELOG.md
+++ b/sdk/resourcemanager/azure-resourcemanager/CHANGELOG.md
@@ -1,14 +1,26 @@
 # Release History
 
-## 2.63.0-beta.1 (Unreleased)
+## 2.63.0 (2026-07-07)
 
-### Features Added
+### azure-resourcemanager-compute
 
-### Breaking Changes
+#### Features Added
 
-### Bugs Fixed
+- Added interconnect block/group profile support, including `InterconnectBlockProfile`, `InterconnectGroupProfile`, `InterconnectBlockProperties`, `InterconnectBlockInstanceView`, `InterconnectInstanceView`, `AutomaticSkuMigrationPolicy`, and related properties on virtual machine scale set VM/network profile and SKU profile models.
+
+#### Dependency Updates
+
+- Updated `ComputeRP api-version` to `2026-03-01`.
+
+### azure-resourcemanager-containerservice
+
+#### Dependency Updates
+
+- Updated `api-version` to `2026-04-01`.
 
 ### Other Changes
+
+- Updated dependencies from resources.
 
 ## 2.62.0 (2026-05-08)
 

--- a/sdk/resourcemanager/azure-resourcemanager/README.md
+++ b/sdk/resourcemanager/azure-resourcemanager/README.md
@@ -18,7 +18,7 @@ For documentation on how to use this package, please see [Azure Management Libra
 <dependency>
     <groupId>com.azure.resourcemanager</groupId>
     <artifactId>azure-resourcemanager</artifactId>
-    <version>2.62.0</version>
+    <version>2.63.0</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/resourcemanager/azure-resourcemanager/pom.xml
+++ b/sdk/resourcemanager/azure-resourcemanager/pom.xml
@@ -15,7 +15,7 @@
 
   <groupId>com.azure.resourcemanager</groupId>
   <artifactId>azure-resourcemanager</artifactId>
-  <version>2.63.0-beta.1</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
+  <version>2.63.0</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager;current} -->
   <packaging>jar</packaging>
 
   <name>Microsoft Azure SDK for Management</name>


### PR DESCRIPTION
Prepares the stable release of `azure-resourcemanager` 2.63.0.
release branch based on PR: https://github.com/Azure/azure-sdk-for-java/pull/49731

## Summary
- Bump `azure-resourcemanager` from `2.63.0-beta.1` to stable `2.63.0` in `eng/versioning/version_client.txt`.
- Sync pom versions (`azure-resourcemanager`, `-perf`, `-samples`) via `update_versions.py --sr`.
- Update README dependency version to `2.63.0`.
- Aggregate CHANGELOG for 2.63.0 (2026-07-07) from premium libraries released after the previous 2.62.0 (2026-05-08) release and bundled by the umbrella pom:
  - **azure-resourcemanager-compute** 2.58.0 (Interconnect block/group profile features; api-version 2026-03-01)
  - **azure-resourcemanager-containerservice** 2.60.0 / 2.61.0 (api-version 2026-04-01)

## Verification
- Version/pom/README changes produced by `eng/versioning/update_versions.py`.
- CHANGELOG eligibility cross-checked against the released (2nd) column of `version_client.txt` and each premium library CHANGELOG.
