### PR TITLE
Added ExpirationTime field to Role Assignment response DTO for version 2026-07-01-preview

### DIFF
--- a/sdk/authorization/azure-resourcemanager-authorization/CHANGELOG.md
+++ b/sdk/authorization/azure-resourcemanager-authorization/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added read-only `expirationTime` property to `RoleAssignment` returned by role assignment get and list operations.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/authorization/azure-resourcemanager-authorization/src/main/java/com/azure/resourcemanager/authorization/fluent/models/RoleAssignmentInner.java
+++ b/sdk/authorization/azure-resourcemanager-authorization/src/main/java/com/azure/resourcemanager/authorization/fluent/models/RoleAssignmentInner.java
@@ -309,6 +309,15 @@ public final class RoleAssignmentInner extends ProxyResource {
     }
 
     /**
+     * Get the expirationTime property: Time the role assignment expires.
+     * 
+     * @return the expirationTime value.
+     */
+    public String expirationTime() {
+        return this.innerProperties() == null ? null : this.innerProperties().expirationTime();
+    }
+
+    /**
      * Validates the instance.
      * 
      * @throws IllegalArgumentException thrown if the instance is not valid.

--- a/sdk/authorization/azure-resourcemanager-authorization/src/main/java/com/azure/resourcemanager/authorization/fluent/models/RoleAssignmentProperties.java
+++ b/sdk/authorization/azure-resourcemanager-authorization/src/main/java/com/azure/resourcemanager/authorization/fluent/models/RoleAssignmentProperties.java
@@ -82,6 +82,11 @@ public final class RoleAssignmentProperties implements JsonSerializable<RoleAssi
      */
     private String delegatedManagedIdentityResourceId;
 
+    /*
+     * Time the role assignment expires
+     */
+    private String expirationTime;
+
     /**
      * Creates an instance of RoleAssignmentProperties class.
      */
@@ -278,6 +283,15 @@ public final class RoleAssignmentProperties implements JsonSerializable<RoleAssi
     }
 
     /**
+     * Get the expirationTime property: Time the role assignment expires.
+     * 
+     * @return the expirationTime value.
+     */
+    public String expirationTime() {
+        return this.expirationTime;
+    }
+
+    /**
      * Validates the instance.
      * 
      * @throws IllegalArgumentException thrown if the instance is not valid.
@@ -355,6 +369,8 @@ public final class RoleAssignmentProperties implements JsonSerializable<RoleAssi
                     deserializedRoleAssignmentProperties.updatedBy = reader.getString();
                 } else if ("delegatedManagedIdentityResourceId".equals(fieldName)) {
                     deserializedRoleAssignmentProperties.delegatedManagedIdentityResourceId = reader.getString();
+                } else if ("expirationTime".equals(fieldName)) {
+                    deserializedRoleAssignmentProperties.expirationTime = reader.getString();
                 } else {
                     reader.skipChildren();
                 }

--- a/sdk/authorization/azure-resourcemanager-authorization/src/main/java/com/azure/resourcemanager/authorization/models/RoleAssignmentCreateParameters.java
+++ b/sdk/authorization/azure-resourcemanager-authorization/src/main/java/com/azure/resourcemanager/authorization/models/RoleAssignmentCreateParameters.java
@@ -251,6 +251,15 @@ public final class RoleAssignmentCreateParameters implements JsonSerializable<Ro
     }
 
     /**
+     * Get the expirationTime property: Time the role assignment expires.
+     * 
+     * @return the expirationTime value.
+     */
+    public String expirationTime() {
+        return this.innerProperties() == null ? null : this.innerProperties().expirationTime();
+    }
+
+    /**
      * Validates the instance.
      * 
      * @throws IllegalArgumentException thrown if the instance is not valid.


### PR DESCRIPTION
# Description

Added ExpirationTime field to Role Assignment response DTO for version 2026-07-01-preview
https://github.com/Azure/azure-rest-api-specs/pull/44421

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
