### PR TITLE
Add @azure-tools/typespec-azure-portal-core 0.69.0 to emitter dependencies

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -11,6 +11,7 @@
         "@azure-tools/openai-typespec": "1.20.0",
         "@azure-tools/typespec-autorest": "0.69.1",
         "@azure-tools/typespec-azure-core": "0.69.0",
+        "@azure-tools/typespec-azure-portal-core": "0.69.0",
         "@azure-tools/typespec-azure-resource-manager": "0.69.2",
         "@azure-tools/typespec-azure-rulesets": "0.69.2",
         "@azure-tools/typespec-client-generator-core": "0.69.2",
@@ -144,6 +145,17 @@
         "@typespec/compiler": "^1.13.0",
         "@typespec/http": "^1.13.0",
         "@typespec/rest": "^0.83.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-portal-core": {
+      "version": "0.69.0",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-tools/typespec-azure-portal-core/-/typespec-azure-portal-core-0.69.0.tgz",
+      "integrity": "sha1-CwUnMOD0QI6haF+tPF2gR76UAs8=",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
+        "@typespec/compiler": "^1.13.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -7,6 +7,7 @@
     "@azure-tools/openai-typespec": "1.20.0",
     "@azure-tools/typespec-autorest": "0.69.1",
     "@azure-tools/typespec-azure-core": "0.69.0",
+    "@azure-tools/typespec-azure-portal-core": "0.69.0",
     "@azure-tools/typespec-azure-resource-manager": "0.69.2",
     "@azure-tools/typespec-azure-rulesets": "0.69.2",
     "@azure-tools/typespec-client-generator-core": "0.69.2",


### PR DESCRIPTION
## Summary
- fix generation failure for https://github.com/Azure/azure-rest-api-specs-pr/pull/29346, same root cause observed first by python
Adds `@azure-tools/typespec-azure-portal-core@0.69.0` to the emitter dependencies.

## Changes
- Add `@azure-tools/typespec-azure-portal-core: 0.69.0` to `devDependencies` in `eng/emitter-package.json`.
- Regenerate `eng/emitter-package-lock.json` via `tsp-client` (npm 10, matching CI) so the diff contains only the new package block.

## Verification
- Lock file regenerated with npm 10.9.2 to match the CI Node 22 toolchain; diff limited to the portal-core entry.
- generation succeeds locally
