### PR TITLE
Remove temporary test content from template READMEs

### DIFF
--- a/sdk/template/azure-sdk-template-three/README.md
+++ b/sdk/template/azure-sdk-template-three/README.md
@@ -153,6 +153,3 @@ This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For m
 [coc]: https://opensource.microsoft.com/codeofconduct/
 [coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
 [coc_contact]: mailto:opencode@microsoft.com
-
-## Test
-Test content

--- a/sdk/template/azure-sdk-template-two/README.md
+++ b/sdk/template/azure-sdk-template-two/README.md
@@ -153,6 +153,3 @@ This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For m
 [coc]: https://opensource.microsoft.com/codeofconduct/
 [coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
 [coc_contact]: mailto:opencode@microsoft.com
-
-## Test
-Test content


### PR DESCRIPTION
## Summary
- Remove the temporary `Test` section from the template two README.
- Remove the temporary `Test` section from the template three README.

## Reason
This reverts temporary test content from the template README files.

## Verification
Review the updated README files:
- `sdk/template/azure-sdk-template-two/README.md`
- `sdk/template/azure-sdk-template-three/README.md`
