### PR TITLE
feat(eventhubs): add single-event send to EventHubProducerClient and EventHubProducerAsyncClient

### DIFF
--- a/eng/lintingconfigs/revapi/track2/revapi.json
+++ b/eng/lintingconfigs/revapi/track2/revapi.json
@@ -329,6 +329,14 @@
           "justification": "Cosmos SDK removes the Beta annotation to GA its APIs. Only Beta annotation removals are permitted; removal of any other annotation (Deprecated, Jackson, etc.) will still fail the build."
         },
         {
+          "code": "java.method.visibilityIncreased",
+          "old": {
+            "matcher": "regex",
+            "match": "method (void|reactor\\.core\\.publisher\\.Mono<java\\.lang\\.Void>) com\\.azure\\.messaging\\.eventhubs\\.EventHubProducer(Async)?Client::send\\(com\\.azure\\.messaging\\.eventhubs\\.EventData(, com\\.azure\\.messaging\\.eventhubs\\.models\\.SendOptions)?\\)"
+          },
+          "justification": "The single-event send methods on the Event Hubs producer clients change from package-private to public. This adds API surface and removes none, so callers stay source and binary compatible. See https://github.com/Azure/azure-sdk-for-java/issues/41395"
+        },
+        {
           "code": "java.method.removed",
           "old": {
             "matcher": "regex",

--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Features Added
 
+- Added public single-event send methods to the producer clients: `EventHubProducerClient.send(EventData)`,
+  `EventHubProducerClient.send(EventData, SendOptions)`, `EventHubProducerAsyncClient.send(EventData)`, and
+  `EventHubProducerAsyncClient.send(EventData, SendOptions)`. These methods were present but package-private. You no
+  longer must wrap a single event in an `EventDataBatch` or a list. For high throughput, continue to use
+  `EventDataBatch`. ([#41395](https://github.com/Azure/azure-sdk-for-java/issues/41395))
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added public single-event send methods to the producer clients: `EventHubProducerClient.send(EventData)`,
   `EventHubProducerClient.send(EventData, SendOptions)`, `EventHubProducerAsyncClient.send(EventData)`, and
   `EventHubProducerAsyncClient.send(EventData, SendOptions)`. These methods were present but package-private. You no
-  longer must wrap a single event in an `EventDataBatch` or a list. For high throughput, continue to use
+  longer need to wrap a single event in an `EventDataBatch` or a list. For high throughput, continue to use
   `EventDataBatch`. ([#41395](https://github.com/Azure/azure-sdk-for-java/issues/41395))
 
 ### Breaking Changes

--- a/sdk/eventhubs/azure-messaging-eventhubs/README.md
+++ b/sdk/eventhubs/azure-messaging-eventhubs/README.md
@@ -34,6 +34,7 @@ documentation][event_hubs_product_docs] | [Samples][sample_examples] | [Troubles
 - [Examples](#examples)
   - [Publish events to an Event Hub](#publish-events-to-an-event-hub)
     - [Create an Event Hub producer and publish events](#create-an-event-hub-producer-and-publish-events)
+    - [Publish a single event](#publish-a-single-event)
     - [Publish events using partition identifier](#publish-events-using-partition-identifier)
     - [Publish events using partition key](#publish-events-using-partition-key)
   - [Consume events from an Event Hub partition](#consume-events-from-an-event-hub-partition)
@@ -243,6 +244,21 @@ producer.close();
 ```
 Note that `EventDataBatch.tryAdd(EventData)` is not thread-safe. Please make sure to synchronize the method access
 when using multiple threads to add events.
+
+#### Publish a single event
+
+A batch is not necessary to publish one event. The producer clients have a `send(EventData)` overload that publishes a
+single event. There is also a `send(EventData, SendOptions)` overload that accepts a partition id or a partition key.
+The synchronous overload is shown below. `EventHubProducerAsyncClient` has the same overloads and returns a
+`Mono<Void>`.
+
+```java com.azure.messaging.eventhubs.eventhubproducerclient.send#EventData
+EventData event = new EventData("maple");
+producer.send(event);
+```
+
+Use these overloads for low volume publishing. For high throughput, use `EventDataBatch` or `send(Iterable)`, because
+each `send(EventData)` call makes its own network round trip.
 
 #### Publish events using partition identifier
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/main/java/com/azure/messaging/eventhubs/EventHubProducerAsyncClient.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/main/java/com/azure/messaging/eventhubs/EventHubProducerAsyncClient.java
@@ -398,10 +398,25 @@ public class EventHubProducerAsyncClient implements Closeable {
      * <a href="https://docs.microsoft.com/azure/event-hubs/event-hubs-quotas">Azure Event Hubs Quotas and Limits</a>.
      * </p>
      *
+     * <!-- src_embed com.azure.messaging.eventhubs.eventhubasyncproducerclient.send#EventData -->
+     * <pre>
+     * EventData event = new EventData&#40;&quot;maple&quot;&#41;;
+     *
+     * producer.send&#40;event&#41;
+     *     .subscribe&#40;unused -&gt; &#123;
+     *     &#125;,
+     *         error -&gt; System.err.println&#40;&quot;Error occurred while sending event:&quot; + error&#41;,
+     *         &#40;&#41; -&gt; System.out.println&#40;&quot;Send complete.&quot;&#41;&#41;;
+     * </pre>
+     * <!-- end com.azure.messaging.eventhubs.eventhubasyncproducerclient.send#EventData -->
+     *
      * @param event Event to send to the service.
      * @return A {@link Mono} that completes when the event is pushed to the service.
+     * @throws NullPointerException if {@code event} is {@code null}.
+     * @throws AmqpException if the size of {@code event} exceeds the maximum size of a single batch.
      */
-    Mono<Void> send(EventData event) {
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> send(EventData event) {
         if (event == null) {
             return monoError(LOGGER, new NullPointerException("'event' cannot be null."));
         }
@@ -410,8 +425,23 @@ public class EventHubProducerAsyncClient implements Closeable {
     }
 
     /**
-     * Sends a single event to the associated Event Hub with the send options. If the size of the single event exceeds
-     * the maximum size allowed, an exception will be triggered and the send will fail.
+     * <p>Sends a single event to the associated Event Hub with the send options. If the size of the single event
+     * exceeds the maximum size allowed, an exception will be triggered and the send will fail. For high throughput
+     * publishing scenarios, using {@link EventDataBatch} to publish events is recommended. Batches are created using
+     * {@link #createBatch()} and {@link #createBatch(CreateBatchOptions)}.</p>
+     *
+     * <!-- src_embed com.azure.messaging.eventhubs.eventhubasyncproducerclient.send#EventData-SendOptions -->
+     * <pre>
+     * EventData event = new EventData&#40;&quot;Melbourne&quot;&#41;;
+     *
+     * SendOptions sendOptions = new SendOptions&#40;&#41;.setPartitionKey&#40;&quot;cities&quot;&#41;;
+     * producer.send&#40;event, sendOptions&#41;
+     *     .subscribe&#40;unused -&gt; &#123;
+     *     &#125;,
+     *         error -&gt; System.err.println&#40;&quot;Error occurred while sending event:&quot; + error&#41;,
+     *         &#40;&#41; -&gt; System.out.println&#40;&quot;Send complete.&quot;&#41;&#41;;
+     * </pre>
+     * <!-- end com.azure.messaging.eventhubs.eventhubasyncproducerclient.send#EventData-SendOptions -->
      *
      * <p>
      * For more information regarding the maximum event size allowed, see
@@ -422,8 +452,11 @@ public class EventHubProducerAsyncClient implements Closeable {
      * @param event Event to send to the service.
      * @param options The set of options to consider when sending this event.
      * @return A {@link Mono} that completes when the event is pushed to the service.
+     * @throws NullPointerException if {@code event} or {@code options} is {@code null}.
+     * @throws AmqpException if the size of {@code event} exceeds the maximum size of a single batch.
      */
-    Mono<Void> send(EventData event, SendOptions options) {
+    @ServiceMethod(returns = ReturnType.SINGLE)
+    public Mono<Void> send(EventData event, SendOptions options) {
         if (event == null) {
             return monoError(LOGGER, new NullPointerException("'event' cannot be null."));
         } else if (options == null) {

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/main/java/com/azure/messaging/eventhubs/EventHubProducerClient.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/main/java/com/azure/messaging/eventhubs/EventHubProducerClient.java
@@ -274,8 +274,16 @@ public class EventHubProducerClient implements Closeable {
     }
 
     /**
-     * Sends a single event to the associated Event Hub. If the size of the single event exceeds the maximum size
-     * allowed, an exception will be triggered and the send will fail.
+     * <p>Sends a single event to the associated Event Hub. If the size of the single event exceeds the maximum size
+     * allowed, an exception will be triggered and the send will fail. For high throughput publishing, use
+     * {@link EventDataBatch} or the {@link #send(Iterable)} overload to publish more than one event in one call.</p>
+     *
+     * <!-- src_embed com.azure.messaging.eventhubs.eventhubproducerclient.send#EventData -->
+     * <pre>
+     * EventData event = new EventData&#40;&quot;maple&quot;&#41;;
+     * producer.send&#40;event&#41;;
+     * </pre>
+     * <!-- end com.azure.messaging.eventhubs.eventhubproducerclient.send#EventData -->
      *
      * <p>
      * For more information regarding the maximum event size allowed, see
@@ -284,15 +292,28 @@ public class EventHubProducerClient implements Closeable {
      * </p>
      *
      * @param event Event to send to the service.
+     * @throws NullPointerException if {@code event} is {@code null}.
+     * @throws AmqpException if the size of {@code event} exceeds the maximum size of a single batch.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    void send(EventData event) {
+    public void send(EventData event) {
         producer.send(event).block();
     }
 
     /**
-     * Sends a single event to the associated Event Hub with the send options. If the size of the single event exceeds
-     * the maximum size allowed, an exception will be triggered and the send will fail.
+     * <p>Sends a single event to the associated Event Hub with the send options. If the size of the single event
+     * exceeds the maximum size allowed, an exception will be triggered and the send will fail. For high throughput
+     * publishing, use {@link EventDataBatch} or the {@link #send(Iterable, SendOptions)} overload to publish more
+     * than one event in one call.</p>
+     *
+     * <!-- src_embed com.azure.messaging.eventhubs.eventhubproducerclient.send#EventData-SendOptions -->
+     * <pre>
+     * EventData event = new EventData&#40;&quot;Melbourne&quot;&#41;;
+     *
+     * SendOptions sendOptions = new SendOptions&#40;&#41;.setPartitionKey&#40;&quot;cities&quot;&#41;;
+     * producer.send&#40;event, sendOptions&#41;;
+     * </pre>
+     * <!-- end com.azure.messaging.eventhubs.eventhubproducerclient.send#EventData-SendOptions -->
      *
      * <p>
      * For more information regarding the maximum event size allowed, see
@@ -302,9 +323,11 @@ public class EventHubProducerClient implements Closeable {
      *
      * @param event Event to send to the service.
      * @param options The set of options to consider when sending this event.
+     * @throws NullPointerException if {@code event} or {@code options} is {@code null}.
+     * @throws AmqpException if the size of {@code event} exceeds the maximum size of a single batch.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    void send(EventData event, SendOptions options) {
+    public void send(EventData event, SendOptions options) {
         producer.send(event, options).block();
     }
 

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/samples/java/com/azure/messaging/eventhubs/EventHubsJavaDocCodeSamples.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/samples/java/com/azure/messaging/eventhubs/EventHubsJavaDocCodeSamples.java
@@ -488,6 +488,42 @@ public class EventHubsJavaDocCodeSamples {
     }
 
     /**
+     * Code snippet to demonstrate how to send a single event using
+     * {@link EventHubProducerAsyncClient#send(EventData)}.
+     */
+    public void sendSingleEventSampleAsync() {
+        final EventHubProducerAsyncClient producer = builder.buildAsyncProducerClient();
+        // BEGIN: com.azure.messaging.eventhubs.eventhubasyncproducerclient.send#EventData
+        EventData event = new EventData("maple");
+
+        producer.send(event)
+            .subscribe(unused -> {
+            },
+                error -> System.err.println("Error occurred while sending event:" + error),
+                () -> System.out.println("Send complete."));
+        // END: com.azure.messaging.eventhubs.eventhubasyncproducerclient.send#EventData
+    }
+
+    /**
+     * Code snippet to demonstrate how to send a single event using
+     * {@link EventHubProducerAsyncClient#send(EventData, SendOptions)}.
+     */
+    public void sendSingleEventWithPartitionKeySampleAsync() {
+        final EventHubProducerAsyncClient producer = builder.buildAsyncProducerClient();
+
+        // BEGIN: com.azure.messaging.eventhubs.eventhubasyncproducerclient.send#EventData-SendOptions
+        EventData event = new EventData("Melbourne");
+
+        SendOptions sendOptions = new SendOptions().setPartitionKey("cities");
+        producer.send(event, sendOptions)
+            .subscribe(unused -> {
+            },
+                error -> System.err.println("Error occurred while sending event:" + error),
+                () -> System.out.println("Send complete."));
+        // END: com.azure.messaging.eventhubs.eventhubasyncproducerclient.send#EventData-SendOptions
+    }
+
+    /**
      * Code snippet to demonstrate how to send a list of events using
      * {@link EventHubProducerAsyncClient#send(Iterable)}.
      */
@@ -648,6 +684,31 @@ public class EventHubsJavaDocCodeSamples {
             }
         }
         // END: com.azure.messaging.eventhubs.eventhubproducerclient.createBatch#CreateBatchOptions-int
+    }
+
+    /**
+     * Code snippet to demonstrate how to send a single event using {@link EventHubProducerClient#send(EventData)}.
+     */
+    public void sendSingleEventSample() {
+        final EventHubProducerClient producer = builder.buildProducerClient();
+        // BEGIN: com.azure.messaging.eventhubs.eventhubproducerclient.send#EventData
+        EventData event = new EventData("maple");
+        producer.send(event);
+        // END: com.azure.messaging.eventhubs.eventhubproducerclient.send#EventData
+    }
+
+    /**
+     * Code snippet to demonstrate how to send a single event using
+     * {@link EventHubProducerClient#send(EventData, SendOptions)}.
+     */
+    public void sendSingleEventWithPartitionKeySample() {
+        final EventHubProducerClient producer = builder.buildProducerClient();
+        // BEGIN: com.azure.messaging.eventhubs.eventhubproducerclient.send#EventData-SendOptions
+        EventData event = new EventData("Melbourne");
+
+        SendOptions sendOptions = new SendOptions().setPartitionKey("cities");
+        producer.send(event, sendOptions);
+        // END: com.azure.messaging.eventhubs.eventhubproducerclient.send#EventData-SendOptions
     }
 
     /**

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/test/java/com/azure/messaging/eventhubs/EventHubProducerAsyncClientTest.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/test/java/com/azure/messaging/eventhubs/EventHubProducerAsyncClientTest.java
@@ -204,6 +204,28 @@ class EventHubProducerAsyncClientTest {
     }
 
     /**
+     * Verifies that a null event or null options results in a NullPointerException.
+     */
+    @Test
+    void sendSingleMessageNullArguments() {
+        // Arrange
+        final EventData testData = new EventData(TEST_CONTENTS.getBytes(UTF_8));
+
+        // Act & Assert
+        StepVerifier.create(producer.send((EventData) null))
+            .expectError(NullPointerException.class)
+            .verify(DEFAULT_TIMEOUT);
+
+        StepVerifier.create(producer.send((EventData) null, new SendOptions()))
+            .expectError(NullPointerException.class)
+            .verify(DEFAULT_TIMEOUT);
+
+        StepVerifier.create(producer.send(testData, null))
+            .expectError(NullPointerException.class)
+            .verify(DEFAULT_TIMEOUT);
+    }
+
+    /**
      * Verifies that sending multiple events will result in calling producer.send(List&lt;Message&gt;).
      */
     @Test

--- a/sdk/eventhubs/azure-messaging-eventhubs/src/test/java/com/azure/messaging/eventhubs/EventHubProducerClientTest.java
+++ b/sdk/eventhubs/azure-messaging-eventhubs/src/test/java/com/azure/messaging/eventhubs/EventHubProducerClientTest.java
@@ -173,6 +173,26 @@ public class EventHubProducerClientTest {
     }
 
     /**
+     * Verifies that a null event or null options throws a NullPointerException.
+     */
+    @Test
+    public void sendSingleMessageNullArguments() {
+        // Arrange
+        final EventHubProducerClient producer = new EventHubProducerClient(asyncProducer);
+        final EventData eventData = new EventData("hello-world".getBytes(UTF_8));
+
+        // Act & Assert
+        try {
+            Assertions.assertThrows(NullPointerException.class, () -> producer.send((EventData) null));
+            Assertions.assertThrows(NullPointerException.class,
+                () -> producer.send((EventData) null, new SendOptions()));
+            Assertions.assertThrows(NullPointerException.class, () -> producer.send(eventData, null));
+        } finally {
+            producer.close();
+        }
+    }
+
+    /**
      *Verifies start and end span invoked when sending a single message.
      */
     @Test


### PR DESCRIPTION
Fixes #41395

## Summary

`EventHubProducerClient` and `EventHubProducerAsyncClient` contain `send(EventData)` and `send(EventData, SendOptions)`. All four methods are package-private. To publish one event, a caller must wrap it in an `EventDataBatch` or pass a one-element `Iterable` to `send(Iterable)`. This change makes the four methods public. The implementations do not change.

## Motivation

PR #6257 made the single-event, `Iterable`, and `Flux` send overloads package-private in 2019. The methods waited on architecture board review. The 2020 review (Azure/azure-sdk#1259) approved the multi-event form, and PR #10528 restored `send(Iterable)` only. The single-event form stayed package-private, and no one revisited it.

Two problems follow. The class Javadoc and the README show only the `EventDataBatch` workflow, so `send(Iterable)` is hard to find. `send(Iterable)` is also awkward for one event.

Other Azure SDKs ship the same API. `azure-eventhub` for Python added `send_event` in 5.11.0. This library exposes single-event `enqueueEvent(EventData)` on `EventHubBufferedProducerAsyncClient`.

One `send(EventData)` call makes one network round trip. The new Javadoc and the README both state this, and they point high throughput callers to `EventDataBatch` and `send(Iterable)`.

## Changes

- `EventHubProducerClient.send(EventData)` and `send(EventData, SendOptions)` become public.
- `EventHubProducerAsyncClient.send(EventData)` and `send(EventData, SendOptions)` become public. Both get `@ServiceMethod(returns = ReturnType.SINGLE)`, which the sync pair already has.
- Javadoc on the four methods gets `@throws NullPointerException`, `@throws AmqpException`, a code snippet, and a line that points high throughput callers to `EventDataBatch`.
- `EventHubsJavaDocCodeSamples` gets four snippets.
- The README gets a new section, "Publish a single event".
- The CHANGELOG gets an entry under 5.22.0-beta.1.
- Both producer test classes get null-argument tests.
- `eng/lintingconfigs/revapi/track2/revapi.json` gets one exclusion. Revapi reports `java.method.visibilityIncreased` for the four methods and fails the build. The change adds API surface and removes none, so callers stay source and binary compatible. A regex limits the exclusion to these four methods.

The `send(Flux<EventData>)` overloads stay package-private. The 2020 review examined a `Flux` overload and did not approve it.

## Test plan

- `mvn -f sdk/eventhubs/azure-messaging-eventhubs/pom.xml clean install -DskipTests` passes. This runs checkstyle, spotless, revapi, javadoc, and codesnippet verification.
- `mvn -f sdk/eventhubs/azure-messaging-eventhubs/pom.xml test -Dtest='EventHubProducerClientTest,EventHubProducerAsyncClientTest'` passes. 50 tests, 0 failures, 0 errors.
- The integration tests need live Event Hubs credentials and did not run locally. They called these methods before this change.

## Note for reviewers

This adds public API to a GA library, so it needs API review sign-off before merge. The ApiView diff shows four new methods and no other change to the surface.

The PR closes two defects. The public API is one. The docs are the other. If API review declines the overloads, the README, Javadoc, and CHANGELOG changes still fix the discoverability problem in #41395, which is the root cause of the report. The docs never showed that `send(Iterable)` exists.

/cc @anuchandy @conniey
