### PR TITLE
Release azure-resourcemanager-appconfiguration 1.2.0-beta.2 instead of empty 1.2.0-beta.3

### DIFF
--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -338,7 +338,7 @@ com.azure.resourcemanager:azure-resourcemanager-automation;1.0.0;1.1.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-resourcemover;1.2.0;1.3.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-datafactory;1.2.0;1.3.0-beta.2
 com.azure.resourcemanager:azure-resourcemanager-advisor;1.0.0;1.1.0-beta.1
-com.azure.resourcemanager:azure-resourcemanager-appconfiguration;1.1.0;1.2.0-beta.3
+com.azure.resourcemanager:azure-resourcemanager-appconfiguration;1.1.0;1.2.0-beta.2
 com.azure.resourcemanager:azure-resourcemanager-attestation;1.0.0-beta.3;1.0.0-beta.4
 com.azure.resourcemanager:azure-resourcemanager-azurestack;1.0.0;1.1.0-beta.1
 com.azure.resourcemanager:azure-resourcemanager-azurestackhci;1.1.0;1.2.0-beta.1

--- a/sdk/appconfiguration/azure-resourcemanager-appconfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/azure-resourcemanager-appconfiguration/CHANGELOG.md
@@ -1,16 +1,6 @@
 # Release History
 
-## 1.2.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
-## 1.2.0-beta.2 (2026-04-28)
+## 1.2.0-beta.2 (2026-07-22)
 
 - Azure Resource Manager AppConfiguration client library for Java. This package contains Microsoft Azure SDK for AppConfiguration Management SDK. // (missing-service-description) Add service description. Package api-version 2025-08-01-preview. For documentation on how to use this package, please see [Azure Management Libraries for Java](https://aka.ms/azsdk/java/mgmt).
 

--- a/sdk/appconfiguration/azure-resourcemanager-appconfiguration/pom.xml
+++ b/sdk/appconfiguration/azure-resourcemanager-appconfiguration/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>com.azure.resourcemanager</groupId>
   <artifactId>azure-resourcemanager-appconfiguration</artifactId>
-  <version>1.2.0-beta.3</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-appconfiguration;current} -->
+  <version>1.2.0-beta.2</version> <!-- {x-version-update;com.azure.resourcemanager:azure-resourcemanager-appconfiguration;current} -->
   <packaging>jar</packaging>
 
   <name>Microsoft Azure SDK for AppConfiguration Management</name>


### PR DESCRIPTION
Fixes release pipeline blockers for release plan 2206.

1.2.0-beta.2 was never actually released (the earlier release attempt failed), and 1.2.0-beta.3 has no new changes over beta.2 — the only source diffs since the version bump were internal Javadoc comment updates from TypeSpec regeneration (#49169, #49553), not user-facing changes.

Rather than shipping an empty beta.3 entry, this reverts the package version back to \1.2.0-beta.2\:
- \pom.xml\: version \1.2.0-beta.3\ -> \1.2.0-beta.2\
- \ng/versioning/version_client.txt\: current version \1.2.0-beta.3\ -> \1.2.0-beta.2\
- \CHANGELOG.md\: removed the empty \1.2.0-beta.3 (Unreleased)\ section and set today's date (2026-07-22) on the \1.2.0-beta.2\ entry, which is now what actually gets released.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>