### PR TITLE
Use 'none' environment for auto-release publish

### DIFF
--- a/eng/pipelines/templates/stages/archetype-java-auto-release-batch.yml
+++ b/eng/pipelines/templates/stages/archetype-java-auto-release-batch.yml
@@ -223,10 +223,7 @@ stages:
           condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
           timeoutInMinutes: 120
           # Auto-release is post-merge automation, so use an environment with no approval checks.
-          ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), not(contains(variables['Build.DefinitionName'], 'tests-weekly'))) }}:
-            environment: none
-          ${{ else }}:
-            environment: ${{ parameters.PublicPublishEnvironment }}
+          environment: none
           dependsOn: TagRepository
           templateContext:
             type: releaseJob

--- a/eng/pipelines/templates/stages/archetype-java-auto-release-batch.yml
+++ b/eng/pipelines/templates/stages/archetype-java-auto-release-batch.yml
@@ -222,7 +222,11 @@ stages:
           displayName: Publish auto-release packages to Maven Central via ESRP
           condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
           timeoutInMinutes: 120
-          environment: ${{ parameters.PublicPublishEnvironment }}
+          # Auto-release is post-merge automation, so use an environment with no approval checks.
+          ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), not(contains(variables['Build.DefinitionName'], 'tests-weekly'))) }}:
+            environment: none
+          ${{ else }}:
+            environment: ${{ parameters.PublicPublishEnvironment }}
           dependsOn: TagRepository
           templateContext:
             type: releaseJob


### PR DESCRIPTION
## What
The Maven Central publish deployment now targets the `none` environment for auto-release runs.

## Why
Auto-release is a fully automated post-merge CI flow on `main`; a manual approval gate would block the publish step.

## Impact
Manual releases are unaffected and keep using the existing approval-gated public publish environment.

## Note
`none` must be, or will be auto-created as, an Azure DevOps environment with no approvals/checks.