### PR TITLE
[Storage][Tests] Fix Azurite install failing behind CFSClean's npm registry block

### DIFF
--- a/sdk/storage/tests-install-azurite.yml
+++ b/sdk/storage/tests-install-azurite.yml
@@ -13,11 +13,21 @@ steps:
           path: ${{ parameters.AzuriteLocation }}
           cacheHitVar: STORAGE_AZURITE_CACHE_RESTORED
       displayName: Cache Azurite installation
-    - task: Npm@1
-      inputs:
-          command: custom
-          customCommand: install --prefix ${{ parameters.AzuriteLocation }} azurite@${{ parameters.AzuriteVersion }}
-      condition: ne(variables.STORAGE_AZURITE_CACHE_RESTORED, 'true')
+    # CFSClean blocks registry.npmjs.org, so configure the authenticated Azure SDK CFS feed.
+    # npmrcPath is explicit (rather than the default $HOME/.npmrc) because it must be threaded
+    # into the Install Azurite step below via --userconfig. This intentionally uses a plain pwsh
+    # script rather than the Npm@1 task: Npm@1 always generates and forces its own per-build
+    # userconfig (D:\a\_work\1\npm\<buildId>.npmrc), silently overriding any npm_config_userconfig
+    # env var, even in "custom" command mode. Every other caller of this template in this repo
+    # (eval-shard.yml, archetype-typespec-emitter.yml) likewise invokes npm directly instead of
+    # going through Npm@1, for the same reason.
+    - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+      parameters:
+          npmrcPath: $(Agent.TempDirectory)/azurite-npmrc/.npmrc
+          CustomCondition: and(succeeded(), ne(variables.STORAGE_AZURITE_CACHE_RESTORED, 'true'))
+    - pwsh: |
+          npm install --prefix '${{ parameters.AzuriteLocation }}' azurite@${{ parameters.AzuriteVersion }} --userconfig '$(Agent.TempDirectory)/azurite-npmrc/.npmrc'
+      condition: and(succeeded(), ne(variables.STORAGE_AZURITE_CACHE_RESTORED, 'true'))
       displayName: Install Azurite
     - task: PowerShell@2
       displayName: Add Azurite location as environment variable


### PR DESCRIPTION
## Summary
- Configure the authenticated Azure SDK CFS npm feed before installing Azurite on cache misses.
- Invoke npm directly instead of through the `Npm@1` task.

## Motivation
CFSClean blocks direct access to `registry.npmjs.org`, so installing Azurite via a plain npm install fails with:
```
npm error FetchError: request to https://registry.npmjs.org/azurite failed, reason: connect EACCES 192.0.2.18:443
```

The fix authenticates a `.npmrc` against the Azure SDK CFS npm feed before install. That `.npmrc` is deliberately not the default `$HOME/.npmrc` - it's threaded into the install step via an explicit `--userconfig` flag, because the `Npm@1` task unconditionally generates and forces its own per-build userconfig (`<tempdir>\npm\<buildId>.npmrc`), even in `command: custom` mode, silently overriding any `npm_config_userconfig` env var set on the task. Because of that, this step invokes `npm` directly from a `pwsh` script rather than through `Npm@1` - matching how every other caller of `create-authenticated-npmrc.yml` in this repo (`eval-shard.yml`, `archetype-typespec-emitter.yml`) already does it.

## Validation
- Verified against a real CI run that the previous (env-var-based) approach was silently ignored by `Npm@1`, and that this direct-invocation approach resolves through the CFS feed successfully.
- YAML parses successfully.

## How to verify
Re-run the `java - storage - tests` pipeline on a Windows/Linux/macOS leg with a cold Azurite cache (or bump the cache key) and confirm the `Install Azurite` step resolves through `pkgs.dev.azure.com` instead of `registry.npmjs.org`.