### PR TITLE
Add mirror settings for pom-only release template

### DIFF
--- a/eng/pipelines/templates/stages/archetype-java-release-pom-only.yml
+++ b/eng/pipelines/templates/stages/archetype-java-release-pom-only.yml
@@ -46,6 +46,11 @@ stages:
             displayName: 'Download Signed Artifacts'
             artifact: packages-signed
 
+          # Setup Maven mirror settings and authenticate with Azure Artifacts
+          - template: /eng/pipelines/templates/steps/maven-authenticate.yml
+            parameters:
+              SourceDirectory: $(Pipeline.Workspace)/azure-sdk-for-java
+
           # gpg-sign and create the flattened directory for ESRP bulk publish
           # Note: The maven release requires the files to be local GPG signed
           # Dev feed publishes use the gpg-sign-and-deply to do it in one step


### PR DESCRIPTION
## Summary
- Adds Maven mirror/authentication setup to the pom-only release signing stage before GPG signing.
- Ensures pom-only release artifacts use the authenticated Maven settings consistently with the Java release flow.

## Validation
- [template run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6621453&view=logs&j=a75c6bfa-0dc4-5d88-fb2b-7264dee1cb48&t=0919ba35-e1c1-5a7b-325a-5192ec9df2c4)