### PR TITLE
Add Maven auth to pom-only dev feed publish

### DIFF
--- a/eng/pipelines/templates/stages/archetype-java-release-pom-only.yml
+++ b/eng/pipelines/templates/stages/archetype-java-release-pom-only.yml
@@ -151,6 +151,10 @@ stages:
                     - Name: Azure/azure-sdk-for-java
                       Commitish: $(Build.SourceVersion)
                       WorkingDirectory: $(Pipeline.Workspace)/azure-sdk-for-java
+              # Setup Maven mirror settings and authenticate with Azure Artifacts
+              - template: /eng/pipelines/templates/steps/maven-authenticate.yml
+                parameters:
+                  SourceDirectory: $(Pipeline.Workspace)/azure-sdk-for-java
               - template: tools/gpg/gpg.yml@azure-sdk-build-tools
               # Publish to the azure-sdk-for-java feed.
               - template: /eng/pipelines/templates/steps/java-dev-feed-publishing.yml


### PR DESCRIPTION
## Summary
- Adds the Maven authentication/mirror setup step to the pom-only release pipeline's Java dev feed publish job.
- Ensures dev feed publishing resolves dependencies through the configured authenticated Maven settings after sparse checkout.

## Validation
- [Template test run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6622849&view=results)