### PR TITLE
Change containerserviceaimanager release to Unreleased

### DIFF
--- a/sdk/containerserviceaimanager/azure-resourcemanager-containerserviceaimanager/CHANGELOG.md
+++ b/sdk/containerserviceaimanager/azure-resourcemanager-containerserviceaimanager/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (2026-07-28)
+## 1.0.0-beta.1 (Unreleased)
 
 - Azure Resource Manager Container Service AI Manager client library for Java. This package contains Microsoft Azure SDK for Container Service AI Manager Management SDK. Azure Kubernetes AI Manager api client. Package api-version 2026-05-02-preview. For documentation on how to use this package, please see [Azure Management Libraries for Java](https://aka.ms/azsdk/java/mgmt).
 ### Features Added


### PR DESCRIPTION
Changes the 1.0.0-beta.1 release date to (Unreleased) in the containerserviceaimanager CHANGELOG.

namespace review not completed, set it to Unreleased