### PR TITLE
Fix Arrow source shading configuration

### DIFF
--- a/sdk/storage/azure-storage-blob/pom.xml
+++ b/sdk/storage/azure-storage-blob/pom.xml
@@ -222,7 +222,7 @@
           <artifactId>arrow-format</artifactId>
           <version>19.0.0</version> <!-- {x-version-update;org.apache.arrow:arrow-format;external_dependency} -->
         </dependency>
-        <!-- Must match arrow-format's dep.fbs.version. dependencyConvergence below rejects version drift. -->
+        <!-- Must match arrow-format's dep.fbs.version -->
         <dependency>
           <groupId>com.google.flatbuffers</groupId>
           <artifactId>flatbuffers-java</artifactId>

--- a/sdk/storage/azure-storage-blob/pom.xml
+++ b/sdk/storage/azure-storage-blob/pom.xml
@@ -256,8 +256,8 @@
 
               <artifactSet>
                 <includes>
-                  <include>org.apache.arrow:arrow-format:[19.0.0]</include> <!-- {x-include-update;org.apache.arrow:arrow-format;external_dependency} -->
-                  <include>com.google.flatbuffers:flatbuffers-java:[25.2.10]</include> <!-- {x-include-update;com.google.flatbuffers:flatbuffers-java;external_dependency} -->
+                  <include>org.apache.arrow:arrow-format</include>
+                  <include>com.google.flatbuffers:flatbuffers-java</include>
                 </includes>
               </artifactSet>
 
@@ -274,26 +274,6 @@
             </configuration>
           </plugin>
 
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <version>3.6.1</version> <!-- {x-version-update;org.apache.maven.plugins:maven-enforcer-plugin;external_dependency} -->
-            <configuration>
-              <rules>
-                <dependencyConvergence>
-                  <includes>
-                    <include>com.google.flatbuffers:flatbuffers-java</include>
-                  </includes>
-                </dependencyConvergence>
-                <bannedDependencies>
-                  <includes>
-                    <include>org.apache.arrow:arrow-format:[19.0.0]</include> <!-- {x-include-update;org.apache.arrow:arrow-format;external_dependency} -->
-                    <include>com.google.flatbuffers:flatbuffers-java:[25.2.10]</include> <!-- {x-include-update;com.google.flatbuffers:flatbuffers-java;external_dependency} -->
-                  </includes>
-                </bannedDependencies>
-              </rules>
-            </configuration>
-          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION

- use versionless Shade artifact selectors for Arrow and FlatBuffers
- remove the obsolete profile-specific Maven Enforcer rules.