### PR TITLE
Update ACR web app sample to use managed identity

### DIFF
--- a/sdk/resourcemanager/azure-resourcemanager/assets.json
+++ b/sdk/resourcemanager/azure-resourcemanager/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "java",
   "TagPrefix": "java/resourcemanager/azure-resourcemanager",
-  "Tag": "java/resourcemanager/azure-resourcemanager_b40f5da6f5"
+  "Tag": "java/resourcemanager/azure-resourcemanager_c1f995f55c"
 }

--- a/sdk/resourcemanager/azure-resourcemanager/src/samples/README.md
+++ b/sdk/resourcemanager/azure-resourcemanager/src/samples/README.md
@@ -26,7 +26,7 @@ For additional code snippets grouped by service, see [SAMPLE.md][RESOURCEMANAGER
 
 - [Connect a web app to a SQL database (passwordless)][sample_connect_web_app_to_sql_database]
 - [Connect a web app to a storage account (passwordless)][sample_connect_web_app_to_storage_account]
-- [Deploy an image from Azure Container Registry to a Linux web app (passwordless)][sample_deploy_image_from_acr_to_linux_web_app]
+- [Deploy an image from Azure Container Registry to a Linux web app][sample_deploy_image_from_acr_to_linux_web_app]
 - [Manage web app deployment slots][sample_manage_web_app_slots]
 - [Manage a web app with a custom domain][sample_manage_web_app_with_custom_domain]
 - [Scale a web app across multiple regions with a Traffic Manager][sample_scale_web_app_with_traffic_manager]

--- a/sdk/resourcemanager/azure-resourcemanager/src/samples/README.md
+++ b/sdk/resourcemanager/azure-resourcemanager/src/samples/README.md
@@ -26,7 +26,7 @@ For additional code snippets grouped by service, see [SAMPLE.md][RESOURCEMANAGER
 
 - [Connect a web app to a SQL database (passwordless)][sample_connect_web_app_to_sql_database]
 - [Connect a web app to a storage account (passwordless)][sample_connect_web_app_to_storage_account]
-- [Deploy an image from Azure Container Registry to a Linux web app][sample_deploy_image_from_acr_to_linux_web_app]
+- [Deploy an image from Azure Container Registry to a Linux web app (passwordless)][sample_deploy_image_from_acr_to_linux_web_app]
 - [Manage web app deployment slots][sample_manage_web_app_slots]
 - [Manage a web app with a custom domain][sample_manage_web_app_with_custom_domain]
 - [Scale a web app across multiple regions with a Traffic Manager][sample_scale_web_app_with_traffic_manager]

--- a/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/appservice/samples/DeployImageFromAcrToLinuxWebApp.java
+++ b/sdk/resourcemanager/azure-resourcemanager/src/samples/java/com/azure/resourcemanager/appservice/samples/DeployImageFromAcrToLinuxWebApp.java
@@ -12,17 +12,18 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.appservice.models.PricingTier;
 import com.azure.resourcemanager.appservice.models.WebApp;
-import com.azure.resourcemanager.containerregistry.models.AccessKeyType;
+import com.azure.resourcemanager.authorization.models.BuiltInRole;
 import com.azure.resourcemanager.containerregistry.models.Registry;
-import com.azure.resourcemanager.containerregistry.models.RegistryCredentials;
 import com.azure.resourcemanager.samples.SampleUtils;
 
 /**
  * Azure App Service sample for deploying an image from Azure Container Registry to a Linux web app.
- *  - Create an Azure Container Registry
- *  - Create a Linux web app that runs an image from the registry
+ *  - Create an Azure Container Registry with the admin user disabled
+ *  - Create a Linux web app that pulls an image using its system-assigned managed identity
+ *  - Grant the web app's managed identity the {@code AcrPull} role on the registry
  * <p>
  * The image ({@code samples/tomcat:latest}) is expected to be pushed to the registry beforehand with the Docker CLI.
+ * The caller must have permission to create role assignments.
  */
 public final class DeployImageFromAcrToLinuxWebApp {
 
@@ -39,19 +40,17 @@ public final class DeployImageFromAcrToLinuxWebApp {
         final Region region = Region.JAPAN_EAST;
 
         try {
-            // Create an Azure Container Registry with the admin user enabled.
+            // Create an Azure Container Registry without the admin user (admin credentials are discouraged).
             Registry azureRegistry = azureResourceManager.containerRegistries()
                 .define(acrName)
                 .withRegion(region)
                 .withNewResourceGroup(rgName)
                 .withBasicSku()
-                .withRegistryNameAsAdminUser()
                 .create();
 
-            RegistryCredentials acrCredentials = azureRegistry.getCredentials();
             String privateImage = azureRegistry.loginServerUrl() + "/samples/tomcat:latest";
 
-            // Create a Linux web app that pulls its image from the private registry.
+            // Create a Linux web app that authenticates to the private registry with its system-assigned identity.
             // HTTPS-only is enforced; minimum TLS 1.2 and FTPS-only are already the App Service defaults.
             WebApp app = azureResourceManager.webApps()
                 .define(appName)
@@ -59,9 +58,19 @@ public final class DeployImageFromAcrToLinuxWebApp {
                 .withExistingResourceGroup(rgName)
                 .withNewLinuxPlan(PricingTier.STANDARD_S1)
                 .withPrivateRegistryImage(privateImage, "https://" + azureRegistry.loginServerUrl())
-                .withCredentials(acrCredentials.username(), acrCredentials.accessKeys().get(AccessKeyType.PRIMARY))
+                .withManagedIdentityCredentials()
+                .withSystemAssignedManagedServiceIdentity()
                 .withAppSetting("PORT", "8080")
                 .withHttpsOnly(true)
+                .create();
+
+            // Grant the web app's identity least-privilege pull access to the registry.
+            azureResourceManager.accessManagement()
+                .roleAssignments()
+                .define(SampleUtils.randomUuid(azureResourceManager))
+                .forObjectId(app.systemAssignedManagedServiceIdentityPrincipalId())
+                .withBuiltInRole(BuiltInRole.ACR_PULL)
+                .withResourceScope(azureRegistry)
                 .create();
 
             System.out.println("Deployed image " + privateImage + " to web app " + app.defaultHostname());

--- a/sdk/resourcemanager/azure-resourcemanager/src/test/java/com/azure/resourcemanager/samples/AppServiceSampleTests.java
+++ b/sdk/resourcemanager/azure-resourcemanager/src/test/java/com/azure/resourcemanager/samples/AppServiceSampleTests.java
@@ -52,8 +52,8 @@ public class AppServiceSampleTests extends SamplesTestBase {
         Assertions.assertTrue(ConnectWebAppToStorageAccount.runSample(azureResourceManager));
     }
 
-    // Recorded on a personal subscription (Japan East) because the shared test subscription's policy disables
-    // the ACR admin account and its US-region App Service "Total VMs" quota is 0.
+    // Recorded on a personal subscription (Japan East) because the sample's AcrPull grant requires
+    // Microsoft.Authorization/roleAssignments/write and the shared subscription's App Service quota is unavailable.
     @Test
     public void testDeployImageFromAcrToLinuxWebApp() {
         Assertions.assertTrue(DeployImageFromAcrToLinuxWebApp.runSample(azureResourceManager));


### PR DESCRIPTION
## Summary
- update the Linux web app ACR sample to use a system-assigned managed identity
- grant the identity the registry-scoped `AcrPull` role instead of enabling ACR admin credentials
- document the passwordless flow and role-assignment permission requirement

Uses the App Service support released in #49936.

## Verification
- `mvn -f sdk\resourcemanager\azure-resourcemanager\pom.xml -DskipTests test-compile spotless:check checkstyle:check`