### PR TITLE
Restore two 6.x-only eng customizations dropped by the eng/ sync

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -88,51 +88,6 @@
           "TestGoals": "surefire:test failsafe:integration-test failsafe:verify"
         }
       }
-    },
-    {
-      "Agent": {
-        "ubuntu-24.04": { "OSVmImage": "env:LINUXVMIMAGE", "Pool": "env:LINUXPOOL" }
-      },
-      "JavaTestVersion": "1.21",
-      "AZURE_TEST_HTTP_CLIENTS": "netty",
-      "Options": {
-        "NotFromSource_TestsOnly": {
-          "TestFromSource": false,
-          "RunAggregateReports": false,
-          "TestOptions": "",
-          "TestGoals": "surefire:test failsafe:integration-test failsafe:verify"
-        }
-      }
-    },
-    {
-      "Agent": {
-        "ubuntu-24.04": { "OSVmImage": "env:LINUXVMIMAGE", "Pool": "env:LINUXPOOL" }
-      },
-      "JavaTestVersion": "1.21",
-      "AZURE_TEST_HTTP_CLIENTS": "JdkHttpClientProvider",
-      "Options": {
-        "NotFromSource_TestsOnly": {
-          "TestFromSource": false,
-          "RunAggregateReports": false,
-          "TestOptions": "",
-          "TestGoals": "surefire:test failsafe:integration-test failsafe:verify"
-        }
-      }
-    },
-    {
-      "Agent": {
-        "ubuntu-24.04": { "OSVmImage": "env:LINUXVMIMAGE", "Pool": "env:LINUXPOOL" }
-      },
-      "JavaTestVersion": "1.21",
-      "AZURE_TEST_HTTP_CLIENTS": "VertxHttpClientProvider",
-      "Options": {
-        "NotFromSource_TestsOnly": {
-          "TestFromSource": false,
-          "RunAggregateReports": false,
-          "TestOptions": "",
-          "TestGoals": "surefire:test failsafe:integration-test failsafe:verify"
-        }
-      }
     }
   ]
 }

--- a/eng/versioning/pom_file_version_scanner.ps1
+++ b/eng/versioning/pom_file_version_scanner.ps1
@@ -541,10 +541,12 @@ if ($script:FoundError)
     exit 1
 }
 
-# Loop through every client and data POM file and perform the verification. Right now
-# management isn't being processed, when it is the checks below will go away and every
-# POM file under the sdk directory will get processed.
-Get-ChildItem -Path $Path -Filter pom*.xml -Recurse -File | ForEach-Object {
+# Loop through POM files under sdk/spring and sdk/boms directories only.
+$ScanPaths = @(
+    (Join-Path $SdkRoot "spring"),
+    (Join-Path $SdkRoot "boms")
+)
+Get-ChildItem -Path $ScanPaths -Filter pom*.xml -Recurse -File | ForEach-Object {
     $pomFile = $_.FullName
     $xmlPomFile = $null
 


### PR DESCRIPTION
Follow-up to #50004.

## Why

#50004 replaced the whole `eng/` directory with `main` so the release branch runs the latest engineering code. That also overwrote customizations that **only ever existed on this release branch**, and the `Analyze` job's **Verify versions in POM files** step started failing with 19 errors:

```text
processing pomFile=/mnt/vss/_work/1/s/sdk/keyvault-v2/azure-security-keyvault-administration/pom.xml
Error: unreleased_com.azure.v2:azure-core's dependency type is 'dependency' but the dependency does not exist in any of the version_*.txt files. Should this be an external_dependency? Please ensure the dependency type is correct or the dependency is added to the appropriate file.
...
There were errors encountered during execution. Please fix errors and run the script again.
```

## What

### 1. `eng/versioning/pom_file_version_scanner.ps1`

This branch scans **only `sdk/spring` and `sdk/boms`** — introduced by #48927 (`Upgrade Spring Boot to 3.5.14 and Spring Cloud to 2025.0.2`). `main` scans the whole repository:

```diff
-# Loop through every client and data POM file and perform the verification. ...
-Get-ChildItem -Path $Path -Filter pom*.xml -Recurse -File | ForEach-Object {
+# Loop through POM files under sdk/spring and sdk/boms directories only.
+$ScanPaths = @(
+    (Join-Path $SdkRoot "spring"),
+    (Join-Path $SdkRoot "boms")
+)
+Get-ChildItem -Path $ScanPaths -Filter pom*.xml -Recurse -File | ForEach-Object {
```

`eng/versioning/version_client.txt` is intentionally kept at the 6.x baseline (see #50004) and carries **no `unreleased_` entries**, so POM files outside `sdk/spring` and `sdk/boms` cannot validate on this branch. The narrowing is restored; everything else in the script stays at `main`'s version.

### 2. `eng/pipelines/templates/stages/platform-matrix.json`

#48985 (`remove some matrix`) deliberately removed three Java 21 `NotFromSource_TestsOnly` matrix entries on this branch. Restored to the pre-sync state.

### Not restored (deliberately)

Every file the sync modified was checked by testing whether its pre-sync blob ever existed in `main`'s history for the same path — 104 of 111 were simply older copies of `main`; 7 carried branch-only edits. Besides the two above and the two version files already excluded by #50004:

| File | Why keeping `main`'s version is safe |
| --- | --- |
| `archetype-java-release-patch.yml`<br>`archetype-java-release-pom-only.yml` | They only differed by not passing `AuthToken: ''`. That parameter is supported by the `eng/common` templates that arrived with the same sync (`create-tags-and-git-release.yml`, `create-pull-request.yml`), and `archetype-java-release-batch.yml` — the template this branch actually releases through — already passes it. |
| `eng/automation/changelog/pom.xml` | Management-plane codegen tooling; not used by this branch. |

## Verification

Negative first, then positive, using `pwsh -NoProfile -File eng/versioning/pom_file_version_scanner.ps1` locally:

- **Before the fix**: reproduced the CI failure exactly — 19 errors, same artifacts and same counts as the pipeline log (`unreleased_com.azure.v2:azure-core` ×8, `unreleased_com.azure.v2:azure-identity` ×6, `unreleased_com.azure:azure-data-appconfiguration` ×2, plus `azure-resourcemanager-containerservice`, `azure-core-test`, `io.clientcore:http-netty4`).
- **After the fix**: exit code 0, no errors.
- **The narrowed scan is still live, not silently disabled**: `$ScanPaths` resolves to 62 POM files, and temporarily setting `spring-cloud-azure-core`'s version to `9.9.9` is caught with `Error: com.azure.spring:spring-cloud-azure-core's <version> is '9.9.9' but the current version is listed as 6.5.0`. Probe reverted, working tree clean.
- `platform-matrix.json` is byte-identical to the pre-sync state and parses as valid JSON.
