### PR TITLE
Keep find_unused_dependencies.py on the springboot3_ prefix

### DIFF
--- a/eng/versioning/find_unused_dependencies.py
+++ b/eng/versioning/find_unused_dependencies.py
@@ -9,8 +9,8 @@ import os
 from utils import load_version_map_from_file
 from utils import version_update_marker
 
-IGNORED_DEPENDENCIES = {'springboot4_org.springframework.boot:spring-boot-dependencies',
-                        'springboot4_org.springframework.cloud:spring-cloud-dependencies'}
+IGNORED_DEPENDENCIES = {'springboot3_org.springframework.boot:spring-boot-dependencies',
+                        'springboot3_org.springframework.cloud:spring-cloud-dependencies'}
 
 def fixup_version_map(version_file, version_map):
     # uses the util function to load the version map from the file, then adds a bool to each entry to track if it is visisted


### PR DESCRIPTION
Follow-up to #50004 / #50005.

## Why

The `Analyze` job's **Verify version text files** step fails:

```text
/opt/hostedtoolcache/Python/3.11.15/x64/bin/python /mnt/vss/_work/1/s/eng/versioning/find_unused_dependencies.py
Unused external_dependencies.txt entries:
  springboot3_org.springframework.boot:spring-boot-dependencies
  springboot3_org.springframework.cloud:spring-cloud-dependencies
##[error]The process '...python' failed with exit code 1
```

`eng/versioning/find_unused_dependencies.py` carries an `IGNORED_DEPENDENCIES` allow-list. `main` flipped it from `springboot3_` to `springboot4_` during the Spring Boot 4 migration:

```python
IGNORED_DEPENDENCIES = {'springboot4_org.springframework.boot:spring-boot-dependencies',
                        'springboot4_org.springframework.cloud:spring-cloud-dependencies'}
```

The `eng/` sync in #50004 took that version, but `eng/versioning/external_dependencies.txt` is deliberately kept at the 6.x baseline and uses the `springboot3_` area prefix:

| branch | area prefix | entries |
| --- | --- | --- |
| `release/spring-cloud-azure_6.5.0` | `springboot3_` | 99 |
| `main` | `springboot4_` | 102 |

So the two `springboot3_` entries no longer matched the allow-list and were reported as unused.

This allow-list is **branch-generation data embedded in a script** — it has to track `external_dependencies.txt`, not `main`. The `springboot3_` values are restored; `main`'s trailing-newline fix is kept.

> Note this file was *not* flagged by the branch-only-edit check used in #50005: its pre-sync content **did** exist in `main`'s history (before the SB4 migration). The branch is deliberately pinned to that older upstream state, which is a different situation from a branch-only edit.

## Verification

- **Negative**: on the current release branch head (`d2168cb3e61`), `python eng/versioning/find_unused_dependencies.py` reproduces the CI failure exactly — same two entries, exit code 1.
- **Positive**: after the fix, exit code 0 with no output.
- **The check is still live, not disabled**: appending a genuinely unused entry `probe_com.example:unused-probe;1.0.0` to `external_dependencies.txt` is reported (`Unused external_dependencies.txt entries: probe_com.example:unused-probe`, exit 1). Probe reverted, working tree clean.
- **Swept the same class of coupling across `eng/`**: extracted every area prefix present in this branch's `version_client.txt` / `external_dependencies.txt` (`clientcore`, `cosmos`, `otel`, `resourcemanager`, `springboot3`, `storage`, `test`, `testdep`) and searched all `eng/**` sources for `<prefix>_<group>:<artifact>` literals using a prefix this branch does not have — these two lines were the only hits.
- Also checked every hardcoded `group:artifact` literal in `eng/versioning/*.py` / `*.ps1` against this branch's data files; the only one absent is `com.azure:azure-sdk-all` in `set_versions.py`, which is a deny-list entry absent from `main`'s data files too.
- Reviewed every step the sync added to the templates this branch actually builds through (`sdk/spring/ci.yml` → `archetype-sdk-client.yml` → `jobs/ci.yml`): `Use Node.js 22.x` + `create-authenticated-npmrc.yml` now run **before** `check-spelling.yml` and cspell receives `NpmConfigUserConfig`, which fixes the npm isolation failure this branch previously hit; `Verify Swagger and TypeSpec Code Generation` became `Verify TypeSpec Code Generation`; `verify-links.yml` was dropped upstream. No further gaps found.
