### PR TITLE
Increment spring-cloud-azure-dependencies package version for spring releases

### DIFF
--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -220,7 +220,7 @@ com.azure.spring:spring-cloud-azure-appconfiguration-config;6.5.0;6.6.0-beta.1
 com.azure.spring:spring-cloud-azure-feature-management-web;6.5.0;6.6.0-beta.1
 com.azure.spring:spring-cloud-azure-feature-management;6.5.0;6.6.0-beta.1
 com.azure.spring:spring-cloud-azure-starter-appconfiguration-config;6.5.0;6.6.0-beta.1
-com.azure.spring:spring-cloud-azure-dependencies;6.4.0;6.5.0
+com.azure.spring:spring-cloud-azure-dependencies;6.5.0;6.6.0-beta.1
 com.azure.spring:spring-messaging-azure;6.5.0;6.6.0-beta.1
 com.azure.spring:spring-messaging-azure-eventhubs;6.5.0;6.6.0-beta.1
 com.azure.spring:spring-messaging-azure-servicebus;6.5.0;6.6.0-beta.1

--- a/sdk/boms/spring-cloud-azure-dependencies/pom.xml
+++ b/sdk/boms/spring-cloud-azure-dependencies/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.azure.spring</groupId>
   <artifactId>spring-cloud-azure-dependencies</artifactId>
-  <version>6.5.0</version> <!-- {x-version-update;com.azure.spring:spring-cloud-azure-dependencies;current} -->
+  <version>6.6.0-beta.1</version> <!-- {x-version-update;com.azure.spring:spring-cloud-azure-dependencies;current} -->
   <packaging>pom</packaging>
 
   <name>Spring Cloud Azure Dependencies</name>


### PR DESCRIPTION
### Description

The automated increment PR #50014 bumped every Spring Cloud Azure 6.x module to `6.5.0;6.6.0-beta.1`, but left `com.azure.spring:spring-cloud-azure-dependencies` at the already-released `6.5.0`. This PR syncs the BOM with the rest of the 6.x modules.

- `eng/versioning/version_client.txt`: `com.azure.spring:spring-cloud-azure-dependencies;6.4.0;6.5.0` -> `;6.5.0;6.6.0-beta.1`
- `sdk/boms/spring-cloud-azure-dependencies/pom.xml`: `<version>` -> `6.6.0-beta.1`, refreshed by `python eng/versioning/update_versions.py --skip-readme`

This matches `main`, where the BOM sits at `7.4.0;7.5.0-beta.1` after the 7.4.0 release. `sdk/spring/README.md` intentionally keeps the released `6.5.0`, consistent with `main` and with the `--skip-readme` behavior of the increment automation.
