### PR TITLE
Relax Java pipeline path length checks

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -420,7 +420,7 @@ jobs:
         parameters:
           ServiceDirectories: $(PRServiceDirectories)
 
-      # Use BasePathLength of 18 to allow longer repository-relative paths.
+      # verify-path-length adds BasePathLength (assumed Windows checkout-root length) to repo-relative paths; set to 18 to allow longer repo-relative paths.
       - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
         parameters:
           SourceDirectory: $(Build.SourcesDirectory)

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -420,11 +420,11 @@ jobs:
         parameters:
           ServiceDirectories: $(PRServiceDirectories)
 
-      # Use BasePathLength of 38 instead of the default 49 as some released files fail when the number is higher.
+      # Use BasePathLength of 18 to allow longer repository-relative paths.
       - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
         parameters:
           SourceDirectory: $(Build.SourcesDirectory)
-          BasePathLength: 38
+          BasePathLength: 18
 
       # Authenticate with Azure Artifacts
       - template: /eng/pipelines/templates/steps/maven-authenticate.yml

--- a/eng/pipelines/templates/stages/archetype-sdk-client-patch.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client-patch.yml
@@ -300,11 +300,11 @@ extends:
               parameters:
                 ServiceDirectories: $(ServiceDirectories)
 
-            # Use BasePathLength of 38 instead of the default 49 as some released files fail when the number is higher.
+            # Use BasePathLength of 18 to allow longer repository-relative paths.
             - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
               parameters:
                 SourceDirectory: $(Build.SourcesDirectory)
-                BasePathLength: 38
+                BasePathLength: 18
 
             - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
 


### PR DESCRIPTION
## Summary
- Reduce the Java CI path-length base reservation from 38 to 18 characters.
- Apply the change to both standard CI and patch-release pipelines.

This allows repository-relative file and directory paths to be 20 characters longer while retaining the Windows 260-character file-path and 248-character directory-path checks.

---

Reason here https://github.com/Azure/azure-rest-api-specs/pull/44457#discussion_r3629539725

---

I am leaving the PR at review state for as long as I can, before the next mgmt PR from service that requires this relax. At that time, I will also double check whether we do need to relax to 18, or e.g. a more moderate relax be enough for it.