### PR TITLE
feat(spring): support Key Vault certificate alias filters 6x

### DIFF
--- a/sdk/spring/CHANGELOG.md
+++ b/sdk/spring/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Release History
+## 6.6.0-beta.1 (Unreleased)
+
+### Spring Cloud Azure Autoconfigure
+
+#### Features Added
+
+- Added `spring.ssl.bundle.keyvault.<bundle-name>.keystore.certificate-alias-filter-patterns` and `spring.ssl.bundle.keyvault.<bundle-name>.truststore.certificate-alias-filter-patterns` configuration. The patterns are passed to the Key Vault JCA provider to limit which certificate aliases are loaded. ([#50013](https://github.com/Azure/azure-sdk-for-java/issues/50013))
+
 ## 6.5.0 (2026-07-29)
 - This release is compatible with Spring Boot 3.5.0-3.5.14. (Note: 3.5.x (x>14) should be supported, but they aren't tested with this release.)
 - This release is compatible with Spring Cloud 2025.0.0-2025.0.2. (Note: 2025.0.x (x>2) should be supported, but they aren't tested with this release.)

--- a/sdk/spring/spring-cloud-azure-autoconfigure/CHANGELOG.md
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `spring.ssl.bundle.keyvault.<bundle-name>.keystore.certificate-alias-filter-patterns` and `spring.ssl.bundle.keyvault.<bundle-name>.truststore.certificate-alias-filter-patterns` configuration. The patterns are passed to the Key Vault JCA provider to limit which certificate aliases are loaded. ([#50013](https://github.com/Azure/azure-sdk-for-java/issues/50013))
+
 ### Breaking Changes
 
 ### Bugs Fixed
@@ -245,4 +247,3 @@ Please refer to [spring/CHANGELOG.md](https://github.com/Azure/azure-sdk-for-jav
 ## 4.0.0-beta.2 (2021-11-22)
 
 Please refer to [spring/CHANGELOG.md](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/spring/CHANGELOG.md#400-beta2-2021-11-22) for more details.
-

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/keyvault/jca/AzureKeyVaultSslBundleRegistrar.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/keyvault/jca/AzureKeyVaultSslBundleRegistrar.java
@@ -51,6 +51,7 @@ public class AzureKeyVaultSslBundleRegistrar implements SslBundleRegistrar, Reso
         "azure.keyvault.client-secret",
         "azure.keyvault.managed-identity",
         "azure.keyvault.jca.certificates-refresh-interval",
+        "azure.keyvault.jca.certificate-alias-filter-patterns",
         "azure.keyvault.jca.refresh-certificates-when-have-un-trust-certificate",
         "azure.cert-path.well-known",
         "azure.cert-path.custom"
@@ -209,6 +210,10 @@ public class AzureKeyVaultSslBundleRegistrar implements SslBundleRegistrar, Reso
         pm.from(keyStoreProperties.getCertificatesRefreshInterval())
             .when(Objects::nonNull)
             .to(v -> System.setProperty("azure.keyvault.jca.certificates-refresh-interval", String.valueOf(v.toMillis())));
+        pm.from(keyStoreProperties.getCertificateAliasFilterPatterns())
+            .when(patterns -> !patterns.isEmpty())
+            .to(patterns -> System.setProperty("azure.keyvault.jca.certificate-alias-filter-patterns",
+                String.join(",", patterns)));
         pm.from(keyStoreProperties.isRefreshCertificatesWhenHaveUntrustedCertificate())
             .to(v -> System.setProperty("azure.keyvault.jca.refresh-certificates-when-have-un-trust-certificate", Boolean.toString(v)));
 

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/keyvault/jca/properties/AzureKeyVaultSslBundleProperties.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/keyvault/jca/properties/AzureKeyVaultSslBundleProperties.java
@@ -8,7 +8,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -76,6 +78,12 @@ public class AzureKeyVaultSslBundleProperties {
          * Time interval to refresh all Key Vault certificate.
          */
         private Duration certificatesRefreshInterval;
+        /**
+         * Key Vault certificate alias filter patterns. Include patterns are configured as regular expressions and
+         * exclude patterns are prefixed with {@code !}. If no patterns are configured, all certificate aliases are
+         * loaded.
+         */
+        private final List<String> certificateAliasFilterPatterns = new ArrayList<>();
 
         @NestedConfigurationProperty
         private final CertificatePathsProperties certificatePaths = new CertificatePathsProperties();
@@ -102,6 +110,10 @@ public class AzureKeyVaultSslBundleProperties {
 
         public void setCertificatesRefreshInterval(Duration certificatesRefreshInterval) {
             this.certificatesRefreshInterval = certificatesRefreshInterval;
+        }
+
+        public List<String> getCertificateAliasFilterPatterns() {
+            return certificateAliasFilterPatterns;
         }
 
         public CertificatePathsProperties getCertificatePaths() {

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/keyvault/jca/AzureKeyVaultJcaAutoConfigurationTests.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/keyvault/jca/AzureKeyVaultJcaAutoConfigurationTests.java
@@ -52,8 +52,12 @@ class AzureKeyVaultJcaAutoConfigurationTests {
                 "spring.cloud.azure.keyvault.jca.vaults.kv2.endpoint=" + String.format(ENDPOINT, "test2"),
                 "spring.ssl.bundle.keyvault.testBundle1.truststore.certificate-paths.custom=classpath:keyvault/certificate-paths/custom",
                 "spring.ssl.bundle.keyvault.testBundle2.truststore.keyvault-ref=kv2",
+                "spring.ssl.bundle.keyvault.testBundle2.truststore.certificate-alias-filter-patterns[0]=^prod-.*",
+                "spring.ssl.bundle.keyvault.testBundle2.truststore.certificate-alias-filter-patterns[1]=!^prod-deprecated$",
                 "spring.ssl.bundle.keyvault.testBundle3.truststore.keyvault-ref=kv1",
-                "spring.ssl.bundle.keyvault.testBundle3.keystore.keyvault-ref=kv2"
+                "spring.ssl.bundle.keyvault.testBundle3.keystore.keyvault-ref=kv2",
+                "spring.ssl.bundle.keyvault.testBundle3.keystore.certificate-alias-filter-patterns[0]=client-cert",
+                "spring.ssl.bundle.keyvault.testBundle3.keystore.certificate-alias-filter-patterns[1]=!old-client-cert"
             )
             .run(context -> {
                 assertThat(context).hasSingleBean(AzureKeyVaultJcaAutoConfiguration.class);
@@ -71,8 +75,12 @@ class AzureKeyVaultJcaAutoConfigurationTests {
                 assertThat(sslBundlesProperties.getKeyvault()).hasSize(3);
                 assertThat(sslBundlesProperties.getKeyvault().get("testBundle1").getTruststore().getCertificatePaths().getCustom()).isEqualTo("classpath:keyvault/certificate-paths/custom");
                 assertThat(sslBundlesProperties.getKeyvault().get("testBundle2").getTruststore().getKeyvaultRef()).isEqualTo("kv2");
+                assertThat(sslBundlesProperties.getKeyvault().get("testBundle2").getTruststore()
+                    .getCertificateAliasFilterPatterns()).containsExactly("^prod-.*", "!^prod-deprecated$");
                 assertThat(sslBundlesProperties.getKeyvault().get("testBundle3").getTruststore().getKeyvaultRef()).isEqualTo("kv1");
                 assertThat(sslBundlesProperties.getKeyvault().get("testBundle3").getKeystore().getKeyvaultRef()).isEqualTo("kv2");
+                assertThat(sslBundlesProperties.getKeyvault().get("testBundle3").getKeystore()
+                    .getCertificateAliasFilterPatterns()).containsExactly("client-cert", "!old-client-cert");
             });
     }
 

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/keyvault/jca/AzureKeyVaultSslBundleRegistrarTests.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/keyvault/jca/AzureKeyVaultSslBundleRegistrarTests.java
@@ -22,8 +22,11 @@ import org.springframework.util.ClassUtils;
 
 import java.security.KeyStore;
 import java.security.Security;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -95,7 +98,8 @@ class AzureKeyVaultSslBundleRegistrarTests {
     void registerKeyVaultSslBundle(CapturedOutput capturedOutput) {
         AzureKeyVaultJcaProperties jcaProperties = new AzureKeyVaultJcaProperties();
         AzureKeyVaultSslBundleProperties sslBundleProperties = new AzureKeyVaultSslBundleProperties();
-        AzureKeyVaultSslBundleRegistrar registrar = new AzureKeyVaultSslBundleRegistrar(jcaProperties, sslBundleProperties);
+        AzureKeyVaultSslBundleRegistrar registrar
+            = new AzureKeyVaultSslBundleRegistrar(jcaProperties, sslBundleProperties);
         registrar.setResourceLoader(new DefaultResourceLoader());
         SslBundleRegistry registry = Mockito.mock(SslBundleRegistry.class);
 
@@ -206,6 +210,47 @@ class AzureKeyVaultSslBundleRegistrarTests {
                 String log = "Registered Azure Key Vault SSL bundle '" + bundleName + "'.";
                 assertTrue(allOutput.contains(log));
             });
+        }
+    }
+
+    @Test
+    void configureCertificateAliasFilterPatterns() {
+        AzureKeyVaultJcaProperties jcaProperties = new AzureKeyVaultJcaProperties();
+        AzureKeyVaultSslBundleProperties sslBundleProperties = new AzureKeyVaultSslBundleProperties();
+        AzureKeyVaultSslBundleRegistrar registrar = new AzureKeyVaultSslBundleRegistrar(jcaProperties, sslBundleProperties);
+        registrar.setResourceLoader(new DefaultResourceLoader());
+
+        try (MockedStatic<KeyStore> keyStoreMockedStatic = mockStatic(KeyStore.class)) {
+            KeyStore keyStore = Mockito.mock(KeyStore.class);
+            List<String> configuredFilterPatterns = new ArrayList<>();
+            keyStoreMockedStatic.when(() -> KeyStore.getInstance(KeyVaultJcaProvider.PROVIDER_NAME))
+                .thenAnswer(invocation -> {
+                    configuredFilterPatterns.add(
+                        System.getProperty("azure.keyvault.jca.certificate-alias-filter-patterns"));
+                    return keyStore;
+                });
+
+            AzureKeyVaultJcaProperties.JcaVaultProperties vaultProperties
+                = new AzureKeyVaultJcaProperties.JcaVaultProperties();
+            vaultProperties.setEndpoint("https://test.vault.azure.net/");
+            jcaProperties.getVaults().put("keyvault1", vaultProperties);
+
+            AzureKeyVaultSslBundleProperties.KeyVaultSslBundleProperties bundleProperties
+                = new AzureKeyVaultSslBundleProperties.KeyVaultSslBundleProperties();
+            bundleProperties.getKeystore().setKeyvaultRef("keyvault1");
+            bundleProperties.getKeystore().getCertificateAliasFilterPatterns()
+                .addAll(Arrays.asList("^prod-.*", "!^prod-deprecated$"));
+            bundleProperties.getTruststore().setKeyvaultRef("keyvault1");
+            bundleProperties.getTruststore().getCertificateAliasFilterPatterns()
+                .addAll(Arrays.asList("^partner-.*", "!^partner-deprecated$"));
+            sslBundleProperties.getKeyvault().put("testBundle", bundleProperties);
+
+            registrar.registerBundles(Mockito.mock(SslBundleRegistry.class));
+
+            assertThat(configuredFilterPatterns)
+                .containsExactly("^prod-.*,!^prod-deprecated$", "^partner-.*,!^partner-deprecated$");
+        } finally {
+            System.clearProperty("azure.keyvault.jca.certificate-alias-filter-patterns");
         }
     }
 


### PR DESCRIPTION
# Description

Adds Spring configuration support for filtering the certificate aliases loaded by the Azure Key Vault JCA provider.

Applications can now configure alias filter patterns independently for an SSL bundle's keystore and truststore:

- `spring.ssl.bundle.keyvault.<bundle-name>.keystore.certificate-alias-filter-patterns`
- `spring.ssl.bundle.keyvault.<bundle-name>.truststore.certificate-alias-filter-patterns`

The configured list is passed to the JCA provider through the `azure.keyvault.jca.certificate-alias-filter-patterns` system property. Include patterns are regular expressions, while exclusion patterns use the `!` prefix. When the list is empty, all certificate aliases continue to be loaded, preserving the existing behavior.

The JCA system property is cleared between keystore and truststore initialization to prevent filter settings from leaking between SSL bundles or stores.

This change also:

- Adds Spring configuration binding coverage for the new properties.
- Adds unit coverage for propagation to the JCA system property.
- Updates the Spring Cloud Azure and autoconfigure changelogs.

Resolves #50013.

Depends on #49774, which adds the corresponding certificate alias filtering support to `azure-security-keyvault-jca`.

The focused tests are:

```
mvn -f sdk/spring/pom.xml -pl spring-cloud-azure-autoconfigure -am \
  -Dtest=AzureKeyVaultJcaAutoConfigurationTests,AzureKeyVaultSslBundleRegistrarTests \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
