### PR TITLE
[Storage] Fix double encoding of path names on Datalake clients 

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Fixed a bug where the client returned by `rename`, `renameWithResponse`, and `undeletePath` URL-encoded the path
   name a second time, causing subsequent requests made through that client to target a double-encoded path when the
   name contained characters such as `%`, `#`, or a space.
+- Fixed a bug where the sync `DataLakeFileClient`/`DataLakeDirectoryClient` returned by `rename`/`renameWithResponse`
+  kept its internal async client rooted at the original source path. Operations delegated to that async client (such as
+  file `append`, `flush`, and `upload`, or directory child/ACL clients) targeted the old path instead of the renamed
+  destination.
 
 ### Other Changes
 - Corrected documentation on `DataLakeFileSystemClient`/`DataLakeFileSystemAsyncClient` path client getters and on

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -7,8 +7,14 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed a bug where the client returned by `rename`, `renameWithResponse`, and `undeletePath` URL-encoded the path
+  name a second time, causing subsequent requests made through that client to target a double-encoded path when the
+  name contained characters such as `%`, `#`, or a space.
 
 ### Other Changes
+- Corrected documentation on `DataLakeFileSystemClient`/`DataLakeFileSystemAsyncClient` path client getters and on
+  `DataLakePathClientBuilder.pathName(String)`, which incorrectly instructed callers to pass a URL-encoded path name.
+  Path names have been used verbatim since 12.22.0 and are percent-encoded by the client when the request URL is built.
 
 ## 12.29.0-beta.1 (2026-07-28)
 

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeDirectoryAsyncClient.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeDirectoryAsyncClient.java
@@ -21,7 +21,6 @@ import com.azure.core.util.logging.ClientLogger;
 import com.azure.storage.blob.BlobContainerAsyncClient;
 import com.azure.storage.blob.specialized.BlockBlobAsyncClient;
 import com.azure.storage.blob.specialized.SpecializedBlobClientBuilder;
-import com.azure.storage.common.Utility;
 import com.azure.storage.common.implementation.Constants;
 import com.azure.storage.file.datalake.implementation.models.CpkInfo;
 import com.azure.storage.file.datalake.implementation.models.FileSystemsListPathsHeaders;
@@ -91,10 +90,9 @@ public final class DataLakeDirectoryAsyncClient extends DataLakePathAsyncClient 
     DataLakeDirectoryAsyncClient(DataLakePathAsyncClient dataLakePathAsyncClient) {
         super(dataLakePathAsyncClient.getHttpPipeline(), dataLakePathAsyncClient.getAccountUrl(),
             dataLakePathAsyncClient.getServiceVersion(), dataLakePathAsyncClient.getAccountName(),
-            dataLakePathAsyncClient.getFileSystemName(), Utility.urlEncode(dataLakePathAsyncClient.pathName),
-            PathResourceType.DIRECTORY, dataLakePathAsyncClient.getBlockBlobAsyncClient(),
-            dataLakePathAsyncClient.getSasToken(), dataLakePathAsyncClient.getCpkInfo(),
-            dataLakePathAsyncClient.isTokenCredentialAuthenticated());
+            dataLakePathAsyncClient.getFileSystemName(), dataLakePathAsyncClient.pathName, PathResourceType.DIRECTORY,
+            dataLakePathAsyncClient.getBlockBlobAsyncClient(), dataLakePathAsyncClient.getSasToken(),
+            dataLakePathAsyncClient.getCpkInfo(), dataLakePathAsyncClient.isTokenCredentialAuthenticated());
     }
 
     /**

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeDirectoryClient.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeDirectoryClient.java
@@ -17,7 +17,6 @@ import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.Context;
 import com.azure.storage.blob.specialized.BlockBlobClient;
 import com.azure.storage.blob.specialized.SpecializedBlobClientBuilder;
-import com.azure.storage.common.Utility;
 import com.azure.storage.common.implementation.Constants;
 import com.azure.storage.common.implementation.StorageImplUtils;
 import com.azure.storage.file.datalake.implementation.models.CpkInfo;
@@ -77,8 +76,8 @@ public class DataLakeDirectoryClient extends DataLakePathClient {
         super(dataLakePathClient.dataLakePathAsyncClient, dataLakePathClient.blockBlobClient,
             dataLakePathClient.getHttpPipeline(), dataLakePathClient.getAccountUrl(),
             dataLakePathClient.getServiceVersion(), dataLakePathClient.getAccountName(),
-            dataLakePathClient.getFileSystemName(), Utility.urlEncode(dataLakePathClient.pathName),
-            PathResourceType.DIRECTORY, dataLakePathClient.getSasToken(), dataLakePathClient.getCpkInfo(),
+            dataLakePathClient.getFileSystemName(), dataLakePathClient.pathName, PathResourceType.DIRECTORY,
+            dataLakePathClient.getSasToken(), dataLakePathClient.getCpkInfo(),
             dataLakePathClient.isTokenCredentialAuthenticated());
         this.dataLakeDirectoryAsyncClient
             = new DataLakeDirectoryAsyncClient(dataLakePathClient.dataLakePathAsyncClient);

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileAsyncClient.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileAsyncClient.java
@@ -24,7 +24,6 @@ import com.azure.storage.blob.BlobContainerAsyncClient;
 import com.azure.storage.blob.options.BlobDownloadToFileOptions;
 import com.azure.storage.blob.specialized.BlockBlobAsyncClient;
 import com.azure.storage.common.ParallelTransferOptions;
-import com.azure.storage.common.Utility;
 import com.azure.storage.common.implementation.BufferAggregator;
 import com.azure.storage.common.implementation.BufferStagingArea;
 import com.azure.storage.common.implementation.Constants;
@@ -127,10 +126,9 @@ public class DataLakeFileAsyncClient extends DataLakePathAsyncClient {
 
     DataLakeFileAsyncClient(DataLakePathAsyncClient pathAsyncClient) {
         super(pathAsyncClient.getHttpPipeline(), pathAsyncClient.getAccountUrl(), pathAsyncClient.getServiceVersion(),
-            pathAsyncClient.getAccountName(), pathAsyncClient.getFileSystemName(),
-            Utility.urlEncode(pathAsyncClient.pathName), PathResourceType.FILE,
-            pathAsyncClient.getBlockBlobAsyncClient(), pathAsyncClient.getSasToken(), pathAsyncClient.getCpkInfo(),
-            pathAsyncClient.isTokenCredentialAuthenticated());
+            pathAsyncClient.getAccountName(), pathAsyncClient.getFileSystemName(), pathAsyncClient.pathName,
+            PathResourceType.FILE, pathAsyncClient.getBlockBlobAsyncClient(), pathAsyncClient.getSasToken(),
+            pathAsyncClient.getCpkInfo(), pathAsyncClient.isTokenCredentialAuthenticated());
     }
 
     /**

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileClient.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileClient.java
@@ -117,8 +117,8 @@ public class DataLakeFileClient extends DataLakePathClient {
         super(dataLakePathClient.dataLakePathAsyncClient, dataLakePathClient.getBlockBlobClient(),
             dataLakePathClient.getHttpPipeline(), dataLakePathClient.getAccountUrl(),
             dataLakePathClient.getServiceVersion(), dataLakePathClient.getAccountName(),
-            dataLakePathClient.getFileSystemName(), Utility.urlEncode(dataLakePathClient.pathName),
-            PathResourceType.FILE, dataLakePathClient.getSasToken(), dataLakePathClient.getCpkInfo(),
+            dataLakePathClient.getFileSystemName(), dataLakePathClient.pathName, PathResourceType.FILE,
+            dataLakePathClient.getSasToken(), dataLakePathClient.getCpkInfo(),
             dataLakePathClient.isTokenCredentialAuthenticated());
         this.dataLakeFileAsyncClient = new DataLakeFileAsyncClient(dataLakePathClient.dataLakePathAsyncClient);
     }

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileSystemAsyncClient.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileSystemAsyncClient.java
@@ -167,8 +167,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.getFileAsyncClient#String -->
      *
-     * @param fileName A {@code String} representing the name of the file. If the path name contains special characters,
-     * pass in the url encoded version of the path name.
+     * @param fileName A {@code String} representing the name of the file. Pass the name unencoded; the client
+     * percent-encodes it when building the request URL.
      * @return A new {@link DataLakeFileAsyncClient} object which references the file with the specified name in this
      * file system.
      */
@@ -197,8 +197,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.getDirectoryAsyncClient#String -->
      *
-     * @param directoryName A {@code String} representing the name of the directory. If the path name contains special
-     * characters, pass in the url encoded version of the path name.
+     * @param directoryName A {@code String} representing the name of the directory. Pass the name unencoded; the client
+     * percent-encodes it when building the request URL.
      * @return A new {@link DataLakeDirectoryAsyncClient} object which references the directory with the specified name
      * in this file system.
      */
@@ -1220,8 +1220,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.createDirectory#String -->
      *
-     * @param directoryName Name of the directory to create. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @return A {@link Mono} containing a {@link DataLakeDirectoryAsyncClient} used to interact with the directory
      * created.
      */
@@ -1243,8 +1243,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.createDirectory#String-boolean -->
      *
-     * @param directoryName Name of the directory to create. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param overwrite Whether to overwrite, should a directory exist.
      * @return A {@link Mono} containing a {@link DataLakeDirectoryAsyncClient} used to interact with the directory
      * created.
@@ -1282,8 +1282,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.createDirectoryWithResponse#String-String-String-PathHttpHeaders-Map-DataLakeRequestConditions -->
      *
-     * @param directoryName Name of the directory to create. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param permissions POSIX access permissions for the directory owner, the directory owning group, and others.
      * @param umask Restricts permissions of the directory to be created.
      * @param headers {@link PathHttpHeaders}
@@ -1347,8 +1347,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.createDirectoryWithResponse#String-DataLakePathCreateOptions -->
      *
-     * @param directoryName Name of the directory to create. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param options {@link DataLakePathCreateOptions}
      * @return A {@link Mono} containing a {@link Response} whose {@link Response#getValue() value} contains a {@link
      * DataLakeDirectoryAsyncClient} used to interact with the directory created.
@@ -1378,8 +1378,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.createDirectoryIfNotExists#String -->
      *
-     * @param directoryName Name of the directory to create. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @return A {@link Mono} containing a {@link DataLakeDirectoryAsyncClient} used to interact with the directory
      * created.
      */
@@ -1418,8 +1418,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.createDirectoryIfNotExistsWithResponse#String-DataLakePathCreateOptions -->
      *
-     * @param directoryName Name of the directory to create. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param options {@link DataLakePathCreateOptions}
      * @return A {@link Mono} containing a {@link Response} whose {@link Response#getValue() value} contains a
      * {@link DataLakeDirectoryAsyncClient} used to interact with the directory created. If {@link Response}'s status
@@ -1459,8 +1459,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.deleteDirectory#String -->
      *
-     * @param directoryName Name of the directory to delete. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to delete. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @return A reactive response signalling completion.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
@@ -1486,8 +1486,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.deleteDirectoryWithResponse#String-boolean-DataLakeRequestConditions -->
      *
-     * @param directoryName Name of the directory to delete. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to delete. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param recursive Whether to delete all paths beneath the directory.
      * @param requestConditions {@link DataLakeRequestConditions}
      * @return A {@link Mono} containing status code and HTTP headers
@@ -1524,8 +1524,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.deleteDirectoryIfExists#String -->
      *
-     * @param directoryName Name of the directory to delete. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to delete. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @return a reactive response signaling completion. {@code true} indicates that the specified directory was
      * successfully deleted, {@code false} indicates that the specified directory did not exist.
      */
@@ -1560,8 +1560,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.deleteDirectoryIfExistsWithResponse#String-DataLakePathDeleteOptions -->
      *
-     * @param directoryName Name of the directory to delete. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to delete. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param options {@link DataLakePathDeleteOptions}
      * @return A reactive response signaling completion. If {@link Response}'s status code is 200, the file was
      * successfully deleted. If status code is 404, the file does not exist.

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileSystemAsyncClient.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileSystemAsyncClient.java
@@ -197,8 +197,8 @@ public class DataLakeFileSystemAsyncClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemAsyncClient.getDirectoryAsyncClient#String -->
      *
-     * @param directoryName A {@code String} representing the name of the directory. Pass the name unencoded; the client
-     * percent-encodes it when building the request URL.
+     * @param directoryName A {@code String} representing the name of the directory.
+     *     Pass the name unencoded; the client percent-encodes it when building the request URL.
      * @return A new {@link DataLakeDirectoryAsyncClient} object which references the directory with the specified name
      * in this file system.
      */

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileSystemClient.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileSystemClient.java
@@ -142,8 +142,8 @@ public class DataLakeFileSystemClient {
      * Initializes a new DataLakeFileClient object by concatenating fileName to the end of DataLakeFileSystemClient's
      * URL. The new DataLakeFileClient uses the same request policy pipeline as the DataLakeFileSystemClient.
      *
-     * @param fileName A {@code String} representing the name of the file. If the path name contains special characters,
-     * pass in the url encoded version of the path name.
+     * @param fileName A {@code String} representing the name of the file. Pass the name unencoded; the client
+     * percent-encodes it when building the request URL.
      *
      * <p><strong>Code Samples</strong></p>
      *
@@ -170,8 +170,8 @@ public class DataLakeFileSystemClient {
      * DataLakeFileSystemClient's URL. The new DataLakeDirectoryClient uses the same request policy pipeline as the
      * DataLakeFileSystemClient.
      *
-     * @param directoryName A {@code String} representing the name of the directory. If the path name contains special
-     * characters, pass in the url encoded version of the path name.
+     * @param directoryName A {@code String} representing the name of the directory. Pass the name unencoded; the client
+     * percent-encodes it when building the request URL.
      *
      * <p><strong>Code Samples</strong></p>
      *
@@ -1151,8 +1151,8 @@ public class DataLakeFileSystemClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemClient.createDirectory#String -->
      *
-     * @param directoryName Name of the directory to create. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @return A {@link DataLakeDirectoryClient} used to interact with the directory created.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
@@ -1173,8 +1173,8 @@ public class DataLakeFileSystemClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemClient.createDirectory#String-boolean -->
      *
-     * @param directoryName Name of the directory to create. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param overwrite Whether to overwrite, should a directory exist.
      * @return A {@link DataLakeDirectoryClient} used to interact with the directory created.
      */
@@ -1210,8 +1210,8 @@ public class DataLakeFileSystemClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemClient.createDirectoryWithResponse#String-String-String-PathHttpHeaders-Map-DataLakeRequestConditions-Duration-Context -->
      *
-     * @param directoryName Name of the directory to create.  If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param permissions POSIX access permissions for the directory owner, the directory owning group, and others.
      * @param umask Restricts permissions of the directory to be created.
      * @param headers {@link PathHttpHeaders}
@@ -1274,8 +1274,8 @@ public class DataLakeFileSystemClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemClient.createDirectoryWithResponse#String-DataLakePathCreateOptions-Duration-Context -->
      *
-     * @param directoryName Name of the directory to create.  If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param options {@link DataLakePathCreateOptions}
      * @param timeout An optional timeout value beyond which a {@link RuntimeException} will be raised.
      * @param context Additional context that is passed through the Http pipeline during the service call.
@@ -1305,8 +1305,8 @@ public class DataLakeFileSystemClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemClient.createDirectoryIfNotExists#String -->
      *
-     * @param directoryName Name of the directory to create. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @return A {@link DataLakeDirectoryClient} used to interact with the subdirectory created.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
@@ -1344,8 +1344,8 @@ public class DataLakeFileSystemClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemClient.createDirectoryIfNotExistsWithResponse#String-DataLakePathCreateOptions-Duration-Context -->
      *
-     * @param directoryName Name of the directory to create.  If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to create. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param options {@link DataLakePathCreateOptions}
      * @param timeout An optional timeout value beyond which a {@link RuntimeException} will be raised.
      * @param context Additional context that is passed through the Http pipeline during the service call.
@@ -1376,8 +1376,8 @@ public class DataLakeFileSystemClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemClient.deleteDirectory#String -->
      *
-     * @param directoryName Name of the directory to delete.  If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to delete. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
     public void deleteDirectory(String directoryName) {
@@ -1403,8 +1403,8 @@ public class DataLakeFileSystemClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemClient.deleteDirectoryWithResponse#String-boolean-DataLakeRequestConditions-Duration-Context -->
      *
-     * @param directoryName Name of the directory to delete. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to delete. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param recursive Whether to delete all paths beneath the directory.
      * @param requestConditions {@link DataLakeRequestConditions}
      * @param timeout An optional timeout value beyond which a {@link RuntimeException} will be raised.
@@ -1431,8 +1431,8 @@ public class DataLakeFileSystemClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemClient.deleteDirectoryIfExists#String -->
      *
-     * @param directoryName Name of the directory to delete.  If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to delete. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @return {@code true} if the directory is successfully deleted, {@code false} if the directory does not exist.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
@@ -1466,8 +1466,8 @@ public class DataLakeFileSystemClient {
      * </pre>
      * <!-- end com.azure.storage.file.datalake.DataLakeFileSystemClient.deleteDirectoryIfExistsWithResponse#String-DataLakePathDeleteOptions-Duration-Context -->
      *
-     * @param directoryName Name of the directory to delete. If the path name contains special characters, pass in the
-     * url encoded version of the path name.
+     * @param directoryName Name of the directory to delete. Pass the name unencoded; the client percent-encodes it when
+     * building the request URL.
      * @param options {@link DataLakePathDeleteOptions}
      * @param timeout An optional timeout value beyond which a {@link RuntimeException} will be raised.
      * @param context Additional context that is passed through the Http pipeline during the service call.

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileSystemClient.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeFileSystemClient.java
@@ -170,8 +170,8 @@ public class DataLakeFileSystemClient {
      * DataLakeFileSystemClient's URL. The new DataLakeDirectoryClient uses the same request policy pipeline as the
      * DataLakeFileSystemClient.
      *
-     * @param directoryName A {@code String} representing the name of the directory. Pass the name unencoded; the client
-     * percent-encodes it when building the request URL.
+     * @param directoryName A {@code String} representing the name of the directory.
+     *     Pass the name unencoded; the client percent-encodes it when building the request URL.
      *
      * <p><strong>Code Samples</strong></p>
      *

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakePathClient.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakePathClient.java
@@ -1441,7 +1441,13 @@ public class DataLakePathClient {
             throw LOGGER.logExceptionAsError(new IllegalArgumentException("'destinationPath' can not be set to null"));
         }
 
-        return new DataLakePathClient(dataLakePathAsyncClient,
+        // Build an async client rooted at the destination path so that operations delegated to the async client (for
+        // example file upload/append/flush or directory child/ACL clients) target the destination rather than the
+        // original source path.
+        DataLakePathAsyncClient destinationAsyncClient
+            = dataLakePathAsyncClient.getPathAsyncClient(destinationFileSystem, destinationPath);
+
+        return new DataLakePathClient(destinationAsyncClient,
             dataLakePathAsyncClient.prepareBuilderReplacePath(destinationFileSystem, destinationPath)
                 .buildBlockBlobClient(),
             getHttpPipeline(), getAccountUrl(), serviceVersion, accountName, destinationFileSystem, destinationPath,

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakePathClientBuilder.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakePathClientBuilder.java
@@ -426,8 +426,8 @@ public final class DataLakePathClientBuilder
     /**
      * Sets the name of the file/directory.
      *
-     * @param pathName Name of the path. Pass the name unencoded; the client percent-encodes it when building the
-     * request URL.
+     * @param pathName Name of the path.
+     *     Pass the name unencoded; the client percent-encodes it when building the request URL.
      * @return the updated DataLakePathClientBuilder object
      * @throws NullPointerException If {@code pathName} is {@code null}
      */

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakePathClientBuilder.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakePathClientBuilder.java
@@ -426,8 +426,8 @@ public final class DataLakePathClientBuilder
     /**
      * Sets the name of the file/directory.
      *
-     * @param pathName Name of the path. If the path name contains special characters, pass in the url encoded version
-     * of the path name.
+     * @param pathName Name of the path. Pass the name unencoded; the client percent-encodes it when building the
+     * request URL.
      * @return the updated DataLakePathClientBuilder object
      * @throws NullPointerException If {@code pathName} is {@code null}
      */

--- a/sdk/storage/azure-storage-file-datalake/src/test/java/com/azure/storage/file/datalake/DataLakePathNameEncodingTests.java
+++ b/sdk/storage/azure-storage-file-datalake/src/test/java/com/azure/storage/file/datalake/DataLakePathNameEncodingTests.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Offline tests that document exactly how {@code azure-storage-file-datalake} treats special characters in path names
@@ -387,17 +388,24 @@ public class DataLakePathNameEncodingTests {
         DataLakeFileClient renamed = fileSystemClient.getFileClient("source.txt").rename(null, "my file.txt");
         String renameUrl = httpClient.getUrlPath();
         assertEquals("/" + FILE_SYSTEM_NAME + "/my%20file.txt", renameUrl);
+        HttpRequest renameRequest = httpClient.getRequest();
 
         // append is delegated to the internal async client - it must address the renamed path. The mock cannot return
-        // a valid append response, but the request URL is captured when the request is put on the wire, which is all
-        // this routing regression cares about.
+        // a valid append response, but the request is captured when it is put on the wire, which is all this routing
+        // regression cares about.
         byte[] data = new byte[] { 1, 2, 3 };
         try {
             renamed.append(new ByteArrayInputStream(data), 0, data.length);
         } catch (RuntimeException ignored) {
             // The offline mock does not satisfy the append response contract; only the request routing matters here.
         }
-        assertEquals("/" + FILE_SYSTEM_NAME + "/my%20file.txt", httpClient.getUrlPath());
+
+        HttpRequest appendRequest = httpClient.getRequest();
+        // Guard against a false pass: the append must actually have reached the HTTP client (a distinct request was
+        // captured) rather than failing earlier and leaving the rename request in place.
+        assertNotSame(renameRequest, appendRequest);
+        assertEquals(HttpMethod.PATCH, appendRequest.getHttpMethod());
+        assertEquals("/" + FILE_SYSTEM_NAME + "/my%20file.txt", appendRequest.getUrl().getPath());
     }
 
     /**
@@ -411,16 +419,23 @@ public class DataLakePathNameEncodingTests {
         DataLakeFileSystemClient fileSystemClient = fileSystemClient(httpClient);
 
         DataLakeDirectoryClient renamed = fileSystemClient.getDirectoryClient("source").rename(null, "dest dir");
+        HttpRequest renameRequest = httpClient.getRequest();
 
         // setAccessControlRecursive is delegated to the internal async client - it must address the renamed path. The
-        // mock cannot return a valid response body, but the request URL is captured when the request is put on the
-        // wire, which is all this routing regression cares about.
+        // mock cannot return a valid response body, but the request is captured when it is put on the wire, which is
+        // all this routing regression cares about.
         try {
             renamed.setAccessControlRecursive(PathAccessControlEntry.parseList("user::rwx"));
         } catch (RuntimeException ignored) {
             // The offline mock does not satisfy the response contract; only the request routing matters here.
         }
-        assertEquals("/" + FILE_SYSTEM_NAME + "/dest%20dir", httpClient.getUrlPath());
+
+        HttpRequest aclRequest = httpClient.getRequest();
+        // Guard against a false pass: the recursive ACL update must actually have reached the HTTP client (a distinct
+        // request was captured) rather than failing earlier and leaving the rename request in place.
+        assertNotSame(renameRequest, aclRequest);
+        assertEquals(HttpMethod.PATCH, aclRequest.getHttpMethod());
+        assertEquals("/" + FILE_SYSTEM_NAME + "/dest%20dir", aclRequest.getUrl().getPath());
     }
 
     /**

--- a/sdk/storage/azure-storage-file-datalake/src/test/java/com/azure/storage/file/datalake/DataLakePathNameEncodingTests.java
+++ b/sdk/storage/azure-storage-file-datalake/src/test/java/com/azure/storage/file/datalake/DataLakePathNameEncodingTests.java
@@ -12,6 +12,7 @@ import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import com.azure.core.test.http.MockHttpResponse;
 import com.azure.core.test.utils.MockTokenCredential;
+import com.azure.storage.file.datalake.models.PathAccessControlEntry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -20,6 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Mono;
 
+import java.io.ByteArrayInputStream;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -370,6 +372,55 @@ public class DataLakePathNameEncodingTests {
 
         renamed.getProperties();
         assertEquals(renameUrl, httpClient.getUrlPath());
+    }
+
+    /**
+     * Regression test. {@code DataLakeFileClient} delegates {@code append}/{@code flush}/{@code upload} to its internal
+     * async client. That async client must be rooted at the renamed (destination) path; otherwise these operations
+     * would address the original source path even though {@code create}/{@code getProperties} address the destination.
+     */
+    @Test
+    public void fileClientReturnedByRenameDelegatesToTheRenamedPath() {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+        DataLakeFileSystemClient fileSystemClient = fileSystemClient(httpClient);
+
+        DataLakeFileClient renamed = fileSystemClient.getFileClient("source.txt").rename(null, "my file.txt");
+        String renameUrl = httpClient.getUrlPath();
+        assertEquals("/" + FILE_SYSTEM_NAME + "/my%20file.txt", renameUrl);
+
+        // append is delegated to the internal async client - it must address the renamed path. The mock cannot return
+        // a valid append response, but the request URL is captured when the request is put on the wire, which is all
+        // this routing regression cares about.
+        byte[] data = new byte[] { 1, 2, 3 };
+        try {
+            renamed.append(new ByteArrayInputStream(data), 0, data.length);
+        } catch (RuntimeException ignored) {
+            // The offline mock does not satisfy the append response contract; only the request routing matters here.
+        }
+        assertEquals("/" + FILE_SYSTEM_NAME + "/my%20file.txt", httpClient.getUrlPath());
+    }
+
+    /**
+     * Regression test. {@code DataLakeDirectoryClient} delegates operations such as {@code setAccessControlRecursive}
+     * to its internal (base) async client. That async client must be rooted at the renamed (destination) path so that
+     * a recursive ACL update targets the renamed directory rather than the original source path.
+     */
+    @Test
+    public void directoryClientReturnedByRenameDelegatesToTheRenamedPath() {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+        DataLakeFileSystemClient fileSystemClient = fileSystemClient(httpClient);
+
+        DataLakeDirectoryClient renamed = fileSystemClient.getDirectoryClient("source").rename(null, "dest dir");
+
+        // setAccessControlRecursive is delegated to the internal async client - it must address the renamed path. The
+        // mock cannot return a valid response body, but the request URL is captured when the request is put on the
+        // wire, which is all this routing regression cares about.
+        try {
+            renamed.setAccessControlRecursive(PathAccessControlEntry.parseList("user::rwx"));
+        } catch (RuntimeException ignored) {
+            // The offline mock does not satisfy the response contract; only the request routing matters here.
+        }
+        assertEquals("/" + FILE_SYSTEM_NAME + "/dest%20dir", httpClient.getUrlPath());
     }
 
     /**

--- a/sdk/storage/azure-storage-file-datalake/src/test/java/com/azure/storage/file/datalake/DataLakePathNameEncodingTests.java
+++ b/sdk/storage/azure-storage-file-datalake/src/test/java/com/azure/storage/file/datalake/DataLakePathNameEncodingTests.java
@@ -1,0 +1,406 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package com.azure.storage.file.datalake;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpPipeline;
+import com.azure.core.http.HttpPipelineBuilder;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.test.http.MockHttpResponse;
+import com.azure.core.test.utils.MockTokenCredential;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.publisher.Mono;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Offline tests that document exactly how {@code azure-storage-file-datalake} treats special characters in path names
+ * for {@code getFileClient}, {@code getDirectoryClient} and {@code renameWithResponse}.
+ *
+ * <p>These tests do not talk to the service. They capture the {@link HttpRequest} that the SDK would have put on the
+ * wire so the encoding contract can be asserted deterministically.</p>
+ *
+ * <p>The contract being verified is:</p>
+ * <ul>
+ *     <li>Path names passed to the client factory methods are stored verbatim - the SDK never URL-decodes them
+ *     (see {@code DataLakePathAsyncClient}'s constructor which assigns {@code this.pathName = pathName}).</li>
+ *     <li>The SDK percent-encodes the path itself when building the request URL. This is done by
+ *     {@code UrlEscapers.PATH_ESCAPER} in {@code azure-core} because the generated {@code PathsService} declares
+ *     {@code @PathParam("path")} without {@code encoded = true}.</li>
+ *     <li>The rename source header is encoded by {@code Utility.urlEncode} in
+ *     {@code DataLakePathAsyncClient.renameWithResponse}.</li>
+ * </ul>
+ */
+public class DataLakePathNameEncodingTests {
+    private static final String ENDPOINT = "https://account.dfs.core.windows.net";
+    private static final String FILE_SYSTEM_NAME = "filesystem";
+
+    /**
+     * Characters that {@code UrlEscapers.PATH_ESCAPER} treats as safe, meaning they travel to the service as-is and
+     * must therefore NOT be percent-encoded by the caller.
+     */
+    private static final String UNRESERVED_AND_SUB_DELIMS = "-._~!$&'()*+,;=:@";
+
+    private static class RequestCapturingHttpClient implements HttpClient {
+        private final HttpHeaders responseHeaders;
+        private final Integer forcedStatus;
+        private volatile HttpRequest request;
+
+        RequestCapturingHttpClient() {
+            this(new HttpHeaders(), null);
+        }
+
+        RequestCapturingHttpClient(HttpHeaders responseHeaders, Integer forcedStatus) {
+            this.responseHeaders = responseHeaders;
+            this.forcedStatus = forcedStatus;
+        }
+
+        @Override
+        public Mono<HttpResponse> send(HttpRequest request) {
+            this.request = request;
+            int status = forcedStatus != null ? forcedStatus : (request.getHttpMethod() == HttpMethod.PUT ? 201 : 200);
+            return Mono.just(new MockHttpResponse(request, status, responseHeaders));
+        }
+
+        HttpRequest getRequest() {
+            return request;
+        }
+
+        String getUrlPath() {
+            return request.getUrl().getPath();
+        }
+    }
+
+    private static DataLakeFileSystemClient fileSystemClient(HttpClient httpClient) {
+        HttpPipeline pipeline = new HttpPipelineBuilder().httpClient(httpClient).build();
+
+        return new DataLakeFileSystemClientBuilder().endpoint(ENDPOINT)
+            .fileSystemName(FILE_SYSTEM_NAME)
+            .credential(new MockTokenCredential())
+            .pipeline(pipeline)
+            .buildClient();
+    }
+
+    /*
+     * ------------------------------------------------------------------------------------------------------------
+     * 1. The name handed to getFileClient/getDirectoryClient is stored verbatim - it is neither decoded nor encoded.
+     * ------------------------------------------------------------------------------------------------------------
+     */
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "file",
+            "100%done",
+            "a#b",
+            "a+b",
+            "a b",
+            "a&b",
+            "a?b",
+            "a@b",
+            "a=b",
+            "a,b",
+            "a;b",
+            "a'b",
+            "a\"b",
+            "a<b>c",
+            "a|b",
+            "a*b",
+            "a:b",
+            "a\\b",
+            "a[b]c",
+            "a{b}c",
+            "a^b",
+            "a`b",
+            "斑點",
+            "%E6%96%91%E9%BB%9E",
+            "path/to]a file" })
+    public void pathNameIsStoredVerbatim(String name) {
+        DataLakeFileSystemClient fileSystemClient = fileSystemClient(new RequestCapturingHttpClient());
+
+        assertEquals(name, fileSystemClient.getFileClient(name).getFilePath());
+        assertEquals(name, fileSystemClient.getDirectoryClient(name).getDirectoryPath());
+    }
+
+    /**
+     * Raw {@code %} and {@code #} used to throw {@code IllegalArgumentException} ("Illegal hex characters in escape
+     * (%) pattern") because the SDK called {@code Utility.urlDecode} on the name. Since 12.19.0 the name is stored
+     * verbatim, so raw names never throw.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { "100%done", "50%", "%", "%zz", "a%2", "report#1", "a%b#c" })
+    public void rawPercentOrHashNeverThrows(String name) {
+        DataLakeFileSystemClient fileSystemClient = fileSystemClient(new RequestCapturingHttpClient());
+
+        assertDoesNotThrow(() -> fileSystemClient.getFileClient(name));
+        assertDoesNotThrow(() -> fileSystemClient.getDirectoryClient(name));
+        assertDoesNotThrow(() -> fileSystemClient.getDirectoryClient("dir").getFileClient(name));
+        assertDoesNotThrow(() -> fileSystemClient.getDirectoryClient("dir").getSubdirectoryClient(name));
+    }
+
+    /*
+     * ------------------------------------------------------------------------------------------------------------
+     * 2. The SDK percent-encodes the path when it builds the request URL.
+     * ------------------------------------------------------------------------------------------------------------
+     */
+
+    @ParameterizedTest
+    @MethodSource("wireEncodingSupplier")
+    public void specialCharactersAreEncodedByTheSdkOnTheWire(String rawName, String expectedEncodedPath) {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+
+        fileSystemClient(httpClient).getFileClient(rawName).create(true);
+
+        assertEquals("/" + FILE_SYSTEM_NAME + "/" + expectedEncodedPath, httpClient.getUrlPath());
+    }
+
+    @ParameterizedTest
+    @MethodSource("wireEncodingSupplier")
+    public void specialCharactersAreEncodedByTheSdkOnTheWireForDirectories(String rawName, String expectedEncodedPath) {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+
+        fileSystemClient(httpClient).getDirectoryClient(rawName).create(true);
+
+        assertEquals("/" + FILE_SYSTEM_NAME + "/" + expectedEncodedPath, httpClient.getUrlPath());
+    }
+
+    private static Stream<Arguments> wireEncodingSupplier() {
+        return Stream.of(
+            // raw name passed to the SDK | path that appears on the wire
+            Arguments.of("file.txt", "file.txt"),
+            // Characters that are reserved/unsafe in a URL path are percent-encoded by the SDK.
+            Arguments.of("a b", "a%20b"), Arguments.of("a\"b", "a%22b"), Arguments.of("report#1", "report%231"),
+            Arguments.of("100%done", "100%25done"), Arguments.of("a<b", "a%3Cb"), Arguments.of("a>b", "a%3Eb"),
+            Arguments.of("a?b", "a%3Fb"), Arguments.of("a[b", "a%5Bb"), Arguments.of("a\\b", "a%5Cb"),
+            Arguments.of("a]b", "a%5Db"), Arguments.of("a^b", "a%5Eb"), Arguments.of("a`b", "a%60b"),
+            Arguments.of("a{b", "a%7Bb"), Arguments.of("a|b", "a%7Cb"), Arguments.of("a}b", "a%7Db"),
+            // '/' is a path separator in the name; it is encoded so the whole name is addressed as one path parameter.
+            Arguments.of("dir/file.txt", "dir%2Ffile.txt"),
+            // Non-ASCII is UTF-8 percent-encoded.
+            Arguments.of("斑點", "%E6%96%91%E9%BB%9E"),
+            // Unreserved + sub-delims are safe and are NOT encoded.
+            Arguments.of("a+b", "a+b"), Arguments.of("a&b", "a&b"), Arguments.of("a=b", "a=b"),
+            Arguments.of("a,b", "a,b"), Arguments.of("a;b", "a;b"), Arguments.of("a'b", "a'b"),
+            Arguments.of("a!b", "a!b"), Arguments.of("a$b", "a$b"), Arguments.of("a(b)c", "a(b)c"),
+            Arguments.of("a*b", "a*b"), Arguments.of("a:b", "a:b"), Arguments.of("a@b", "a@b"),
+            Arguments.of("a-b_c.d~e", "a-b_c.d~e"));
+    }
+
+    /**
+     * Every unreserved character and sub-delimiter is placed on the wire as-is. Callers must not encode these.
+     */
+    @Test
+    public void unreservedAndSubDelimitersAreNotEncoded() {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+        String name = "file" + UNRESERVED_AND_SUB_DELIMS + "txt";
+
+        fileSystemClient(httpClient).getFileClient(name).create(true);
+
+        assertEquals("/" + FILE_SYSTEM_NAME + "/" + name, httpClient.getUrlPath());
+    }
+
+    /**
+     * The characters the issue asks about - {@code " \ / : | < > * ?} - are all accepted by the client. The client
+     * performs no name validation at all; only the service enforces naming rules.
+     */
+    @ParameterizedTest
+    @MethodSource("windowsReservedCharacterSupplier")
+    public void windowsReservedCharactersAreNotRejectedByTheClient(String rawName, String expectedEncodedPath) {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+
+        assertDoesNotThrow(() -> fileSystemClient(httpClient).getFileClient(rawName).create(true));
+
+        assertEquals("/" + FILE_SYSTEM_NAME + "/" + expectedEncodedPath, httpClient.getUrlPath());
+    }
+
+    private static Stream<Arguments> windowsReservedCharacterSupplier() {
+        return Stream.of(Arguments.of("a\"b", "a%22b"), Arguments.of("a\\b", "a%5Cb"), Arguments.of("a/b", "a%2Fb"),
+            Arguments.of("a:b", "a:b"), Arguments.of("a|b", "a%7Cb"), Arguments.of("a<b", "a%3Cb"),
+            Arguments.of("a>b", "a%3Eb"), Arguments.of("a*b", "a*b"), Arguments.of("a?b", "a%3Fb"));
+    }
+
+    /*
+     * ------------------------------------------------------------------------------------------------------------
+     * 3. Pre-encoding by the caller results in double encoding - i.e. a different resource.
+     * ------------------------------------------------------------------------------------------------------------
+     */
+
+    @ParameterizedTest
+    @CsvSource({
+        "my%20file,my%2520file",
+        "my%2Ffile,my%252Ffile",
+        "test%25test,test%2525test",
+        "%E6%96%91%E9%BB%9E,%25E6%2596%2591%25E9%25BB%259E" })
+    public void callerSuppliedEncodingIsDoubleEncoded(String preEncodedName, String expectedEncodedPath) {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+
+        fileSystemClient(httpClient).getFileClient(preEncodedName).create(true);
+
+        // The '%' of the caller's escape sequence is itself escaped to %25, so a differently named resource is
+        // addressed. Callers must pass the raw, unencoded name.
+        assertEquals("/" + FILE_SYSTEM_NAME + "/" + expectedEncodedPath, httpClient.getUrlPath());
+    }
+
+    /*
+     * ------------------------------------------------------------------------------------------------------------
+     * 4. Sub-paths: DataLakeDirectoryClient.getFileClient / getSubdirectoryClient concatenate with '/' and then the
+     *    whole path is encoded as a single path parameter.
+     * ------------------------------------------------------------------------------------------------------------
+     */
+
+    @Test
+    public void directoryChildPathsAreConcatenatedRawAndEncodedOnce() {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+        DataLakeDirectoryClient directoryClient = fileSystemClient(httpClient).getDirectoryClient("my dir");
+
+        DataLakeFileClient fileClient = directoryClient.getFileClient("100%done.txt");
+        assertEquals("my dir/100%done.txt", fileClient.getFilePath());
+
+        fileClient.create(true);
+        assertEquals("/" + FILE_SYSTEM_NAME + "/my%20dir%2F100%25done.txt", httpClient.getUrlPath());
+
+        DataLakeDirectoryClient subdirectoryClient = directoryClient.getSubdirectoryClient("sub+dir");
+        assertEquals("my dir/sub+dir", subdirectoryClient.getDirectoryPath());
+
+        subdirectoryClient.create(true);
+        assertEquals("/" + FILE_SYSTEM_NAME + "/my%20dir%2Fsub+dir", httpClient.getUrlPath());
+    }
+
+    /*
+     * ------------------------------------------------------------------------------------------------------------
+     * 5. renameWithResponse: the destination is a raw path too, and the SDK builds the x-ms-rename-source header.
+     * ------------------------------------------------------------------------------------------------------------
+     */
+
+    @ParameterizedTest
+    @MethodSource("renameSupplier")
+    public void renameEncodesSourceHeaderAndDestinationUrl(String sourceName, String destinationName,
+        String expectedRenameSource, String expectedDestinationPath) {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+        DataLakeFileClient fileClient = fileSystemClient(httpClient).getFileClient(sourceName);
+
+        DataLakeFileClient renamed
+            = fileClient.renameWithResponse(null, destinationName, null, null, null, null).getValue();
+
+        HttpRequest request = httpClient.getRequest();
+        assertNotNull(request);
+
+        // Source is sent in the x-ms-rename-source header, percent-encoded by the SDK.
+        assertEquals("/" + FILE_SYSTEM_NAME + "/" + expectedRenameSource,
+            request.getHeaders().getValue(HttpHeaderName.fromString("x-ms-rename-source")));
+
+        // Destination is the request URL, percent-encoded by the SDK.
+        assertEquals("/" + FILE_SYSTEM_NAME + "/" + expectedDestinationPath, request.getUrl().getPath());
+
+        // The returned client reports the raw destination name, exactly as it was passed in.
+        assertEquals(destinationName, renamed.getFilePath());
+    }
+
+    private static Stream<Arguments> renameSupplier() {
+        return Stream.of(
+            // source | destination | expected x-ms-rename-source | expected destination path
+            Arguments.of("file.txt", "renamed.txt", "file.txt", "renamed.txt"),
+            Arguments.of("100%done.txt", "100%25done.txt", "100%25done.txt", "100%2525done.txt"),
+            Arguments.of("a b.txt", "c d.txt", "a%20b.txt", "c%20d.txt"),
+            Arguments.of("a+b.txt", "c+d.txt", "a%2Bb.txt", "c+d.txt"),
+            Arguments.of("dir/file.txt", "dir/renamed.txt", "dir%2Ffile.txt", "dir%2Frenamed.txt"),
+            Arguments.of("斑點.txt", "點斑.txt", "%E6%96%91%E9%BB%9E.txt", "%E9%BB%9E%E6%96%91.txt"));
+    }
+
+    /**
+     * Regression test. The client returned by {@code rename}/{@code renameWithResponse} used to be constructed with
+     * {@code Utility.urlEncode(pathName)}, which left it internally inconsistent: blob-backed operations (such as
+     * {@code getProperties}) addressed the correct path while Data Lake endpoint operations (such as {@code create})
+     * double-encoded it. The returned client must address exactly the path that the rename created.
+     */
+    @Test
+    public void clientReturnedByRenameAddressesTheRenamedPath() {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+        DataLakeFileSystemClient fileSystemClient = fileSystemClient(httpClient);
+
+        DataLakeFileClient renamed = fileSystemClient.getFileClient("source.txt").rename(null, "my file.txt");
+        String renameUrl = httpClient.getUrlPath();
+
+        assertEquals("/" + FILE_SYSTEM_NAME + "/my%20file.txt", renameUrl);
+        assertEquals("my file.txt", renamed.getFilePath());
+        assertEquals(ENDPOINT + "/" + FILE_SYSTEM_NAME + "/my%20file.txt", renamed.getFileUrl());
+
+        // A Data Lake endpoint operation addresses the path that was just created.
+        renamed.createIfNotExists();
+        assertEquals(renameUrl, httpClient.getUrlPath());
+
+        // A blob endpoint operation addresses the same path.
+        renamed.getProperties();
+        assertEquals(renameUrl, httpClient.getUrlPath());
+
+        // And it agrees with a freshly acquired client.
+        fileSystemClient.getFileClient("my file.txt").createIfNotExists();
+        assertEquals(renameUrl, httpClient.getUrlPath());
+    }
+
+    /**
+     * The same consistency requirement for directories, and for a name containing a literal {@code %}.
+     */
+    @Test
+    public void directoryClientReturnedByRenameAddressesTheRenamedPath() {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+        DataLakeFileSystemClient fileSystemClient = fileSystemClient(httpClient);
+
+        DataLakeDirectoryClient renamed = fileSystemClient.getDirectoryClient("source").rename(null, "100%done dir");
+        String renameUrl = httpClient.getUrlPath();
+
+        assertEquals("/" + FILE_SYSTEM_NAME + "/100%25done%20dir", renameUrl);
+        assertEquals("100%done dir", renamed.getDirectoryPath());
+
+        renamed.createIfNotExists();
+        assertEquals(renameUrl, httpClient.getUrlPath());
+
+        renamed.getProperties();
+        assertEquals(renameUrl, httpClient.getUrlPath());
+    }
+
+    /**
+     * {@code undeletePath} builds its result client through the same copy constructors, so it must round-trip the
+     * deleted path name unchanged too.
+     */
+    @Test
+    public void undeletedClientReportsRawPathName() {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient(
+            new HttpHeaders().set(HttpHeaderName.fromString("x-ms-resource-type"), "file"), 200);
+
+        DataLakePathClient undeleted = fileSystemClient(httpClient).undeletePath("my file.txt", "deletionId");
+
+        assertEquals("my file.txt", undeleted.getObjectPath());
+        assertEquals(ENDPOINT + "/" + FILE_SYSTEM_NAME + "/my%20file.txt", undeleted.getPathUrl());
+    }
+
+    /**
+     * The rename source header and the request URL use two different (but both valid) percent-encoding sets. Anything
+     * a caller pre-encodes is escaped again in both, so pre-encoding is never correct.
+     */
+    @Test
+    public void renameOfPreEncodedNameIsDoubleEncoded() {
+        RequestCapturingHttpClient httpClient = new RequestCapturingHttpClient();
+
+        fileSystemClient(httpClient).getFileClient("my%20file.txt")
+            .renameWithResponse(null, "my%20renamed.txt", null, null, null, null);
+
+        HttpRequest request = httpClient.getRequest();
+        assertEquals("/" + FILE_SYSTEM_NAME + "/my%2520file.txt",
+            request.getHeaders().getValue(HttpHeaderName.fromString("x-ms-rename-source")));
+        assertEquals("/" + FILE_SYSTEM_NAME + "/my%2520renamed.txt", request.getUrl().getPath());
+    }
+}


### PR DESCRIPTION
## Fix double-encoding of path names on clients returned by `rename` / `undeletePath`, and correct stale encoding javadoc

Addresses https://github.com/Azure/azure-sdk-for-java/issues/48040

Two related fixes to `azure-storage-file-datalake`, both surfaced while investigating a customer question about which special characters callers must percent-encode before passing a path name to the SDK:

1. **Bug fix** — the `DataLakeFileClient` / `DataLakeDirectoryClient` (and async equivalents) returned by `rename`, `renameWithResponse`, and `undeletePath` carried a URL-encoded path name, so subsequent Data Lake endpoint requests made through that client targeted a double-encoded path.
2. **Documentation fix** — 25 javadoc sites still instructed callers to pre-encode path names. That guidance has been wrong since 12.22.0 and actively causes the double-encoding it claims to prevent.

### Reason for the change

#### The bug

`DataLakeFileClient(DataLakePathClient)`, `DataLakeDirectoryClient(DataLakePathClient)`, `DataLakeFileAsyncClient(DataLakePathAsyncClient)` and `DataLakeDirectoryAsyncClient(DataLakePathAsyncClient)` each applied `Utility.urlEncode(pathName)` when copying the parent client's state.

This was **correct at the time it was written**. `DataLakePathAsyncClient` used to store `Utility.urlDecode(pathName)`, so the encode simply round-tripped the name back to its stored form. Commit `4316086b1d0` (blob, 12.19.0) and `b93671528c7` (datalake, 12.22.0) removed the decode — both shipped as documented breaking changes — but the matching encode in the copy constructors was left behind, turning a round-trip into a double-encode.

The resulting client was **internally inconsistent**, which is why this went unnoticed:

- Blob-backed operations (`getProperties`, `delete`, …) reuse the parent's `BlockBlobClient`, which was built from the raw name → correct URL.
- Data Lake-backed operations (`create`, `setAccessControl`, …) and `getFileUrl()` / `getDirectoryUrl()` use the re-encoded `pathName` → double-encoded URL.

Measured behaviour before the fix, renaming to `dest%20%25`:

| Call | URL | |
|---|---|---|
| the `rename` request itself | `/fs/dest%2520%2525` | ✅ |
| `renamed.getProperties()` (blob endpoint) | `/fs/dest%2520%2525` | ✅ |
| `renamed.create()` (dfs endpoint) | `/fs/dest%252520%252525` | ❌ |
| `renamed.getFileUrl()` | `.../dest%252520%252525` | ❌ |

The existing recorded test `FileApiTest.renameUrlEncoded` passes despite the bug because it only asserts `getPropertiesWithResponse` — the blob-endpoint half.

I verified every call site of these four constructors (`rename` in the four path clients, `undeletePath` in the two file system clients). In all six the source `pathName` is the raw, user-supplied name, so dropping the encode is correct everywhere.

#### The javadoc

`DataLakePathAsyncClient` stores `pathName` verbatim and never decodes it. Encoding happens once, at request-build time: `PathsImpl` declares `@PathParam("path")` **without** `encoded = true`, so `SwaggerMethodParser` applies `UrlEscapers.PATH_ESCAPER`. Anything a caller pre-encodes therefore gets escaped a second time — the `%` in `%20` becomes `%25`.

The javadoc on `DataLakeFileSystemClient.getFileClient` / `getDirectoryClient` / `createDirectory*` / `deleteDirectory*` (and async equivalents) and on `DataLakePathClientBuilder.pathName(String)` still said:

> If the path name contains special characters, pass in the url encoded version of the path name.

That is the pre-12.22.0 contract and is now precisely backwards.

### Changes

emoved the stale `Utility.urlEncode(...)` from the four copy constructors: `DataLakeFileClient.java`,  `DataLakeDirectoryClient.java`, `DataLakeFileAsyncClient.java` and `DataLakeDirectoryAsyncClient.java`.

**Javadoc fix** — 25 occurrences replaced with:

> Pass the name unencoded; the client percent-encodes it when building the request URL.

12 in `DataLakeFileSystemClient`, 12 in `DataLakeFileSystemAsyncClient`, plus `DataLakePathClientBuilder.pathName(String)`.

**Deliberately not changed:** `DataLakePathClientBuilder.endpoint(String)` javadoc, which says a path embedded in the endpoint URL must be url-encoded. That one is **correct** — endpoint parsing goes through `BlobUrlParts.getBlobName()`, which calls `Utility.urlDecode` (`BlobUrlParts.java:152`). Only the separate `pathName(String)` setter, which stores verbatim, was stale.

**New tests** — `DataLakePathNameEncodingTests.java` (406 lines, 119 tests). Fully offline; uses a request-capturing mock `HttpClient` to assert what the SDK actually puts on the wire rather than what it's documented to do. Covers:

- path names are stored verbatim and never decoded
- raw `%` and `#` no longer throw `IllegalArgumentException: Illegal hex characters in escape (%) pattern`
- the full wire-encoding table: safe set `A–Z a–z 0–9 - . _ ~ ! $ & ' ( ) * + , ; = : @`, encoded set `(space) " # % / < > ? [ ] ^ \` { | } \` and non-ASCII
- the Windows-reserved characters the customer asked about (`" \ / : | < > * ?`)
- pre-encoded input is double-encoded (the anti-pattern)
- `x-ms-rename-source` uses `Utility.urlEncode` while the URL path uses `UrlEscapers.PATH_ESCAPER` — two different but individually valid encodings
- **regression guards** for this fix: the client returned by `rename` / `undeletePath` addresses the same URL from both the blob and dfs code paths, and agrees with a freshly acquired client

**CHANGELOG.md** — entries under `12.29.0-beta.2` → Bugs Fixed and Other Changes.