### PR TITLE
[confidentialledger] Reduce live test matrix width and serialize resource provisioning

### DIFF
--- a/sdk/confidentialledger/azure-security-confidentialledger/tests.yml
+++ b/sdk/confidentialledger/azure-security-confidentialledger/tests.yml
@@ -4,6 +4,9 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: confidentialledger
+    MaxParallel: 1
+    MatrixFilters:
+      - AZURE_TEST_HTTP_CLIENTS=^netty$
     Artifacts:
       - name: azure-security-confidentialledger
         groupId: com.azure


### PR DESCRIPTION
### What

Two parameters added to `sdk/confidentialledger/azure-security-confidentialledger/tests.yml`:

- `MatrixFilters: [AZURE_TEST_HTTP_CLIENTS=^netty$]` — takes the live matrix from **10 legs to 6**
- `MaxParallel: 1` — runs those legs serially instead of concurrently

No other changes. No test code is modified and `ci.yml` is untouched.

### Why

Every leg of this live matrix provisions its own Azure Confidential Ledger. That resource is heavier than most test resources in this repo: it stands up a three-replica CCF cluster on confidential (SNP) hardware and takes roughly eight minutes to create.

Measured from the service side, this pipeline created **519 ledgers over the last 30 days**, across 27 active days, in bursts of up to 10 simultaneous provisions. Azure Confidential Ledger is a small service, and that burst shape is harder on regional provisioning capacity than a higher but steady rate would be. Several of these bursts have coincided with regional provisioning failures, which surfaced on the Confidential Ledger on-call rotation rather than as failures visible to this repo.

### The four dropped legs are duplicates

The matrix expands to 10 legs (3 from the sparse base, 7 from `include`). Four differ from a retained leg only in `AZURE_TEST_HTTP_CLIENTS`:

| Agent | JDK | `AZURE_TEST_HTTP_CLIENTS` |
|---|---|---|
| ubuntu-24.04 | 1.8 | okhttp |
| macos-latest | 1.8 | okhttp |
| ubuntu-24.04 | 1.21 | JdkHttpClientProvider |
| ubuntu-24.04 | 1.21 | VertxHttpClientProvider |

That dimension has no effect in this package, for two independent reasons:

1. **The providers are not on the test classpath.** `azure-security-confidentialledger/pom.xml` declares only `azure-core-http-netty`. There is no `azure-core-http-okhttp`, `azure-core-http-vertx` or `azure-core-http-jdk-httpclient` dependency, so the `HttpClientProvider` SPI lookup resolves to Netty whatever the variable is set to.
2. **The dataplane client hardcodes Netty regardless.** `ConfidentialLedgerClientTestBase` builds a `reactor.netty` `HttpClient` with an `SslContext` that trusts the ledger's own TLS certificate — required because CCF presents a self-signed cert — wraps it in `NettyAsyncHttpClientBuilder`, and passes it to `.httpClient(...)`. An explicitly supplied client bypasses provider selection.

So those four legs execute the same transport as the Netty legs, each provisioning a dedicated CCF cluster to run identical code.

### Coverage impact

Retained in the live matrix (6 legs):

| Agent | JDK | Options |
|---|---|---|
| windows-2022 | 1.25 | NotFromSource_TestsOnly |
| ubuntu-24.04 | 1.25 | FromSource_SkipRebuild_Verify |
| ubuntu-24.04 | 1.25 | NotFromSource_AggregateReports_SkipRebuild_Verify |
| ubuntu-24.04 | 1.11 | NotFromSource_TestsOnly |
| ubuntu-24.04 | 1.17 | NotFromSource_TestsOnly |
| ubuntu-24.04 | 1.21 | NotFromSource_TestsOnly |

JDK 1.11 / 1.17 / 1.21 / 1.25, both Windows and Linux, and both the FromSource and NotFromSource build paths are still exercised live.

The only dimensions leaving the live matrix are **JDK 1.8** and **macOS**, dropped incidentally because both 1.8 legs in the sparse base happen to be the okhttp legs. Both remain covered by `ci.yml`, which consumes the same `eng/pipelines/templates/stages/platform-matrix.json` and provisions nothing.

`tests.yml` is `trigger: none` and runs on a schedule, so no PR-required check depends on the dropped legs.

### On MaxParallel

`MaxParallel: 1` does not change how many ledgers are created; it changes their arrival shape from a burst of 10 concurrent creates to a serial sequence. It costs live-pipeline wall-clock time and no coverage. `sdk/confidentialledger/tests.yml` in `azure-sdk-for-python` already sets this same parameter.

### Net effect

Live matrix 10 legs to 6; peak concurrent provisions 10 to 1. At the current schedule that is roughly 519 to ~310 ledgers per 30 days.

### Follow-up

Separately, we are looking at whether these tests can run against a long-lived shared ledger rather than provisioning per run, which would remove this cost entirely. This change is independent of that and does not block it.
