### PR TITLE
Use dedicated JMS listener connection factory in 6.x

### DIFF
--- a/sdk/spring/CHANGELOG.md
+++ b/sdk/spring/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Release History
+## 6.6.0-beta.1 (Unreleased)
+
+### Spring Cloud Azure Autoconfigure
+
+#### Bugs Fixed
+
+- Fixed Service Bus JMS listener containers using `JmsPoolConnectionFactory` when both `spring.jms.servicebus.pool.enabled=true` and `spring.jms.cache.enabled=false`. The sender continues to use `JmsPoolConnectionFactory`, while listener containers now use a dedicated `ServiceBusJmsConnectionFactory`, enabling topic subscriptions on the Standard tier. ([#49308](https://github.com/Azure/azure-sdk-for-java/issues/49308))
+
 ## 6.5.0 (2026-07-29)
 - This release is compatible with Spring Boot 3.5.0-3.5.14. (Note: 3.5.x (x>14) should be supported, but they aren't tested with this release.)
 - This release is compatible with Spring Cloud 2025.0.0-2025.0.2. (Note: 2025.0.x (x>2) should be supported, but they aren't tested with this release.)

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/jms/ServiceBusJmsContainerConfiguration.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/main/java/com/azure/spring/cloud/autoconfigure/implementation/jms/ServiceBusJmsContainerConfiguration.java
@@ -52,7 +52,7 @@ class ServiceBusJmsContainerConfiguration implements DisposableBean {
      *   <tr><td>not set</td><td>false</td><td>ServiceBusJmsConnectionFactory</td></tr>
      *   <tr><td>true</td><td>not set</td><td>JmsPoolConnectionFactory</td></tr>
      *   <tr><td>true</td><td>true</td><td>CachingConnectionFactory</td></tr>
-     *   <tr><td>true</td><td>false</td><td>JmsPoolConnectionFactory</td></tr>
+     *   <tr><td>true</td><td>false</td><td>ServiceBusJmsConnectionFactory</td></tr>
      *   <tr><td>false</td><td>not set</td><td>ServiceBusJmsConnectionFactory</td></tr>
      *   <tr><td>false</td><td>true</td><td>CachingConnectionFactory</td></tr>
      *   <tr><td>false</td><td>false</td><td>ServiceBusJmsConnectionFactory</td></tr>
@@ -62,7 +62,7 @@ class ServiceBusJmsContainerConfiguration implements DisposableBean {
         // pool: not set
         {SERVICE_BUS, CACHE, SERVICE_BUS}, // cache: not set, true, false
         // pool: true
-        {POOL, CACHE, POOL}, // cache: not set, true, false
+        {POOL, CACHE, SERVICE_BUS}, // cache: not set, true, false
         // pool: false
         {SERVICE_BUS, CACHE, SERVICE_BUS} // cache: not set, true, false
     };

--- a/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/jms/ServiceBusJmsAutoConfigurationTests.java
+++ b/sdk/spring/spring-cloud-azure-autoconfigure/src/test/java/com/azure/spring/cloud/autoconfigure/implementation/jms/ServiceBusJmsAutoConfigurationTests.java
@@ -564,6 +564,39 @@ class ServiceBusJmsAutoConfigurationTests {
 
     @ParameterizedTest
     @ValueSource(strings = {"standard", "premium"})
+    void listenerContainerUsesDedicatedServiceBusConnectionFactoryWhenPoolEnabledAndCacheDisabled(String pricingTier) {
+        this.contextRunner
+            .withPropertyValues(
+                "spring.jms.servicebus.pricing-tier=" + pricingTier,
+                "spring.jms.servicebus.connection-string=" + CONNECTION_STRING,
+                "spring.jms.servicebus.pool.enabled=true",
+                "spring.jms.cache.enabled=false"
+            )
+            .run(context -> {
+                JmsPoolConnectionFactory senderBean = context.getBean(JmsPoolConnectionFactory.class);
+                Object pooledTarget = senderBean.getConnectionFactory();
+                DefaultJmsListenerContainerFactory queueFactory = context.getBean(
+                    "jmsListenerContainerFactory", DefaultJmsListenerContainerFactory.class);
+                DefaultJmsListenerContainerFactory topicFactory = context.getBean(
+                    "topicJmsListenerContainerFactory", DefaultJmsListenerContainerFactory.class);
+
+                DefaultMessageListenerContainer queueContainer =
+                    queueFactory.createListenerContainer(mock(JmsListenerEndpoint.class));
+                DefaultMessageListenerContainer topicContainer =
+                    topicFactory.createListenerContainer(mock(JmsListenerEndpoint.class));
+
+                assertThat(queueContainer.getConnectionFactory())
+                    .isInstanceOf(ServiceBusJmsConnectionFactory.class)
+                    .isNotSameAs(pooledTarget);
+                assertThat(topicContainer.getConnectionFactory())
+                    .isInstanceOf(ServiceBusJmsConnectionFactory.class)
+                    .isNotSameAs(pooledTarget)
+                    .isSameAs(queueContainer.getConnectionFactory());
+            });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"standard", "premium"})
     void listenerContainerUsesDedicatedServiceBusConnectionFactoryWhenPoolDisabled(String pricingTier) {
         this.contextRunner
             .withPropertyValues(


### PR DESCRIPTION
# Description

Port https://github.com/Azure/azure-sdk-for-java/pull/49833

This ports the Service Bus JMS listener connection factory fix to the Spring Boot 3 / Spring Cloud Azure 6.x branch. When `spring.jms.servicebus.pool.enabled=true` and `spring.jms.cache.enabled=false`, sender operations continue to use `JmsPoolConnectionFactory`, while queue and topic listener containers use a shared dedicated `ServiceBusJmsConnectionFactory`. This enables topic subscriptions on the Service Bus Standard tier.

Related to https://github.com/Azure/azure-sdk-for-java/issues/49308.

## Testing

- Negative verification with the old decision-table entry: `Tests run: 2, Failures: 2, Errors: 0`; both variants returned `JmsPoolConnectionFactory`.
- Focused positive verification: `Tests run: 2, Failures: 0, Errors: 0`; reactor build succeeded.
- Full `ServiceBusJmsAutoConfigurationTests`: `Tests run: 53, Failures: 0, Errors: 0, Skipped: 0`; build succeeded.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up your commits, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.