### PR TITLE
Prepare azure-resourcemanager-test 2.0.0-beta.3 release

### DIFF
--- a/sdk/resourcemanager/azure-resourcemanager-test/CHANGELOG.md
+++ b/sdk/resourcemanager/azure-resourcemanager-test/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 2.0.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 2.0.0-beta.3 (2026-08-12)
 
 ### Other Changes
+
+- Added `Accept` to ignored headers.
 
 ## 2.0.0-beta.2 (2025-08-20)
 


### PR DESCRIPTION
Updates the `azure-resourcemanager-test` 2.0.0-beta.3 release entry:

- Sets the release date to 2026-08-12.
- Notes that `Accept` was added to ignored headers.
- Removes empty changelog sections.
