### PR TITLE
chore: add core AMQP owners to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,7 +63,7 @@
 # AzureSdkOwners:                                                  @alzimmermsft @samvaity
 
 # PRLabel: %Azure.Core.AMQP
-/sdk/core/azure-core-amqp/                                         @conniey @Azure/azure-java-sdk
+/sdk/core/azure-core-amqp/                                         @conniey @j7nw4r @sagar0207 @SwayGom @sjkwak @hmlam @Azure/azure-java-sdk
 
 # ServiceLabel: %Azure.Core.AMQP
 # AzureSdkOwners:                                                  @conniey


### PR DESCRIPTION
## Summary

The core AMQP library lists one individual owner, so review requests for it go to a single person.

## Motivation

`/sdk/core/azure-core-amqp/` is owned by @conniey and `@Azure/azure-java-sdk`. The people who work on the AMQP stack across the Azure SDK languages are not on the entry, so GitHub does not ask them for review. A wider owner list spreads the review load and matches the ownership of the messaging libraries that depend on this one.

## Changes

Add @j7nw4r, @sagar0207, @SwayGom, @sjkwak, and @hmlam to the `/sdk/core/azure-core-amqp/` entry. The current owners stay on the entry and keep their review rights.

## Validation

The change is one line. The codeowners linter runs on this pull request.
