### PR TITLE
[WIP]: Improve PPCB failback diagnostics

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/PerPartitionCircuitBreakerE2ETests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/PerPartitionCircuitBreakerE2ETests.java
@@ -58,6 +58,7 @@ import com.azure.cosmos.test.faultinjection.FaultInjectionRule;
 import com.azure.cosmos.test.faultinjection.FaultInjectionRuleBuilder;
 import com.azure.cosmos.test.faultinjection.FaultInjectionServerErrorResult;
 import com.azure.cosmos.test.faultinjection.FaultInjectionServerErrorType;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -3807,6 +3808,7 @@ public class PerPartitionCircuitBreakerE2ETests extends FaultInjectionTestBase {
                         testId,
                         executeDataPlaneOperation,
                         operationInvocationParamsWrapper);
+                    List<JsonNode> ppcbStateByRegionNodes = getPpcbStateByRegionNodes(response);
 
                     ConsecutiveExceptionBasedCircuitBreaker consecutiveExceptionBasedCircuitBreaker
                         = globalPartitionEndpointManagerForPerPartitionCircuitBreaker.getConsecutiveExceptionBasedCircuitBreaker();
@@ -3832,6 +3834,9 @@ public class PerPartitionCircuitBreakerE2ETests extends FaultInjectionTestBase {
 
                     if (executionCountAfterCircuitBreakingThresholdBreached > 1) {
                         validateResponseInAbsenceOfFailures.accept(response);
+                        assertPpcbHealthStatus(
+                            ppcbStateByRegionNodes,
+                            LocationHealthStatus.Unavailable);
                     }
 
                     if (response.cosmosItemResponse != null) {
@@ -3898,6 +3903,10 @@ public class PerPartitionCircuitBreakerE2ETests extends FaultInjectionTestBase {
                         executeDataPlaneOperation,
                         operationInvocationParamsWrapper);
                     validateResponseInAbsenceOfFailures.accept(response);
+                    assertPpcbHealthStatus(
+                        getPpcbStateByRegionNodes(response),
+                        LocationHealthStatus.HealthyTentative,
+                        LocationHealthStatus.Healthy);
 
                     if (response.cosmosItemResponse != null) {
                         assertThat(response.cosmosItemResponse).isNotNull();
@@ -3956,6 +3965,57 @@ public class PerPartitionCircuitBreakerE2ETests extends FaultInjectionTestBase {
             return response.batchResponse.getDiagnostics().getDiagnosticsContext();
         }
         return null;
+    }
+
+    private static List<JsonNode> getPpcbStateByRegionNodes(ResponseWrapper<?> response) {
+        CosmosDiagnosticsContext diagnosticsContext = getDiagnosticsContext(response);
+        assertThat(diagnosticsContext).isNotNull();
+
+        try {
+            JsonNode diagnostics = Utils.getSimpleObjectMapper().readTree(diagnosticsContext.toJson());
+            List<JsonNode> stateByRegionNodes = new ArrayList<>();
+            for (JsonNode ppcbNode : diagnostics.findValues("ppcb")) {
+                JsonNode stateByRegion = ppcbNode.get("stateByRegion");
+                if (stateByRegion != null && stateByRegion.isObject()) {
+                    stateByRegionNodes.add(stateByRegion);
+                }
+            }
+
+            assertThat(stateByRegionNodes)
+                .as("Expected every PPCB-enabled data-plane operation to include ppcb.stateByRegion. Diagnostics: %s", diagnostics)
+                .isNotEmpty();
+            return stateByRegionNodes;
+        } catch (Exception e) {
+            throw new AssertionError("Failed to parse CosmosDiagnostics for PPCB state", e);
+        }
+    }
+
+    private static void assertPpcbHealthStatus(
+        List<JsonNode> stateByRegionNodes,
+        LocationHealthStatus... expectedStatuses) {
+
+        List<String> actualStatuses = new ArrayList<>();
+        for (JsonNode stateByRegion : stateByRegionNodes) {
+            Iterator<JsonNode> regionStates = stateByRegion.elements();
+            while (regionStates.hasNext()) {
+                JsonNode healthStatus = regionStates.next().get("locationHealthStatus");
+                if (healthStatus != null) {
+                    actualStatuses.add(healthStatus.asText());
+                }
+            }
+        }
+
+        boolean expectedStatusFound = false;
+        for (LocationHealthStatus expectedStatus : expectedStatuses) {
+            if (actualStatuses.contains(expectedStatus.toString())) {
+                expectedStatusFound = true;
+                break;
+            }
+        }
+
+        assertThat(expectedStatusFound)
+            .as("Expected PPCB health status to be one of %s but found %s", Arrays.toString(expectedStatuses), actualStatuses)
+            .isTrue();
     }
 
     private ResponseWrapper<?> executeDataPlaneOperationWithTransient4041002Retry(

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/PerPartitionCircuitBreakerE2ETests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/PerPartitionCircuitBreakerE2ETests.java
@@ -3808,7 +3808,6 @@ public class PerPartitionCircuitBreakerE2ETests extends FaultInjectionTestBase {
                         testId,
                         executeDataPlaneOperation,
                         operationInvocationParamsWrapper);
-                    List<JsonNode> ppcbStateByRegionNodes = getPpcbStateByRegionNodes(response);
 
                     ConsecutiveExceptionBasedCircuitBreaker consecutiveExceptionBasedCircuitBreaker
                         = globalPartitionEndpointManagerForPerPartitionCircuitBreaker.getConsecutiveExceptionBasedCircuitBreaker();
@@ -3835,7 +3834,7 @@ public class PerPartitionCircuitBreakerE2ETests extends FaultInjectionTestBase {
                     if (executionCountAfterCircuitBreakingThresholdBreached > 1) {
                         validateResponseInAbsenceOfFailures.accept(response);
                         assertPpcbHealthStatus(
-                            ppcbStateByRegionNodes,
+                            getPpcbStateByRegionNodes(response),
                             LocationHealthStatus.Unavailable);
                     }
 

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/PerPartitionCircuitBreakerE2ETests.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/PerPartitionCircuitBreakerE2ETests.java
@@ -3833,9 +3833,16 @@ public class PerPartitionCircuitBreakerE2ETests extends FaultInjectionTestBase {
 
                     if (executionCountAfterCircuitBreakingThresholdBreached > 1) {
                         validateResponseInAbsenceOfFailures.accept(response);
-                        assertPpcbHealthStatus(
-                            getPpcbStateByRegionNodes(response),
-                            LocationHealthStatus.Unavailable);
+                        List<JsonNode> stateByRegionNodes = getPpcbStateByRegionNodes(response);
+                        if (isAnyRegionShortCircuitedForPartition(
+                            partitionKeyRangeWrapper,
+                            partitionKeyRangeToLocationSpecificUnavailabilityInfo,
+                            locationEndpointToLocationSpecificContextForPartitionField)) {
+
+                            assertPpcbHealthStatus(
+                                stateByRegionNodes,
+                                LocationHealthStatus.Unavailable);
+                        }
                     }
 
                     if (response.cosmosItemResponse != null) {
@@ -5716,6 +5723,25 @@ public class PerPartitionCircuitBreakerE2ETests extends FaultInjectionTestBase {
         }
 
         return 0d;
+    }
+
+    private static boolean isAnyRegionShortCircuitedForPartition(
+        PartitionKeyRangeWrapper partitionKeyRangeWrapper,
+        ConcurrentHashMap<PartitionKeyRangeWrapper, ?> partitionKeyRangeToLocationSpecificUnavailabilityInfo,
+        Field locationEndpointToLocationSpecificContextForPartitionField) throws IllegalAccessException {
+
+        Object partitionLevelLocationUnavailabilityInfo
+            = partitionKeyRangeToLocationSpecificUnavailabilityInfo.get(partitionKeyRangeWrapper);
+        if (partitionLevelLocationUnavailabilityInfo == null) {
+            return false;
+        }
+
+        ConcurrentHashMap<RegionalRoutingContext, LocationSpecificHealthContext> locationSpecificHealthContexts
+            = (ConcurrentHashMap<RegionalRoutingContext, LocationSpecificHealthContext>)
+            locationEndpointToLocationSpecificContextForPartitionField.get(partitionLevelLocationUnavailabilityInfo);
+
+        return locationSpecificHealthContexts.values().stream().anyMatch(
+            context -> context.getLocationHealthStatus() == LocationHealthStatus.Unavailable);
     }
 
     private static FaultInjectionConnectionType evaluateFaultInjectionConnectionType(ConnectionMode connectionMode) {

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PerPartitionCircuitBreakerInfoHolderTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PerPartitionCircuitBreakerInfoHolderTest.java
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.perPartitionCircuitBreaker;
+
+import com.azure.cosmos.implementation.ClientSideRequestStatistics;
+import com.azure.cosmos.implementation.CrossRegionAvailabilityContextForRxDocumentServiceRequest;
+import com.azure.cosmos.implementation.DiagnosticsClientContext;
+import com.azure.cosmos.implementation.GlobalEndpointManager;
+import com.azure.cosmos.implementation.OperationType;
+import com.azure.cosmos.implementation.PartitionKeyRange;
+import com.azure.cosmos.implementation.ResourceType;
+import com.azure.cosmos.implementation.RxDocumentServiceRequest;
+import com.azure.cosmos.implementation.apachecommons.collections.list.UnmodifiableList;
+import com.azure.cosmos.implementation.directconnectivity.StoreResponseDiagnostics;
+import com.azure.cosmos.implementation.perPartitionAutomaticFailover.PerPartitionAutomaticFailoverInfoHolder;
+import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.time.Instant;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+
+public class PerPartitionCircuitBreakerInfoHolderTest {
+
+    @Test(groups = {"unit"})
+    public void storesImmutableStateSnapshot() {
+        LocationSpecificHealthContext healthContext = createHealthContext(LocationHealthStatus.Unavailable);
+        Map<String, LocationSpecificHealthContext> currentState = new LinkedHashMap<>();
+        currentState.put("eastus", healthContext);
+
+        PerPartitionCircuitBreakerInfoHolder holder = new PerPartitionCircuitBreakerInfoHolder();
+        holder.setPerPartitionCircuitBreakerInfoHolder(currentState);
+        currentState.clear();
+
+        assertThat(holder.getPerPartitionCircuitBreakerInfoHolder())
+            .containsOnlyKeys("eastus")
+            .containsValue(healthContext);
+        assertThatThrownBy(() -> holder.getPerPartitionCircuitBreakerInfoHolder().clear())
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test(groups = {"unit"})
+    public void initializedEmptyStateIsSerialized() throws Exception {
+        PerPartitionCircuitBreakerInfoHolder holder = new PerPartitionCircuitBreakerInfoHolder();
+        holder.setPerPartitionCircuitBreakerInfoHolder(Collections.emptyMap());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new SimpleModule().addSerializer(
+            PerPartitionCircuitBreakerInfoHolder.class,
+            new PerPartitionCircuitBreakerInfoHolder.PerPartitionCircuitBreakerInfoHolderSerializer()));
+
+        assertThat(objectMapper.writeValueAsString(holder))
+            .isEqualTo("{\"stateByRegion\":{}}");
+        assertThat(objectMapper.writeValueAsString(PerPartitionCircuitBreakerInfoHolder.EMPTY))
+            .isEqualTo("null");
+    }
+
+    @Test(groups = {"unit"})
+    public void responseStatisticsRetainStateAtRecordTime() {
+        DiagnosticsClientContext diagnosticsClientContext = Mockito.mock(DiagnosticsClientContext.class);
+        PerPartitionCircuitBreakerInfoHolder holder = new PerPartitionCircuitBreakerInfoHolder();
+        holder.setPerPartitionCircuitBreakerInfoHolder(Collections.singletonMap(
+            "eastus",
+            createHealthContext(LocationHealthStatus.Unavailable)));
+
+        RxDocumentServiceRequest request = RxDocumentServiceRequest.create(
+            diagnosticsClientContext,
+            OperationType.Read,
+            ResourceType.Document);
+        request.requestContext.setCrossRegionAvailabilityContext(
+            new CrossRegionAvailabilityContextForRxDocumentServiceRequest(
+                null,
+                null,
+                null,
+                new AtomicBoolean(false),
+                holder,
+                new PerPartitionAutomaticFailoverInfoHolder()));
+
+        ClientSideRequestStatistics statistics = new ClientSideRequestStatistics(diagnosticsClientContext);
+        statistics.recordResponse(request, null, null);
+        holder.setPerPartitionCircuitBreakerInfoHolder(Collections.singletonMap(
+            "westus",
+            createHealthContext(LocationHealthStatus.Healthy)));
+
+        PerPartitionCircuitBreakerInfoHolder recordedHolder = statistics.getResponseStatisticsList()
+            .iterator()
+            .next()
+            .getPerPartitionCircuitBreakerInfoHolder();
+        assertThat(recordedHolder.getPerPartitionCircuitBreakerInfoHolder()).containsOnlyKeys("eastus");
+    }
+
+    @Test(groups = {"unit"})
+    public void gatewayStatisticsRetainStateAtRecordTime() throws Exception {
+        DiagnosticsClientContext diagnosticsClientContext = Mockito.mock(DiagnosticsClientContext.class);
+        PerPartitionCircuitBreakerInfoHolder holder = new PerPartitionCircuitBreakerInfoHolder();
+        holder.setPerPartitionCircuitBreakerInfoHolder(Collections.singletonMap(
+            "eastus",
+            createHealthContext(LocationHealthStatus.Unavailable)));
+        RxDocumentServiceRequest request = createRequest(diagnosticsClientContext, holder);
+
+        ClientSideRequestStatistics statistics = new ClientSideRequestStatistics(diagnosticsClientContext);
+        statistics.recordGatewayResponse(request, Mockito.mock(StoreResponseDiagnostics.class), null);
+        holder.setPerPartitionCircuitBreakerInfoHolder(Collections.singletonMap(
+            "westus",
+            createHealthContext(LocationHealthStatus.Healthy)));
+
+        PerPartitionCircuitBreakerInfoHolder recordedHolder = statistics.getGatewayStatisticsList()
+            .get(0)
+            .getPerPartitionCircuitBreakerInfoHolder();
+        assertThat(recordedHolder.getPerPartitionCircuitBreakerInfoHolder()).containsOnlyKeys("eastus");
+        assertThat(new ObjectMapper().writeValueAsString(statistics))
+            .contains("\"ppcb\":{\"stateByRegion\":{\"eastus\":");
+    }
+
+    @Test(groups = {"unit"})
+    public void routingLookupInitializesEmptyStateWhenNoCircuitExists() throws Exception {
+        DiagnosticsClientContext diagnosticsClientContext = Mockito.mock(DiagnosticsClientContext.class);
+        PerPartitionCircuitBreakerInfoHolder holder = new PerPartitionCircuitBreakerInfoHolder();
+        RxDocumentServiceRequest request = createRequest(diagnosticsClientContext, holder);
+        request.setResourceId("collectionRid");
+        PartitionKeyRange partitionKeyRange = new PartitionKeyRange("0", "AA", "BB");
+        request.requestContext.resolvedPartitionKeyRange = partitionKeyRange;
+        request.requestContext.resolvedPartitionKeyRangeForCircuitBreaker = partitionKeyRange;
+
+        RegionalRoutingContext eastUs = new RegionalRoutingContext(URI.create("https://eastus.documents.azure.com"));
+        RegionalRoutingContext westUs = new RegionalRoutingContext(URI.create("https://westus.documents.azure.com"));
+        GlobalEndpointManager globalEndpointManager = Mockito.mock(GlobalEndpointManager.class);
+        doReturn(false).when(globalEndpointManager).canUseMultipleWriteLocations(request);
+        doReturn(UnmodifiableList.unmodifiableList(Arrays.asList(eastUs, westUs)))
+            .when(globalEndpointManager)
+            .getApplicableReadRegionalRoutingContexts(Collections.emptyList());
+
+        GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker manager
+            = new GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker(globalEndpointManager);
+        manager.resetCircuitBreakerConfig(PartitionLevelCircuitBreakerConfig.fromJsonString(
+            "{\"isPartitionLevelCircuitBreakerEnabled\":true,"
+                + "\"consecutiveExceptionCountToleratedForReads\":10,"
+                + "\"consecutiveExceptionCountToleratedForWrites\":5}"));
+
+        assertThat(manager.getUnavailableRegionsForPartitionKeyRange(request, "collectionRid", partitionKeyRange))
+            .isEmpty();
+        assertThat(holder.isInitialized()).isTrue();
+        assertThat(holder.getPerPartitionCircuitBreakerInfoHolder()).isEmpty();
+
+        ClientSideRequestStatistics statistics = new ClientSideRequestStatistics(diagnosticsClientContext);
+        statistics.recordResponse(request, null, null);
+        assertThat(new ObjectMapper().writeValueAsString(statistics))
+            .contains("\"ppcb\":{\"stateByRegion\":{}}");
+    }
+
+    private static RxDocumentServiceRequest createRequest(
+        DiagnosticsClientContext diagnosticsClientContext,
+        PerPartitionCircuitBreakerInfoHolder holder) {
+
+        RxDocumentServiceRequest request = RxDocumentServiceRequest.create(
+            diagnosticsClientContext,
+            OperationType.Read,
+            ResourceType.Document);
+        request.requestContext.setCrossRegionAvailabilityContext(
+            new CrossRegionAvailabilityContextForRxDocumentServiceRequest(
+                null,
+                null,
+                null,
+                new AtomicBoolean(false),
+                holder,
+                new PerPartitionAutomaticFailoverInfoHolder()));
+        return request;
+    }
+
+    private static LocationSpecificHealthContext createHealthContext(LocationHealthStatus healthStatus) {
+        return new LocationSpecificHealthContext.Builder()
+            .withLocationHealthStatus(healthStatus)
+            .withUnavailableSince(Instant.EPOCH)
+            .build();
+    }
+}

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
@@ -192,33 +192,36 @@ public class PpcbFailbackLoggingTest {
     }
 
     @Test(groups = {"unit"})
-    public void failbackRemainingGaugeIsPerCollectionAndReportsZero() {
+    public void failbackPendingRecoveryGaugeIsPerCollectionAndReportsZero() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
-        Map<String, AtomicInteger> remainingByCollection = new HashMap<>();
-        remainingByCollection.put("collectionA", new AtomicInteger(3));
-        remainingByCollection.put("collectionB", new AtomicInteger(2));
+        Map<String, AtomicInteger> pendingRecoveryByCollection = new HashMap<>();
+        pendingRecoveryByCollection.put("collectionA", new AtomicInteger(3));
+        pendingRecoveryByCollection.put("collectionB", new AtomicInteger(2));
 
         try {
-            assertThat(CosmosMetricName.fromString("cosmos.client.ppcb.failback.pendingPartitionCount"))
-                .isSameAs(CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT);
-            this.manager.registerFailbackRemainingMeter(
+            assertThat(CosmosMetricName.fromString("cosmos.client.ppcb.failback.pendingRecoveryCount"))
+                .isSameAs(CosmosMetricName.PPCB_FAILBACK_PENDING_RECOVERY_COUNT);
+            this.manager.registerFailbackPendingRecoveryMeter(
                 registry,
                 Tag.of("ClientCorrelationId", "client1"));
-            this.manager.recordFailbackRemainingByCollection(remainingByCollection);
+            this.manager.recordFailbackPendingRecoveryByCollection(pendingRecoveryByCollection);
 
-            assertThat(getFailbackRemainingGauge(registry, "collectionA").value()).isEqualTo(3);
-            assertThat(getFailbackRemainingGauge(registry, "collectionB").value()).isEqualTo(2);
+            assertThat(getPendingRecoveryGauge(registry, "collectionA").value()).isEqualTo(3);
+            assertThat(getPendingRecoveryGauge(registry, "collectionB").value()).isEqualTo(2);
 
-            Map<String, AtomicInteger> updatedRemainingByCollection = new HashMap<>();
-            updatedRemainingByCollection.put("collectionA", new AtomicInteger());
-            updatedRemainingByCollection.put("collectionB", new AtomicInteger(1));
-            this.manager.recordFailbackRemainingByCollection(updatedRemainingByCollection);
+            pendingRecoveryByCollection.get("collectionA").decrementAndGet();
+            assertThat(getPendingRecoveryGauge(registry, "collectionA").value()).isEqualTo(2);
 
-            assertThat(getFailbackRemainingGauge(registry, "collectionA").value()).isZero();
-            assertThat(getFailbackRemainingGauge(registry, "collectionB").value()).isEqualTo(1);
+            Map<String, AtomicInteger> updatedPendingRecoveryByCollection = new HashMap<>();
+            updatedPendingRecoveryByCollection.put("collectionA", new AtomicInteger());
+            updatedPendingRecoveryByCollection.put("collectionB", new AtomicInteger(1));
+            this.manager.recordFailbackPendingRecoveryByCollection(updatedPendingRecoveryByCollection);
+
+            assertThat(getPendingRecoveryGauge(registry, "collectionA").value()).isZero();
+            assertThat(getPendingRecoveryGauge(registry, "collectionB").value()).isEqualTo(1);
 
             this.manager.close();
-            assertThat(registry.find(CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT.toString())
+            assertThat(registry.find(CosmosMetricName.PPCB_FAILBACK_PENDING_RECOVERY_COUNT.toString())
                 .gauges()).isEmpty();
         } finally {
             this.manager.close();
@@ -226,9 +229,9 @@ public class PpcbFailbackLoggingTest {
         }
     }
 
-    private static Gauge getFailbackRemainingGauge(SimpleMeterRegistry registry, String collectionRid) {
+    private static Gauge getPendingRecoveryGauge(SimpleMeterRegistry registry, String collectionRid) {
         return registry
-            .get(CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT.toString())
+            .get(CosmosMetricName.PPCB_FAILBACK_PENDING_RECOVERY_COUNT.toString())
             .tag("ClientCorrelationId", "client1")
             .tag("CollectionRid", collectionRid)
             .gauge();

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
@@ -200,8 +200,8 @@ public class PpcbFailbackLoggingTest {
         remainingByCollection.put("collectionB", new HashSet<>(Arrays.asList("3", "4")));
 
         try {
-            assertThat(CosmosMetricName.fromString("cosmos.client.ppcb.failback.remaining"))
-                .isSameAs(CosmosMetricName.PPCB_FAILBACK_REMAINING);
+            assertThat(CosmosMetricName.fromString("cosmos.client.ppcb.failback.pendingPartitionCount"))
+                .isSameAs(CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT);
             this.manager.registerFailbackRemainingMeter(
                 registry,
                 Tag.of("ClientCorrelationId", "client1"));
@@ -219,7 +219,7 @@ public class PpcbFailbackLoggingTest {
             assertThat(getFailbackRemainingGauge(registry, "collectionB").value()).isEqualTo(1);
 
             this.manager.close();
-            assertThat(registry.find(CosmosMetricName.PPCB_FAILBACK_REMAINING.toString())
+            assertThat(registry.find(CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT.toString())
                 .gauges()).isEmpty();
         } finally {
             this.manager.close();
@@ -229,7 +229,7 @@ public class PpcbFailbackLoggingTest {
 
     private static Gauge getFailbackRemainingGauge(SimpleMeterRegistry registry, String collectionRid) {
         return registry
-            .get(CosmosMetricName.PPCB_FAILBACK_REMAINING.toString())
+            .get(CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT.toString())
             .tag("ClientCorrelationId", "client1")
             .tag("CollectionRid", collectionRid)
             .gauge();

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
@@ -209,9 +209,6 @@ public class PpcbFailbackLoggingTest {
             assertThat(getPendingRecoveryGauge(registry, "collectionA").value()).isEqualTo(3);
             assertThat(getPendingRecoveryGauge(registry, "collectionB").value()).isEqualTo(2);
 
-            pendingRecoveryByCollection.get("collectionA").decrementAndGet();
-            assertThat(getPendingRecoveryGauge(registry, "collectionA").value()).isEqualTo(2);
-
             Map<String, AtomicInteger> updatedPendingRecoveryByCollection = new HashMap<>();
             updatedPendingRecoveryByCollection.put("collectionA", new AtomicInteger());
             updatedPendingRecoveryByCollection.put("collectionB", new AtomicInteger(1));
@@ -227,6 +224,18 @@ public class PpcbFailbackLoggingTest {
             this.manager.close();
             registry.close();
         }
+    }
+
+    @Test(groups = {"unit"})
+    public void failbackLogsIncludeClientCorrelationId() {
+        RuntimeException failure = new RuntimeException("failure");
+        this.manager.setClientCorrelationId("client1");
+
+        this.manager.logFailbackBacklog(7);
+        this.manager.logFailbackFailure(PARTITION, REGION, "OPEN_CONNECTION_TASK", failure);
+
+        verify(this.logger).info(contains("clientCorrelationId: client1"));
+        verify(this.logger).warn(contains("clientCorrelationId: client1"), same(failure));
     }
 
     private static Gauge getPendingRecoveryGauge(SimpleMeterRegistry registry, String collectionRid) {

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
@@ -22,10 +22,9 @@ import reactor.core.scheduler.Schedulers;
 
 import java.net.URI;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -195,9 +194,9 @@ public class PpcbFailbackLoggingTest {
     @Test(groups = {"unit"})
     public void failbackRemainingGaugeIsPerCollectionAndReportsZero() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
-        Map<String, Set<String>> remainingByCollection = new HashMap<>();
-        remainingByCollection.put("collectionA", new HashSet<>(Arrays.asList("0", "1", "2")));
-        remainingByCollection.put("collectionB", new HashSet<>(Arrays.asList("3", "4")));
+        Map<String, AtomicInteger> remainingByCollection = new HashMap<>();
+        remainingByCollection.put("collectionA", new AtomicInteger(3));
+        remainingByCollection.put("collectionB", new AtomicInteger(2));
 
         try {
             assertThat(CosmosMetricName.fromString("cosmos.client.ppcb.failback.pendingPartitionCount"))
@@ -210,9 +209,9 @@ public class PpcbFailbackLoggingTest {
             assertThat(getFailbackRemainingGauge(registry, "collectionA").value()).isEqualTo(3);
             assertThat(getFailbackRemainingGauge(registry, "collectionB").value()).isEqualTo(2);
 
-            Map<String, Set<String>> updatedRemainingByCollection = new HashMap<>();
-            updatedRemainingByCollection.put("collectionA", Collections.emptySet());
-            updatedRemainingByCollection.put("collectionB", Collections.singleton("4"));
+            Map<String, AtomicInteger> updatedRemainingByCollection = new HashMap<>();
+            updatedRemainingByCollection.put("collectionA", new AtomicInteger());
+            updatedRemainingByCollection.put("collectionB", new AtomicInteger(1));
             this.manager.recordFailbackRemainingByCollection(updatedRemainingByCollection);
 
             assertThat(getFailbackRemainingGauge(registry, "collectionA").value()).isZero();

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
@@ -7,9 +7,18 @@ import com.azure.cosmos.implementation.GlobalEndpointManager;
 import com.azure.cosmos.implementation.OperationType;
 import com.azure.cosmos.implementation.PartitionKeyRange;
 import com.azure.cosmos.implementation.PartitionKeyRangeWrapper;
+import com.azure.cosmos.implementation.ResourceType;
+import com.azure.cosmos.implementation.RxDocumentServiceRequest;
+import com.azure.cosmos.implementation.CrossRegionAvailabilityContextForRxDocumentServiceRequest;
+import com.azure.cosmos.implementation.DiagnosticsClientContext;
+import com.azure.cosmos.implementation.apachecommons.collections.list.UnmodifiableList;
+import com.azure.cosmos.implementation.directconnectivity.GatewayAddressCache;
+import com.azure.cosmos.implementation.directconnectivity.GlobalAddressResolver;
+import com.azure.cosmos.implementation.perPartitionAutomaticFailover.PerPartitionAutomaticFailoverInfoHolder;
 import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
 import com.azure.cosmos.models.CosmosMetricName;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.mockito.Mockito;
@@ -22,12 +31,18 @@ import reactor.core.scheduler.Schedulers;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.ToDoubleFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.contains;
@@ -41,8 +56,13 @@ public class PpcbFailbackLoggingTest {
     private static final PartitionKeyRangeWrapper PARTITION = new PartitionKeyRangeWrapper(
         new PartitionKeyRange("0", "AA", "BB"),
         "collectionRid");
+    private static final PartitionKeyRangeWrapper SECOND_PARTITION = new PartitionKeyRangeWrapper(
+        new PartitionKeyRange("1", "BB", "CC"),
+        "collectionRid");
     private static final RegionalRoutingContext REGION = new RegionalRoutingContext(
         URI.create("https://contoso-east-us.documents.azure.com"));
+    private static final RegionalRoutingContext SECOND_REGION = new RegionalRoutingContext(
+        URI.create("https://contoso-west-us.documents.azure.com"));
 
     private GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker manager;
     private Logger logger;
@@ -53,12 +73,23 @@ public class PpcbFailbackLoggingTest {
         doReturn("eastus").when(globalEndpointManager).getRegionName(
             REGION.getGatewayRegionalEndpoint(),
             OperationType.Read);
+        doReturn("westus").when(globalEndpointManager).getRegionName(
+            SECOND_REGION.getGatewayRegionalEndpoint(),
+            OperationType.Read);
+        doReturn(false).when(globalEndpointManager).canUseMultipleWriteLocations(Mockito.any());
+        doReturn(UnmodifiableList.unmodifiableList(Arrays.asList(REGION, SECOND_REGION)))
+            .when(globalEndpointManager)
+            .getApplicableReadRegionalRoutingContexts(Mockito.anyList());
         this.logger = Mockito.mock(Logger.class);
         doReturn(true).when(this.logger).isWarnEnabled();
         doReturn(true).when(this.logger).isDebugEnabled();
         this.manager = new GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker(
             globalEndpointManager,
             this.logger);
+        this.manager.resetCircuitBreakerConfig(PartitionLevelCircuitBreakerConfig.fromJsonString(
+            "{\"isPartitionLevelCircuitBreakerEnabled\":true,"
+                + "\"consecutiveExceptionCountToleratedForReads\":1,"
+                + "\"consecutiveExceptionCountToleratedForWrites\":1}"));
     }
 
     @Test(groups = {"unit"})
@@ -126,6 +157,25 @@ public class PpcbFailbackLoggingTest {
                 "OPEN_CONNECTION_TASK",
                 failure);
         }
+
+        verify(this.logger, times(11)).warn(contains("reason: RuntimeException"), same(failure));
+        verify(this.logger, times(89)).debug(contains("reason: RuntimeException"), same(failure));
+    }
+
+    @Test(groups = {"unit"})
+    public void concurrentFailuresPreserveGlobalSamplingCadence() {
+        RuntimeException failure = new RuntimeException("failure");
+
+        Flux.range(0, 100)
+            .parallel(4)
+            .runOn(Schedulers.parallel())
+            .doOnNext(ignored -> this.manager.logFailbackFailure(
+                PARTITION,
+                REGION,
+                "OPEN_CONNECTION_TASK",
+                failure))
+            .sequential()
+            .blockLast(Duration.ofSeconds(5));
 
         verify(this.logger, times(11)).warn(contains("reason: RuntimeException"), same(failure));
         verify(this.logger, times(89)).debug(contains("reason: RuntimeException"), same(failure));
@@ -227,6 +277,85 @@ public class PpcbFailbackLoggingTest {
     }
 
     @Test(groups = {"unit"})
+    public void meterCleanupWinsRaceWithInFlightRowPublication() throws Exception {
+        AtomicInteger gaugeRegistrationCount = new AtomicInteger();
+        CountDownLatch secondGaugeRegistrationStarted = new CountDownLatch(1);
+        CountDownLatch allowSecondGaugeRegistration = new CountDownLatch(1);
+        SimpleMeterRegistry registry = new SimpleMeterRegistry() {
+            @Override
+            protected <T> Gauge newGauge(Meter.Id id, T object, ToDoubleFunction<T> valueFunction) {
+                if (gaugeRegistrationCount.incrementAndGet() == 2) {
+                    secondGaugeRegistrationStarted.countDown();
+                    try {
+                        if (!allowSecondGaugeRegistration.await(5, TimeUnit.SECONDS)) {
+                            throw new IllegalStateException("Timed out waiting to continue gauge registration.");
+                        }
+                    } catch (InterruptedException error) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException("Interrupted while coordinating gauge registration.", error);
+                    }
+                }
+
+                return super.newGauge(id, object, valueFunction);
+            }
+        };
+        Map<String, AtomicInteger> initialRecoveryCount = Collections.singletonMap(
+            "collectionA",
+            new AtomicInteger(1));
+        Map<String, AtomicInteger> updatedRecoveryCount = Collections.singletonMap(
+            "collectionA",
+            new AtomicInteger(2));
+
+        try {
+            this.manager.registerFailbackPendingRecoveryMeter(
+                registry,
+                Tag.of("ClientCorrelationId", "client1"));
+            this.manager.recordFailbackPendingRecoveryByCollection(initialRecoveryCount);
+
+            AtomicReference<Throwable> publisherFailure = new AtomicReference<>();
+            AtomicReference<Throwable> cleanupFailure = new AtomicReference<>();
+            Thread publisher = new Thread(
+                () -> {
+                    try {
+                        this.manager.recordFailbackPendingRecoveryByCollection(updatedRecoveryCount);
+                    } catch (Throwable error) {
+                        publisherFailure.set(error);
+                    }
+                },
+                "ppcb-meter-publisher");
+            CountDownLatch cleanupFinished = new CountDownLatch(1);
+            Thread cleanup = new Thread(() -> {
+                try {
+                    this.manager.removeFailbackPendingRecoveryMeter();
+                } catch (Throwable error) {
+                    cleanupFailure.set(error);
+                } finally {
+                    cleanupFinished.countDown();
+                }
+            }, "ppcb-meter-cleanup");
+
+            publisher.start();
+            assertThat(secondGaugeRegistrationStarted.await(1, TimeUnit.SECONDS)).isTrue();
+            cleanup.start();
+            cleanupFinished.await(1, TimeUnit.SECONDS);
+            allowSecondGaugeRegistration.countDown();
+            publisher.join(1000);
+            cleanup.join(1000);
+
+            assertThat(publisher.isAlive()).isFalse();
+            assertThat(cleanup.isAlive()).isFalse();
+            assertThat(publisherFailure.get()).isNull();
+            assertThat(cleanupFailure.get()).isNull();
+            assertThat(registry.find(CosmosMetricName.PPCB_FAILBACK_PENDING_RECOVERY_COUNT.toString())
+                .gauges()).isEmpty();
+        } finally {
+            allowSecondGaugeRegistration.countDown();
+            this.manager.close();
+            registry.close();
+        }
+    }
+
+    @Test(groups = {"unit"})
     public void failbackLogsIncludeClientCorrelationId() {
         RuntimeException failure = new RuntimeException("failure");
         this.manager.setClientCorrelationId("client1");
@@ -236,6 +365,217 @@ public class PpcbFailbackLoggingTest {
 
         verify(this.logger).info(contains("clientCorrelationId: client1"));
         verify(this.logger).warn(contains("clientCorrelationId: client1"), same(failure));
+    }
+
+    @Test(groups = {"unit"})
+    public void successfulFailbackTransitionsUnavailableRegionAndRefreshesGaugeOnNextScan() {
+        RxDocumentServiceRequest request = createReadRequest();
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        GatewayAddressCache gatewayAddressCache = Mockito.mock(GatewayAddressCache.class);
+        GlobalAddressResolver globalAddressResolver = Mockito.mock(GlobalAddressResolver.class);
+
+        try {
+            markRegionUnavailable(request);
+            doReturn(gatewayAddressCache).when(globalAddressResolver)
+                .getGatewayAddressCache(REGION.getGatewayRegionalEndpoint());
+            doReturn(Flux.empty()).when(gatewayAddressCache)
+                .submitOpenConnectionTasks(PARTITION.getPartitionKeyRange(), PARTITION.getCollectionResourceId());
+            this.manager.setGlobalAddressResolver(globalAddressResolver);
+            this.manager.registerFailbackPendingRecoveryMeter(
+                registry,
+                Tag.of("ClientCorrelationId", "client1"));
+
+            this.manager.runFailbackRecoveryCycle().blockLast(Duration.ofSeconds(1));
+
+            assertThat(getUnavailableRegions(request)).isEmpty();
+            assertThat(getRegionHealthStatus(request)).isEqualTo(LocationHealthStatus.HealthyTentative);
+            assertThat(getPendingRecoveryGauge(registry, "collectionRid").value()).isEqualTo(1);
+
+            this.manager.runFailbackRecoveryCycle().blockLast(Duration.ofSeconds(1));
+
+            assertThat(getPendingRecoveryGauge(registry, "collectionRid").value()).isZero();
+            verify(gatewayAddressCache).submitOpenConnectionTasks(
+                PARTITION.getPartitionKeyRange(),
+                PARTITION.getCollectionResourceId());
+        } finally {
+            this.manager.close();
+            registry.close();
+        }
+    }
+
+    @Test(groups = {"unit"})
+    public void failedFailbackProbeKeepsRegionUnavailableAndNextCycleCanRecover() {
+        RuntimeException failure = new RuntimeException("probe failed");
+        RxDocumentServiceRequest request = createReadRequest();
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        GatewayAddressCache gatewayAddressCache = Mockito.mock(GatewayAddressCache.class);
+        GlobalAddressResolver globalAddressResolver = Mockito.mock(GlobalAddressResolver.class);
+
+        try {
+            markRegionUnavailable(request);
+            doReturn(gatewayAddressCache).when(globalAddressResolver)
+                .getGatewayAddressCache(REGION.getGatewayRegionalEndpoint());
+            Mockito.when(gatewayAddressCache.submitOpenConnectionTasks(
+                    PARTITION.getPartitionKeyRange(),
+                    PARTITION.getCollectionResourceId()))
+                .thenReturn(Flux.error(failure), Flux.empty());
+            this.manager.setGlobalAddressResolver(globalAddressResolver);
+            this.manager.registerFailbackPendingRecoveryMeter(
+                registry,
+                Tag.of("ClientCorrelationId", "client1"));
+
+            this.manager.runFailbackRecoveryCycle().blockLast(Duration.ofSeconds(1));
+
+            assertThat(getUnavailableRegions(request)).containsExactly("eastus");
+            assertThat(getRegionHealthStatus(request)).isEqualTo(LocationHealthStatus.Unavailable);
+            assertThat(getPendingRecoveryGauge(registry, "collectionRid").value()).isEqualTo(1);
+            verify(this.logger).warn(contains("stage: OPEN_CONNECTION_TASK"), same(failure));
+
+            this.manager.runFailbackRecoveryCycle().blockLast(Duration.ofSeconds(1));
+
+            assertThat(getUnavailableRegions(request)).isEmpty();
+            assertThat(getRegionHealthStatus(request)).isEqualTo(LocationHealthStatus.HealthyTentative);
+            assertThat(getPendingRecoveryGauge(registry, "collectionRid").value()).isEqualTo(1);
+
+            this.manager.runFailbackRecoveryCycle().blockLast(Duration.ofSeconds(1));
+
+            assertThat(getPendingRecoveryGauge(registry, "collectionRid").value()).isZero();
+            verify(gatewayAddressCache, times(2)).submitOpenConnectionTasks(
+                PARTITION.getPartitionKeyRange(),
+                PARTITION.getCollectionResourceId());
+        } finally {
+            this.manager.close();
+            registry.close();
+        }
+    }
+
+    @Test(groups = {"unit"})
+    public void missingGatewayAddressCacheKeepsRegionUnavailable() {
+        RxDocumentServiceRequest request = createReadRequest(PARTITION);
+        GlobalAddressResolver globalAddressResolver = Mockito.mock(GlobalAddressResolver.class);
+
+        markRegionUnavailable(request, PARTITION);
+        this.manager.setGlobalAddressResolver(globalAddressResolver);
+
+        this.manager.runFailbackRecoveryCycle().blockLast(Duration.ofSeconds(1));
+
+        assertThat(getUnavailableRegions(request, PARTITION)).containsExactly("eastus");
+        assertThat(getRegionHealthStatus(request)).isEqualTo(LocationHealthStatus.Unavailable);
+        verify(this.logger).warn(
+            contains("stage: RESOLVE_GATEWAY_ADDRESS_CACHE, reason: IllegalStateException"),
+            Mockito.any(IllegalStateException.class));
+    }
+
+    @Test(groups = {"unit"})
+    public void failedCandidateDoesNotBlockAnotherCandidateRecovery() {
+        RuntimeException failure = new RuntimeException("probe failed");
+        RxDocumentServiceRequest failedRequest = createReadRequest(PARTITION);
+        RxDocumentServiceRequest recoveredRequest = createReadRequest(SECOND_PARTITION);
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        GatewayAddressCache gatewayAddressCache = Mockito.mock(GatewayAddressCache.class);
+        GlobalAddressResolver globalAddressResolver = Mockito.mock(GlobalAddressResolver.class);
+
+        try {
+            markRegionUnavailable(failedRequest, PARTITION);
+            markRegionUnavailable(recoveredRequest, SECOND_PARTITION);
+            doReturn(gatewayAddressCache).when(globalAddressResolver)
+                .getGatewayAddressCache(REGION.getGatewayRegionalEndpoint());
+            Mockito.when(gatewayAddressCache.submitOpenConnectionTasks(
+                    Mockito.any(PartitionKeyRange.class),
+                    Mockito.eq(PARTITION.getCollectionResourceId())))
+                .thenAnswer(invocation -> {
+                    PartitionKeyRange partitionKeyRange = invocation.getArgument(0);
+                    return partitionKeyRange.getId().equals(PARTITION.getPartitionKeyRange().getId())
+                        ? Flux.error(failure)
+                        : Flux.empty();
+                });
+            this.manager.setGlobalAddressResolver(globalAddressResolver);
+            this.manager.registerFailbackPendingRecoveryMeter(
+                registry,
+                Tag.of("ClientCorrelationId", "client1"));
+
+            this.manager.runFailbackRecoveryCycle().blockLast(Duration.ofSeconds(1));
+
+            assertThat(getUnavailableRegions(failedRequest, PARTITION)).containsExactly("eastus");
+            assertThat(getRegionHealthStatus(failedRequest)).isEqualTo(LocationHealthStatus.Unavailable);
+            assertThat(getUnavailableRegions(recoveredRequest, SECOND_PARTITION)).isEmpty();
+            assertThat(getRegionHealthStatus(recoveredRequest)).isEqualTo(LocationHealthStatus.HealthyTentative);
+            assertThat(getPendingRecoveryGauge(registry, "collectionRid").value()).isEqualTo(2);
+            verify(this.logger).warn(contains("stage: OPEN_CONNECTION_TASK"), same(failure));
+            verify(gatewayAddressCache, times(2)).submitOpenConnectionTasks(
+                Mockito.any(PartitionKeyRange.class),
+                Mockito.eq(PARTITION.getCollectionResourceId()));
+        } finally {
+            this.manager.close();
+            registry.close();
+        }
+    }
+
+    private void markRegionUnavailable(RxDocumentServiceRequest request) {
+        this.markRegionUnavailable(request, PARTITION);
+    }
+
+    private void markRegionUnavailable(
+        RxDocumentServiceRequest request,
+        PartitionKeyRangeWrapper partitionKeyRangeWrapper) {
+
+        int failureCount = this.manager.getConsecutiveExceptionBasedCircuitBreaker()
+            .getAllowedExceptionCountToMaintainStatus(LocationHealthStatus.HealthyWithFailures, true);
+
+        for (int failure = 0; failure < failureCount; failure++) {
+            this.manager.handleLocationExceptionForPartitionKeyRange(request, REGION, false);
+        }
+
+        assertThat(getUnavailableRegions(request, partitionKeyRangeWrapper)).containsExactly("eastus");
+    }
+
+    private java.util.List<String> getUnavailableRegions(RxDocumentServiceRequest request) {
+        return this.getUnavailableRegions(request, PARTITION);
+    }
+
+    private java.util.List<String> getUnavailableRegions(
+        RxDocumentServiceRequest request,
+        PartitionKeyRangeWrapper partitionKeyRangeWrapper) {
+
+        return this.manager.getUnavailableRegionsForPartitionKeyRange(
+            request,
+            partitionKeyRangeWrapper.getCollectionResourceId(),
+            partitionKeyRangeWrapper.getPartitionKeyRange());
+    }
+
+    private static LocationHealthStatus getRegionHealthStatus(RxDocumentServiceRequest request) {
+        return request.requestContext
+            .getPerPartitionCircuitBreakerInfoHolder()
+            .getPerPartitionCircuitBreakerInfoHolder()
+            .get("eastus")
+            .getLocationHealthStatus();
+    }
+
+    private static RxDocumentServiceRequest createReadRequest() {
+        return createReadRequest(PARTITION);
+    }
+
+    private static RxDocumentServiceRequest createReadRequest(
+        PartitionKeyRangeWrapper partitionKeyRangeWrapper) {
+
+        RxDocumentServiceRequest request = RxDocumentServiceRequest.create(
+            Mockito.mock(DiagnosticsClientContext.class),
+            OperationType.Read,
+            ResourceType.Document);
+        request.setResourceId(partitionKeyRangeWrapper.getCollectionResourceId());
+        request.requestContext.resolvedPartitionKeyRange = partitionKeyRangeWrapper.getPartitionKeyRange();
+        request.requestContext.resolvedPartitionKeyRangeForCircuitBreaker = partitionKeyRangeWrapper.getPartitionKeyRange();
+        request.requestContext.regionalRoutingContextToRoute = REGION;
+        request.requestContext.setExcludeRegions(Collections.emptyList());
+        request.requestContext.setCrossRegionAvailabilityContext(
+            new CrossRegionAvailabilityContextForRxDocumentServiceRequest(
+                null,
+                null,
+                null,
+                new AtomicBoolean(false),
+                new PerPartitionCircuitBreakerInfoHolder(),
+                new PerPartitionAutomaticFailoverInfoHolder()));
+        return request;
     }
 
     private static Gauge getPendingRecoveryGauge(SimpleMeterRegistry registry, String collectionRid) {

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
@@ -511,6 +511,25 @@ public class PpcbFailbackLoggingTest {
         }
     }
 
+    @Test(groups = {"unit"})
+    public void allRegionsUnavailableClearsExclusionsAndPublishesEmptyState() {
+        RxDocumentServiceRequest request = createReadRequest(PARTITION);
+        int failureCount = this.manager.getConsecutiveExceptionBasedCircuitBreaker()
+            .getAllowedExceptionCountToMaintainStatus(LocationHealthStatus.HealthyWithFailures, true);
+
+        for (int failure = 0; failure < failureCount; failure++) {
+            this.manager.handleLocationExceptionForPartitionKeyRange(request, REGION, false);
+        }
+        for (int failure = 0; failure < failureCount; failure++) {
+            this.manager.handleLocationExceptionForPartitionKeyRange(request, SECOND_REGION, false);
+        }
+
+        assertThat(getUnavailableRegions(request, PARTITION)).isEmpty();
+        assertThat(request.requestContext
+            .getPerPartitionCircuitBreakerInfoHolder()
+            .getPerPartitionCircuitBreakerInfoHolder()).isEmpty();
+    }
+
     private void markRegionUnavailable(RxDocumentServiceRequest request) {
         this.markRegionUnavailable(request, PARTITION);
     }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
@@ -8,6 +8,10 @@ import com.azure.cosmos.implementation.OperationType;
 import com.azure.cosmos.implementation.PartitionKeyRange;
 import com.azure.cosmos.implementation.PartitionKeyRangeWrapper;
 import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
+import com.azure.cosmos.models.CosmosMetricName;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.testng.annotations.BeforeMethod;
@@ -18,7 +22,11 @@ import reactor.core.scheduler.Schedulers;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -182,5 +190,48 @@ public class PpcbFailbackLoggingTest {
             "PPCB failback backlog: unavailablePartitionRegionCount: 7"));
         verify(this.logger).info(contains(
             "PPCB failback backlog: unavailablePartitionRegionCount: 0"));
+    }
+
+    @Test(groups = {"unit"})
+    public void failbackRemainingGaugeIsPerCollectionAndReportsZero() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Map<String, Set<String>> remainingByCollection = new HashMap<>();
+        remainingByCollection.put("collectionA", new HashSet<>(Arrays.asList("0", "1", "2")));
+        remainingByCollection.put("collectionB", new HashSet<>(Arrays.asList("3", "4")));
+
+        try {
+            assertThat(CosmosMetricName.fromString("cosmos.client.ppcb.failback.remaining"))
+                .isSameAs(CosmosMetricName.PPCB_FAILBACK_REMAINING);
+            this.manager.registerFailbackRemainingMeter(
+                registry,
+                Tag.of("ClientCorrelationId", "client1"));
+            this.manager.recordFailbackRemainingByCollection(remainingByCollection);
+
+            assertThat(getFailbackRemainingGauge(registry, "collectionA").value()).isEqualTo(3);
+            assertThat(getFailbackRemainingGauge(registry, "collectionB").value()).isEqualTo(2);
+
+            Map<String, Set<String>> updatedRemainingByCollection = new HashMap<>();
+            updatedRemainingByCollection.put("collectionA", Collections.emptySet());
+            updatedRemainingByCollection.put("collectionB", Collections.singleton("4"));
+            this.manager.recordFailbackRemainingByCollection(updatedRemainingByCollection);
+
+            assertThat(getFailbackRemainingGauge(registry, "collectionA").value()).isZero();
+            assertThat(getFailbackRemainingGauge(registry, "collectionB").value()).isEqualTo(1);
+
+            this.manager.close();
+            assertThat(registry.find(CosmosMetricName.PPCB_FAILBACK_REMAINING.toString())
+                .gauges()).isEmpty();
+        } finally {
+            this.manager.close();
+            registry.close();
+        }
+    }
+
+    private static Gauge getFailbackRemainingGauge(SimpleMeterRegistry registry, String collectionRid) {
+        return registry
+            .get(CosmosMetricName.PPCB_FAILBACK_REMAINING.toString())
+            .tag("ClientCorrelationId", "client1")
+            .tag("CollectionRid", collectionRid)
+            .gauge();
     }
 }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
@@ -13,9 +13,13 @@ import org.slf4j.Logger;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -116,23 +120,67 @@ public class PpcbFailbackLoggingTest {
                 failure);
         }
 
-            verify(this.logger, times(11)).warn(contains("reason: RuntimeException"), same(failure));
-            verify(this.logger, times(89)).debug(contains("reason: RuntimeException"), same(failure));
+        verify(this.logger, times(11)).warn(contains("reason: RuntimeException"), same(failure));
+        verify(this.logger, times(89)).debug(contains("reason: RuntimeException"), same(failure));
     }
 
-        @Test(groups = {"unit"})
-        public void unexpectedStreamFailureIsLoggedAndRetried() {
-            RuntimeException failure = new RuntimeException("failure");
-            AtomicInteger subscriptions = new AtomicInteger();
-            Flux<String> recoveryWork = Flux.defer(() -> subscriptions.incrementAndGet() == 1
-                ? Flux.error(failure)
-                : Flux.just("recovered"));
+    @Test(groups = {"unit"})
+    public void unexpectedStreamFailureIsLoggedAndRetried() {
+        RuntimeException failure = new RuntimeException("failure");
+        AtomicInteger subscriptions = new AtomicInteger();
+        Flux<String> recoveryWork = Flux.defer(() -> subscriptions.incrementAndGet() == 1
+            ? Flux.error(failure)
+            : Flux.just("recovered"));
+
+        Object result = this.manager.keepFailbackRecoveryAlive(recoveryWork)
+            .blockFirst(Duration.ofSeconds(1));
+
+        assertThat(result).isEqualTo("recovered");
+        assertThat(subscriptions.get()).isEqualTo(2);
+        verify(this.logger).warn(contains("stage: RECOVERY_STREAM"), same(failure));
+    }
+
+    @Test(groups = {"unit"})
+    public void recoverySurvivesRepeatedFailuresOnOneThreadScheduler() {
+        Scheduler scheduler = Schedulers.newBoundedElastic(1, 1, "ppcb-resilience-test");
+        AtomicInteger subscriptions = new AtomicInteger();
+        Set<String> threadNames = new HashSet<>();
+
+        try {
+            Flux<String> recoveryWork = Flux.defer(() -> {
+                threadNames.add(Thread.currentThread().getName());
+                return subscriptions.incrementAndGet() <= 3
+                    ? Flux.error(new RuntimeException("failure"))
+                    : Flux.just("recovered");
+            }).subscribeOn(scheduler);
 
             Object result = this.manager.keepFailbackRecoveryAlive(recoveryWork)
-                .blockFirst(Duration.ofSeconds(1));
+                .blockFirst(Duration.ofSeconds(5));
 
             assertThat(result).isEqualTo("recovered");
-            assertThat(subscriptions.get()).isEqualTo(2);
-            verify(this.logger).warn(contains("stage: RECOVERY_STREAM"), same(failure));
+            assertThat(subscriptions.get()).isEqualTo(4);
+            assertThat(threadNames).hasSize(1);
+            assertThat(threadNames.iterator().next()).startsWith("ppcb-resilience-test");
+            verify(this.logger, times(1)).warn(contains("stage: RECOVERY_STREAM"), Mockito.any(RuntimeException.class));
+            verify(this.logger, times(2)).debug(contains("stage: RECOVERY_STREAM"), Mockito.any(RuntimeException.class));
+        } finally {
+            scheduler.dispose();
         }
+    }
+
+    @Test(groups = {"unit"})
+    public void failbackBacklogProgressIsSampledAndCompletionIsLogged() {
+        for (int scan = 0; scan < 10; scan++) {
+            this.manager.logFailbackBacklog(7);
+        }
+        this.manager.logFailbackBacklog(0);
+        this.manager.logFailbackBacklog(0);
+
+        verify(this.logger, times(2)).info(contains(
+            "PPCB failback backlog: unavailablePartitionRegionCount: 7"));
+        verify(this.logger, times(8)).debug(contains(
+            "PPCB failback backlog: unavailablePartitionRegionCount: 7"));
+        verify(this.logger).info(contains(
+            "PPCB failback backlog: unavailablePartitionRegionCount: 0"));
+    }
 }

--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PpcbFailbackLoggingTest.java
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.implementation.perPartitionCircuitBreaker;
+
+import com.azure.cosmos.implementation.GlobalEndpointManager;
+import com.azure.cosmos.implementation.OperationType;
+import com.azure.cosmos.implementation.PartitionKeyRange;
+import com.azure.cosmos.implementation.PartitionKeyRangeWrapper;
+import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import reactor.core.publisher.Flux;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class PpcbFailbackLoggingTest {
+
+    private static final PartitionKeyRangeWrapper PARTITION = new PartitionKeyRangeWrapper(
+        new PartitionKeyRange("0", "AA", "BB"),
+        "collectionRid");
+    private static final RegionalRoutingContext REGION = new RegionalRoutingContext(
+        URI.create("https://contoso-east-us.documents.azure.com"));
+
+    private GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker manager;
+    private Logger logger;
+
+    @BeforeMethod(groups = {"unit"})
+    public void setup() {
+        GlobalEndpointManager globalEndpointManager = Mockito.mock(GlobalEndpointManager.class);
+        doReturn("eastus").when(globalEndpointManager).getRegionName(
+            REGION.getGatewayRegionalEndpoint(),
+            OperationType.Read);
+        this.logger = Mockito.mock(Logger.class);
+        doReturn(true).when(this.logger).isWarnEnabled();
+        doReturn(true).when(this.logger).isDebugEnabled();
+        this.manager = new GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker(
+            globalEndpointManager,
+            this.logger);
+    }
+
+    @Test(groups = {"unit"})
+    public void repeatedFailuresAreSampledByPartitionRegionStageAndReason() {
+        RuntimeException failure = new RuntimeException("failure");
+
+        for (int occurrence = 0; occurrence < 10; occurrence++) {
+            this.manager.logFailbackFailure(PARTITION, REGION, "OPEN_CONNECTION_TASK", failure);
+        }
+
+        verify(this.logger, times(2)).warn(
+            contains("collectionResourceId: collectionRid, partitionKeyRangeId: 0, region: eastus, stage: OPEN_CONNECTION_TASK, reason: RuntimeException"),
+            same(failure));
+        verify(this.logger, times(8)).debug(
+            contains("collectionResourceId: collectionRid, partitionKeyRangeId: 0, region: eastus, stage: OPEN_CONNECTION_TASK, reason: RuntimeException"),
+            same(failure));
+    }
+
+    @Test(groups = {"unit"})
+    public void changedFailureReasonUsesTheSameCounter() {
+        RuntimeException firstFailure = new RuntimeException("first");
+        IllegalStateException changedFailure = new IllegalStateException("changed");
+
+        this.manager.logFailbackFailure(PARTITION, REGION, "OPEN_CONNECTION_TASK", firstFailure);
+        this.manager.logFailbackFailure(PARTITION, REGION, "OPEN_CONNECTION_TASK", firstFailure);
+        this.manager.logFailbackFailure(PARTITION, REGION, "OPEN_CONNECTION_TASK", changedFailure);
+
+        verify(this.logger).warn(contains("reason: RuntimeException"), same(firstFailure));
+        verify(this.logger).debug(contains("reason: RuntimeException"), same(firstFailure));
+        verify(this.logger).debug(contains("reason: IllegalStateException"), same(changedFailure));
+    }
+
+    @Test(groups = {"unit"})
+    public void differentStagesUseTheSameCounter() {
+        RuntimeException failure = new RuntimeException("failure");
+
+        this.manager.logFailbackFailure(PARTITION, REGION, "OPEN_CONNECTION_TASK", failure);
+        this.manager.logFailbackFailure(PARTITION, REGION, "RECOVERY_PIPELINE", failure);
+
+        verify(this.logger).warn(contains("stage: OPEN_CONNECTION_TASK"), same(failure));
+        verify(this.logger).debug(contains("stage: RECOVERY_PIPELINE"), same(failure));
+    }
+
+    @Test(groups = {"unit"})
+    public void streamFailureWithoutPartitionIdentityIsStillLogged() {
+        RuntimeException failure = new RuntimeException("failure");
+
+        this.manager.logFailbackFailure(null, null, "RECOVERY_STREAM", failure);
+
+        verify(this.logger).warn(
+            contains("collectionResourceId: , partitionKeyRangeId: , region: , stage: RECOVERY_STREAM, reason: RuntimeException"),
+            same(failure));
+    }
+
+    @Test(groups = {"unit"})
+    public void manyPartitionsUseConstantSamplingState() {
+        RuntimeException failure = new RuntimeException("failure");
+
+        for (int rangeId = 0; rangeId < 100; rangeId++) {
+            this.manager.logFailbackFailure(
+                new PartitionKeyRangeWrapper(
+                    new PartitionKeyRange(String.valueOf(rangeId), "AA", "BB"),
+                    "collectionRid"),
+                REGION,
+                "OPEN_CONNECTION_TASK",
+                failure);
+        }
+
+            verify(this.logger, times(11)).warn(contains("reason: RuntimeException"), same(failure));
+            verify(this.logger, times(89)).debug(contains("reason: RuntimeException"), same(failure));
+    }
+
+        @Test(groups = {"unit"})
+        public void unexpectedStreamFailureIsLoggedAndRetried() {
+            RuntimeException failure = new RuntimeException("failure");
+            AtomicInteger subscriptions = new AtomicInteger();
+            Flux<String> recoveryWork = Flux.defer(() -> subscriptions.incrementAndGet() == 1
+                ? Flux.error(failure)
+                : Flux.just("recovered"));
+
+            Object result = this.manager.keepFailbackRecoveryAlive(recoveryWork)
+                .blockFirst(Duration.ofSeconds(1));
+
+            assertThat(result).isEqualTo("recovered");
+            assertThat(subscriptions.get()).isEqualTo(2);
+            verify(this.logger).warn(contains("stage: RECOVERY_STREAM"), same(failure));
+        }
+}

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Features Added
 * Enabled Gateway V2 (thin-client) data-plane routing by default for `Cosmos(Async)Client` instances configured with `gatewayMode` and HTTP/2, gated by an HTTP/2 connectivity probe with automatic fallback to Gateway V1. - See [PR 49437](https://github.com/Azure/azure-sdk-for-java/pull/49437)
 * Added support for QueryPlan and Execute Stored Procedure requests to be routed to Gateway V2. - See [PR 47759](https://github.com/Azure/azure-sdk-for-java/pull/47759)
+* Added the `cosmos.client.ppcb.failback.remaining` gauge (`CosmosMetricName.PPCB_FAILBACK_REMAINING`) to report partition key ranges remaining to fail back per collection. - See [PR 50122](https://github.com/Azure/azure-sdk-for-java/pull/50122)
 
 #### Breaking Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -5,7 +5,7 @@
 #### Features Added
 * Enabled Gateway V2 (thin-client) data-plane routing by default for `Cosmos(Async)Client` instances configured with `gatewayMode` and HTTP/2, gated by an HTTP/2 connectivity probe with automatic fallback to Gateway V1. - See [PR 49437](https://github.com/Azure/azure-sdk-for-java/pull/49437)
 * Added support for QueryPlan and Execute Stored Procedure requests to be routed to Gateway V2. - See [PR 47759](https://github.com/Azure/azure-sdk-for-java/pull/47759)
-* Added the `cosmos.client.ppcb.failback.pendingPartitionCount` gauge (`CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT`) to report partition key ranges remaining to fail back per collection. - See [PR 50122](https://github.com/Azure/azure-sdk-for-java/pull/50122)
+* Added the `cosmos.client.ppcb.failback.pendingRecoveryCount` gauge (`CosmosMetricName.PPCB_FAILBACK_PENDING_RECOVERY_COUNT`) to report partition range-region recovery actions pending failback per collection. - See [PR 50122](https://github.com/Azure/azure-sdk-for-java/pull/50122)
 
 #### Breaking Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -5,7 +5,7 @@
 #### Features Added
 * Enabled Gateway V2 (thin-client) data-plane routing by default for `Cosmos(Async)Client` instances configured with `gatewayMode` and HTTP/2, gated by an HTTP/2 connectivity probe with automatic fallback to Gateway V1. - See [PR 49437](https://github.com/Azure/azure-sdk-for-java/pull/49437)
 * Added support for QueryPlan and Execute Stored Procedure requests to be routed to Gateway V2. - See [PR 47759](https://github.com/Azure/azure-sdk-for-java/pull/47759)
-* Added the `cosmos.client.ppcb.failback.remaining` gauge (`CosmosMetricName.PPCB_FAILBACK_REMAINING`) to report partition key ranges remaining to fail back per collection. - See [PR 50122](https://github.com/Azure/azure-sdk-for-java/pull/50122)
+* Added the `cosmos.client.ppcb.failback.pendingPartitionCount` gauge (`CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT`) to report partition key ranges remaining to fail back per collection. - See [PR 50122](https://github.com/Azure/azure-sdk-for-java/pull/50122)
 
 #### Breaking Changes
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosAsyncClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosAsyncClient.java
@@ -221,7 +221,7 @@ public final class CosmosAsyncClient implements Closeable {
         CosmosMeterOptions memoryMeterOptions = clientTelemetryConfigAccessor()
             .getMeterOptions(effectiveTelemetryConfig, CosmosMetricName.SYSTEM_MEMORY_FREE);
         CosmosMeterOptions failbackRemainingMeterOptions = clientTelemetryConfigAccessor()
-            .getMeterOptions(effectiveTelemetryConfig, CosmosMetricName.PPCB_FAILBACK_REMAINING);
+            .getMeterOptions(effectiveTelemetryConfig, CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT);
 
         if (clientMetricRegistrySnapshot != null) {
             ClientTelemetryMetrics.add(clientMetricRegistrySnapshot, cpuMeterOptions, memoryMeterOptions);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosAsyncClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosAsyncClient.java
@@ -220,8 +220,8 @@ public final class CosmosAsyncClient implements Closeable {
             .getMeterOptions(effectiveTelemetryConfig, CosmosMetricName.SYSTEM_CPU);
         CosmosMeterOptions memoryMeterOptions = clientTelemetryConfigAccessor()
             .getMeterOptions(effectiveTelemetryConfig, CosmosMetricName.SYSTEM_MEMORY_FREE);
-        CosmosMeterOptions failbackRemainingMeterOptions = clientTelemetryConfigAccessor()
-            .getMeterOptions(effectiveTelemetryConfig, CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT);
+        CosmosMeterOptions failbackPendingRecoveryMeterOptions = clientTelemetryConfigAccessor()
+            .getMeterOptions(effectiveTelemetryConfig, CosmosMetricName.PPCB_FAILBACK_PENDING_RECOVERY_COUNT);
 
         if (clientMetricRegistrySnapshot != null) {
             ClientTelemetryMetrics.add(clientMetricRegistrySnapshot, cpuMeterOptions, memoryMeterOptions);
@@ -238,10 +238,10 @@ public final class CosmosAsyncClient implements Closeable {
                 effectiveTelemetryConfig,
                 this.accountTagValue
             );
-            if (failbackRemainingMeterOptions.isEnabled()) {
+            if (failbackPendingRecoveryMeterOptions.isEnabled()) {
                 this.asyncDocumentClient
                     .getGlobalPartitionEndpointManagerForCircuitBreaker()
-                    .registerFailbackRemainingMeter(
+                    .registerFailbackPendingRecoveryMeter(
                         this.clientMetricRegistrySnapshot,
                         this.clientCorrelationTag);
             }
@@ -574,7 +574,7 @@ public final class CosmosAsyncClient implements Closeable {
         if (this.clientMetricRegistrySnapshot != null) {
             this.asyncDocumentClient
                 .getGlobalPartitionEndpointManagerForCircuitBreaker()
-                .removeFailbackRemainingMeter();
+                .removeFailbackPendingRecoveryMeter();
             ClientTelemetryMetrics.remove(this.clientMetricRegistrySnapshot);
         }
         asyncDocumentClient.close();

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosAsyncClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosAsyncClient.java
@@ -212,6 +212,9 @@ public final class CosmosAsyncClient implements Closeable {
         this.clientCorrelationTag = Tag.of(
             TagName.ClientCorrelationId.toString(),
             ClientTelemetryMetrics.escape(effectiveClientCorrelationId));
+        this.asyncDocumentClient
+            .getGlobalPartitionEndpointManagerForCircuitBreaker()
+            .setClientCorrelationId(this.clientCorrelationTag.getValue());
 
         this.clientMetricRegistrySnapshot = clientTelemetryConfigAccessor()
             .getClientMetricRegistry(effectiveTelemetryConfig);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosAsyncClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/CosmosAsyncClient.java
@@ -220,6 +220,8 @@ public final class CosmosAsyncClient implements Closeable {
             .getMeterOptions(effectiveTelemetryConfig, CosmosMetricName.SYSTEM_CPU);
         CosmosMeterOptions memoryMeterOptions = clientTelemetryConfigAccessor()
             .getMeterOptions(effectiveTelemetryConfig, CosmosMetricName.SYSTEM_MEMORY_FREE);
+        CosmosMeterOptions failbackRemainingMeterOptions = clientTelemetryConfigAccessor()
+            .getMeterOptions(effectiveTelemetryConfig, CosmosMetricName.PPCB_FAILBACK_REMAINING);
 
         if (clientMetricRegistrySnapshot != null) {
             ClientTelemetryMetrics.add(clientMetricRegistrySnapshot, cpuMeterOptions, memoryMeterOptions);
@@ -236,6 +238,13 @@ public final class CosmosAsyncClient implements Closeable {
                 effectiveTelemetryConfig,
                 this.accountTagValue
             );
+            if (failbackRemainingMeterOptions.isEnabled()) {
+                this.asyncDocumentClient
+                    .getGlobalPartitionEndpointManagerForCircuitBreaker()
+                    .registerFailbackRemainingMeter(
+                        this.clientMetricRegistrySnapshot,
+                        this.clientCorrelationTag);
+            }
 
             clientTelemetryConfigAccessor().addDiagnosticsHandler(
                 effectiveTelemetryConfig,
@@ -563,6 +572,9 @@ public final class CosmosAsyncClient implements Closeable {
     @Override
     public void close() {
         if (this.clientMetricRegistrySnapshot != null) {
+            this.asyncDocumentClient
+                .getGlobalPartitionEndpointManagerForCircuitBreaker()
+                .removeFailbackRemainingMeter();
             ClientTelemetryMetrics.remove(this.clientMetricRegistrySnapshot);
         }
         asyncDocumentClient.close();

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ClientSideRequestStatistics.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ClientSideRequestStatistics.java
@@ -12,6 +12,7 @@ import com.azure.cosmos.implementation.http.ReactorNettyRequestRecord;
 import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -174,7 +175,8 @@ public class ClientSideRequestStatistics {
 
             this.approximateInsertionCountInBloomFilter = request.requestContext.getApproximateBloomFilterInsertionCount();
             storeResponseStatistics.sessionTokenEvaluationResults = request.requestContext.getSessionTokenEvaluationResults();
-            storeResponseStatistics.perPartitionCircuitBreakerInfoHolder = request.requestContext.getPerPartitionCircuitBreakerInfoHolder();
+            storeResponseStatistics.perPartitionCircuitBreakerInfoHolder
+                = request.requestContext.getPerPartitionCircuitBreakerInfoHolder().snapshot();
             storeResponseStatistics.perPartitionAutomaticFailoverInfoHolder = request.requestContext.getPerPartitionFailoverContextHolder();
 
             if (request.requestContext.getCrossRegionAvailabilityContext() != null) {
@@ -268,7 +270,8 @@ public class ClientSideRequestStatistics {
 
                 if (rxDocumentServiceRequest.requestContext != null) {
                     gatewayStatistics.sessionTokenEvaluationResults = rxDocumentServiceRequest.requestContext.getSessionTokenEvaluationResults();
-                    gatewayStatistics.perPartitionCircuitBreakerInfoHolder = rxDocumentServiceRequest.requestContext.getPerPartitionCircuitBreakerInfoHolder();
+                    gatewayStatistics.perPartitionCircuitBreakerInfoHolder
+                        = rxDocumentServiceRequest.requestContext.getPerPartitionCircuitBreakerInfoHolder().snapshot();
                     gatewayStatistics.perPartitionAutomaticFailoverInfoHolder = rxDocumentServiceRequest.requestContext.getPerPartitionFailoverContextHolder();
                     gatewayStatistics.isHubRegionProcessingOnly = "false";
 
@@ -742,6 +745,7 @@ public class ClientSideRequestStatistics {
         private Set<String> sessionTokenEvaluationResults;
 
         @JsonSerialize(using = PerPartitionCircuitBreakerInfoHolder.PerPartitionCircuitBreakerInfoHolderSerializer.class)
+        @JsonProperty("ppcb")
         private PerPartitionCircuitBreakerInfoHolder perPartitionCircuitBreakerInfoHolder;
 
         @JsonSerialize(using = PerPartitionAutomaticFailoverInfoHolder.PerPartitionFailoverInfoHolderSerializer.class)
@@ -1113,7 +1117,7 @@ public class ClientSideRequestStatistics {
                 }
 
                 this.writeNonEmptyStringSetField(jsonGenerator, "sessionTokenEvaluationResults", gatewayStatistics.getSessionTokenEvaluationResults());
-                this.writeNonNullObjectField(jsonGenerator, "perPartitionCircuitBreakerInfoHolder", gatewayStatistics.getPerPartitionCircuitBreakerInfoHolder());
+                this.writeNonNullObjectField(jsonGenerator, "ppcb", gatewayStatistics.getPerPartitionCircuitBreakerInfoHolder());
                 this.writeNonNullObjectField(jsonGenerator, "perPartitionAutomaticFailoverInfoHolder", gatewayStatistics.getPerPartitionFailoverInfoHolder());
 
                 this.writeNonNullStringField(jsonGenerator, "requestTCG", gatewayStatistics.getRequestThroughputControlGroupName());

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
@@ -21,6 +21,11 @@ import com.azure.cosmos.implementation.apachecommons.lang.tuple.Pair;
 import com.azure.cosmos.implementation.directconnectivity.GatewayAddressCache;
 import com.azure.cosmos.implementation.directconnectivity.GlobalAddressResolver;
 import com.azure.cosmos.implementation.routing.RegionalRoutingContext;
+import com.azure.cosmos.models.CosmosMetricName;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MultiGauge;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
@@ -33,9 +38,11 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -46,6 +53,7 @@ import static com.azure.cosmos.implementation.guava25.base.Preconditions.checkNo
 public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.class);
+    private static final String COLLECTION_RID_TAG_NAME = "CollectionRid";
     private static final Map<String, String> EMPTY_MAP = new HashMap<>();
     private static final String BASE_EXCEPTION_MESSAGE = "FAILED IN Per-Partition Circuit Breaker: ";
 
@@ -61,6 +69,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
     private final Logger failbackLogger;
     private final AtomicInteger failbackFailureLogCount;
     private final AtomicInteger failbackBacklogScanCount;
+    private final AtomicReference<MultiGauge> failbackRemainingGauge;
 
     public GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker(GlobalEndpointManager globalEndpointManager) {
         this(globalEndpointManager, logger);
@@ -75,6 +84,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         this.failbackLogger = checkNotNull(failbackLogger, "Argument 'failbackLogger' cannot be null!");
         this.failbackFailureLogCount = new AtomicInteger();
         this.failbackBacklogScanCount = new AtomicInteger();
+        this.failbackRemainingGauge = new AtomicReference<>();
 
         PartitionLevelCircuitBreakerConfig partitionLevelCircuitBreakerConfig = Configs.getPartitionLevelCircuitBreakerConfig();
         this.consecutiveExceptionBasedCircuitBreaker = new ConsecutiveExceptionBasedCircuitBreaker(partitionLevelCircuitBreakerConfig);
@@ -396,11 +406,16 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
     private Flux<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, LocationSpecificHealthContext>>> getFailbackBacklog() {
         List<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, LocationSpecificHealthContext>>> failbackBacklog
             = new ArrayList<>();
+        Map<String, Set<String>> remainingPartitionRangeIdsByCollection = new HashMap<>();
 
         for (Map.Entry<PartitionKeyRangeWrapper, PartitionLevelLocationUnavailabilityInfo> entry
             : this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.entrySet()) {
 
             PartitionKeyRangeWrapper partitionKeyRangeWrapper = entry.getKey();
+            Set<String> remainingPartitionRangeIds = remainingPartitionRangeIdsByCollection
+                .computeIfAbsent(
+                    partitionKeyRangeWrapper.getCollectionResourceId(),
+                    ignored -> new HashSet<>());
 
             try {
                 PartitionLevelLocationUnavailabilityInfo partitionLevelLocationUnavailabilityInfo = entry.getValue();
@@ -420,6 +435,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                                     Pair.of(
                                         locationWithStaleUnavailabilityInfo,
                                         locationSpecificHealthContext)));
+                            remainingPartitionRangeIds.add(partitionKeyRangeWrapper.getPartitionKeyRange().getId());
                         }
                     }
                 }
@@ -433,7 +449,42 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         }
 
         this.logFailbackBacklog(failbackBacklog.size());
+        this.recordFailbackRemainingByCollection(remainingPartitionRangeIdsByCollection);
         return Flux.fromIterable(failbackBacklog);
+    }
+
+    public synchronized void registerFailbackRemainingMeter(MeterRegistry meterRegistry, Tag clientCorrelationTag) {
+        if (meterRegistry == null || clientCorrelationTag == null || this.failbackRemainingGauge.get() != null) {
+            return;
+        }
+
+        this.failbackRemainingGauge.set(
+            MultiGauge.builder(CosmosMetricName.PPCB_FAILBACK_REMAINING.toString())
+                .description("Number of PPCB partition key ranges remaining to fail back")
+                .baseUnit("partitions")
+                .tags(Collections.singletonList(clientCorrelationTag))
+                .register(meterRegistry));
+    }
+
+    void recordFailbackRemainingByCollection(Map<String, Set<String>> remainingPartitionRangeIdsByCollection) {
+        MultiGauge gauge = this.failbackRemainingGauge.get();
+        if (gauge == null) {
+            return;
+        }
+
+        List<MultiGauge.Row<?>> rows = new ArrayList<>();
+        remainingPartitionRangeIdsByCollection.forEach((collectionRid, partitionRangeIds) ->
+            rows.add(MultiGauge.Row.of(
+                Tags.of(COLLECTION_RID_TAG_NAME, collectionRid),
+                partitionRangeIds.size())));
+        gauge.register(rows, true);
+    }
+
+    public void removeFailbackRemainingMeter() {
+        MultiGauge gauge = this.failbackRemainingGauge.getAndSet(null);
+        if (gauge != null) {
+            gauge.register(Collections.emptyList(), true);
+        }
     }
 
     void logFailbackBacklog(int unavailablePartitionRegionCount) {
@@ -577,6 +628,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         this.isClosed.set(true);
         this.failbackFailureLogCount.set(0);
         this.failbackBacklogScanCount.set(0);
+        this.removeFailbackRemainingMeter();
         Disposable disposable = this.partitionRecoveryDisposable.getAndSet(null);
         if (disposable != null && !disposable.isDisposed()) {
             disposable.dispose();

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
@@ -60,6 +60,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
     private final AtomicReference<Disposable> partitionRecoveryDisposable = new AtomicReference<>();
     private final Logger failbackLogger;
     private final AtomicInteger failbackFailureLogCount;
+    private final AtomicInteger failbackBacklogScanCount;
 
     public GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker(GlobalEndpointManager globalEndpointManager) {
         this(globalEndpointManager, logger);
@@ -73,6 +74,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         this.globalEndpointManager = globalEndpointManager;
         this.failbackLogger = checkNotNull(failbackLogger, "Argument 'failbackLogger' cannot be null!");
         this.failbackFailureLogCount = new AtomicInteger();
+        this.failbackBacklogScanCount = new AtomicInteger();
 
         PartitionLevelCircuitBreakerConfig partitionLevelCircuitBreakerConfig = Configs.getPartitionLevelCircuitBreakerConfig();
         this.consecutiveExceptionBasedCircuitBreaker = new ConsecutiveExceptionBasedCircuitBreaker(partitionLevelCircuitBreakerConfig);
@@ -312,52 +314,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         Flux<?> recoveryWork = Mono.just(1)
             .delayElement(Duration.ofSeconds(Configs.getStalePartitionUnavailabilityRefreshIntervalInSeconds()))
             .repeat(() -> !this.isClosed.get())
-            .flatMap(ignore -> Flux.fromIterable(this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.entrySet()), 1, 1)
-            .flatMap(partitionKeyRangeWrapperToPartitionKeyRangeWrapperPair -> {
-
-                logger.debug("Background updateStaleLocationInfo kicking in...");
-                PartitionKeyRangeWrapper partitionKeyRangeWrapper
-                    = partitionKeyRangeWrapperToPartitionKeyRangeWrapperPair.getKey();
-
-                try {
-                    PartitionLevelLocationUnavailabilityInfo partitionLevelLocationUnavailabilityInfo = this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.get(partitionKeyRangeWrapper);
-
-                    if (partitionLevelLocationUnavailabilityInfo != null) {
-
-                        List<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, LocationSpecificHealthContext>>> locationToLocationSpecificHealthContextList = new ArrayList<>();
-
-                        for (Map.Entry<RegionalRoutingContext, LocationSpecificHealthContext> locationToLocationLevelMetrics : partitionLevelLocationUnavailabilityInfo.locationEndpointToLocationSpecificContextForPartition.entrySet()) {
-
-                            RegionalRoutingContext locationWithStaleUnavailabilityInfo = locationToLocationLevelMetrics.getKey();
-                            LocationSpecificHealthContext locationSpecificHealthContext = locationToLocationLevelMetrics.getValue();
-
-                            if (!locationSpecificHealthContext.isRegionAvailableToProcessRequests()) {
-                                locationToLocationSpecificHealthContextList.add(
-                                    Pair.of(
-                                        partitionKeyRangeWrapper,
-                                        Pair.of(
-                                            locationWithStaleUnavailabilityInfo,
-                                            locationSpecificHealthContext)));
-                            }
-                        }
-
-                        if (locationToLocationSpecificHealthContextList.isEmpty()) {
-                            return Flux.empty();
-                        } else {
-                            return Flux.fromIterable(locationToLocationSpecificHealthContextList);
-                        }
-                    } else {
-                        return Mono.empty();
-                    }
-                } catch (Exception e) {
-                    this.logFailbackFailure(
-                        partitionKeyRangeWrapper,
-                        null,
-                        "SCAN_UNAVAILABLE_PARTITIONS",
-                        e);
-                    return Flux.empty();
-                }
-            }, 1, 1)
+            .flatMap(ignore -> this.getFailbackBacklog(), 1, 1)
             .flatMap(locationToLocationSpecificHealthContextPair -> {
 
                 try {
@@ -434,6 +391,73 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
             }, 1, 1);
 
         return this.keepFailbackRecoveryAlive(recoveryWork);
+    }
+
+    private Flux<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, LocationSpecificHealthContext>>> getFailbackBacklog() {
+        List<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, LocationSpecificHealthContext>>> failbackBacklog
+            = new ArrayList<>();
+
+        for (Map.Entry<PartitionKeyRangeWrapper, PartitionLevelLocationUnavailabilityInfo> entry
+            : this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.entrySet()) {
+
+            PartitionKeyRangeWrapper partitionKeyRangeWrapper = entry.getKey();
+
+            try {
+                PartitionLevelLocationUnavailabilityInfo partitionLevelLocationUnavailabilityInfo = entry.getValue();
+
+                if (partitionLevelLocationUnavailabilityInfo != null) {
+
+                    for (Map.Entry<RegionalRoutingContext, LocationSpecificHealthContext> locationToLocationLevelMetrics
+                        : partitionLevelLocationUnavailabilityInfo.locationEndpointToLocationSpecificContextForPartition.entrySet()) {
+
+                        RegionalRoutingContext locationWithStaleUnavailabilityInfo = locationToLocationLevelMetrics.getKey();
+                        LocationSpecificHealthContext locationSpecificHealthContext = locationToLocationLevelMetrics.getValue();
+
+                        if (!locationSpecificHealthContext.isRegionAvailableToProcessRequests()) {
+                            failbackBacklog.add(
+                                Pair.of(
+                                    partitionKeyRangeWrapper,
+                                    Pair.of(
+                                        locationWithStaleUnavailabilityInfo,
+                                        locationSpecificHealthContext)));
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                this.logFailbackFailure(
+                    partitionKeyRangeWrapper,
+                    null,
+                    "SCAN_UNAVAILABLE_PARTITIONS",
+                    e);
+            }
+        }
+
+        this.logFailbackBacklog(failbackBacklog.size());
+        return Flux.fromIterable(failbackBacklog);
+    }
+
+    void logFailbackBacklog(int unavailablePartitionRegionCount) {
+        int previousScanCount = unavailablePartitionRegionCount == 0
+            ? this.failbackBacklogScanCount.getAndSet(0)
+            : this.failbackBacklogScanCount.updateAndGet(
+                current -> current == Integer.MAX_VALUE ? 1 : current + 1);
+
+        if (unavailablePartitionRegionCount == 0 && previousScanCount == 0) {
+            return;
+        }
+
+        String message = "PPCB failback backlog: unavailablePartitionRegionCount: "
+            + unavailablePartitionRegionCount
+            + ", trackedPartitionKeyRangeCount: "
+            + this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.size()
+            + ", consecutiveBacklogScanCount: "
+            + (unavailablePartitionRegionCount == 0 ? 0 : previousScanCount);
+
+        if (unavailablePartitionRegionCount == 0 || previousScanCount == 1 || previousScanCount % 10 == 0) {
+            this.failbackLogger.info(message);
+        } else {
+            this.failbackLogger.debug(message);
+        }
     }
 
     Flux<?> keepFailbackRecoveryAlive(Flux<?> recoveryWork) {
@@ -552,6 +576,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
     public void close() {
         this.isClosed.set(true);
         this.failbackFailureLogCount.set(0);
+        this.failbackBacklogScanCount.set(0);
         Disposable disposable = this.partitionRecoveryDisposable.getAndSet(null);
         if (disposable != null && !disposable.isDisposed()) {
             disposable.dispose();

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
@@ -68,6 +68,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
     private final AtomicInteger failbackFailureLogCount;
     private final AtomicInteger failbackBacklogScanCount;
     private final AtomicReference<MultiGauge> failbackPendingRecoveryGauge;
+    private final AtomicReference<String> clientCorrelationId;
 
     public GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker(GlobalEndpointManager globalEndpointManager) {
         this(globalEndpointManager, logger);
@@ -83,6 +84,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         this.failbackFailureLogCount = new AtomicInteger();
         this.failbackBacklogScanCount = new AtomicInteger();
         this.failbackPendingRecoveryGauge = new AtomicReference<>();
+        this.clientCorrelationId = new AtomicReference<>(StringUtils.EMPTY);
 
         PartitionLevelCircuitBreakerConfig partitionLevelCircuitBreakerConfig = Configs.getPartitionLevelCircuitBreakerConfig();
         this.consecutiveExceptionBasedCircuitBreaker = new ConsecutiveExceptionBasedCircuitBreaker(partitionLevelCircuitBreakerConfig);
@@ -323,12 +325,11 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
             .delayElement(Duration.ofSeconds(Configs.getStalePartitionUnavailabilityRefreshIntervalInSeconds()))
             .repeat(() -> !this.isClosed.get())
             .flatMap(ignore -> this.getFailbackBacklog(), 1, 1)
-            .flatMap(failbackRecoveryCandidate -> {
+            .flatMap(failbackRecoveryEntry -> {
 
                 try {
-                    PartitionKeyRangeWrapper partitionKeyRangeWrapper = failbackRecoveryCandidate.getLeft();
-                    RegionalRoutingContext locationWithStaleUnavailabilityInfo = failbackRecoveryCandidate.getRight().getLeft();
-                    AtomicInteger pendingRecoveryCount = failbackRecoveryCandidate.getRight().getRight();
+                    PartitionKeyRangeWrapper partitionKeyRangeWrapper = failbackRecoveryEntry.getLeft();
+                    RegionalRoutingContext locationWithStaleUnavailabilityInfo = failbackRecoveryEntry.getRight();
 
                     PartitionLevelLocationUnavailabilityInfo partitionLevelLocationUnavailabilityInfo = this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.get(partitionKeyRangeWrapper);
 
@@ -353,13 +354,11 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                                             + partitionKeyRangeWrapper.getCollectionResourceId() +
                                             " has succeeded...");
 
-                                        if (partitionLevelLocationUnavailabilityInfo.handleSuccess(
-                                                partitionKeyRangeWrapper,
-                                                locationWithStaleUnavailabilityInfo,
-                                                true,
-                                                true)) {
-                                            this.markFailbackRecoveryCompleted(pendingRecoveryCount);
-                                        }
+                                        partitionLevelLocationUnavailabilityInfo.handleSuccess(
+                                            partitionKeyRangeWrapper,
+                                            locationWithStaleUnavailabilityInfo,
+                                            true,
+                                            true);
 
                                     })
                                     .onErrorResume(throwable -> {
@@ -378,20 +377,18 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                                     new IllegalStateException("GatewayAddressCache is not available."));
                             }
                         } else {
-                            if (partitionLevelLocationUnavailabilityInfo.handleSuccess(
-                                    partitionKeyRangeWrapper,
-                                    locationWithStaleUnavailabilityInfo,
-                                    true,
-                                    true)) {
-                                this.markFailbackRecoveryCompleted(pendingRecoveryCount);
-                            }
+                            partitionLevelLocationUnavailabilityInfo.handleSuccess(
+                                partitionKeyRangeWrapper,
+                                locationWithStaleUnavailabilityInfo,
+                                true,
+                                true);
 
                         }
                     }
                 } catch (Exception e) {
-                    PartitionKeyRangeWrapper partitionKeyRangeWrapper = failbackRecoveryCandidate.getLeft();
+                    PartitionKeyRangeWrapper partitionKeyRangeWrapper = failbackRecoveryEntry.getLeft();
                     RegionalRoutingContext locationWithStaleUnavailabilityInfo
-                        = failbackRecoveryCandidate.getRight().getLeft();
+                        = failbackRecoveryEntry.getRight();
                     this.logFailbackFailure(
                         partitionKeyRangeWrapper,
                         locationWithStaleUnavailabilityInfo,
@@ -406,8 +403,8 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         return this.keepFailbackRecoveryAlive(recoveryWork);
     }
 
-    private Flux<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, AtomicInteger>>> getFailbackBacklog() {
-        List<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, AtomicInteger>>> failbackBacklog
+    private Flux<Pair<PartitionKeyRangeWrapper, RegionalRoutingContext>> getFailbackBacklog() {
+        List<Pair<PartitionKeyRangeWrapper, RegionalRoutingContext>> failbackBacklog
             = new ArrayList<>();
         Map<String, AtomicInteger> pendingRecoveryCountByCollection = new HashMap<>();
 
@@ -433,9 +430,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
 
                         if (!locationSpecificHealthContext.isRegionAvailableToProcessRequests()) {
                             pendingRecoveryCount.incrementAndGet();
-                            failbackBacklog.add(Pair.of(
-                                partitionKeyRangeWrapper,
-                                Pair.of(locationWithStaleUnavailabilityInfo, pendingRecoveryCount)));
+                            failbackBacklog.add(Pair.of(partitionKeyRangeWrapper, locationWithStaleUnavailabilityInfo));
                         }
                     }
                 }
@@ -454,11 +449,11 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         return Flux.fromIterable(failbackBacklog);
     }
 
-    private void markFailbackRecoveryCompleted(AtomicInteger pendingRecoveryCount) {
-        pendingRecoveryCount.updateAndGet(current -> Math.max(0, current - 1));
-    }
-
     public synchronized void registerFailbackPendingRecoveryMeter(MeterRegistry meterRegistry, Tag clientCorrelationTag) {
+        if (clientCorrelationTag != null) {
+            this.clientCorrelationId.set(clientCorrelationTag.getValue());
+        }
+
         if (meterRegistry == null || clientCorrelationTag == null || this.failbackPendingRecoveryGauge.get() != null) {
             return;
         }
@@ -469,6 +464,10 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                 .baseUnit("recoveries")
                 .tags(Collections.singletonList(clientCorrelationTag))
                 .register(meterRegistry));
+    }
+
+    public void setClientCorrelationId(String clientCorrelationId) {
+        this.clientCorrelationId.set(clientCorrelationId == null ? StringUtils.EMPTY : clientCorrelationId);
     }
 
     void recordFailbackPendingRecoveryByCollection(Map<String, AtomicInteger> pendingRecoveryCountByCollection) {
@@ -507,7 +506,9 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
             + ", trackedPartitionKeyRangeCount: "
             + this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.size()
             + ", consecutiveBacklogScanCount: "
-            + (unavailablePartitionRegionCount == 0 ? 0 : previousScanCount);
+            + (unavailablePartitionRegionCount == 0 ? 0 : previousScanCount)
+            + ", clientCorrelationId: "
+            + this.clientCorrelationId.get();
 
         if (unavailablePartitionRegionCount == 0 || previousScanCount == 1 || previousScanCount % 10 == 0) {
             this.failbackLogger.info(message);
@@ -550,7 +551,9 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
             + ", stage: "
             + stage
             + ", reason: "
-            + reason;
+            + reason
+            + ", clientCorrelationId: "
+            + this.clientCorrelationId.get();
 
         if (this.shouldLogFailbackFailureAtWarn()) {
             this.failbackLogger.warn(message, throwable);
@@ -700,13 +703,12 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
             return isExceptionThresholdBreached.get();
         }
 
-        private boolean handleSuccess(
+        private void handleSuccess(
             PartitionKeyRangeWrapper partitionKeyRangeWrapper,
             RegionalRoutingContext succeededLocation,
             boolean isReadOnlyRequest,
             boolean forceStatusChange) {
 
-            AtomicBoolean transitionedFromUnavailable = new AtomicBoolean(false);
             this.locationEndpointToLocationSpecificContextForPartition.compute(succeededLocation, (locationAsKey, locationSpecificContextAsVal) -> {
 
                 LocationSpecificHealthContext locationSpecificHealthContextAfterTransition;
@@ -724,16 +726,12 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                         .build();
                 }
 
-                LocationHealthStatus previousHealthStatus = locationSpecificContextAsVal.getLocationHealthStatus();
                 locationSpecificHealthContextAfterTransition = this.locationSpecificHealthContextTransitionHandler.handleSuccess(
                     locationSpecificContextAsVal,
                     partitionKeyRangeWrapper,
                     GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.this.regionalRoutingContextToRegion.getOrDefault(succeededLocation, StringUtils.EMPTY),
                     forceStatusChange,
                     isReadOnlyRequest);
-                transitionedFromUnavailable.set(
-                    previousHealthStatus == LocationHealthStatus.Unavailable
-                        && locationSpecificHealthContextAfterTransition.getLocationHealthStatus() != LocationHealthStatus.Unavailable);
 
                 // used only for building diagnostics - so creating a lookup for URI and region name
 
@@ -750,8 +748,6 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
 
                 return locationSpecificHealthContextAfterTransition;
             });
-
-            return transitionedFromUnavailable.get();
         }
 
         public boolean areLocationsAvailableForPartitionKeyRange(List<RegionalRoutingContext> availableLocationsAtAccountLevel) {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
@@ -38,11 +38,9 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -406,16 +404,17 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
     private Flux<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, LocationSpecificHealthContext>>> getFailbackBacklog() {
         List<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, LocationSpecificHealthContext>>> failbackBacklog
             = new ArrayList<>();
-        Map<String, Set<String>> remainingPartitionRangeIdsByCollection = new HashMap<>();
+        Map<String, AtomicInteger> remainingPartitionCountByCollection = new HashMap<>();
 
         for (Map.Entry<PartitionKeyRangeWrapper, PartitionLevelLocationUnavailabilityInfo> entry
             : this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.entrySet()) {
 
             PartitionKeyRangeWrapper partitionKeyRangeWrapper = entry.getKey();
-            Set<String> remainingPartitionRangeIds = remainingPartitionRangeIdsByCollection
+            AtomicInteger remainingPartitionCount = remainingPartitionCountByCollection
                 .computeIfAbsent(
                     partitionKeyRangeWrapper.getCollectionResourceId(),
-                    ignored -> new HashSet<>());
+                    ignored -> new AtomicInteger());
+            boolean isPartitionRangeUnavailable = false;
 
             try {
                 PartitionLevelLocationUnavailabilityInfo partitionLevelLocationUnavailabilityInfo = entry.getValue();
@@ -429,13 +428,13 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                         LocationSpecificHealthContext locationSpecificHealthContext = locationToLocationLevelMetrics.getValue();
 
                         if (!locationSpecificHealthContext.isRegionAvailableToProcessRequests()) {
+                            isPartitionRangeUnavailable = true;
                             failbackBacklog.add(
                                 Pair.of(
                                     partitionKeyRangeWrapper,
                                     Pair.of(
                                         locationWithStaleUnavailabilityInfo,
                                         locationSpecificHealthContext)));
-                            remainingPartitionRangeIds.add(partitionKeyRangeWrapper.getPartitionKeyRange().getId());
                         }
                     }
                 }
@@ -446,10 +445,14 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                     "SCAN_UNAVAILABLE_PARTITIONS",
                     e);
             }
+
+            if (isPartitionRangeUnavailable) {
+                remainingPartitionCount.incrementAndGet();
+            }
         }
 
         this.logFailbackBacklog(failbackBacklog.size());
-        this.recordFailbackRemainingByCollection(remainingPartitionRangeIdsByCollection);
+        this.recordFailbackRemainingByCollection(remainingPartitionCountByCollection);
         return Flux.fromIterable(failbackBacklog);
     }
 
@@ -466,17 +469,17 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                 .register(meterRegistry));
     }
 
-    void recordFailbackRemainingByCollection(Map<String, Set<String>> remainingPartitionRangeIdsByCollection) {
+    void recordFailbackRemainingByCollection(Map<String, AtomicInteger> remainingPartitionCountByCollection) {
         MultiGauge gauge = this.failbackRemainingGauge.get();
         if (gauge == null) {
             return;
         }
 
         List<MultiGauge.Row<?>> rows = new ArrayList<>();
-        remainingPartitionRangeIdsByCollection.forEach((collectionRid, partitionRangeIds) ->
+        remainingPartitionCountByCollection.forEach((collectionRid, partitionCount) ->
             rows.add(MultiGauge.Row.of(
                 Tags.of(COLLECTION_RID_TAG_NAME, collectionRid),
-                partitionRangeIds.size())));
+                partitionCount)));
         gauge.register(rows, true);
     }
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
@@ -98,15 +98,9 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         if (this.consecutiveExceptionBasedCircuitBreaker.isPartitionLevelCircuitBreakerEnabled()
             && this.isPartitionRecoveryTaskRunning.compareAndSet(false, true)) {
 
-            Disposable recoveryDisposable = this.updateStaleLocationInfo()
+            this.partitionRecoveryDisposable.set(this.updateStaleLocationInfo()
                 .subscribeOn(CosmosSchedulers.PARTITION_AVAILABILITY_CHECK_BOUNDED_ELASTIC)
-                .subscribe();
-            this.partitionRecoveryDisposable.set(recoveryDisposable);
-
-            if (this.isClosed.get()
-                && this.partitionRecoveryDisposable.compareAndSet(recoveryDisposable, null)) {
-                recoveryDisposable.dispose();
-            }
+                .subscribe());
         }
     }
 
@@ -324,8 +318,13 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         Flux<?> recoveryWork = Mono.just(1)
             .delayElement(Duration.ofSeconds(Configs.getStalePartitionUnavailabilityRefreshIntervalInSeconds()))
             .repeat(() -> !this.isClosed.get())
-            .flatMap(ignore -> this.getFailbackBacklog(), 1, 1)
-            .flatMap(failbackRecoveryEntry -> {
+            .flatMap(ignore -> this.runFailbackRecoveryCycle(), 1, 1);
+
+        return this.keepFailbackRecoveryAlive(recoveryWork);
+    }
+
+    Flux<?> runFailbackRecoveryCycle() {
+        return this.getFailbackBacklog().flatMap(failbackRecoveryEntry -> {
 
                 try {
                     PartitionKeyRangeWrapper partitionKeyRangeWrapper = failbackRecoveryEntry.getLeft();
@@ -399,8 +398,6 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
 
                 return Flux.empty();
             }, 1, 1);
-
-        return this.keepFailbackRecoveryAlive(recoveryWork);
     }
 
     private Flux<Pair<PartitionKeyRangeWrapper, RegionalRoutingContext>> getFailbackBacklog() {
@@ -470,7 +467,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         this.clientCorrelationId.set(clientCorrelationId == null ? StringUtils.EMPTY : clientCorrelationId);
     }
 
-    void recordFailbackPendingRecoveryByCollection(Map<String, AtomicInteger> pendingRecoveryCountByCollection) {
+    synchronized void recordFailbackPendingRecoveryByCollection(Map<String, AtomicInteger> pendingRecoveryCountByCollection) {
         MultiGauge gauge = this.failbackPendingRecoveryGauge.get();
         if (gauge == null) {
             return;
@@ -484,7 +481,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         gauge.register(rows, true);
     }
 
-    public void removeFailbackPendingRecoveryMeter() {
+    public synchronized void removeFailbackPendingRecoveryMeter() {
         MultiGauge gauge = this.failbackPendingRecoveryGauge.getAndSet(null);
         if (gauge != null) {
             gauge.register(Collections.emptyList(), true);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
@@ -67,7 +67,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
     private final Logger failbackLogger;
     private final AtomicInteger failbackFailureLogCount;
     private final AtomicInteger failbackBacklogScanCount;
-    private final AtomicReference<MultiGauge> failbackRemainingGauge;
+    private final AtomicReference<MultiGauge> failbackPendingRecoveryGauge;
 
     public GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker(GlobalEndpointManager globalEndpointManager) {
         this(globalEndpointManager, logger);
@@ -82,7 +82,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         this.failbackLogger = checkNotNull(failbackLogger, "Argument 'failbackLogger' cannot be null!");
         this.failbackFailureLogCount = new AtomicInteger();
         this.failbackBacklogScanCount = new AtomicInteger();
-        this.failbackRemainingGauge = new AtomicReference<>();
+        this.failbackPendingRecoveryGauge = new AtomicReference<>();
 
         PartitionLevelCircuitBreakerConfig partitionLevelCircuitBreakerConfig = Configs.getPartitionLevelCircuitBreakerConfig();
         this.consecutiveExceptionBasedCircuitBreaker = new ConsecutiveExceptionBasedCircuitBreaker(partitionLevelCircuitBreakerConfig);
@@ -323,11 +323,12 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
             .delayElement(Duration.ofSeconds(Configs.getStalePartitionUnavailabilityRefreshIntervalInSeconds()))
             .repeat(() -> !this.isClosed.get())
             .flatMap(ignore -> this.getFailbackBacklog(), 1, 1)
-            .flatMap(locationToLocationSpecificHealthContextPair -> {
+            .flatMap(failbackRecoveryCandidate -> {
 
                 try {
-                    PartitionKeyRangeWrapper partitionKeyRangeWrapper = locationToLocationSpecificHealthContextPair.getLeft();
-                    RegionalRoutingContext locationWithStaleUnavailabilityInfo = locationToLocationSpecificHealthContextPair.getRight().getLeft();
+                    PartitionKeyRangeWrapper partitionKeyRangeWrapper = failbackRecoveryCandidate.getLeft();
+                    RegionalRoutingContext locationWithStaleUnavailabilityInfo = failbackRecoveryCandidate.getRight().getLeft();
+                    AtomicInteger pendingRecoveryCount = failbackRecoveryCandidate.getRight().getRight();
 
                     PartitionLevelLocationUnavailabilityInfo partitionLevelLocationUnavailabilityInfo = this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.get(partitionKeyRangeWrapper);
 
@@ -352,11 +353,13 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                                             + partitionKeyRangeWrapper.getCollectionResourceId() +
                                             " has succeeded...");
 
-                                        partitionLevelLocationUnavailabilityInfo.handleSuccess(
-                                            partitionKeyRangeWrapper,
-                                            locationWithStaleUnavailabilityInfo,
-                                            true,
-                                            true);
+                                        if (partitionLevelLocationUnavailabilityInfo.handleSuccess(
+                                                partitionKeyRangeWrapper,
+                                                locationWithStaleUnavailabilityInfo,
+                                                true,
+                                                true)) {
+                                            this.markFailbackRecoveryCompleted(pendingRecoveryCount);
+                                        }
 
                                     })
                                     .onErrorResume(throwable -> {
@@ -375,18 +378,20 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                                     new IllegalStateException("GatewayAddressCache is not available."));
                             }
                         } else {
-                            partitionLevelLocationUnavailabilityInfo.handleSuccess(
-                                partitionKeyRangeWrapper,
-                                locationWithStaleUnavailabilityInfo,
-                                true,
-                                true);
+                            if (partitionLevelLocationUnavailabilityInfo.handleSuccess(
+                                    partitionKeyRangeWrapper,
+                                    locationWithStaleUnavailabilityInfo,
+                                    true,
+                                    true)) {
+                                this.markFailbackRecoveryCompleted(pendingRecoveryCount);
+                            }
 
                         }
                     }
                 } catch (Exception e) {
-                    PartitionKeyRangeWrapper partitionKeyRangeWrapper = locationToLocationSpecificHealthContextPair.getLeft();
+                    PartitionKeyRangeWrapper partitionKeyRangeWrapper = failbackRecoveryCandidate.getLeft();
                     RegionalRoutingContext locationWithStaleUnavailabilityInfo
-                        = locationToLocationSpecificHealthContextPair.getRight().getLeft();
+                        = failbackRecoveryCandidate.getRight().getLeft();
                     this.logFailbackFailure(
                         partitionKeyRangeWrapper,
                         locationWithStaleUnavailabilityInfo,
@@ -401,20 +406,19 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         return this.keepFailbackRecoveryAlive(recoveryWork);
     }
 
-    private Flux<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, LocationSpecificHealthContext>>> getFailbackBacklog() {
-        List<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, LocationSpecificHealthContext>>> failbackBacklog
+    private Flux<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, AtomicInteger>>> getFailbackBacklog() {
+        List<Pair<PartitionKeyRangeWrapper, Pair<RegionalRoutingContext, AtomicInteger>>> failbackBacklog
             = new ArrayList<>();
-        Map<String, AtomicInteger> remainingPartitionCountByCollection = new HashMap<>();
+        Map<String, AtomicInteger> pendingRecoveryCountByCollection = new HashMap<>();
 
         for (Map.Entry<PartitionKeyRangeWrapper, PartitionLevelLocationUnavailabilityInfo> entry
             : this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.entrySet()) {
 
             PartitionKeyRangeWrapper partitionKeyRangeWrapper = entry.getKey();
-            AtomicInteger remainingPartitionCount = remainingPartitionCountByCollection
+            AtomicInteger pendingRecoveryCount = pendingRecoveryCountByCollection
                 .computeIfAbsent(
                     partitionKeyRangeWrapper.getCollectionResourceId(),
                     ignored -> new AtomicInteger());
-            boolean isPartitionRangeUnavailable = false;
 
             try {
                 PartitionLevelLocationUnavailabilityInfo partitionLevelLocationUnavailabilityInfo = entry.getValue();
@@ -428,13 +432,10 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                         LocationSpecificHealthContext locationSpecificHealthContext = locationToLocationLevelMetrics.getValue();
 
                         if (!locationSpecificHealthContext.isRegionAvailableToProcessRequests()) {
-                            isPartitionRangeUnavailable = true;
-                            failbackBacklog.add(
-                                Pair.of(
-                                    partitionKeyRangeWrapper,
-                                    Pair.of(
-                                        locationWithStaleUnavailabilityInfo,
-                                        locationSpecificHealthContext)));
+                            pendingRecoveryCount.incrementAndGet();
+                            failbackBacklog.add(Pair.of(
+                                partitionKeyRangeWrapper,
+                                Pair.of(locationWithStaleUnavailabilityInfo, pendingRecoveryCount)));
                         }
                     }
                 }
@@ -446,45 +447,46 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                     e);
             }
 
-            if (isPartitionRangeUnavailable) {
-                remainingPartitionCount.incrementAndGet();
-            }
         }
 
         this.logFailbackBacklog(failbackBacklog.size());
-        this.recordFailbackRemainingByCollection(remainingPartitionCountByCollection);
+        this.recordFailbackPendingRecoveryByCollection(pendingRecoveryCountByCollection);
         return Flux.fromIterable(failbackBacklog);
     }
 
-    public synchronized void registerFailbackRemainingMeter(MeterRegistry meterRegistry, Tag clientCorrelationTag) {
-        if (meterRegistry == null || clientCorrelationTag == null || this.failbackRemainingGauge.get() != null) {
+    private void markFailbackRecoveryCompleted(AtomicInteger pendingRecoveryCount) {
+        pendingRecoveryCount.updateAndGet(current -> Math.max(0, current - 1));
+    }
+
+    public synchronized void registerFailbackPendingRecoveryMeter(MeterRegistry meterRegistry, Tag clientCorrelationTag) {
+        if (meterRegistry == null || clientCorrelationTag == null || this.failbackPendingRecoveryGauge.get() != null) {
             return;
         }
 
-        this.failbackRemainingGauge.set(
-            MultiGauge.builder(CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT.toString())
-                .description("Number of PPCB partition key ranges remaining to fail back")
-                .baseUnit("partitions")
+        this.failbackPendingRecoveryGauge.set(
+            MultiGauge.builder(CosmosMetricName.PPCB_FAILBACK_PENDING_RECOVERY_COUNT.toString())
+                .description("Number of PPCB partition range-region recovery actions pending failback")
+                .baseUnit("recoveries")
                 .tags(Collections.singletonList(clientCorrelationTag))
                 .register(meterRegistry));
     }
 
-    void recordFailbackRemainingByCollection(Map<String, AtomicInteger> remainingPartitionCountByCollection) {
-        MultiGauge gauge = this.failbackRemainingGauge.get();
+    void recordFailbackPendingRecoveryByCollection(Map<String, AtomicInteger> pendingRecoveryCountByCollection) {
+        MultiGauge gauge = this.failbackPendingRecoveryGauge.get();
         if (gauge == null) {
             return;
         }
 
         List<MultiGauge.Row<?>> rows = new ArrayList<>();
-        remainingPartitionCountByCollection.forEach((collectionRid, partitionCount) ->
+        pendingRecoveryCountByCollection.forEach((collectionRid, recoveryCount) ->
             rows.add(MultiGauge.Row.of(
                 Tags.of(COLLECTION_RID_TAG_NAME, collectionRid),
-                partitionCount)));
+                recoveryCount)));
         gauge.register(rows, true);
     }
 
-    public void removeFailbackRemainingMeter() {
-        MultiGauge gauge = this.failbackRemainingGauge.getAndSet(null);
+    public void removeFailbackPendingRecoveryMeter() {
+        MultiGauge gauge = this.failbackPendingRecoveryGauge.getAndSet(null);
         if (gauge != null) {
             gauge.register(Collections.emptyList(), true);
         }
@@ -631,7 +633,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         this.isClosed.set(true);
         this.failbackFailureLogCount.set(0);
         this.failbackBacklogScanCount.set(0);
-        this.removeFailbackRemainingMeter();
+        this.removeFailbackPendingRecoveryMeter();
         Disposable disposable = this.partitionRecoveryDisposable.getAndSet(null);
         if (disposable != null && !disposable.isDisposed()) {
             disposable.dispose();
@@ -698,12 +700,13 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
             return isExceptionThresholdBreached.get();
         }
 
-        private void handleSuccess(
+        private boolean handleSuccess(
             PartitionKeyRangeWrapper partitionKeyRangeWrapper,
             RegionalRoutingContext succeededLocation,
             boolean isReadOnlyRequest,
             boolean forceStatusChange) {
 
+            AtomicBoolean transitionedFromUnavailable = new AtomicBoolean(false);
             this.locationEndpointToLocationSpecificContextForPartition.compute(succeededLocation, (locationAsKey, locationSpecificContextAsVal) -> {
 
                 LocationSpecificHealthContext locationSpecificHealthContextAfterTransition;
@@ -721,12 +724,16 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                         .build();
                 }
 
+                LocationHealthStatus previousHealthStatus = locationSpecificContextAsVal.getLocationHealthStatus();
                 locationSpecificHealthContextAfterTransition = this.locationSpecificHealthContextTransitionHandler.handleSuccess(
                     locationSpecificContextAsVal,
                     partitionKeyRangeWrapper,
                     GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.this.regionalRoutingContextToRegion.getOrDefault(succeededLocation, StringUtils.EMPTY),
                     forceStatusChange,
                     isReadOnlyRequest);
+                transitionedFromUnavailable.set(
+                    previousHealthStatus == LocationHealthStatus.Unavailable
+                        && locationSpecificHealthContextAfterTransition.getLocationHealthStatus() != LocationHealthStatus.Unavailable);
 
                 // used only for building diagnostics - so creating a lookup for URI and region name
 
@@ -743,6 +750,8 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
 
                 return locationSpecificHealthContextAfterTransition;
             });
+
+            return transitionedFromUnavailable.get();
         }
 
         public boolean areLocationsAvailableForPartitionKeyRange(List<RegionalRoutingContext> availableLocationsAtAccountLevel) {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.azure.cosmos.implementation.guava25.base.Preconditions.checkNotNull;
@@ -57,10 +58,21 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
     private final AtomicBoolean isPartitionRecoveryTaskRunning = new AtomicBoolean(false);
     private final AtomicReference<Disposable> partitionRecoveryDisposable = new AtomicReference<>();
+    private final Logger failbackLogger;
+    private final AtomicInteger failbackFailureLogCount;
 
     public GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker(GlobalEndpointManager globalEndpointManager) {
+        this(globalEndpointManager, logger);
+    }
+
+    GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker(
+        GlobalEndpointManager globalEndpointManager,
+        Logger failbackLogger) {
+
         this.partitionKeyRangeToLocationSpecificUnavailabilityInfo = new ConcurrentHashMap<>();
         this.globalEndpointManager = globalEndpointManager;
+        this.failbackLogger = checkNotNull(failbackLogger, "Argument 'failbackLogger' cannot be null!");
+        this.failbackFailureLogCount = new AtomicInteger();
 
         PartitionLevelCircuitBreakerConfig partitionLevelCircuitBreakerConfig = Configs.getPartitionLevelCircuitBreakerConfig();
         this.consecutiveExceptionBasedCircuitBreaker = new ConsecutiveExceptionBasedCircuitBreaker(partitionLevelCircuitBreakerConfig);
@@ -74,9 +86,15 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         if (this.consecutiveExceptionBasedCircuitBreaker.isPartitionLevelCircuitBreakerEnabled()
             && this.isPartitionRecoveryTaskRunning.compareAndSet(false, true)) {
 
-            this.partitionRecoveryDisposable.set(this.updateStaleLocationInfo()
+            Disposable recoveryDisposable = this.updateStaleLocationInfo()
                 .subscribeOn(CosmosSchedulers.PARTITION_AVAILABILITY_CHECK_BOUNDED_ELASTIC)
-                .subscribe());
+                .subscribe();
+            this.partitionRecoveryDisposable.set(recoveryDisposable);
+
+            if (this.isClosed.get()
+                && this.partitionRecoveryDisposable.compareAndSet(recoveryDisposable, null)) {
+                recoveryDisposable.dispose();
+            }
         }
     }
 
@@ -109,7 +127,8 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
             // so we skip circuit breaking in this case if cancellation kick in ungracefully (e.g. user cancelled the request, or end-to-end timeout on the operation before routing decision is made)
             // if the exception is not due to a cancellation, then we should have enough information to decide if we should circuit break or not
             // so we proceed with circuit breaking in this case
-            if (resolvedPartitionKeyRangeForCircuitBreaker == null && isCancellationException) {
+            if (resolvedPartitionKeyRangeForCircuitBreaker == null
+                && isCancellationException) {
                 logger.warn("Skipping circuit breaking for operation as partitionKeyRange information isn't available for an e2e timeout cancelled request with operationType: " +
                     request.getOperationType() +
                     " and collectionResourceId: " +
@@ -146,9 +165,10 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
 
                     isFailoverPossible.set(
                         partitionLevelLocationUnavailabilityInfoAsVal.areLocationsAvailableForPartitionKeyRange(applicableRegionalRoutingContexts));
+
                 }
 
-                request.requestContext.setPerPartitionCircuitBreakerInfoHolder(partitionLevelLocationUnavailabilityInfoAsVal.regionToLocationSpecificHealthContext);
+                this.publishSnapshot(request, partitionLevelLocationUnavailabilityInfoAsVal);
                 return partitionLevelLocationUnavailabilityInfoAsVal;
             });
 
@@ -207,9 +227,10 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                 partitionKeyRangeToFailoverInfoAsVal.handleSuccess(
                     partitionKeyRangeWrapper,
                     succeededRegionalRoutingContext,
-                    request.isReadOnlyRequest());
+                    request.isReadOnlyRequest(),
+                    false);
 
-                request.requestContext.setPerPartitionCircuitBreakerInfoHolder(partitionKeyRangeToFailoverInfoAsVal.regionToLocationSpecificHealthContext);
+                this.publishSnapshot(request, partitionKeyRangeToFailoverInfoAsVal);
                 return partitionKeyRangeToFailoverInfoAsVal;
             });
         } catch (Exception e) {
@@ -236,6 +257,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                 this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.get(partitionKeyRangeWrapper);
 
             List<String> unavailableRegions = new ArrayList<>();
+            this.publishSnapshot(request, partitionLevelLocationUnavailabilityInfoSnapshot);
 
             if (partitionLevelLocationUnavailabilityInfoSnapshot != null) {
                 Map<RegionalRoutingContext, LocationSpecificHealthContext> locationEndpointToFailureMetricsForPartition =
@@ -278,18 +300,26 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         }
     }
 
+    private void publishSnapshot(
+        RxDocumentServiceRequest request,
+        PartitionLevelLocationUnavailabilityInfo info) {
+
+        request.requestContext.setPerPartitionCircuitBreakerInfoHolder(
+            info == null ? Collections.emptyMap() : info.regionToLocationSpecificHealthContext);
+    }
+
     private Flux<?> updateStaleLocationInfo() {
-        return Mono.just(1)
+        Flux<?> recoveryWork = Mono.just(1)
             .delayElement(Duration.ofSeconds(Configs.getStalePartitionUnavailabilityRefreshIntervalInSeconds()))
             .repeat(() -> !this.isClosed.get())
             .flatMap(ignore -> Flux.fromIterable(this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.entrySet()), 1, 1)
             .flatMap(partitionKeyRangeWrapperToPartitionKeyRangeWrapperPair -> {
 
                 logger.debug("Background updateStaleLocationInfo kicking in...");
+                PartitionKeyRangeWrapper partitionKeyRangeWrapper
+                    = partitionKeyRangeWrapperToPartitionKeyRangeWrapperPair.getKey();
 
                 try {
-                    PartitionKeyRangeWrapper partitionKeyRangeWrapper = partitionKeyRangeWrapperToPartitionKeyRangeWrapperPair.getKey();
-
                     PartitionLevelLocationUnavailabilityInfo partitionLevelLocationUnavailabilityInfo = this.partitionKeyRangeToLocationSpecificUnavailabilityInfo.get(partitionKeyRangeWrapper);
 
                     if (partitionLevelLocationUnavailabilityInfo != null) {
@@ -320,7 +350,11 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                         return Mono.empty();
                     }
                 } catch (Exception e) {
-                    logger.warn("An exception was thrown trying to recover an Unavailable partitionKeyRange!", e);
+                    this.logFailbackFailure(
+                        partitionKeyRangeWrapper,
+                        null,
+                        "SCAN_UNAVAILABLE_PARTITIONS",
+                        e);
                     return Flux.empty();
                 }
             }, 1, 1)
@@ -353,52 +387,118 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                                             + partitionKeyRangeWrapper.getCollectionResourceId() +
                                             " has succeeded...");
 
-                                        partitionLevelLocationUnavailabilityInfo.locationEndpointToLocationSpecificContextForPartition.compute(locationWithStaleUnavailabilityInfo, (locationWithStaleUnavailabilityInfoAsKey, locationSpecificContextAsVal) -> {
+                                        partitionLevelLocationUnavailabilityInfo.handleSuccess(
+                                            partitionKeyRangeWrapper,
+                                            locationWithStaleUnavailabilityInfo,
+                                            true,
+                                            true);
 
-                                            if (locationSpecificContextAsVal != null) {
-                                                locationSpecificContextAsVal = GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker
-                                                    .this.locationSpecificHealthContextTransitionHandler.handleSuccess(
-                                                    locationSpecificContextAsVal,
-                                                    partitionKeyRangeWrapper,
-                                                    this.regionalRoutingContextToRegion.getOrDefault(locationWithStaleUnavailabilityInfoAsKey, StringUtils.EMPTY),
-                                                    false,
-                                                    true);
-                                            }
-                                            return locationSpecificContextAsVal;
-                                        });
                                     })
                                     .onErrorResume(throwable -> {
-                                        logger.debug("An exception was thrown trying to recover an Unavailable partition key range!", throwable);
+                                        this.logFailbackFailure(
+                                            partitionKeyRangeWrapper,
+                                            locationWithStaleUnavailabilityInfo,
+                                            "OPEN_CONNECTION_TASK",
+                                            throwable);
                                         return Mono.empty();
                                     });
+                            } else {
+                                this.logFailbackFailure(
+                                    partitionKeyRangeWrapper,
+                                    locationWithStaleUnavailabilityInfo,
+                                    "RESOLVE_GATEWAY_ADDRESS_CACHE",
+                                    new IllegalStateException("GatewayAddressCache is not available."));
                             }
                         } else {
-                            partitionLevelLocationUnavailabilityInfo.locationEndpointToLocationSpecificContextForPartition.compute(locationWithStaleUnavailabilityInfo, (locationWithStaleUnavailabilityInfoAsKey, locationSpecificContextAsVal) -> {
+                            partitionLevelLocationUnavailabilityInfo.handleSuccess(
+                                partitionKeyRangeWrapper,
+                                locationWithStaleUnavailabilityInfo,
+                                true,
+                                true);
 
-                                if (locationSpecificContextAsVal != null) {
-                                    locationSpecificContextAsVal = GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker
-                                        .this.locationSpecificHealthContextTransitionHandler.handleSuccess(
-                                        locationSpecificContextAsVal,
-                                        partitionKeyRangeWrapper,
-                                        this.regionalRoutingContextToRegion.getOrDefault(locationWithStaleUnavailabilityInfoAsKey, StringUtils.EMPTY),
-                                        false,
-                                        true);
-                                }
-                                return locationSpecificContextAsVal;
-                            });
                         }
                     }
                 } catch (Exception e) {
-                    logger.debug("An exception was thrown trying to recover an Unavailable partition key range!", e);
+                    PartitionKeyRangeWrapper partitionKeyRangeWrapper = locationToLocationSpecificHealthContextPair.getLeft();
+                    RegionalRoutingContext locationWithStaleUnavailabilityInfo
+                        = locationToLocationSpecificHealthContextPair.getRight().getLeft();
+                    this.logFailbackFailure(
+                        partitionKeyRangeWrapper,
+                        locationWithStaleUnavailabilityInfo,
+                        "RECOVERY_PIPELINE",
+                        e);
                     return Flux.empty();
                 }
 
                 return Flux.empty();
-            }, 1, 1)
-            .onErrorResume(throwable -> {
-                logger.warn("An exception : was thrown trying to recover an Unavailable partitionKeyRange!, fail-back flow won't be executed!", throwable);
-                return Flux.empty();
-            });
+            }, 1, 1);
+
+        return this.keepFailbackRecoveryAlive(recoveryWork);
+    }
+
+    Flux<?> keepFailbackRecoveryAlive(Flux<?> recoveryWork) {
+        return recoveryWork
+            .doOnError(throwable -> this.logFailbackFailure(
+                null,
+                null,
+                "RECOVERY_STREAM",
+                throwable))
+            .retry();
+    }
+
+    void logFailbackFailure(
+        PartitionKeyRangeWrapper partitionKeyRangeWrapper,
+        RegionalRoutingContext regionalRoutingContext,
+        String stage,
+        Throwable throwable) {
+
+        String region = this.resolveRegionName(regionalRoutingContext);
+        String reason = throwable == null ? "UNKNOWN" : throwable.getClass().getSimpleName();
+        String collectionResourceId = partitionKeyRangeWrapper == null
+            ? StringUtils.EMPTY
+            : partitionKeyRangeWrapper.getCollectionResourceId();
+        String partitionKeyRangeId = partitionKeyRangeWrapper == null
+            || partitionKeyRangeWrapper.getPartitionKeyRange() == null
+            ? StringUtils.EMPTY
+            : partitionKeyRangeWrapper.getPartitionKeyRange().getId();
+        String message = "PPCB failback failed for collectionResourceId: "
+            + collectionResourceId
+            + ", partitionKeyRangeId: "
+            + partitionKeyRangeId
+            + ", region: "
+            + region
+            + ", stage: "
+            + stage
+            + ", reason: "
+            + reason;
+
+        if (this.shouldLogFailbackFailureAtWarn()) {
+            this.failbackLogger.warn(message, throwable);
+        } else {
+            this.failbackLogger.debug(message, throwable);
+        }
+
+    }
+
+    private boolean shouldLogFailbackFailureAtWarn() {
+        int count = this.failbackFailureLogCount.updateAndGet(
+            current -> current == Integer.MAX_VALUE ? 1 : current + 1);
+        return count == 1 || count % 10 == 0;
+    }
+
+    private String resolveRegionName(RegionalRoutingContext regionalRoutingContext) {
+        if (regionalRoutingContext == null) {
+            return StringUtils.EMPTY;
+        }
+
+        String region = this.regionalRoutingContextToRegion.get(regionalRoutingContext);
+        if (!StringUtils.isEmpty(region)) {
+            return region;
+        }
+
+        return this.globalEndpointManager.getRegionName(
+            regionalRoutingContext.getGatewayRegionalEndpoint(),
+            OperationType.Read);
     }
 
     public boolean isPerPartitionLevelCircuitBreakingApplicable(RxDocumentServiceRequest request) {
@@ -451,6 +551,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
     @Override
     public void close() {
         this.isClosed.set(true);
+        this.failbackFailureLogCount.set(0);
         Disposable disposable = this.partitionRecoveryDisposable.getAndSet(null);
         if (disposable != null && !disposable.isDisposed()) {
             disposable.dispose();
@@ -520,7 +621,8 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         private void handleSuccess(
             PartitionKeyRangeWrapper partitionKeyRangeWrapper,
             RegionalRoutingContext succeededLocation,
-            boolean isReadOnlyRequest) {
+            boolean isReadOnlyRequest,
+            boolean forceStatusChange) {
 
             this.locationEndpointToLocationSpecificContextForPartition.compute(succeededLocation, (locationAsKey, locationSpecificContextAsVal) -> {
 
@@ -543,7 +645,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
                     locationSpecificContextAsVal,
                     partitionKeyRangeWrapper,
                     GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.this.regionalRoutingContextToRegion.getOrDefault(succeededLocation, StringUtils.EMPTY),
-                    false,
+                    forceStatusChange,
                     isReadOnlyRequest);
 
                 // used only for building diagnostics - so creating a lookup for URI and region name

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker.java
@@ -459,7 +459,7 @@ public class GlobalPartitionEndpointManagerForPerPartitionCircuitBreaker impleme
         }
 
         this.failbackRemainingGauge.set(
-            MultiGauge.builder(CosmosMetricName.PPCB_FAILBACK_REMAINING.toString())
+            MultiGauge.builder(CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT.toString())
                 .description("Number of PPCB partition key ranges remaining to fail back")
                 .baseUnit("partitions")
                 .tags(Collections.singletonList(clientCorrelationTag))

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PerPartitionCircuitBreakerInfoHolder.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/perPartitionCircuitBreaker/PerPartitionCircuitBreakerInfoHolder.java
@@ -6,23 +6,43 @@ package com.azure.cosmos.implementation.perPartitionCircuitBreaker;
 import com.azure.cosmos.implementation.Utils;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
+@JsonSerialize(using = PerPartitionCircuitBreakerInfoHolder.PerPartitionCircuitBreakerInfoHolderSerializer.class)
 public class PerPartitionCircuitBreakerInfoHolder implements Serializable {
 
     public static final PerPartitionCircuitBreakerInfoHolder EMPTY = new PerPartitionCircuitBreakerInfoHolder();
 
     private final Utils.ValueHolder<Map<String, LocationSpecificHealthContext>> perPartitionCircuitBreakerInfoHolder = new Utils.ValueHolder<Map<String, LocationSpecificHealthContext>>();
+    private boolean initialized;
 
     public synchronized void setPerPartitionCircuitBreakerInfoHolder(final Map<String, LocationSpecificHealthContext> locationSpecificHealthContext) {
-        this.perPartitionCircuitBreakerInfoHolder.v = locationSpecificHealthContext;
+        this.initialized = true;
+        this.perPartitionCircuitBreakerInfoHolder.v = locationSpecificHealthContext == null
+            ? Collections.emptyMap()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(locationSpecificHealthContext));
     }
 
     public synchronized Map<String, LocationSpecificHealthContext> getPerPartitionCircuitBreakerInfoHolder() {
         return perPartitionCircuitBreakerInfoHolder.v;
+    }
+
+    public synchronized PerPartitionCircuitBreakerInfoHolder snapshot() {
+        PerPartitionCircuitBreakerInfoHolder snapshot = new PerPartitionCircuitBreakerInfoHolder();
+        if (this.initialized) {
+            snapshot.setPerPartitionCircuitBreakerInfoHolder(this.perPartitionCircuitBreakerInfoHolder.v);
+        }
+        return snapshot;
+    }
+
+    synchronized boolean isInitialized() {
+        return this.initialized;
     }
 
     public static class PerPartitionCircuitBreakerInfoHolderSerializer extends com.fasterxml.jackson.databind.JsonSerializer<PerPartitionCircuitBreakerInfoHolder> {
@@ -32,10 +52,10 @@ public class PerPartitionCircuitBreakerInfoHolder implements Serializable {
 
             Map<String, LocationSpecificHealthContext> locationToLocationSpecificHealthContext = value.getPerPartitionCircuitBreakerInfoHolder();
 
-            if (locationToLocationSpecificHealthContext != null && !locationToLocationSpecificHealthContext.isEmpty()) {
+            if (value.isInitialized()) {
                 gen.writeStartObject();
 
-                gen.writePOJOField("locSpecificHealthCtx", locationToLocationSpecificHealthContext);
+                gen.writePOJOField("stateByRegion", locationToLocationSpecificHealthContext);
 
                 gen.writeEndObject();
             } else {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosMetricName.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosMetricName.java
@@ -77,10 +77,10 @@ public final class CosmosMetricName {
         CosmosMetricCategory.OPERATION_DETAILS);
 
     /**
-     * Number of PPCB partition key ranges remaining to fail back, by collection (Gauge)
+     * Number of PPCB partition range-region recovery actions pending failback, by collection (Gauge)
      */
-    public static final CosmosMetricName PPCB_FAILBACK_PENDING_PARTITION_COUNT = new CosmosMetricName(
-        nameOf("ppcb.failback.pendingPartitionCount"),
+    public static final CosmosMetricName PPCB_FAILBACK_PENDING_RECOVERY_COUNT = new CosmosMetricName(
+        nameOf("ppcb.failback.pendingRecoveryCount"),
         CosmosMetricCategory.OPERATION_SUMMARY);
 
     /**
@@ -473,8 +473,8 @@ public final class CosmosMetricName {
         map.put(nameOf("op.actualitemcount"), CosmosMetricName.OPERATION_DETAILS_ACTUAL_ITEM_COUNT);
         map.put(nameOf("op.regionscontacted"), CosmosMetricName.OPERATION_DETAILS_REGIONS_CONTACTED);
         map.put(
-            nameOf("ppcb.failback.pendingpartitioncount"),
-            CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT);
+            nameOf("ppcb.failback.pendingrecoverycount"),
+            CosmosMetricName.PPCB_FAILBACK_PENDING_RECOVERY_COUNT);
         map.put(nameOf("req.rntbd.requests"), CosmosMetricName.REQUEST_SUMMARY_DIRECT_REQUESTS);
         map.put(nameOf("req.rntbd.latency"), CosmosMetricName.REQUEST_SUMMARY_DIRECT_LATENCY);
         map.put(nameOf("req.rntbd.backendlatency"), CosmosMetricName.REQUEST_SUMMARY_DIRECT_BACKEND_LATENCY);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosMetricName.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosMetricName.java
@@ -79,8 +79,8 @@ public final class CosmosMetricName {
     /**
      * Number of PPCB partition key ranges remaining to fail back, by collection (Gauge)
      */
-    public static final CosmosMetricName PPCB_FAILBACK_REMAINING = new CosmosMetricName(
-        nameOf("ppcb.failback.remaining"),
+    public static final CosmosMetricName PPCB_FAILBACK_PENDING_PARTITION_COUNT = new CosmosMetricName(
+        nameOf("ppcb.failback.pendingPartitionCount"),
         CosmosMetricCategory.OPERATION_SUMMARY);
 
     /**
@@ -472,7 +472,9 @@ public final class CosmosMetricName {
         map.put(nameOf("op.maxitemcount"), CosmosMetricName.OPERATION_DETAILS_MAX_ITEM_COUNT);
         map.put(nameOf("op.actualitemcount"), CosmosMetricName.OPERATION_DETAILS_ACTUAL_ITEM_COUNT);
         map.put(nameOf("op.regionscontacted"), CosmosMetricName.OPERATION_DETAILS_REGIONS_CONTACTED);
-        map.put(nameOf("ppcb.failback.remaining"), CosmosMetricName.PPCB_FAILBACK_REMAINING);
+        map.put(
+            nameOf("ppcb.failback.pendingpartitioncount"),
+            CosmosMetricName.PPCB_FAILBACK_PENDING_PARTITION_COUNT);
         map.put(nameOf("req.rntbd.requests"), CosmosMetricName.REQUEST_SUMMARY_DIRECT_REQUESTS);
         map.put(nameOf("req.rntbd.latency"), CosmosMetricName.REQUEST_SUMMARY_DIRECT_LATENCY);
         map.put(nameOf("req.rntbd.backendlatency"), CosmosMetricName.REQUEST_SUMMARY_DIRECT_BACKEND_LATENCY);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosMetricName.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/models/CosmosMetricName.java
@@ -77,6 +77,13 @@ public final class CosmosMetricName {
         CosmosMetricCategory.OPERATION_DETAILS);
 
     /**
+     * Number of PPCB partition key ranges remaining to fail back, by collection (Gauge)
+     */
+    public static final CosmosMetricName PPCB_FAILBACK_REMAINING = new CosmosMetricName(
+        nameOf("ppcb.failback.remaining"),
+        CosmosMetricCategory.OPERATION_SUMMARY);
+
+    /**
      * Number of requests (Counter)
      * NOTE: No percentiles or histogram supported
      */
@@ -465,6 +472,7 @@ public final class CosmosMetricName {
         map.put(nameOf("op.maxitemcount"), CosmosMetricName.OPERATION_DETAILS_MAX_ITEM_COUNT);
         map.put(nameOf("op.actualitemcount"), CosmosMetricName.OPERATION_DETAILS_ACTUAL_ITEM_COUNT);
         map.put(nameOf("op.regionscontacted"), CosmosMetricName.OPERATION_DETAILS_REGIONS_CONTACTED);
+        map.put(nameOf("ppcb.failback.remaining"), CosmosMetricName.PPCB_FAILBACK_REMAINING);
         map.put(nameOf("req.rntbd.requests"), CosmosMetricName.REQUEST_SUMMARY_DIRECT_REQUESTS);
         map.put(nameOf("req.rntbd.latency"), CosmosMetricName.REQUEST_SUMMARY_DIRECT_LATENCY);
         map.put(nameOf("req.rntbd.backendlatency"), CosmosMetricName.REQUEST_SUMMARY_DIRECT_BACKEND_LATENCY);


### PR DESCRIPTION
## Description

- Emit a compact `ppcb.stateByRegion` snapshot for every PPCB-enabled routed request, including healthy empty state.
- Preserve independent PPCB snapshots for direct and gateway request attempts.
- Sample background failback failures with constant memory while retaining partition, region, stage, and reason in each message.
- Log every failback error path and retry escaped recovery-stream failures so background recovery remains active until client close.

## Testing

- Focused Java 8 compilation
- Direct TestNG execution: 11 passed, 0 failed, 0 skipped
- `git diff --check`