### PR TITLE
Fix recoveryservices live test immutability settings

### DIFF
--- a/sdk/recoveryservices/azure-resourcemanager-recoveryservices/src/test/java/com/azure/resourcemanager/recoveryservices/RecoveryServicesManagerTests.java
+++ b/sdk/recoveryservices/azure-resourcemanager-recoveryservices/src/test/java/com/azure/resourcemanager/recoveryservices/RecoveryServicesManagerTests.java
@@ -16,8 +16,10 @@ import com.azure.core.util.CoreUtils;
 import com.azure.resourcemanager.test.utils.TestUtilities;
 import com.azure.resourcemanager.recoveryservices.models.CrossSubscriptionRestoreSettings;
 import com.azure.resourcemanager.recoveryservices.models.CrossSubscriptionRestoreState;
+import com.azure.resourcemanager.recoveryservices.models.ImmutabilityConfiguration;
 import com.azure.resourcemanager.recoveryservices.models.ImmutabilitySettings;
 import com.azure.resourcemanager.recoveryservices.models.ImmutabilityState;
+import com.azure.resourcemanager.recoveryservices.models.ImmutabilityType;
 import com.azure.resourcemanager.recoveryservices.models.PublicNetworkAccess;
 import com.azure.resourcemanager.recoveryservices.models.RestoreSettings;
 import com.azure.resourcemanager.recoveryservices.models.SecuritySettings;
@@ -79,19 +81,25 @@ public class RecoveryServicesManagerTests extends TestProxyTestBase {
         try {
             String vaultName = "vault" + randomPadding();
             // @embedmeStart
-            vault = recoveryServicesManager.vaults()
-                .define(vaultName)
-                .withRegion(REGION)
-                .withExistingResourceGroup(resourceGroupName)
-                .withSku(new Sku().withName(SkuName.RS0).withTier("Standard"))
-                .withProperties(new VaultProperties()
-                    .withSecuritySettings(new SecuritySettings()
-                        .withImmutabilitySettings(new ImmutabilitySettings().withState(ImmutabilityState.UNLOCKED)))
-                    .withPublicNetworkAccess(PublicNetworkAccess.ENABLED)
-                    .withRestoreSettings(new RestoreSettings()
-                        .withCrossSubscriptionRestoreSettings(new CrossSubscriptionRestoreSettings()
-                            .withCrossSubscriptionRestoreState(CrossSubscriptionRestoreState.ENABLED))))
-                .create();
+            vault
+                = recoveryServicesManager.vaults()
+                    .define(vaultName)
+                    .withRegion(REGION)
+                    .withExistingResourceGroup(resourceGroupName)
+                    .withSku(new Sku().withName(SkuName.RS0).withTier("Standard"))
+                    .withProperties(
+                        new VaultProperties()
+                            .withSecuritySettings(
+                                new SecuritySettings()
+                                    .withImmutabilitySettings(
+                                        new ImmutabilitySettings().withState(ImmutabilityState.UNLOCKED)
+                                            .withConfiguration(new ImmutabilityConfiguration()
+                                                .withType(ImmutabilityType.AS_PER_POLICY))))
+                            .withPublicNetworkAccess(PublicNetworkAccess.ENABLED)
+                            .withRestoreSettings(new RestoreSettings()
+                                .withCrossSubscriptionRestoreSettings(new CrossSubscriptionRestoreSettings()
+                                    .withCrossSubscriptionRestoreState(CrossSubscriptionRestoreState.ENABLED))))
+                    .create();
             // @embedmeEnd
             vault.refresh();
             Assertions.assertEquals(vault.name(), vaultName);


### PR DESCRIPTION
Fix the Recovery Services live test request after the service began validating immutability configuration.

`Unlocked` enables immutability, so the request now specifies `AsPerPolicy` as required while omitting `durationInDays`.

Test: `mvn -f sdk/recoveryservices/azure-resourcemanager-recoveryservices/pom.xml -DskipTests -Dgpg.skip=true -Drevapi.skip=true test-compile`
