### PR TITLE
Add generic server-sent events support to Azure Core

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Added optional service-defined terminal-event predicates for server-sent event streams. Predicate overloads complete
   after delivering a terminal event and report an incomplete stream when response-body EOF occurs first; existing
   overloads continue to complete on HTTP 204 or EOF.
+- Server-sent event response streams are single-subscription and accept only closeable HTTP 200 or 204 responses.
+  Terminal-event predicates require a terminal event even when the response is HTTP 204.
 
 ## 1.59.0 (2026-08-12)
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -9,6 +9,9 @@
   does not consume SSE bodies, and streams stop cleanly on HTTP 204 or response-body EOF. Each physical response is
   closed on completion, failure, interruption, or asynchronous cancellation. Asynchronous decoding parses the reactive
   response body without blocking worker threads.
+- Added optional service-defined terminal-event predicates for server-sent event streams. Predicate overloads complete
+  after delivering a terminal event and report an incomplete stream when response-body EOF occurs first; existing
+  overloads continue to complete on HTTP 204 or EOF.
 
 ## 1.59.0 (2026-08-12)
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,12 +4,11 @@
 
 ### Features Added
 
-- Added generic `ServerSentEvent<T>` and `ServerSentEventListener<T>` types for typed, incrementally decoded
-  server-sent event streams. The REST proxy preserves live-body ownership, HTTP response logging does not consume SSE
-  bodies, and clients can reconnect sync and async operations with retained retry and last-event identifier state,
-  including metadata-only updates and retryable mid-body transport failures. Streams stop cleanly on HTTP 204 and
-  close every physical response. Asynchronous decoding parses the reactive response body without blocking worker
-  threads.
+- Added generic `ServerSentEvent<T>`, `ServerSentEventListener<T>`, and `ServerSentEventStreams` for typed,
+  incrementally decoded server-sent event streams. The REST proxy preserves live-body ownership, HTTP response logging
+  does not consume SSE bodies, and streams stop cleanly on HTTP 204 or response-body EOF. Each physical response is
+  closed on completion, failure, interruption, or asynchronous cancellation. Asynchronous decoding parses the reactive
+  response body without blocking worker threads.
 
 ## 1.59.0 (2026-08-12)
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 1.60.0-beta.1 (Unreleased)
+
+### Features Added
+
+- Added generic `ServerSentEvent<T>` and `ServerSentEventListener<T>` types for typed, incrementally decoded
+  server-sent event streams. The REST proxy preserves live-body ownership, HTTP response logging does not consume SSE
+  bodies, and clients can reconnect sync and async operations with retained retry and last-event identifier state,
+  including metadata-only updates and retryable mid-body transport failures. Streams stop cleanly on HTTP 204 and
+  close every physical response. Asynchronous decoding parses the reactive response body without blocking worker
+  threads.
+
 ## 1.59.0 (2026-08-12)
 
 ### Features Added

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEvent.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEvent.java
@@ -15,9 +15,8 @@ import java.time.Duration;
  * The identifier and retry interval represent the effective stream state when the event was dispatched, including
  * values inherited from earlier metadata-only blocks.</p>
  *
- * <p>Generated clients may use the effective identifier and retry interval to reconnect after a response body ends.
- * These values remain available to callers for diagnostics and service-specific stream handling. Metadata-only
- * updates received after the latest emitted event aren't exposed as an additional event.</p>
+ * <p>The identifier and retry interval are protocol metadata only. Azure Core does not reconnect or replay the
+ * request. Metadata-only updates received after the latest emitted event aren't exposed as an additional event.</p>
  *
  * @param <T> The type of the event data.
  * @see <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream">
@@ -52,8 +51,7 @@ public final class ServerSentEvent<T> {
      * Gets the effective last-event identifier when this event was dispatched.
      *
      * @return The effective last-event identifier, {@code null} if no valid {@code id} field was received before this
-     * event, or an empty string if an empty {@code id} field reset the identifier. An empty identifier should not be
-     * sent as a {@code Last-Event-Id} request header.
+     * event, or an empty string if an empty {@code id} field reset the identifier.
      */
     public String getId() {
         return id;
@@ -87,9 +85,9 @@ public final class ServerSentEvent<T> {
     }
 
     /**
-     * Gets the effective reconnection delay when this event was dispatched.
+     * Gets the effective retry interval when this event was dispatched.
      *
-     * @return The latest valid reconnection delay received before this event, or {@code null} if no valid
+     * @return The latest valid retry interval received before this event, or {@code null} if no valid
      * {@code retry} field was received.
      */
     public Duration getRetryAfter() {

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEvent.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEvent.java
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.http;
+
+import com.azure.core.annotation.Immutable;
+import com.azure.core.implementation.util.ServerSentEventHelper;
+
+import java.time.Duration;
+
+/**
+ * Represents a server-sent event with a typed data payload.
+ *
+ * <p>An emitted server-sent event contains data and may expose an identifier, event name, comment, and retry interval.
+ * The identifier and retry interval represent the effective stream state when the event was dispatched, including
+ * values inherited from earlier metadata-only blocks.</p>
+ *
+ * <p>Generated clients may use the effective identifier and retry interval to reconnect after a response body ends.
+ * These values remain available to callers for diagnostics and service-specific stream handling. Metadata-only
+ * updates received after the latest emitted event aren't exposed as an additional event.</p>
+ *
+ * @param <T> The type of the event data.
+ * @see <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream">
+ * Parsing an event stream</a>
+ */
+@Immutable
+public final class ServerSentEvent<T> {
+    private final String id;
+    private final String event;
+    private final T data;
+    private final String comment;
+    private final Duration retryAfter;
+
+    static {
+        ServerSentEventHelper.setAccessor(new ServerSentEventHelper.ServerSentEventAccessor() {
+            @Override
+            public <U> ServerSentEvent<U> create(String id, String event, U data, String comment, Duration retryAfter) {
+                return new ServerSentEvent<>(id, event, data, comment, retryAfter);
+            }
+        });
+    }
+
+    private ServerSentEvent(String id, String event, T data, String comment, Duration retryAfter) {
+        this.id = id;
+        this.event = event;
+        this.data = data;
+        this.comment = comment;
+        this.retryAfter = retryAfter;
+    }
+
+    /**
+     * Gets the effective last-event identifier when this event was dispatched.
+     *
+     * @return The effective last-event identifier, {@code null} if no valid {@code id} field was received before this
+     * event, or an empty string if an empty {@code id} field reset the identifier. An empty identifier should not be
+     * sent as a {@code Last-Event-Id} request header.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the event name.
+     *
+     * @return The event name, or {@code message} if no non-empty {@code event} field was specified.
+     */
+    public String getEvent() {
+        return event;
+    }
+
+    /**
+     * Gets the event data.
+     *
+     * @return The event data, or {@code null} if event data wasn't specified.
+     */
+    public T getData() {
+        return data;
+    }
+
+    /**
+     * Gets the event comment.
+     *
+     * @return The event comment, or {@code null} if it wasn't specified.
+     */
+    public String getComment() {
+        return comment;
+    }
+
+    /**
+     * Gets the effective reconnection delay when this event was dispatched.
+     *
+     * @return The latest valid reconnection delay received before this event, or {@code null} if no valid
+     * {@code retry} field was received.
+     */
+    public Duration getRetryAfter() {
+        return retryAfter;
+    }
+
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventListener.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventListener.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.http;
+
+/**
+ * A listener for receiving server-sent events.
+ *
+ * <p>Errors terminate processing, invoke {@link #onError(Throwable)} and {@link #onClose()}, and are rethrown to the
+ * synchronous service caller as unchecked exceptions.</p>
+ *
+ * <p>Generated Azure Core clients consume this listener above the HTTP transport after receiving a streaming response
+ * body. The listener isn't attached to the underlying {@link HttpRequest}.</p>
+ *
+ * @param <T> The type of the event data.
+ */
+@FunctionalInterface
+public interface ServerSentEventListener<T> {
+    /**
+     * Handles a server-sent event.
+     *
+     * @param event The server-sent event.
+     * @throws RuntimeException If an error occurs while handling the event.
+     */
+    void onEvent(ServerSentEvent<T> event);
+
+    /**
+     * Handles an error that terminates event processing.
+     *
+     * @param error The error that terminated event processing.
+     */
+    default void onError(Throwable error) {
+        // No-op by default.
+    }
+
+    /**
+     * Handles closure of the event stream.
+     */
+    default void onClose() {
+        // No-op by default.
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventStreams.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventStreams.java
@@ -16,6 +16,13 @@ import java.util.function.Predicate;
  *
  * <p>The supplied response must implement {@link java.io.Closeable}. The stream closes the physical response when
  * consumption ends; a response that is not closeable is rejected with {@link IllegalArgumentException}.</p>
+ *
+ * <p>A returned {@link Flux} consumes one supplied physical response and supports exactly one subscription. Before
+ * that subscription claims the response, ownership remains with the caller; if it is never subscribed, the caller
+ * must close the response.</p>
+ *
+ * <p>If both stream processing and eager response cleanup fail, the cleanup failure is emitted and the processing
+ * failure is suppressed.</p>
  */
 public final class ServerSentEventStreams {
     private ServerSentEventStreams() {
@@ -25,7 +32,8 @@ public final class ServerSentEventStreams {
      * Decodes a single server-sent event response as a {@link Flux}.
      *
      * <p>The response body is validated as {@code text/event-stream}, decoded incrementally, and closed on
-     * completion, failure, or cancellation. A 204 response produces an empty {@link Flux}.</p>
+     * completion, failure, or cancellation. A 204 response produces an empty {@link Flux}. Only HTTP 200 and 204
+     * responses are accepted.</p>
      *
      * @param response The streaming response.
      * @param converter Converts an event name and data payload into the generated event type.
@@ -42,9 +50,9 @@ public final class ServerSentEventStreams {
      * Decodes a single server-sent event response as a {@link Flux} until an inclusive terminal event is emitted.
      *
      * <p>The response body is validated as {@code text/event-stream}, decoded incrementally, and closed after a
-     * terminal event, on failure, or on cancellation. A 204 response produces an empty {@link Flux}. If the response
-     * body ends before a terminal event is emitted, the flux fails. This method does not reconnect or replay a
-     * request.</p>
+     * terminal event, on failure, or on cancellation. A 204 response does not evaluate the predicate and fails
+     * because it cannot satisfy the terminal-event requirement. If the response body ends before a terminal event is
+     * emitted, the flux fails. This method does not reconnect or replay a request.</p>
      *
      * @param response The streaming response.
      * @param converter Converts an event name and data payload into the generated event type.
@@ -62,7 +70,8 @@ public final class ServerSentEventStreams {
      * Decodes a single server-sent event response and invokes a listener for each event.
      *
      * <p>The response body is validated as {@code text/event-stream}, decoded incrementally, and closed on EOF,
-     * failure, or interruption. A 204 response completes without events.</p>
+     * failure, or interruption. A 204 response completes without events. Only HTTP 200 and 204 responses are
+     * accepted.</p>
      *
      * @param response The streaming response.
      * @param converter Converts an event name and data payload into the generated event type.
@@ -79,9 +88,9 @@ public final class ServerSentEventStreams {
      * Decodes a single server-sent event response until an inclusive terminal event is delivered to a listener.
      *
      * <p>The response body is validated as {@code text/event-stream}, decoded incrementally, and closed after a
-     * terminal event, on failure, or on interruption. A 204 response completes without events. If the response body
-     * ends before a terminal event is delivered, this method fails. This method does not reconnect or replay a
-     * request.</p>
+     * terminal event, on failure, or on interruption. A 204 response does not evaluate the predicate and fails
+     * because it cannot satisfy the terminal-event requirement. If the response body ends before a terminal event is
+     * delivered, this method fails. This method does not reconnect or replay a request.</p>
      *
      * @param response The streaming response.
      * @param converter Converts an event name and data payload into the generated event type.

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventStreams.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventStreams.java
@@ -23,6 +23,9 @@ import java.util.function.Predicate;
  *
  * <p>If both stream processing and eager response cleanup fail, the cleanup failure is emitted and the processing
  * failure is suppressed.</p>
+ *
+ * <p>A single event may contain at most 16 MiB of non-line-ending bytes. Larger events fail stream processing to
+ * prevent an incomplete event from consuming memory without bound.</p>
  */
 public final class ServerSentEventStreams {
     private ServerSentEventStreams() {

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventStreams.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventStreams.java
@@ -9,6 +9,7 @@ import com.azure.core.util.BinaryData;
 import reactor.core.publisher.Flux;
 
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 
 /**
  * Consumes a single HTTP response as a server-sent event stream.
@@ -34,6 +35,25 @@ public final class ServerSentEventStreams {
     }
 
     /**
+     * Decodes a single server-sent event response as a {@link Flux} until an inclusive terminal event is emitted.
+     *
+     * <p>The response body is validated as {@code text/event-stream}, decoded incrementally, and closed after a
+     * terminal event, on failure, or on cancellation. A 204 response produces an empty {@link Flux}. If the response
+     * body ends before a terminal event is emitted, the flux fails. This method does not reconnect or replay a
+     * request.</p>
+     *
+     * @param response The streaming response.
+     * @param converter Converts an event name and data payload into the generated event type.
+     * @param terminalEvent Identifies the inclusive terminal event.
+     * @param <T> The type of the event data.
+     * @return A flux of decoded server-sent events.
+     */
+    public static <T> Flux<ServerSentEvent<T>> toFlux(Response<BinaryData> response,
+        BiFunction<String, String, T> converter, Predicate<ServerSentEvent<T>> terminalEvent) {
+        return ServerSentEventStream.toFlux(response, converter, terminalEvent);
+    }
+
+    /**
      * Decodes a single server-sent event response and invokes a listener for each event.
      *
      * <p>The response body is validated as {@code text/event-stream}, decoded incrementally, and closed on EOF,
@@ -47,5 +67,24 @@ public final class ServerSentEventStreams {
     public static <T> void listen(Response<BinaryData> response, BiFunction<String, String, T> converter,
         ServerSentEventListener<T> listener) {
         ServerSentEventStream.listen(response, converter, listener);
+    }
+
+    /**
+     * Decodes a single server-sent event response until an inclusive terminal event is delivered to a listener.
+     *
+     * <p>The response body is validated as {@code text/event-stream}, decoded incrementally, and closed after a
+     * terminal event, on failure, or on interruption. A 204 response completes without events. If the response body
+     * ends before a terminal event is delivered, this method fails. This method does not reconnect or replay a
+     * request.</p>
+     *
+     * @param response The streaming response.
+     * @param converter Converts an event name and data payload into the generated event type.
+     * @param terminalEvent Identifies the inclusive terminal event.
+     * @param listener The listener that receives decoded events and lifecycle notifications.
+     * @param <T> The type of the event data.
+     */
+    public static <T> void listen(Response<BinaryData> response, BiFunction<String, String, T> converter,
+        Predicate<ServerSentEvent<T>> terminalEvent, ServerSentEventListener<T> listener) {
+        ServerSentEventStream.listen(response, converter, terminalEvent, listener);
     }
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventStreams.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventStreams.java
@@ -13,6 +13,9 @@ import java.util.function.Predicate;
 
 /**
  * Consumes a single HTTP response as a server-sent event stream.
+ *
+ * <p>The supplied response must implement {@link java.io.Closeable}. The stream closes the physical response when
+ * consumption ends; a response that is not closeable is rejected with {@link IllegalArgumentException}.</p>
  */
 public final class ServerSentEventStreams {
     private ServerSentEventStreams() {
@@ -28,6 +31,7 @@ public final class ServerSentEventStreams {
      * @param converter Converts an event name and data payload into the generated event type.
      * @param <T> The type of the event data.
      * @return A flux of decoded server-sent events.
+     * @throws IllegalArgumentException If {@code response} does not implement {@link java.io.Closeable}.
      */
     public static <T> Flux<ServerSentEvent<T>> toFlux(Response<BinaryData> response,
         BiFunction<String, String, T> converter) {
@@ -47,6 +51,7 @@ public final class ServerSentEventStreams {
      * @param terminalEvent Identifies the inclusive terminal event.
      * @param <T> The type of the event data.
      * @return A flux of decoded server-sent events.
+     * @throws IllegalArgumentException If {@code response} does not implement {@link java.io.Closeable}.
      */
     public static <T> Flux<ServerSentEvent<T>> toFlux(Response<BinaryData> response,
         BiFunction<String, String, T> converter, Predicate<ServerSentEvent<T>> terminalEvent) {
@@ -63,6 +68,7 @@ public final class ServerSentEventStreams {
      * @param converter Converts an event name and data payload into the generated event type.
      * @param listener The listener that receives decoded events and lifecycle notifications.
      * @param <T> The type of the event data.
+     * @throws IllegalArgumentException If {@code response} does not implement {@link java.io.Closeable}.
      */
     public static <T> void listen(Response<BinaryData> response, BiFunction<String, String, T> converter,
         ServerSentEventListener<T> listener) {
@@ -82,6 +88,7 @@ public final class ServerSentEventStreams {
      * @param terminalEvent Identifies the inclusive terminal event.
      * @param listener The listener that receives decoded events and lifecycle notifications.
      * @param <T> The type of the event data.
+     * @throws IllegalArgumentException If {@code response} does not implement {@link java.io.Closeable}.
      */
     public static <T> void listen(Response<BinaryData> response, BiFunction<String, String, T> converter,
         Predicate<ServerSentEvent<T>> terminalEvent, ServerSentEventListener<T> listener) {

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventStreams.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/ServerSentEventStreams.java
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.http;
+
+import com.azure.core.http.rest.Response;
+import com.azure.core.implementation.util.ServerSentEventStream;
+import com.azure.core.util.BinaryData;
+import reactor.core.publisher.Flux;
+
+import java.util.function.BiFunction;
+
+/**
+ * Consumes a single HTTP response as a server-sent event stream.
+ */
+public final class ServerSentEventStreams {
+    private ServerSentEventStreams() {
+    }
+
+    /**
+     * Decodes a single server-sent event response as a {@link Flux}.
+     *
+     * <p>The response body is validated as {@code text/event-stream}, decoded incrementally, and closed on
+     * completion, failure, or cancellation. A 204 response produces an empty {@link Flux}.</p>
+     *
+     * @param response The streaming response.
+     * @param converter Converts an event name and data payload into the generated event type.
+     * @param <T> The type of the event data.
+     * @return A flux of decoded server-sent events.
+     */
+    public static <T> Flux<ServerSentEvent<T>> toFlux(Response<BinaryData> response,
+        BiFunction<String, String, T> converter) {
+        return ServerSentEventStream.toFlux(response, converter);
+    }
+
+    /**
+     * Decodes a single server-sent event response and invokes a listener for each event.
+     *
+     * <p>The response body is validated as {@code text/event-stream}, decoded incrementally, and closed on EOF,
+     * failure, or interruption. A 204 response completes without events.</p>
+     *
+     * @param response The streaming response.
+     * @param converter Converts an event name and data payload into the generated event type.
+     * @param listener The listener that receives decoded events and lifecycle notifications.
+     * @param <T> The type of the event data.
+     */
+    public static <T> void listen(Response<BinaryData> response, BiFunction<String, String, T> converter,
+        ServerSentEventListener<T> listener) {
+        ServerSentEventStream.listen(response, converter, listener);
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/policy/HttpLoggingPolicy.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/policy/HttpLoggingPolicy.java
@@ -21,6 +21,7 @@ import com.azure.core.implementation.util.BinaryDataHelper;
 import com.azure.core.implementation.util.ByteArrayContent;
 import com.azure.core.implementation.util.ByteBufferContent;
 import com.azure.core.implementation.util.HttpHeadersAccessHelper;
+import com.azure.core.implementation.util.HttpUtils;
 import com.azure.core.implementation.util.InputStreamContent;
 import com.azure.core.implementation.util.SerializableContent;
 import com.azure.core.implementation.util.StringContent;
@@ -338,7 +339,7 @@ public class HttpLoggingPolicy implements HttpPipelinePolicy {
             if (httpLogDetailLevel.shouldLogBody()) {
                 String contentTypeHeader = response.getHeaderValue(HttpHeaderName.CONTENT_TYPE);
 
-                if (shouldBodyBeLogged(contentTypeHeader, contentLength)) {
+                if (shouldResponseBodyBeLogged(loggingOptions, contentTypeHeader, contentLength)) {
                     // Make sure we buffer the response body to avoid keeping the connection open.
                     final HttpResponse bufferedResponse = response.buffer();
 
@@ -389,7 +390,7 @@ public class HttpLoggingPolicy implements HttpPipelinePolicy {
             if (httpLogDetailLevel.shouldLogBody()) {
                 String contentTypeHeader = response.getHeaderValue(HttpHeaderName.CONTENT_TYPE);
 
-                if (shouldBodyBeLogged(contentTypeHeader, contentLength)) {
+                if (shouldResponseBodyBeLogged(loggingOptions, contentTypeHeader, contentLength)) {
                     // Make sure we buffer the response body to avoid keeping the connection open.
                     response = response.buffer();
 
@@ -520,6 +521,13 @@ public class HttpLoggingPolicy implements HttpPipelinePolicy {
             && !ContentType.APPLICATION_OCTET_STREAM.equalsIgnoreCase(contentTypeHeader)
             && contentLength != 0
             && contentLength < MAX_BODY_LOG_SIZE;
+    }
+
+    private static boolean shouldResponseBodyBeLogged(HttpResponseLoggingContext loggingOptions,
+        String contentTypeHeader, Long contentLength) {
+        return !HttpUtils.shouldPreserveResponseBodyAsStream(loggingOptions.getContext())
+            && !HttpUtils.isTextEventStreamContentType(contentTypeHeader)
+            && shouldBodyBeLogged(contentTypeHeader, contentLength);
     }
 
     /*

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/rest/AsyncRestProxy.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/rest/AsyncRestProxy.java
@@ -13,6 +13,7 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.http.rest.StreamResponse;
 import com.azure.core.implementation.TypeUtil;
 import com.azure.core.implementation.serializer.HttpResponseDecoder;
+import com.azure.core.implementation.util.HttpUtils;
 import com.azure.core.util.Base64Url;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
@@ -45,8 +46,6 @@ import static com.azure.core.implementation.logging.LoggingKeys.CANCELLED_ERROR_
  * An asynchronous REST proxy implementation.
  */
 public class AsyncRestProxy extends RestProxyBase {
-
-    private static final String TEXT_EVENT_STREAM = "text/event-stream";
 
     /**
      * Create a RestProxy.
@@ -82,6 +81,8 @@ public class AsyncRestProxy extends RestProxyBase {
         if (options != null && requestCallback != null) {
             requestCallback.accept(request);
         }
+
+        context = updateRequestContext(request, context);
 
         final Context finalContext = context;
         final Mono<HttpResponse> asyncResponse = RestProxyUtils.validateLengthAsync(request).flatMap(r -> {
@@ -142,7 +143,10 @@ public class AsyncRestProxy extends RestProxyBase {
     }
 
     private Mono<?> handleRestResponseReturnType(final HttpResponseDecoder.HttpDecodedResponse response,
-        final SwaggerMethodParser methodParser, final Type entityType) {
+        final SwaggerMethodParser methodParser, final Type entityType, boolean preserveResponseBodyAsStream) {
+        final boolean shouldPreserveResponseBodyAsStream = preserveResponseBodyAsStream
+            || HttpUtils.isTextEventStreamContentType(
+                response.getSourceResponse().getHeaders().getValue(HttpHeaderName.CONTENT_TYPE));
         if (methodParser.isStreamResponse()) {
             return Mono.fromSupplier(() -> new StreamResponse(response.getSourceResponse()));
         } else if (TypeUtil.isTypeOrSubTypeOf(entityType, Response.class)) {
@@ -151,15 +155,20 @@ public class AsyncRestProxy extends RestProxyBase {
                 return response.getSourceResponse()
                     .getBody()
                     .ignoreElements()
-                    .then(Mono.fromCallable(() -> createResponse(response, entityType, null)));
+                    .then(Mono.fromCallable(
+                        () -> createResponse(response, entityType, null, shouldPreserveResponseBodyAsStream)));
             } else {
-                return handleBodyReturnType(response.getSourceResponse(), decodeBytes(response), methodParser, bodyType)
-                    .map(bodyAsObject -> createResponse(response, entityType, bodyAsObject))
-                    .switchIfEmpty(Mono.fromCallable(() -> createResponse(response, entityType, null)));
+                return handleBodyReturnType(response.getSourceResponse(), decodeBytes(response), methodParser, bodyType,
+                    shouldPreserveResponseBodyAsStream)
+                        .map(bodyAsObject -> createResponse(response, entityType, bodyAsObject,
+                            shouldPreserveResponseBodyAsStream))
+                        .switchIfEmpty(Mono.fromCallable(
+                            () -> createResponse(response, entityType, null, shouldPreserveResponseBodyAsStream)));
             }
         } else {
             // For now, we're just throwing if the Maybe didn't emit a value.
-            return handleBodyReturnType(response.getSourceResponse(), decodeBytes(response), methodParser, entityType);
+            return handleBodyReturnType(response.getSourceResponse(), decodeBytes(response), methodParser, entityType,
+                shouldPreserveResponseBodyAsStream);
         }
     }
 
@@ -177,7 +186,7 @@ public class AsyncRestProxy extends RestProxyBase {
     }
 
     static Mono<?> handleBodyReturnType(HttpResponse sourceResponse, Function<byte[], Mono<Object>> getDecodedBody,
-        SwaggerMethodParser methodParser, Type entityType) {
+        SwaggerMethodParser methodParser, Type entityType, boolean responseBodyStreaming) {
         final int responseStatusCode = sourceResponse.getStatusCode();
         final HttpMethod httpMethod = methodParser.getHttpMethod();
         final Type returnValueWireType = methodParser.getReturnValueWireType();
@@ -207,9 +216,9 @@ public class AsyncRestProxy extends RestProxyBase {
             // different methods to read the response. The reading of the response is delayed until BinaryData
             // is read and depending on which format the content is converted into, the response is not necessarily
             // fully copied into memory resulting in lesser overall memory usage.
-            if (contentType != null && contentType.startsWith(TEXT_EVENT_STREAM)) {
-                // if the response content type is a stream, create a BinaryData instance with bufferContent set to
-                // false.
+            if (responseBodyStreaming || HttpUtils.isTextEventStreamContentType(contentType)) {
+                // If the request or response content type identifies a stream, create a BinaryData instance with
+                // bufferContent set to false.
                 asyncResult = BinaryData.fromFlux(sourceResponse.getBody(), null, false);
             } else {
                 asyncResult = BinaryData.fromFlux(sourceResponse.getBody());
@@ -222,6 +231,11 @@ public class AsyncRestProxy extends RestProxyBase {
             asyncResult = sourceResponse.getBodyAsByteArray().flatMap(getDecodedBody);
         }
         return asyncResult;
+    }
+
+    static Mono<?> handleBodyReturnType(HttpResponse sourceResponse, Function<byte[], Mono<Object>> getDecodedBody,
+        SwaggerMethodParser methodParser, Type entityType) {
+        return handleBodyReturnType(sourceResponse, getDecodedBody, methodParser, entityType, false);
     }
 
     /**
@@ -238,6 +252,7 @@ public class AsyncRestProxy extends RestProxyBase {
         EnumSet<ErrorOptions> errorOptionsSet) {
         final Mono<HttpResponseDecoder.HttpDecodedResponse> asyncExpectedResponse = endSpanWhenDone(
             ensureExpectedStatus(asyncHttpDecodedResponse, methodParser, options, errorOptionsSet), context);
+        final boolean preserveResponseBodyAsStream = HttpUtils.shouldPreserveResponseBodyAsStream(context);
 
         final Object result;
         if (TypeUtil.isTypeOrSubTypeOf(returnType, Mono.class)) {
@@ -247,8 +262,8 @@ public class AsyncRestProxy extends RestProxyBase {
                 result = asyncExpectedResponse.doOnNext(HttpResponseDecoder.HttpDecodedResponse::close).then();
             } else {
                 // ProxyMethod ReturnType: Mono<? extends ResponseBase<?, ?>>
-                result = asyncExpectedResponse
-                    .flatMap(response -> handleRestResponseReturnType(response, methodParser, monoTypeParam));
+                result = asyncExpectedResponse.flatMap(response -> handleRestResponseReturnType(response, methodParser,
+                    monoTypeParam, preserveResponseBodyAsStream));
             }
         } else if (FluxUtil.isFluxByteBuffer(returnType)) {
             // ProxyMethod ReturnType: Flux<ByteBuffer>
@@ -261,9 +276,8 @@ public class AsyncRestProxy extends RestProxyBase {
         } else {
             // ProxyMethod ReturnType: T where T != async (Mono, Flux) or sync Void
             // Block the deserialization until a value T is received
-            result = asyncExpectedResponse
-                .flatMap(httpResponse -> handleRestResponseReturnType(httpResponse, methodParser, returnType))
-                .block();
+            result = asyncExpectedResponse.flatMap(httpResponse -> handleRestResponseReturnType(httpResponse,
+                methodParser, returnType, preserveResponseBodyAsStream)).block();
         }
         return result;
     }

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/rest/RestProxyBase.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/rest/RestProxyBase.java
@@ -28,7 +28,6 @@ import com.azure.core.implementation.http.UnexpectedExceptionInformation;
 import com.azure.core.implementation.serializer.HttpResponseDecoder;
 import com.azure.core.implementation.serializer.MalformedValueException;
 import com.azure.core.implementation.util.HttpUtils;
-import com.azure.core.implementation.util.ServerSentEventStream;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
 import com.azure.core.util.UrlBuilder;
@@ -153,8 +152,6 @@ public abstract class RestProxyBase {
         HttpRequest request, Context context);
 
     final Context updateRequestContext(HttpRequest request, Context context) {
-        ServerSentEventStream.applyReconnectContext(request, context);
-
         if (HttpUtils.acceptsTextEventStream(request.getHeaders().getValue(HttpHeaderName.ACCEPT))) {
             return context.addData(HttpUtils.AZURE_PRESERVE_RESPONSE_BODY_AS_STREAM, true);
         }

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/rest/RestProxyBase.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/rest/RestProxyBase.java
@@ -28,6 +28,7 @@ import com.azure.core.implementation.http.UnexpectedExceptionInformation;
 import com.azure.core.implementation.serializer.HttpResponseDecoder;
 import com.azure.core.implementation.serializer.MalformedValueException;
 import com.azure.core.implementation.util.HttpUtils;
+import com.azure.core.implementation.util.ServerSentEventStream;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
 import com.azure.core.util.UrlBuilder;
@@ -36,12 +37,14 @@ import com.azure.core.util.serializer.SerializerAdapter;
 import com.azure.core.util.tracing.Tracer;
 import reactor.core.Exceptions;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import static com.azure.core.util.FluxUtil.monoError;
@@ -149,6 +152,16 @@ public abstract class RestProxyBase {
         EnumSet<ErrorOptions> errorOptions, Consumer<HttpRequest> httpRequestConsumer, SwaggerMethodParser methodParser,
         HttpRequest request, Context context);
 
+    final Context updateRequestContext(HttpRequest request, Context context) {
+        ServerSentEventStream.applyReconnectContext(request, context);
+
+        if (HttpUtils.acceptsTextEventStream(request.getHeaders().getValue(HttpHeaderName.ACCEPT))) {
+            return context.addData(HttpUtils.AZURE_PRESERVE_RESPONSE_BODY_AS_STREAM, true);
+        }
+
+        return context;
+    }
+
     /**
      * Update the request with the provided configuration.
      *
@@ -172,6 +185,23 @@ public abstract class RestProxyBase {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public Response createResponse(HttpResponseDecoder.HttpDecodedResponse response, Type entityType,
         Object bodyAsObject) {
+        return createResponse(response, entityType, bodyAsObject, false);
+    }
+
+    /**
+     * Creates a {@link Response} from the provided decoded response.
+     *
+     * @param response the decoded response
+     * @param entityType the type of the response entity
+     * @param bodyAsObject the response body as an object
+     * @param responseBodyStreaming whether the response owns an unconsumed streaming body
+     * @return the {@link Response}
+     * @throws RuntimeException If the response type is a PagedResponse and the bodyAsObject is not an instance of
+     * Page.
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Response createResponse(HttpResponseDecoder.HttpDecodedResponse response, Type entityType,
+        Object bodyAsObject, boolean responseBodyStreaming) {
         final Class<? extends Response<?>> cls = (Class<? extends Response<?>>) TypeUtil.getRawClass(entityType);
 
         final HttpResponse httpResponse = response.getSourceResponse();
@@ -185,6 +215,10 @@ public abstract class RestProxyBase {
         // If the type is either the Response or PagedResponse interface from azure-core a new instance of either
         // ResponseBase or PagedResponseBase can be returned.
         if (cls.equals(Response.class)) {
+            if (responseBodyStreaming) {
+                return cls.cast(new CloseableResponse<>(httpResponse, bodyAsObject, decodedHeaders));
+            }
+
             // For Response return a new instance of ResponseBase cast to the class.
             return cls.cast(new ResponseBase<>(request, statusCode, headers, bodyAsObject, decodedHeaders));
         } else if (cls.equals(PagedResponse.class)) {
@@ -211,6 +245,23 @@ public abstract class RestProxyBase {
         // body as an Object.
         ReflectiveInvoker constructorReflectiveInvoker = RESPONSE_CONSTRUCTORS_CACHE.get(cls);
         return RESPONSE_CONSTRUCTORS_CACHE.invoke(constructorReflectiveInvoker, response, bodyAsObject);
+    }
+
+    private static final class CloseableResponse<T> extends ResponseBase<Object, T> implements Closeable {
+        private final AtomicBoolean closed = new AtomicBoolean();
+        private final HttpResponse response;
+
+        private CloseableResponse(HttpResponse response, T value, Object decodedHeaders) {
+            super(response.getRequest(), response.getStatusCode(), response.getHeaders(), value, decodedHeaders);
+            this.response = response;
+        }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                response.close();
+            }
+        }
     }
 
     /**

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/rest/SyncRestProxy.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/http/rest/SyncRestProxy.java
@@ -3,6 +3,7 @@
 
 package com.azure.core.implementation.http.rest;
 
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpMethod;
 import com.azure.core.http.HttpPipeline;
 import com.azure.core.http.HttpRequest;
@@ -13,6 +14,7 @@ import com.azure.core.http.rest.StreamResponse;
 import com.azure.core.implementation.ImplUtils;
 import com.azure.core.implementation.TypeUtil;
 import com.azure.core.implementation.serializer.HttpResponseDecoder;
+import com.azure.core.implementation.util.HttpUtils;
 import com.azure.core.util.Base64Url;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
@@ -76,6 +78,8 @@ public class SyncRestProxy extends RestProxyBase {
                 requestCallback.accept(request);
             }
 
+            context = updateRequestContext(request, context);
+
             if (request.getBodyAsBinaryData() != null) {
                 request.setBody(RestProxyUtils.validateLengthSync(request));
             }
@@ -136,19 +140,22 @@ public class SyncRestProxy extends RestProxyBase {
     }
 
     private Object handleRestResponseReturnType(HttpResponseDecoder.HttpDecodedResponse response,
-        SwaggerMethodParser methodParser, Type entityType) {
+        SwaggerMethodParser methodParser, Type entityType, boolean responseBodyStreaming) {
+        responseBodyStreaming = responseBodyStreaming
+            || HttpUtils.isTextEventStreamContentType(
+                response.getSourceResponse().getHeaders().getValue(HttpHeaderName.CONTENT_TYPE));
         if (methodParser.isStreamResponse()) {
             return new StreamResponse(response.getSourceResponse());
         } else if (TypeUtil.isTypeOrSubTypeOf(entityType, Response.class)) {
             final Type bodyType = TypeUtil.getRestResponseBodyType(entityType);
             if (TypeUtil.isTypeOrSubTypeOf(bodyType, Void.class)) {
                 response.getSourceResponse().close();
-                return createResponse(response, entityType, null);
+                return createResponse(response, entityType, null, responseBodyStreaming);
             } else {
                 Object bodyAsObject = handleBodyReturnType(response, methodParser, bodyType);
-                Response<?> httpResponse = createResponse(response, entityType, bodyAsObject);
+                Response<?> httpResponse = createResponse(response, entityType, bodyAsObject, responseBodyStreaming);
                 if (httpResponse == null) {
-                    return createResponse(response, entityType, null);
+                    return createResponse(response, entityType, null, responseBodyStreaming);
                 }
                 return httpResponse;
             }
@@ -218,7 +225,8 @@ public class SyncRestProxy extends RestProxyBase {
         } else {
             // ProxyMethod ReturnType: T where T != async (Mono, Flux) or sync Void
             // Block the deserialization until a value T is received
-            result = handleRestResponseReturnType(httpDecodedResponse, methodParser, returnType);
+            result = handleRestResponseReturnType(httpDecodedResponse, methodParser, returnType,
+                HttpUtils.shouldPreserveResponseBodyAsStream(context));
         }
         return result;
     }

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/HttpUtils.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/HttpUtils.java
@@ -91,7 +91,7 @@ public final class HttpUtils {
 
         for (String value : headerValue.split(",")) {
             String[] mediaRange = value.split(";");
-            if (TEXT_EVENT_STREAM.equalsIgnoreCase(mediaRange[0].trim()) && !hasZeroQuality(mediaRange)) {
+            if (TEXT_EVENT_STREAM.equalsIgnoreCase(mediaRange[0].trim()) && hasPositiveQuality(mediaRange)) {
                 return true;
             }
         }
@@ -110,24 +110,54 @@ public final class HttpUtils {
             return false;
         }
 
-        int parameterSeparator = headerValue.indexOf(';');
-        String mediaType = parameterSeparator < 0 ? headerValue : headerValue.substring(0, parameterSeparator);
-        return TEXT_EVENT_STREAM.equalsIgnoreCase(mediaType.trim());
-    }
+        String[] mediaTypeAndParameters = headerValue.split(";");
+        if (!TEXT_EVENT_STREAM.equalsIgnoreCase(mediaTypeAndParameters[0].trim())) {
+            return false;
+        }
 
-    private static boolean hasZeroQuality(String[] mediaRange) {
-        for (int i = 1; i < mediaRange.length; i++) {
-            String parameter = mediaRange[i].trim();
-            if (parameter.regionMatches(true, 0, "q=", 0, 2)) {
-                try {
-                    return Double.parseDouble(parameter.substring(2).trim()) == 0D;
-                } catch (NumberFormatException ignored) {
-                    return false;
-                }
+        for (int i = 1; i < mediaTypeAndParameters.length; i++) {
+            String parameter = mediaTypeAndParameters[i].trim();
+            int equalsIndex = parameter.indexOf('=');
+            if (equalsIndex > 0
+                && "charset".equalsIgnoreCase(parameter.substring(0, equalsIndex).trim())
+                && !isUtf8(parameter.substring(equalsIndex + 1).trim())) {
+                return false;
             }
         }
 
-        return false;
+        return true;
+    }
+
+    private static boolean hasPositiveQuality(String[] mediaRange) {
+        boolean qualityFound = false;
+        for (int i = 1; i < mediaRange.length; i++) {
+            String parameter = mediaRange[i].trim();
+            int equalsIndex = parameter.indexOf('=');
+            if (equalsIndex > 0 && "q".equalsIgnoreCase(parameter.substring(0, equalsIndex).trim())) {
+                if (qualityFound
+                    || !parameter.regionMatches(true, 0, "q=", 0, 2)
+                    || !isValidPositiveQuality(parameter.substring(2))) {
+                    return false;
+                }
+                qualityFound = true;
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean isValidPositiveQuality(String quality) {
+        return quality.matches("0(?:\\.[0-9]{0,3})?|1(?:\\.0{0,3})?") && !quality.matches("0(?:\\.0{0,3})?");
+    }
+
+    private static boolean isUtf8(String charset) {
+        return "utf-8".equalsIgnoreCase(unquote(charset));
+    }
+
+    private static String unquote(String value) {
+        return value.length() > 1 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"'
+            ? value.substring(1, value.length() - 1)
+            : value;
     }
 
     /**

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/HttpUtils.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/HttpUtils.java
@@ -3,6 +3,7 @@
 package com.azure.core.implementation.util;
 
 import com.azure.core.util.Configuration;
+import com.azure.core.util.Context;
 import com.azure.core.util.logging.ClientLogger;
 
 import java.time.Duration;
@@ -17,6 +18,7 @@ import static com.azure.core.util.CoreUtils.getDefaultTimeoutFromEnvironment;
  * Utilities shared with HttpClient implementations.
  */
 public final class HttpUtils {
+    private static final String TEXT_EVENT_STREAM = "text/event-stream";
     private static final ClientLogger LOGGER = new ClientLogger(HttpUtils.class);
 
     private static final Duration MINIMUM_TIMEOUT = Duration.ofMillis(1);
@@ -44,6 +46,12 @@ public final class HttpUtils {
     public static final String AZURE_EAGERLY_READ_RESPONSE = "azure-eagerly-read-response";
 
     /**
+     * Context key that instructs REST proxy response ownership and HTTP response logging to preserve the response body
+     * as a live stream. HTTP client implementations do not consume this key.
+     */
+    public static final String AZURE_PRESERVE_RESPONSE_BODY_AS_STREAM = "azure-preserve-response-body-as-stream";
+
+    /**
      * Context key used to indicate to an HttpClient implementation if the response body should be ignored and eagerly
      * drained from the network.
      */
@@ -59,6 +67,68 @@ public final class HttpUtils {
      * Azure Core HttpHeaders.
      */
     public static final String AZURE_EAGERLY_CONVERT_HEADERS = "azure-eagerly-convert-headers";
+
+    /**
+     * Determines whether the response body must be preserved as a live stream.
+     *
+     * @param context Contextual information about the request.
+     * @return Whether the response body must be preserved as a live stream.
+     */
+    public static boolean shouldPreserveResponseBodyAsStream(Context context) {
+        return Boolean.TRUE.equals(context.getData(AZURE_PRESERVE_RESPONSE_BODY_AS_STREAM).orElse(false));
+    }
+
+    /**
+     * Determines whether an Accept header contains an enabled {@code text/event-stream} media range.
+     *
+     * @param headerValue The header value.
+     * @return Whether the header contains an enabled {@code text/event-stream} media range.
+     */
+    public static boolean acceptsTextEventStream(String headerValue) {
+        if (headerValue == null) {
+            return false;
+        }
+
+        for (String value : headerValue.split(",")) {
+            String[] mediaRange = value.split(";");
+            if (TEXT_EVENT_STREAM.equalsIgnoreCase(mediaRange[0].trim()) && !hasZeroQuality(mediaRange)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines whether a Content-Type header identifies exactly one {@code text/event-stream} representation.
+     *
+     * @param headerValue The Content-Type header value.
+     * @return Whether the header identifies a {@code text/event-stream} representation.
+     */
+    public static boolean isTextEventStreamContentType(String headerValue) {
+        if (headerValue == null || headerValue.indexOf(',') >= 0) {
+            return false;
+        }
+
+        int parameterSeparator = headerValue.indexOf(';');
+        String mediaType = parameterSeparator < 0 ? headerValue : headerValue.substring(0, parameterSeparator);
+        return TEXT_EVENT_STREAM.equalsIgnoreCase(mediaType.trim());
+    }
+
+    private static boolean hasZeroQuality(String[] mediaRange) {
+        for (int i = 1; i < mediaRange.length; i++) {
+            String parameter = mediaRange[i].trim();
+            if (parameter.regionMatches(true, 0, "q=", 0, 2)) {
+                try {
+                    return Double.parseDouble(parameter.substring(2).trim()) == 0D;
+                } catch (NumberFormatException ignored) {
+                    return false;
+                }
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Gets the default connect timeout.

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/HttpUtils.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/HttpUtils.java
@@ -7,6 +7,9 @@ import com.azure.core.util.Context;
 import com.azure.core.util.logging.ClientLogger;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static com.azure.core.util.Configuration.PROPERTY_AZURE_REQUEST_CONNECT_TIMEOUT;
 import static com.azure.core.util.Configuration.PROPERTY_AZURE_REQUEST_READ_TIMEOUT;
@@ -89,9 +92,11 @@ public final class HttpUtils {
             return false;
         }
 
-        for (String value : headerValue.split(",")) {
-            String[] mediaRange = value.split(";");
-            if (TEXT_EVENT_STREAM.equalsIgnoreCase(mediaRange[0].trim()) && hasPositiveQuality(mediaRange)) {
+        for (String value : splitHeaderValue(headerValue, ',')) {
+            List<String> mediaRange = splitHeaderValue(value, ';');
+            if (!mediaRange.isEmpty()
+                && TEXT_EVENT_STREAM.equalsIgnoreCase(mediaRange.get(0).trim())
+                && hasPositiveQuality(mediaRange)) {
                 return true;
             }
         }
@@ -106,17 +111,19 @@ public final class HttpUtils {
      * @return Whether the header identifies a {@code text/event-stream} representation.
      */
     public static boolean isTextEventStreamContentType(String headerValue) {
-        if (headerValue == null || headerValue.indexOf(',') >= 0) {
+        if (headerValue == null) {
             return false;
         }
 
-        String[] mediaTypeAndParameters = headerValue.split(";");
-        if (!TEXT_EVENT_STREAM.equalsIgnoreCase(mediaTypeAndParameters[0].trim())) {
+        List<String> mediaTypeAndParameters = splitHeaderValue(headerValue, ';');
+        if (mediaTypeAndParameters.size() == 0
+            || !TEXT_EVENT_STREAM.equalsIgnoreCase(mediaTypeAndParameters.get(0).trim())
+            || splitHeaderValue(headerValue, ',').size() != 1) {
             return false;
         }
 
-        for (int i = 1; i < mediaTypeAndParameters.length; i++) {
-            String parameter = mediaTypeAndParameters[i].trim();
+        for (int i = 1; i < mediaTypeAndParameters.size(); i++) {
+            String parameter = mediaTypeAndParameters.get(i).trim();
             int equalsIndex = parameter.indexOf('=');
             if (equalsIndex > 0
                 && "charset".equalsIgnoreCase(parameter.substring(0, equalsIndex).trim())
@@ -128,10 +135,10 @@ public final class HttpUtils {
         return true;
     }
 
-    private static boolean hasPositiveQuality(String[] mediaRange) {
+    private static boolean hasPositiveQuality(List<String> mediaRange) {
         boolean qualityFound = false;
-        for (int i = 1; i < mediaRange.length; i++) {
-            String parameter = mediaRange[i].trim();
+        for (int i = 1; i < mediaRange.size(); i++) {
+            String parameter = mediaRange.get(i).trim();
             int equalsIndex = parameter.indexOf('=');
             if (equalsIndex > 0 && "q".equalsIgnoreCase(parameter.substring(0, equalsIndex).trim())) {
                 if (qualityFound
@@ -158,6 +165,34 @@ public final class HttpUtils {
         return value.length() > 1 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"'
             ? value.substring(1, value.length() - 1)
             : value;
+    }
+
+    private static List<String> splitHeaderValue(String value, char delimiter) {
+        List<String> segments = new ArrayList<>();
+        int start = 0;
+        boolean quoted = false;
+        boolean escaped = false;
+
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (escaped) {
+                escaped = false;
+            } else if (quoted && character == '\\') {
+                escaped = true;
+            } else if (character == '"') {
+                quoted = !quoted;
+            } else if (!quoted && character == delimiter) {
+                segments.add(value.substring(start, i));
+                start = i + 1;
+            }
+        }
+
+        if (quoted || escaped) {
+            return Collections.emptyList();
+        }
+
+        segments.add(value.substring(start));
+        return segments;
     }
 
     /**

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventHelper.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventHelper.java
@@ -29,7 +29,7 @@ public final class ServerSentEventHelper {
          * @param event The event name.
          * @param data The event data.
          * @param comment The event comment.
-         * @param retryAfter The reconnection delay.
+         * @param retryAfter The retry interval.
          * @param <T> The type of the event data.
          * @return The server-sent event.
          */
@@ -52,7 +52,7 @@ public final class ServerSentEventHelper {
      * @param event The event name.
      * @param data The event data.
      * @param comment The event comment.
-     * @param retryAfter The reconnection delay.
+     * @param retryAfter The retry interval.
      * @param <T> The type of the event data.
      * @return The server-sent event.
      */

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventHelper.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventHelper.java
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.implementation.util;
+
+import com.azure.core.http.ServerSentEvent;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Helper class that accesses non-public members of {@link ServerSentEvent}.
+ */
+public final class ServerSentEventHelper {
+    private static final AtomicReference<ServerSentEventAccessor> ACCESSOR = new AtomicReference<>();
+
+    private ServerSentEventHelper() {
+    }
+
+    /**
+     * Defines access to non-public members of {@link ServerSentEvent}.
+     */
+    public interface ServerSentEventAccessor {
+        /**
+         * Creates a server-sent event.
+         *
+         * @param id The event identifier.
+         * @param event The event name.
+         * @param data The event data.
+         * @param comment The event comment.
+         * @param retryAfter The reconnection delay.
+         * @param <T> The type of the event data.
+         * @return The server-sent event.
+         */
+        <T> ServerSentEvent<T> create(String id, String event, T data, String comment, Duration retryAfter);
+    }
+
+    /**
+     * Sets the accessor.
+     *
+     * @param serverSentEventAccessor The accessor.
+     */
+    public static void setAccessor(final ServerSentEventAccessor serverSentEventAccessor) {
+        ACCESSOR.set(Objects.requireNonNull(serverSentEventAccessor, "'serverSentEventAccessor' cannot be null."));
+    }
+
+    /**
+     * Creates a server-sent event.
+     *
+     * @param id The event identifier.
+     * @param event The event name.
+     * @param data The event data.
+     * @param comment The event comment.
+     * @param retryAfter The reconnection delay.
+     * @param <T> The type of the event data.
+     * @return The server-sent event.
+     */
+    public static <T> ServerSentEvent<T> create(String id, String event, T data, String comment, Duration retryAfter) {
+        return getAccessor().create(id, event, data, comment, retryAfter);
+    }
+
+    private static ServerSentEventAccessor getAccessor() {
+        ServerSentEventAccessor accessor = ACCESSOR.get();
+        if (accessor == null) {
+            try {
+                Class.forName(ServerSentEvent.class.getName(), true, ServerSentEvent.class.getClassLoader());
+            } catch (ClassNotFoundException exception) {
+                throw new IllegalStateException("Unable to initialize ServerSentEvent.", exception);
+            }
+            accessor = ACCESSOR.get();
+        }
+        return accessor;
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
@@ -33,7 +33,9 @@ import java.util.function.Predicate;
  * non-closeable responses with {@link IllegalArgumentException}, as stream cleanup cannot otherwise be guaranteed.</p>
  */
 public final class ServerSentEventStream {
+    static final int MAX_PENDING_EVENT_BYTES = 16 * 1024 * 1024;
     private static final String DEFAULT_EVENT = "message";
+    private static final String EVENT_TOO_LARGE = "The server-sent event exceeds the maximum supported size of 16 MiB.";
 
     private ServerSentEventStream() {
     }
@@ -327,10 +329,11 @@ public final class ServerSentEventStream {
         private final StreamState state;
         private byte[] lineBytes = new byte[256];
         private int lineLength;
+        private int pendingEventBytes;
         private boolean pendingCarriageReturn;
         private boolean firstLine = true;
         private String event;
-        private List<String> data;
+        private StringBuilder data;
         private String comment;
 
         private ServerSentEventDecoder(StreamState state) {
@@ -370,10 +373,15 @@ public final class ServerSentEventStream {
         }
 
         private void appendByte(byte value) {
+            if (pendingEventBytes == MAX_PENDING_EVENT_BYTES) {
+                throw new IllegalStateException(EVENT_TOO_LARGE);
+            }
+
             if (lineLength == lineBytes.length) {
                 lineBytes = Arrays.copyOf(lineBytes, lineBytes.length * 2);
             }
             lineBytes[lineLength++] = value;
+            pendingEventBytes++;
         }
 
         private String decodeLine() {
@@ -415,9 +423,10 @@ public final class ServerSentEventStream {
 
                 case "data":
                     if (data == null) {
-                        data = new ArrayList<>();
+                        data = new StringBuilder(value);
+                    } else {
+                        data.append('\n').append(value);
                     }
-                    data.add(value);
                     break;
 
                 case "id":
@@ -440,7 +449,7 @@ public final class ServerSentEventStream {
 
         private ServerSentEventFrame buildEvent() {
             String currentEvent = event;
-            List<String> currentData = data;
+            StringBuilder currentData = data;
             String currentComment = comment;
             resetEvent();
 
@@ -452,14 +461,15 @@ public final class ServerSentEventStream {
                 currentEvent = DEFAULT_EVENT;
             }
 
-            return new ServerSentEventFrame(state.lastEventId, currentEvent, String.join("\n", currentData),
-                currentComment, state.retryAfter);
+            return new ServerSentEventFrame(state.lastEventId, currentEvent, currentData.toString(), currentComment,
+                state.retryAfter);
         }
 
         private void resetEvent() {
             event = null;
             data = null;
             comment = null;
+            pendingEventBytes = 0;
         }
     }
 

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
@@ -21,7 +21,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 
 /**
  * Implementation support for parsing one server-sent event response.
@@ -94,6 +96,38 @@ public final class ServerSentEventStream {
     }
 
     /**
+     * Decodes an SSE response until an inclusive terminal event is emitted, closing its physical response.
+     */
+    public static <T> Flux<ServerSentEvent<T>> toFlux(Response<BinaryData> response,
+        BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent) {
+        Objects.requireNonNull(response, "'response' cannot be null.");
+        Objects.requireNonNull(deserializer, "'deserializer' cannot be null.");
+        Objects.requireNonNull(terminalEvent, "'terminalEvent' cannot be null.");
+
+        return Flux.defer(() -> {
+            ServerSentEventStreamResponse streamResponse = ServerSentEventStreamResponse.fromResponse(response);
+            if (streamResponse.getStatusCode() == 204) {
+                streamResponse.close();
+                return Flux.empty();
+            }
+
+            AtomicBoolean terminalObserved = new AtomicBoolean();
+            return decodeBody(streamResponse.getBody(), new StreamState(), deserializer).takeUntil(event -> {
+                boolean terminal = terminalEvent.test(event);
+                if (terminal) {
+                    terminalObserved.set(true);
+                }
+                return terminal;
+            })
+                .concatWith(Flux.defer(() -> terminalObserved.get()
+                    ? Flux.empty()
+                    : Flux.error(
+                        new IllegalStateException("The server-sent event stream ended before a terminal event."))))
+                .doFinally(ignored -> streamResponse.close());
+        });
+    }
+
+    /**
      * Processes an SSE response, closing its physical response on completion, failure, or interruption.
      */
     public static <T> void listen(Response<BinaryData> response, BiFunction<String, String, T> deserializer,
@@ -105,6 +139,32 @@ public final class ServerSentEventStream {
         try (ServerSentEventStreamResponse streamResponse = ServerSentEventStreamResponse.fromResponse(response)) {
             if (streamResponse.getStatusCode() != 204) {
                 processBody(streamResponse.getBody(), new StreamState(), deserializer, listener);
+            }
+        } catch (IOException exception) {
+            listener.onError(exception);
+            throw new UncheckedIOException(exception);
+        } catch (RuntimeException exception) {
+            listener.onError(exception);
+            throw exception;
+        } finally {
+            listener.onClose();
+        }
+    }
+
+    /**
+     * Processes an SSE response until an inclusive terminal event is delivered, closing its physical response.
+     */
+    public static <T> void listen(Response<BinaryData> response, BiFunction<String, String, T> deserializer,
+        Predicate<ServerSentEvent<T>> terminalEvent, ServerSentEventListener<T> listener) {
+        Objects.requireNonNull(response, "'response' cannot be null.");
+        Objects.requireNonNull(deserializer, "'deserializer' cannot be null.");
+        Objects.requireNonNull(terminalEvent, "'terminalEvent' cannot be null.");
+        Objects.requireNonNull(listener, "'listener' cannot be null.");
+
+        try (ServerSentEventStreamResponse streamResponse = ServerSentEventStreamResponse.fromResponse(response)) {
+            if (streamResponse.getStatusCode() != 204
+                && !processBody(streamResponse.getBody(), new StreamState(), deserializer, terminalEvent, listener)) {
+                throw new IllegalStateException("The server-sent event stream ended before a terminal event.");
             }
         } catch (IOException exception) {
             listener.onError(exception);
@@ -149,8 +209,29 @@ public final class ServerSentEventStream {
                     processFrames(decoder.feed(ByteBuffer.wrap(readBuffer, 0, read)), deserializer, listener);
                 }
             }
-
             processFrames(decoder.finish(), deserializer, listener);
+        }
+    }
+
+    private static <T> boolean processBody(BinaryData body, StreamState state,
+        BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent,
+        ServerSentEventListener<T> listener) throws IOException {
+        ServerSentEventDecoder decoder = new ServerSentEventDecoder(state);
+        byte[] readBuffer = new byte[8192];
+
+        try (InputStream stream = new FluxInputStream(body.toFluxByteBuffer())) {
+            while (true) {
+                checkInterrupted();
+                int read = stream.read(readBuffer);
+                if (read == -1) {
+                    return processFrames(decoder.finish(), deserializer, terminalEvent, listener);
+                }
+                if (read > 0
+                    && processFrames(decoder.feed(ByteBuffer.wrap(readBuffer, 0, read)), deserializer, terminalEvent,
+                        listener)) {
+                    return true;
+                }
+            }
         }
     }
 
@@ -163,6 +244,23 @@ public final class ServerSentEventStream {
                 listener.onEvent(frame.toEvent(data));
             }
         }
+    }
+
+    private static <T> boolean processFrames(List<ServerSentEventFrame> frames,
+        BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent,
+        ServerSentEventListener<T> listener) {
+        for (ServerSentEventFrame frame : frames) {
+            checkInterrupted();
+            T data = deserializer.apply(frame.event, frame.data);
+            if (data != null) {
+                ServerSentEvent<T> event = frame.toEvent(data);
+                listener.onEvent(event);
+                if (terminalEvent.test(event)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static void checkInterrupted() {

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
@@ -27,6 +27,9 @@ import java.util.function.Predicate;
 
 /**
  * Implementation support for parsing one server-sent event response.
+ *
+ * <p>Response-based methods require a {@link Response} that implements {@link java.io.Closeable}. They reject
+ * non-closeable responses with {@link IllegalArgumentException}, as stream cleanup cannot otherwise be guaranteed.</p>
  */
 public final class ServerSentEventStream {
     private static final String DEFAULT_EVENT = "message";
@@ -77,6 +80,8 @@ public final class ServerSentEventStream {
 
     /**
      * Decodes an SSE response, closing its physical response on completion, failure, or cancellation.
+     *
+     * @throws IllegalArgumentException If {@code response} does not implement {@link java.io.Closeable}.
      */
     public static <T> Flux<ServerSentEvent<T>> toFlux(Response<BinaryData> response,
         BiFunction<String, String, T> deserializer) {
@@ -97,6 +102,8 @@ public final class ServerSentEventStream {
 
     /**
      * Decodes an SSE response until an inclusive terminal event is emitted, closing its physical response.
+     *
+     * @throws IllegalArgumentException If {@code response} does not implement {@link java.io.Closeable}.
      */
     public static <T> Flux<ServerSentEvent<T>> toFlux(Response<BinaryData> response,
         BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent) {
@@ -129,6 +136,8 @@ public final class ServerSentEventStream {
 
     /**
      * Processes an SSE response, closing its physical response on completion, failure, or interruption.
+     *
+     * @throws IllegalArgumentException If {@code response} does not implement {@link java.io.Closeable}.
      */
     public static <T> void listen(Response<BinaryData> response, BiFunction<String, String, T> deserializer,
         ServerSentEventListener<T> listener) {
@@ -153,6 +162,8 @@ public final class ServerSentEventStream {
 
     /**
      * Processes an SSE response until an inclusive terminal event is delivered, closing its physical response.
+     *
+     * @throws IllegalArgumentException If {@code response} does not implement {@link java.io.Closeable}.
      */
     public static <T> void listen(Response<BinaryData> response, BiFunction<String, String, T> deserializer,
         Predicate<ServerSentEvent<T>> terminalEvent, ServerSentEventListener<T> listener) {

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
@@ -9,6 +9,7 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.implementation.FluxInputStream;
 import com.azure.core.util.BinaryData;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -66,7 +67,7 @@ public final class ServerSentEventStream {
         Objects.requireNonNull(listener, "'listener' cannot be null.");
 
         try {
-            processBody(body, new StreamState(), deserializer, listener);
+            processBody(body, new StreamState(), deserializer, TerminalEventPolicy.endOnResponseCompletion(), listener);
         } catch (IOException exception) {
             listener.onError(exception);
             throw new UncheckedIOException(exception);
@@ -88,16 +89,7 @@ public final class ServerSentEventStream {
         Objects.requireNonNull(response, "'response' cannot be null.");
         Objects.requireNonNull(deserializer, "'deserializer' cannot be null.");
 
-        return Flux.defer(() -> {
-            ServerSentEventStreamResponse streamResponse = ServerSentEventStreamResponse.fromResponse(response);
-            if (streamResponse.getStatusCode() == 204) {
-                streamResponse.close();
-                return Flux.empty();
-            }
-
-            return decodeBody(streamResponse.getBody(), new StreamState(), deserializer)
-                .doFinally(ignored -> streamResponse.close());
-        });
+        return toFlux(response, deserializer, TerminalEventPolicy.endOnResponseCompletion());
     }
 
     /**
@@ -111,26 +103,38 @@ public final class ServerSentEventStream {
         Objects.requireNonNull(deserializer, "'deserializer' cannot be null.");
         Objects.requireNonNull(terminalEvent, "'terminalEvent' cannot be null.");
 
+        return toFlux(response, deserializer, TerminalEventPolicy.requireTerminal(terminalEvent));
+    }
+
+    private static <T> Flux<ServerSentEvent<T>> toFlux(Response<BinaryData> response,
+        BiFunction<String, String, T> deserializer, TerminalEventPolicy<T> terminalPolicy) {
+        AtomicBoolean subscribed = new AtomicBoolean();
         return Flux.defer(() -> {
-            ServerSentEventStreamResponse streamResponse = ServerSentEventStreamResponse.fromResponse(response);
-            if (streamResponse.getStatusCode() == 204) {
-                streamResponse.close();
-                return Flux.empty();
+            if (!subscribed.compareAndSet(false, true)) {
+                return Flux
+                    .error(new IllegalStateException("This server-sent event stream supports only one subscription."));
             }
 
+            ServerSentEventStreamResponse streamResponse = ServerSentEventStreamResponse.fromResponse(response);
             AtomicBoolean terminalObserved = new AtomicBoolean();
-            return decodeBody(streamResponse.getBody(), new StreamState(), deserializer).takeUntil(event -> {
-                boolean terminal = terminalEvent.test(event);
-                if (terminal) {
-                    terminalObserved.set(true);
-                }
-                return terminal;
-            })
-                .concatWith(Flux.defer(() -> terminalObserved.get()
-                    ? Flux.empty()
-                    : Flux.error(
-                        new IllegalStateException("The server-sent event stream ended before a terminal event."))))
-                .doFinally(ignored -> streamResponse.close());
+            Flux<ServerSentEvent<T>> events = streamResponse.getStatusCode() == 204
+                ? Flux.empty()
+                : decodeBody(streamResponse.getBody(), new StreamState(), deserializer);
+            if (terminalPolicy.hasTerminalPredicate()) {
+                events = events.takeUntil(event -> {
+                    boolean terminal = terminalPolicy.isTerminal(event);
+                    if (terminal) {
+                        terminalObserved.set(true);
+                    }
+                    return terminal;
+                });
+            }
+
+            Flux<ServerSentEvent<T>> decodedEvents = events;
+            return Flux.using(() -> streamResponse,
+                ignored -> decodedEvents
+                    .concatWith(Mono.fromRunnable(() -> terminalPolicy.validateCompletion(terminalObserved.get()))),
+                ServerSentEventStreamResponse::close, true);
         });
     }
 
@@ -146,9 +150,10 @@ public final class ServerSentEventStream {
         Objects.requireNonNull(listener, "'listener' cannot be null.");
 
         try (ServerSentEventStreamResponse streamResponse = ServerSentEventStreamResponse.fromResponse(response)) {
-            if (streamResponse.getStatusCode() != 204) {
-                processBody(streamResponse.getBody(), new StreamState(), deserializer, listener);
-            }
+            boolean terminalObserved = streamResponse.getStatusCode() != 204
+                && processBody(streamResponse.getBody(), new StreamState(), deserializer,
+                    TerminalEventPolicy.endOnResponseCompletion(), listener);
+            TerminalEventPolicy.<T>endOnResponseCompletion().validateCompletion(terminalObserved);
         } catch (IOException exception) {
             listener.onError(exception);
             throw new UncheckedIOException(exception);
@@ -173,10 +178,10 @@ public final class ServerSentEventStream {
         Objects.requireNonNull(listener, "'listener' cannot be null.");
 
         try (ServerSentEventStreamResponse streamResponse = ServerSentEventStreamResponse.fromResponse(response)) {
-            if (streamResponse.getStatusCode() != 204
-                && !processBody(streamResponse.getBody(), new StreamState(), deserializer, terminalEvent, listener)) {
-                throw new IllegalStateException("The server-sent event stream ended before a terminal event.");
-            }
+            TerminalEventPolicy<T> terminalPolicy = TerminalEventPolicy.requireTerminal(terminalEvent);
+            boolean terminalObserved = streamResponse.getStatusCode() != 204
+                && processBody(streamResponse.getBody(), new StreamState(), deserializer, terminalPolicy, listener);
+            terminalPolicy.validateCompletion(terminalObserved);
         } catch (IOException exception) {
             listener.onError(exception);
             throw new UncheckedIOException(exception);
@@ -203,7 +208,8 @@ public final class ServerSentEventStream {
         return data == null ? Flux.empty() : Flux.just(frame.toEvent(data));
     }
 
-    private static <T> void processBody(BinaryData body, StreamState state, BiFunction<String, String, T> deserializer,
+    private static <T> boolean processBody(BinaryData body, StreamState state,
+        BiFunction<String, String, T> deserializer, TerminalEventPolicy<T> terminalPolicy,
         ServerSentEventListener<T> listener) throws IOException {
         ServerSentEventDecoder decoder = new ServerSentEventDecoder(state);
         byte[] readBuffer = new byte[8192];
@@ -214,31 +220,10 @@ public final class ServerSentEventStream {
                 checkInterrupted();
                 read = stream.read(readBuffer);
                 if (read == -1) {
-                    break;
-                }
-                if (read > 0) {
-                    processFrames(decoder.feed(ByteBuffer.wrap(readBuffer, 0, read)), deserializer, listener);
-                }
-            }
-            processFrames(decoder.finish(), deserializer, listener);
-        }
-    }
-
-    private static <T> boolean processBody(BinaryData body, StreamState state,
-        BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent,
-        ServerSentEventListener<T> listener) throws IOException {
-        ServerSentEventDecoder decoder = new ServerSentEventDecoder(state);
-        byte[] readBuffer = new byte[8192];
-
-        try (InputStream stream = new FluxInputStream(body.toFluxByteBuffer())) {
-            while (true) {
-                checkInterrupted();
-                int read = stream.read(readBuffer);
-                if (read == -1) {
-                    return processFrames(decoder.finish(), deserializer, terminalEvent, listener);
+                    return processFrames(decoder.finish(), deserializer, terminalPolicy, listener);
                 }
                 if (read > 0
-                    && processFrames(decoder.feed(ByteBuffer.wrap(readBuffer, 0, read)), deserializer, terminalEvent,
+                    && processFrames(decoder.feed(ByteBuffer.wrap(readBuffer, 0, read)), deserializer, terminalPolicy,
                         listener)) {
                     return true;
                 }
@@ -246,19 +231,8 @@ public final class ServerSentEventStream {
         }
     }
 
-    private static <T> void processFrames(List<ServerSentEventFrame> frames, BiFunction<String, String, T> deserializer,
-        ServerSentEventListener<T> listener) {
-        for (ServerSentEventFrame frame : frames) {
-            checkInterrupted();
-            T data = deserializer.apply(frame.event, frame.data);
-            if (data != null) {
-                listener.onEvent(frame.toEvent(data));
-            }
-        }
-    }
-
     private static <T> boolean processFrames(List<ServerSentEventFrame> frames,
-        BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent,
+        BiFunction<String, String, T> deserializer, TerminalEventPolicy<T> terminalPolicy,
         ServerSentEventListener<T> listener) {
         for (ServerSentEventFrame frame : frames) {
             checkInterrupted();
@@ -266,12 +240,42 @@ public final class ServerSentEventStream {
             if (data != null) {
                 ServerSentEvent<T> event = frame.toEvent(data);
                 listener.onEvent(event);
-                if (terminalEvent.test(event)) {
+                if (terminalPolicy.isTerminal(event)) {
                     return true;
                 }
             }
         }
         return false;
+    }
+
+    private static final class TerminalEventPolicy<T> {
+        private final Predicate<ServerSentEvent<T>> terminalPredicate;
+
+        private TerminalEventPolicy(Predicate<ServerSentEvent<T>> terminalPredicate) {
+            this.terminalPredicate = terminalPredicate;
+        }
+
+        private boolean hasTerminalPredicate() {
+            return terminalPredicate != null;
+        }
+
+        private boolean isTerminal(ServerSentEvent<T> event) {
+            return terminalPredicate != null && terminalPredicate.test(event);
+        }
+
+        private void validateCompletion(boolean terminalObserved) {
+            if (terminalPredicate != null && !terminalObserved) {
+                throw new IllegalStateException("The server-sent event stream ended before a terminal event.");
+            }
+        }
+
+        private static <T> TerminalEventPolicy<T> endOnResponseCompletion() {
+            return new TerminalEventPolicy<>(null);
+        }
+
+        private static <T> TerminalEventPolicy<T> requireTerminal(Predicate<ServerSentEvent<T>> terminalPredicate) {
+            return new TerminalEventPolicy<>(terminalPredicate);
+        }
     }
 
     private static void checkInterrupted() {

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
@@ -1,0 +1,539 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.implementation.util;
+
+import com.azure.core.http.ServerSentEvent;
+import com.azure.core.http.ServerSentEventListener;
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.implementation.FluxInputStream;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.Context;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Implementation support for parsing and reconnecting server-sent event streams.
+ *
+ * <p>A logical stream reconnects after a response body completes or fails while being consumed when the server has
+ * supplied a valid {@code retry} value. HTTP request, deserialization, and listener failures terminate the stream.
+ * Reconnection continues without a client-imposed attempt limit until a terminal event, cancellation, interruption,
+ * or a response that has no retry state ends the stream.</p>
+ *
+ * <p>Generated code must use the reconnect callback to issue a fresh, replay-safe request through the normal HTTP
+ * pipeline. A {@code null} callback argument means that {@code Last-Event-Id} must be omitted.</p>
+ */
+public final class ServerSentEventStream {
+    private static final String DEFAULT_EVENT = "message";
+    private static final HttpHeaderName LAST_EVENT_ID = HttpHeaderName.fromString("Last-Event-Id");
+    private static final Object RECONNECT_CONTEXT_KEY = new Object();
+
+    private ServerSentEventStream() {
+    }
+
+    /**
+     * Decodes one server-sent event response body.
+     *
+     * @param body The response body.
+     * @param deserializer The event data deserializer.
+     * @param <T> The event data type.
+     * @return The decoded events.
+     */
+    public static <T> Flux<ServerSentEvent<T>> decode(BinaryData body, BiFunction<String, String, T> deserializer) {
+        Objects.requireNonNull(body, "'body' cannot be null.");
+        Objects.requireNonNull(deserializer, "'deserializer' cannot be null.");
+        return Flux.defer(() -> decodeBody(body, new StreamState(), deserializer));
+    }
+
+    /**
+     * Decodes a logical server-sent event stream, reconnecting after response completion or a response-body failure
+     * when the server has supplied a valid retry interval.
+     *
+     * @param response The initial response.
+     * @param reconnect Creates a fresh response. Its argument is the last event identifier or {@code null} when no
+     * {@code Last-Event-Id} header should be sent.
+     * @param deserializer The event data deserializer.
+     * @param <T> The event data type.
+     * @return The decoded events.
+     */
+    public static <T> Flux<ServerSentEvent<T>> decode(ServerSentEventStreamResponse response,
+        Function<String, Mono<ServerSentEventStreamResponse>> reconnect, BiFunction<String, String, T> deserializer) {
+        Objects.requireNonNull(response, "'response' cannot be null.");
+        Objects.requireNonNull(reconnect, "'reconnect' cannot be null.");
+        Objects.requireNonNull(deserializer, "'deserializer' cannot be null.");
+
+        return Flux.defer(() -> {
+            StreamState state = new StreamState();
+            AtomicReference<ServerSentEventStreamResponse> currentResponse = new AtomicReference<>(response);
+            Flux<ServerSentEvent<T>> decodeCurrentResponse = Flux.defer(() -> {
+                ServerSentEventStreamResponse responseToDecode = currentResponse.get();
+                if (responseToDecode.getStatusCode() == 204) {
+                    state.stopReconnecting = true;
+                    responseToDecode.close();
+                    return Flux.empty();
+                }
+
+                return decodeBody(responseToDecode.getBody(), state, deserializer, true)
+                    .doFinally(ignored -> responseToDecode.close());
+            });
+
+            return decodeCurrentResponse
+                .repeatWhen(
+                    completions -> completions.takeWhile(ignored -> state.retryAfter != null && !state.stopReconnecting)
+                        .concatMap(ignored -> delay(state.retryAfter)
+                            .then(Mono.defer(() -> Objects.requireNonNull(reconnect.apply(state.getReconnectEventId()),
+                                "'reconnect' cannot return null.")))
+                            .doOnNext(currentResponse::set)))
+                .doFinally(ignored -> currentResponse.get().close());
+        });
+    }
+
+    /**
+     * Processes one server-sent event response body.
+     *
+     * @param body The response body.
+     * @param deserializer The event data deserializer.
+     * @param listener The event listener.
+     * @param <T> The event data type.
+     */
+    public static <T> void process(BinaryData body, BiFunction<String, String, T> deserializer,
+        ServerSentEventListener<T> listener) {
+        processInternal(body, null, deserializer, event -> false, listener);
+    }
+
+    /**
+     * Processes a logical server-sent event stream, reconnecting after response completion or a response-body failure
+     * when the server has supplied a valid retry interval.
+     *
+     * @param response The initial response.
+     * @param reconnect Creates a fresh response. Its argument is the last event identifier or {@code null} when no
+     * {@code Last-Event-Id} header should be sent.
+     * @param deserializer The event data deserializer.
+     * @param terminalEvent Identifies an inclusive terminal event.
+     * @param listener The event listener.
+     * @param <T> The event data type.
+     */
+    public static <T> void process(ServerSentEventStreamResponse response,
+        Function<String, ServerSentEventStreamResponse> reconnect, BiFunction<String, String, T> deserializer,
+        Predicate<ServerSentEvent<T>> terminalEvent, ServerSentEventListener<T> listener) {
+        Objects.requireNonNull(reconnect, "'reconnect' cannot be null.");
+        processInternal(response, reconnect, deserializer, terminalEvent, listener);
+    }
+
+    /**
+     * Adds reconnect state to a request context.
+     *
+     * @param context The request context.
+     * @param lastEventId The last event identifier, or {@code null} to omit {@code Last-Event-Id}.
+     * @return The request context containing the reconnect state.
+     */
+    public static Context addReconnectContext(Context context, String lastEventId) {
+        return Objects.requireNonNull(context, "'context' cannot be null.")
+            .addData(RECONNECT_CONTEXT_KEY, new ReconnectState(lastEventId));
+    }
+
+    /**
+     * Applies reconnect state after generated parameters and request options have configured the request.
+     *
+     * @param request The request.
+     * @param context The request context.
+     */
+    public static void applyReconnectContext(HttpRequest request, Context context) {
+        Objects.requireNonNull(request, "'request' cannot be null.");
+        Objects.requireNonNull(context, "'context' cannot be null.");
+
+        Object value = context.getData(RECONNECT_CONTEXT_KEY).orElse(null);
+        if (!(value instanceof ReconnectState)) {
+            return;
+        }
+
+        String lastEventId = ((ReconnectState) value).lastEventId;
+        if (lastEventId == null || lastEventId.isEmpty()) {
+            request.getHeaders().remove(LAST_EVENT_ID);
+        } else {
+            request.getHeaders().set(LAST_EVENT_ID, lastEventId);
+        }
+    }
+
+    private static <T> void processInternal(BinaryData body, Function<String, ServerSentEventStreamResponse> reconnect,
+        BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent,
+        ServerSentEventListener<T> listener) {
+        processInternal(new ServerSentEventStreamResponse(200, body, () -> {
+        }), reconnect, deserializer, terminalEvent, listener);
+    }
+
+    private static <T> void processInternal(ServerSentEventStreamResponse response,
+        Function<String, ServerSentEventStreamResponse> reconnect, BiFunction<String, String, T> deserializer,
+        Predicate<ServerSentEvent<T>> terminalEvent, ServerSentEventListener<T> listener) {
+        Objects.requireNonNull(response, "'response' cannot be null.");
+        Objects.requireNonNull(deserializer, "'deserializer' cannot be null.");
+        Objects.requireNonNull(terminalEvent, "'terminalEvent' cannot be null.");
+        Objects.requireNonNull(listener, "'listener' cannot be null.");
+
+        StreamState state = new StreamState();
+        ServerSentEventStreamResponse currentResponse = response;
+
+        try {
+            while (true) {
+                if (currentResponse.getStatusCode() == 204) {
+                    currentResponse.close();
+                    return;
+                }
+
+                boolean terminal;
+                try (ServerSentEventStreamResponse responseToProcess = currentResponse) {
+                    terminal = processBody(responseToProcess.getBody(), state, deserializer, terminalEvent, listener);
+                } catch (IOException exception) {
+                    if (reconnect == null || state.retryAfter == null) {
+                        throw exception;
+                    }
+                    terminal = false;
+                }
+
+                if (terminal || reconnect == null || state.retryAfter == null) {
+                    return;
+                }
+
+                waitForRetry(state.retryAfter);
+                checkInterrupted();
+                ServerSentEventStreamResponse nextResponse = Objects
+                    .requireNonNull(reconnect.apply(state.getReconnectEventId()), "'reconnect' cannot return null.");
+                try {
+                    checkInterrupted();
+                } catch (RuntimeException exception) {
+                    nextResponse.close();
+                    throw exception;
+                }
+                currentResponse = nextResponse;
+            }
+        } catch (IOException exception) {
+            listener.onError(exception);
+            throw new UncheckedIOException(exception);
+        } catch (RuntimeException exception) {
+            listener.onError(exception);
+            throw exception;
+        } finally {
+            listener.onClose();
+        }
+    }
+
+    private static <T> Flux<ServerSentEvent<T>> decodeBody(BinaryData body, StreamState state,
+        BiFunction<String, String, T> deserializer) {
+        return decodeBody(body, state, deserializer, false);
+    }
+
+    private static <T> Flux<ServerSentEvent<T>> decodeBody(BinaryData body, StreamState state,
+        BiFunction<String, String, T> deserializer, boolean reconnectBodyFailures) {
+        ServerSentEventDecoder decoder = new ServerSentEventDecoder(state);
+        Flux<ByteBuffer> content = body.toFluxByteBuffer();
+        if (reconnectBodyFailures) {
+            content = content.onErrorResume(error -> state.retryAfter == null ? Flux.error(error) : Flux.empty());
+        }
+
+        Flux<ServerSentEventFrame> frames = content.concatMap(buffer -> Flux.fromIterable(decoder.feed(buffer)), 1)
+            .concatWith(Flux.defer(() -> Flux.fromIterable(decoder.finish())));
+        return frames.concatMap(frame -> deserializeFrame(frame, deserializer), 1);
+    }
+
+    private static <T> Flux<ServerSentEvent<T>> deserializeFrame(ServerSentEventFrame frame,
+        BiFunction<String, String, T> deserializer) {
+        T data = deserializer.apply(frame.event, frame.data);
+        return data == null ? Flux.empty() : Flux.just(frame.toEvent(data));
+    }
+
+    private static <T> boolean processBody(BinaryData body, StreamState state,
+        BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent,
+        ServerSentEventListener<T> listener) throws IOException {
+        ServerSentEventDecoder decoder = new ServerSentEventDecoder(state);
+        byte[] readBuffer = new byte[8192];
+
+        try (InputStream stream = new FluxInputStream(body.toFluxByteBuffer())) {
+            int read;
+            while ((read = stream.read(readBuffer)) != -1) {
+                if (read > 0
+                    && processFrames(decoder.feed(ByteBuffer.wrap(readBuffer, 0, read)), deserializer, terminalEvent,
+                        listener)) {
+                    return true;
+                }
+            }
+
+            return processFrames(decoder.finish(), deserializer, terminalEvent, listener);
+        }
+    }
+
+    private static <T> boolean processFrames(List<ServerSentEventFrame> frames,
+        BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent,
+        ServerSentEventListener<T> listener) {
+        for (ServerSentEventFrame frame : frames) {
+            T data = deserializer.apply(frame.event, frame.data);
+            if (data != null) {
+                ServerSentEvent<T> event = frame.toEvent(data);
+                listener.onEvent(event);
+                if (terminalEvent.test(event)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void waitForRetry(Duration retryAfter) {
+        checkInterrupted();
+        if (retryAfter.isZero()) {
+            return;
+        }
+
+        try {
+            Thread.sleep(retryAfter.toMillis());
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting to reconnect the server-sent event stream.",
+                exception);
+        }
+    }
+
+    private static void checkInterrupted() {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new RuntimeException("Interrupted while reconnecting the server-sent event stream.",
+                new InterruptedException());
+        }
+    }
+
+    private static Mono<Long> delay(Duration retryAfter) {
+        return Mono.create(sink -> {
+            Disposable scheduled
+                = Schedulers.parallel().schedule(() -> sink.success(0L), retryAfter.toMillis(), TimeUnit.MILLISECONDS);
+            sink.onDispose(scheduled);
+        });
+    }
+
+    private static String removeOptionalSpace(String value) {
+        return value.startsWith(" ") ? value.substring(1) : value;
+    }
+
+    private static Duration parseRetryAfter(String value) {
+        if (value.isEmpty()) {
+            return null;
+        }
+
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (character < '0' || character > '9') {
+                return null;
+            }
+        }
+
+        try {
+            return Duration.ofMillis(Long.parseLong(value));
+        } catch (NumberFormatException ignored) {
+            // Ignore retry values that don't fit in a long.
+            return null;
+        }
+    }
+
+    private static final class StreamState {
+        private String lastEventId;
+        private Duration retryAfter;
+        private boolean stopReconnecting;
+
+        private void setLastEventId(String lastEventId) {
+            this.lastEventId = lastEventId;
+        }
+
+        private void setRetryAfter(Duration retryAfter) {
+            this.retryAfter = retryAfter;
+        }
+
+        private String getReconnectEventId() {
+            return lastEventId == null || lastEventId.isEmpty() ? null : lastEventId;
+        }
+    }
+
+    private static final class ReconnectState {
+        private final String lastEventId;
+
+        private ReconnectState(String lastEventId) {
+            this.lastEventId = lastEventId;
+        }
+    }
+
+    private static final class ServerSentEventDecoder {
+        private final StreamState state;
+        private byte[] lineBytes = new byte[256];
+        private int lineLength;
+        private boolean pendingCarriageReturn;
+        private boolean firstLine = true;
+        private String event;
+        private List<String> data;
+        private String comment;
+
+        private ServerSentEventDecoder(StreamState state) {
+            this.state = state;
+        }
+
+        private List<ServerSentEventFrame> feed(ByteBuffer source) {
+            ByteBuffer buffer = source.duplicate();
+            List<ServerSentEventFrame> events = new ArrayList<>();
+
+            while (buffer.hasRemaining()) {
+                byte value = buffer.get();
+
+                if (pendingCarriageReturn) {
+                    pendingCarriageReturn = false;
+                    if (value == '\n') {
+                        continue;
+                    }
+                }
+
+                if (value == '\n') {
+                    processLine(decodeLine(), events);
+                } else if (value == '\r') {
+                    processLine(decodeLine(), events);
+                    pendingCarriageReturn = true;
+                } else {
+                    appendByte(value);
+                }
+            }
+
+            return events;
+        }
+
+        private List<ServerSentEventFrame> finish() {
+            // The SSE parsing algorithm discards an event that wasn't terminated by a blank line.
+            return Collections.emptyList();
+        }
+
+        private void appendByte(byte value) {
+            if (lineLength == lineBytes.length) {
+                lineBytes = Arrays.copyOf(lineBytes, lineBytes.length * 2);
+            }
+            lineBytes[lineLength++] = value;
+        }
+
+        private String decodeLine() {
+            String line = new String(lineBytes, 0, lineLength, StandardCharsets.UTF_8);
+            lineLength = 0;
+
+            if (firstLine) {
+                firstLine = false;
+                if (!line.isEmpty() && line.charAt(0) == '\uFEFF') {
+                    return line.substring(1);
+                }
+            }
+
+            return line;
+        }
+
+        private void processLine(String line, List<ServerSentEventFrame> events) {
+            if (line.isEmpty()) {
+                ServerSentEventFrame parsedEvent = buildEvent();
+                if (parsedEvent != null) {
+                    events.add(parsedEvent);
+                }
+                return;
+            }
+
+            if (line.charAt(0) == ':') {
+                comment = removeOptionalSpace(line.substring(1));
+                return;
+            }
+
+            int colonIndex = line.indexOf(':');
+            String field = colonIndex < 0 ? line : line.substring(0, colonIndex);
+            String value = colonIndex < 0 ? "" : removeOptionalSpace(line.substring(colonIndex + 1));
+
+            switch (field) {
+                case "event":
+                    event = value;
+                    break;
+
+                case "data":
+                    if (data == null) {
+                        data = new ArrayList<>();
+                    }
+                    data.add(value);
+                    break;
+
+                case "id":
+                    if (value.indexOf('\0') < 0) {
+                        state.setLastEventId(value);
+                    }
+                    break;
+
+                case "retry":
+                    Duration parsedRetryAfter = parseRetryAfter(value);
+                    if (parsedRetryAfter != null) {
+                        state.setRetryAfter(parsedRetryAfter);
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        private ServerSentEventFrame buildEvent() {
+            String currentEvent = event;
+            List<String> currentData = data;
+            String currentComment = comment;
+            resetEvent();
+
+            if (currentData == null) {
+                return null;
+            }
+
+            if (currentEvent == null || currentEvent.isEmpty()) {
+                currentEvent = DEFAULT_EVENT;
+            }
+
+            return new ServerSentEventFrame(state.lastEventId, currentEvent, String.join("\n", currentData),
+                currentComment, state.retryAfter);
+        }
+
+        private void resetEvent() {
+            event = null;
+            data = null;
+            comment = null;
+        }
+    }
+
+    private static final class ServerSentEventFrame {
+        private final String id;
+        private final String event;
+        private final String data;
+        private final String comment;
+        private final Duration retryAfter;
+
+        private ServerSentEventFrame(String id, String event, String data, String comment, Duration retryAfter) {
+            this.id = id;
+            this.event = event;
+            this.data = data;
+            this.comment = comment;
+            this.retryAfter = retryAfter;
+        }
+
+        private <T> ServerSentEvent<T> toEvent(T data) {
+            return ServerSentEventHelper.create(id, event, data, comment, retryAfter);
+        }
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStream.java
@@ -5,15 +5,10 @@ package com.azure.core.implementation.util;
 
 import com.azure.core.http.ServerSentEvent;
 import com.azure.core.http.ServerSentEventListener;
-import com.azure.core.http.HttpHeaderName;
-import com.azure.core.http.HttpRequest;
+import com.azure.core.http.rest.Response;
 import com.azure.core.implementation.FluxInputStream;
 import com.azure.core.util.BinaryData;
-import com.azure.core.util.Context;
-import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,27 +21,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
- * Implementation support for parsing and reconnecting server-sent event streams.
- *
- * <p>A logical stream reconnects after a response body completes or fails while being consumed when the server has
- * supplied a valid {@code retry} value. HTTP request, deserialization, and listener failures terminate the stream.
- * Reconnection continues without a client-imposed attempt limit until a terminal event, cancellation, interruption,
- * or a response that has no retry state ends the stream.</p>
- *
- * <p>Generated code must use the reconnect callback to issue a fresh, replay-safe request through the normal HTTP
- * pipeline. A {@code null} callback argument means that {@code Last-Event-Id} must be omitted.</p>
+ * Implementation support for parsing one server-sent event response.
  */
 public final class ServerSentEventStream {
     private static final String DEFAULT_EVENT = "message";
-    private static final HttpHeaderName LAST_EVENT_ID = HttpHeaderName.fromString("Last-Event-Id");
-    private static final Object RECONNECT_CONTEXT_KEY = new Object();
 
     private ServerSentEventStream() {
     }
@@ -66,49 +47,6 @@ public final class ServerSentEventStream {
     }
 
     /**
-     * Decodes a logical server-sent event stream, reconnecting after response completion or a response-body failure
-     * when the server has supplied a valid retry interval.
-     *
-     * @param response The initial response.
-     * @param reconnect Creates a fresh response. Its argument is the last event identifier or {@code null} when no
-     * {@code Last-Event-Id} header should be sent.
-     * @param deserializer The event data deserializer.
-     * @param <T> The event data type.
-     * @return The decoded events.
-     */
-    public static <T> Flux<ServerSentEvent<T>> decode(ServerSentEventStreamResponse response,
-        Function<String, Mono<ServerSentEventStreamResponse>> reconnect, BiFunction<String, String, T> deserializer) {
-        Objects.requireNonNull(response, "'response' cannot be null.");
-        Objects.requireNonNull(reconnect, "'reconnect' cannot be null.");
-        Objects.requireNonNull(deserializer, "'deserializer' cannot be null.");
-
-        return Flux.defer(() -> {
-            StreamState state = new StreamState();
-            AtomicReference<ServerSentEventStreamResponse> currentResponse = new AtomicReference<>(response);
-            Flux<ServerSentEvent<T>> decodeCurrentResponse = Flux.defer(() -> {
-                ServerSentEventStreamResponse responseToDecode = currentResponse.get();
-                if (responseToDecode.getStatusCode() == 204) {
-                    state.stopReconnecting = true;
-                    responseToDecode.close();
-                    return Flux.empty();
-                }
-
-                return decodeBody(responseToDecode.getBody(), state, deserializer, true)
-                    .doFinally(ignored -> responseToDecode.close());
-            });
-
-            return decodeCurrentResponse
-                .repeatWhen(
-                    completions -> completions.takeWhile(ignored -> state.retryAfter != null && !state.stopReconnecting)
-                        .concatMap(ignored -> delay(state.retryAfter)
-                            .then(Mono.defer(() -> Objects.requireNonNull(reconnect.apply(state.getReconnectEventId()),
-                                "'reconnect' cannot return null.")))
-                            .doOnNext(currentResponse::set)))
-                .doFinally(ignored -> currentResponse.get().close());
-        });
-    }
-
-    /**
      * Processes one server-sent event response body.
      *
      * @param body The response body.
@@ -118,113 +56,55 @@ public final class ServerSentEventStream {
      */
     public static <T> void process(BinaryData body, BiFunction<String, String, T> deserializer,
         ServerSentEventListener<T> listener) {
-        processInternal(body, null, deserializer, event -> false, listener);
-    }
-
-    /**
-     * Processes a logical server-sent event stream, reconnecting after response completion or a response-body failure
-     * when the server has supplied a valid retry interval.
-     *
-     * @param response The initial response.
-     * @param reconnect Creates a fresh response. Its argument is the last event identifier or {@code null} when no
-     * {@code Last-Event-Id} header should be sent.
-     * @param deserializer The event data deserializer.
-     * @param terminalEvent Identifies an inclusive terminal event.
-     * @param listener The event listener.
-     * @param <T> The event data type.
-     */
-    public static <T> void process(ServerSentEventStreamResponse response,
-        Function<String, ServerSentEventStreamResponse> reconnect, BiFunction<String, String, T> deserializer,
-        Predicate<ServerSentEvent<T>> terminalEvent, ServerSentEventListener<T> listener) {
-        Objects.requireNonNull(reconnect, "'reconnect' cannot be null.");
-        processInternal(response, reconnect, deserializer, terminalEvent, listener);
-    }
-
-    /**
-     * Adds reconnect state to a request context.
-     *
-     * @param context The request context.
-     * @param lastEventId The last event identifier, or {@code null} to omit {@code Last-Event-Id}.
-     * @return The request context containing the reconnect state.
-     */
-    public static Context addReconnectContext(Context context, String lastEventId) {
-        return Objects.requireNonNull(context, "'context' cannot be null.")
-            .addData(RECONNECT_CONTEXT_KEY, new ReconnectState(lastEventId));
-    }
-
-    /**
-     * Applies reconnect state after generated parameters and request options have configured the request.
-     *
-     * @param request The request.
-     * @param context The request context.
-     */
-    public static void applyReconnectContext(HttpRequest request, Context context) {
-        Objects.requireNonNull(request, "'request' cannot be null.");
-        Objects.requireNonNull(context, "'context' cannot be null.");
-
-        Object value = context.getData(RECONNECT_CONTEXT_KEY).orElse(null);
-        if (!(value instanceof ReconnectState)) {
-            return;
-        }
-
-        String lastEventId = ((ReconnectState) value).lastEventId;
-        if (lastEventId == null || lastEventId.isEmpty()) {
-            request.getHeaders().remove(LAST_EVENT_ID);
-        } else {
-            request.getHeaders().set(LAST_EVENT_ID, lastEventId);
-        }
-    }
-
-    private static <T> void processInternal(BinaryData body, Function<String, ServerSentEventStreamResponse> reconnect,
-        BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent,
-        ServerSentEventListener<T> listener) {
-        processInternal(new ServerSentEventStreamResponse(200, body, () -> {
-        }), reconnect, deserializer, terminalEvent, listener);
-    }
-
-    private static <T> void processInternal(ServerSentEventStreamResponse response,
-        Function<String, ServerSentEventStreamResponse> reconnect, BiFunction<String, String, T> deserializer,
-        Predicate<ServerSentEvent<T>> terminalEvent, ServerSentEventListener<T> listener) {
-        Objects.requireNonNull(response, "'response' cannot be null.");
+        Objects.requireNonNull(body, "'body' cannot be null.");
         Objects.requireNonNull(deserializer, "'deserializer' cannot be null.");
-        Objects.requireNonNull(terminalEvent, "'terminalEvent' cannot be null.");
         Objects.requireNonNull(listener, "'listener' cannot be null.");
 
-        StreamState state = new StreamState();
-        ServerSentEventStreamResponse currentResponse = response;
-
         try {
-            while (true) {
-                if (currentResponse.getStatusCode() == 204) {
-                    currentResponse.close();
-                    return;
-                }
+            processBody(body, new StreamState(), deserializer, listener);
+        } catch (IOException exception) {
+            listener.onError(exception);
+            throw new UncheckedIOException(exception);
+        } catch (RuntimeException exception) {
+            listener.onError(exception);
+            throw exception;
+        } finally {
+            listener.onClose();
+        }
+    }
 
-                boolean terminal;
-                try (ServerSentEventStreamResponse responseToProcess = currentResponse) {
-                    terminal = processBody(responseToProcess.getBody(), state, deserializer, terminalEvent, listener);
-                } catch (IOException exception) {
-                    if (reconnect == null || state.retryAfter == null) {
-                        throw exception;
-                    }
-                    terminal = false;
-                }
+    /**
+     * Decodes an SSE response, closing its physical response on completion, failure, or cancellation.
+     */
+    public static <T> Flux<ServerSentEvent<T>> toFlux(Response<BinaryData> response,
+        BiFunction<String, String, T> deserializer) {
+        Objects.requireNonNull(response, "'response' cannot be null.");
+        Objects.requireNonNull(deserializer, "'deserializer' cannot be null.");
 
-                if (terminal || reconnect == null || state.retryAfter == null) {
-                    return;
-                }
+        return Flux.defer(() -> {
+            ServerSentEventStreamResponse streamResponse = ServerSentEventStreamResponse.fromResponse(response);
+            if (streamResponse.getStatusCode() == 204) {
+                streamResponse.close();
+                return Flux.empty();
+            }
 
-                waitForRetry(state.retryAfter);
-                checkInterrupted();
-                ServerSentEventStreamResponse nextResponse = Objects
-                    .requireNonNull(reconnect.apply(state.getReconnectEventId()), "'reconnect' cannot return null.");
-                try {
-                    checkInterrupted();
-                } catch (RuntimeException exception) {
-                    nextResponse.close();
-                    throw exception;
-                }
-                currentResponse = nextResponse;
+            return decodeBody(streamResponse.getBody(), new StreamState(), deserializer)
+                .doFinally(ignored -> streamResponse.close());
+        });
+    }
+
+    /**
+     * Processes an SSE response, closing its physical response on completion, failure, or interruption.
+     */
+    public static <T> void listen(Response<BinaryData> response, BiFunction<String, String, T> deserializer,
+        ServerSentEventListener<T> listener) {
+        Objects.requireNonNull(response, "'response' cannot be null.");
+        Objects.requireNonNull(deserializer, "'deserializer' cannot be null.");
+        Objects.requireNonNull(listener, "'listener' cannot be null.");
+
+        try (ServerSentEventStreamResponse streamResponse = ServerSentEventStreamResponse.fromResponse(response)) {
+            if (streamResponse.getStatusCode() != 204) {
+                processBody(streamResponse.getBody(), new StreamState(), deserializer, listener);
             }
         } catch (IOException exception) {
             listener.onError(exception);
@@ -239,18 +119,9 @@ public final class ServerSentEventStream {
 
     private static <T> Flux<ServerSentEvent<T>> decodeBody(BinaryData body, StreamState state,
         BiFunction<String, String, T> deserializer) {
-        return decodeBody(body, state, deserializer, false);
-    }
-
-    private static <T> Flux<ServerSentEvent<T>> decodeBody(BinaryData body, StreamState state,
-        BiFunction<String, String, T> deserializer, boolean reconnectBodyFailures) {
         ServerSentEventDecoder decoder = new ServerSentEventDecoder(state);
-        Flux<ByteBuffer> content = body.toFluxByteBuffer();
-        if (reconnectBodyFailures) {
-            content = content.onErrorResume(error -> state.retryAfter == null ? Flux.error(error) : Flux.empty());
-        }
-
-        Flux<ServerSentEventFrame> frames = content.concatMap(buffer -> Flux.fromIterable(decoder.feed(buffer)), 1)
+        Flux<ServerSentEventFrame> frames = body.toFluxByteBuffer()
+            .concatMap(buffer -> Flux.fromIterable(decoder.feed(buffer)), 1)
             .concatWith(Flux.defer(() -> Flux.fromIterable(decoder.finish())));
         return frames.concatMap(frame -> deserializeFrame(frame, deserializer), 1);
     }
@@ -261,70 +132,44 @@ public final class ServerSentEventStream {
         return data == null ? Flux.empty() : Flux.just(frame.toEvent(data));
     }
 
-    private static <T> boolean processBody(BinaryData body, StreamState state,
-        BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent,
+    private static <T> void processBody(BinaryData body, StreamState state, BiFunction<String, String, T> deserializer,
         ServerSentEventListener<T> listener) throws IOException {
         ServerSentEventDecoder decoder = new ServerSentEventDecoder(state);
         byte[] readBuffer = new byte[8192];
 
         try (InputStream stream = new FluxInputStream(body.toFluxByteBuffer())) {
             int read;
-            while ((read = stream.read(readBuffer)) != -1) {
-                if (read > 0
-                    && processFrames(decoder.feed(ByteBuffer.wrap(readBuffer, 0, read)), deserializer, terminalEvent,
-                        listener)) {
-                    return true;
+            while (true) {
+                checkInterrupted();
+                read = stream.read(readBuffer);
+                if (read == -1) {
+                    break;
+                }
+                if (read > 0) {
+                    processFrames(decoder.feed(ByteBuffer.wrap(readBuffer, 0, read)), deserializer, listener);
                 }
             }
 
-            return processFrames(decoder.finish(), deserializer, terminalEvent, listener);
+            processFrames(decoder.finish(), deserializer, listener);
         }
     }
 
-    private static <T> boolean processFrames(List<ServerSentEventFrame> frames,
-        BiFunction<String, String, T> deserializer, Predicate<ServerSentEvent<T>> terminalEvent,
+    private static <T> void processFrames(List<ServerSentEventFrame> frames, BiFunction<String, String, T> deserializer,
         ServerSentEventListener<T> listener) {
         for (ServerSentEventFrame frame : frames) {
+            checkInterrupted();
             T data = deserializer.apply(frame.event, frame.data);
             if (data != null) {
-                ServerSentEvent<T> event = frame.toEvent(data);
-                listener.onEvent(event);
-                if (terminalEvent.test(event)) {
-                    return true;
-                }
+                listener.onEvent(frame.toEvent(data));
             }
-        }
-        return false;
-    }
-
-    private static void waitForRetry(Duration retryAfter) {
-        checkInterrupted();
-        if (retryAfter.isZero()) {
-            return;
-        }
-
-        try {
-            Thread.sleep(retryAfter.toMillis());
-        } catch (InterruptedException exception) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while waiting to reconnect the server-sent event stream.",
-                exception);
         }
     }
 
     private static void checkInterrupted() {
         if (Thread.currentThread().isInterrupted()) {
-            throw new RuntimeException("Interrupted while reconnecting the server-sent event stream.",
+            throw new RuntimeException("Interrupted while processing the server-sent event stream.",
                 new InterruptedException());
         }
-    }
-
-    private static Mono<Long> delay(Duration retryAfter) {
-        return Mono.create(sink -> {
-            Disposable scheduled
-                = Schedulers.parallel().schedule(() -> sink.success(0L), retryAfter.toMillis(), TimeUnit.MILLISECONDS);
-            sink.onDispose(scheduled);
-        });
     }
 
     private static String removeOptionalSpace(String value) {
@@ -354,7 +199,6 @@ public final class ServerSentEventStream {
     private static final class StreamState {
         private String lastEventId;
         private Duration retryAfter;
-        private boolean stopReconnecting;
 
         private void setLastEventId(String lastEventId) {
             this.lastEventId = lastEventId;
@@ -364,17 +208,6 @@ public final class ServerSentEventStream {
             this.retryAfter = retryAfter;
         }
 
-        private String getReconnectEventId() {
-            return lastEventId == null || lastEventId.isEmpty() ? null : lastEventId;
-        }
-    }
-
-    private static final class ReconnectState {
-        private final String lastEventId;
-
-        private ReconnectState(String lastEventId) {
-            this.lastEventId = lastEventId;
-        }
     }
 
     private static final class ServerSentEventDecoder {

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStreamResponse.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStreamResponse.java
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.implementation.util;
+
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.logging.ClientLogger;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Owns a physical response used by a logical server-sent event stream.
+ */
+public final class ServerSentEventStreamResponse implements AutoCloseable {
+    private static final ClientLogger LOGGER = new ClientLogger(ServerSentEventStreamResponse.class);
+
+    private final int statusCode;
+    private final BinaryData body;
+    private final Closeable response;
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    ServerSentEventStreamResponse(int statusCode, BinaryData body, Closeable response) {
+        this.statusCode = statusCode;
+        this.body = body;
+        this.response = response;
+    }
+
+    /**
+     * Creates a stream response from a closeable REST response.
+     *
+     * @param response The REST response.
+     * @return The stream response.
+     */
+    public static ServerSentEventStreamResponse fromResponse(Response<BinaryData> response) {
+        Objects.requireNonNull(response, "'response' cannot be null.");
+        if (response.getStatusCode() != 204
+            && !HttpUtils.isTextEventStreamContentType(response.getHeaders().getValue(HttpHeaderName.CONTENT_TYPE))) {
+            closeResponse(response);
+            throw LOGGER.logExceptionAsError(new IllegalStateException(
+                "Expected a successful server-sent event response to have Content-Type 'text/event-stream'."));
+        }
+        if (!(response instanceof Closeable)) {
+            throw new IllegalArgumentException("'response' must own a closeable streaming response.");
+        }
+
+        BinaryData body = response.getValue();
+        if (response.getStatusCode() != 204) {
+            Objects.requireNonNull(body, "'response.getValue()' cannot be null unless the status code is 204.");
+        }
+        return new ServerSentEventStreamResponse(response.getStatusCode(), body, (Closeable) response);
+    }
+
+    private static void closeResponse(Response<BinaryData> response) {
+        if (!(response instanceof Closeable)) {
+            return;
+        }
+
+        try {
+            ((Closeable) response).close();
+        } catch (IOException exception) {
+            throw LOGGER.logExceptionAsError(new UncheckedIOException(exception));
+        }
+    }
+
+    int getStatusCode() {
+        return statusCode;
+    }
+
+    BinaryData getBody() {
+        return body;
+    }
+
+    @Override
+    public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            response.close();
+        } catch (IOException exception) {
+            throw LOGGER.logExceptionAsError(new UncheckedIOException(exception));
+        }
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStreamResponse.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStreamResponse.java
@@ -46,7 +46,12 @@ final class ServerSentEventStreamResponse implements AutoCloseable {
         if (!(response instanceof Closeable)) {
             throw new IllegalArgumentException("'response' must own a closeable streaming response.");
         }
-        if (response.getStatusCode() != 204
+        if (response.getStatusCode() != 200 && response.getStatusCode() != 204) {
+            closeResponse(response);
+            throw LOGGER.logExceptionAsError(
+                new IllegalStateException("Expected a server-sent event response to have status code 200 or 204."));
+        }
+        if (response.getStatusCode() == 200
             && !HttpUtils.isTextEventStreamContentType(response.getHeaders().getValue(HttpHeaderName.CONTENT_TYPE))) {
             closeResponse(response);
             throw LOGGER.logExceptionAsError(new IllegalStateException(
@@ -54,7 +59,7 @@ final class ServerSentEventStreamResponse implements AutoCloseable {
         }
 
         BinaryData body = response.getValue();
-        if (response.getStatusCode() != 204) {
+        if (response.getStatusCode() == 200) {
             if (body == null) {
                 closeResponse(response);
                 throw new NullPointerException("'response.getValue()' cannot be null unless the status code is 204.");

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStreamResponse.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStreamResponse.java
@@ -16,6 +16,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Owns a physical response used by a logical server-sent event stream.
+ *
+ * <p>The source response must implement {@link Closeable}; otherwise this class rejects it with
+ * {@link IllegalArgumentException} because it cannot guarantee physical response cleanup.</p>
  */
 final class ServerSentEventStreamResponse implements AutoCloseable {
     private static final ClientLogger LOGGER = new ClientLogger(ServerSentEventStreamResponse.class);
@@ -36,17 +39,18 @@ final class ServerSentEventStreamResponse implements AutoCloseable {
      *
      * @param response The REST response.
      * @return The stream response.
+     * @throws IllegalArgumentException If {@code response} does not implement {@link Closeable}.
      */
     static ServerSentEventStreamResponse fromResponse(Response<BinaryData> response) {
         Objects.requireNonNull(response, "'response' cannot be null.");
+        if (!(response instanceof Closeable)) {
+            throw new IllegalArgumentException("'response' must own a closeable streaming response.");
+        }
         if (response.getStatusCode() != 204
             && !HttpUtils.isTextEventStreamContentType(response.getHeaders().getValue(HttpHeaderName.CONTENT_TYPE))) {
             closeResponse(response);
             throw LOGGER.logExceptionAsError(new IllegalStateException(
                 "Expected a successful server-sent event response to have Content-Type 'text/event-stream'."));
-        }
-        if (!(response instanceof Closeable)) {
-            throw new IllegalArgumentException("'response' must own a closeable streaming response.");
         }
 
         BinaryData body = response.getValue();

--- a/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStreamResponse.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/implementation/util/ServerSentEventStreamResponse.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Owns a physical response used by a logical server-sent event stream.
  */
-public final class ServerSentEventStreamResponse implements AutoCloseable {
+final class ServerSentEventStreamResponse implements AutoCloseable {
     private static final ClientLogger LOGGER = new ClientLogger(ServerSentEventStreamResponse.class);
 
     private final int statusCode;
@@ -37,7 +37,7 @@ public final class ServerSentEventStreamResponse implements AutoCloseable {
      * @param response The REST response.
      * @return The stream response.
      */
-    public static ServerSentEventStreamResponse fromResponse(Response<BinaryData> response) {
+    static ServerSentEventStreamResponse fromResponse(Response<BinaryData> response) {
         Objects.requireNonNull(response, "'response' cannot be null.");
         if (response.getStatusCode() != 204
             && !HttpUtils.isTextEventStreamContentType(response.getHeaders().getValue(HttpHeaderName.CONTENT_TYPE))) {
@@ -51,7 +51,10 @@ public final class ServerSentEventStreamResponse implements AutoCloseable {
 
         BinaryData body = response.getValue();
         if (response.getStatusCode() != 204) {
-            Objects.requireNonNull(body, "'response.getValue()' cannot be null unless the status code is 204.");
+            if (body == null) {
+                closeResponse(response);
+                throw new NullPointerException("'response.getValue()' cannot be null unless the status code is 204.");
+            }
         }
         return new ServerSentEventStreamResponse(response.getStatusCode(), body, (Closeable) response);
     }

--- a/sdk/core/azure-core/src/test/java/com/azure/core/http/ServerSentEventTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/http/ServerSentEventTests.java
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.http;
+
+import com.azure.core.implementation.util.ServerSentEventHelper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ServerSentEventTests {
+    @Test
+    public void helperCreatesEvent() {
+        ServerSentEvent<String> event
+            = ServerSentEventHelper.create("42", "stockUpdate", "payload", "comment", Duration.ofSeconds(2));
+
+        assertEquals("42", event.getId());
+        assertEquals("stockUpdate", event.getEvent());
+        assertEquals("payload", event.getData());
+        assertEquals("comment", event.getComment());
+        assertEquals(Duration.ofSeconds(2), event.getRetryAfter());
+    }
+}

--- a/sdk/core/azure-core/src/test/java/com/azure/core/http/policy/HttpLoggingPolicyTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/http/policy/HttpLoggingPolicyTests.java
@@ -16,6 +16,7 @@ import com.azure.core.http.clients.NoOpHttpClient;
 import com.azure.core.implementation.AccessibleByteArrayOutputStream;
 import com.azure.core.implementation.accesshelpers.ClientLoggerAccessHelper;
 import com.azure.core.implementation.logging.DefaultLogger;
+import com.azure.core.implementation.util.HttpUtils;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.Context;
 import com.azure.core.util.FluxUtil;
@@ -58,6 +59,7 @@ import static com.azure.core.CoreTestUtils.assertArraysEqual;
 import static com.azure.core.CoreTestUtils.createUrl;
 import static com.azure.core.http.HttpHeaderName.X_MS_REQUEST_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -244,6 +246,44 @@ public class HttpLoggingPolicyTests {
         assertTrue(logString.contains(new String(data, StandardCharsets.UTF_8)));
     }
 
+    @ParameterizedTest(name = "[{index}] {displayName}")
+    @MethodSource("streamingResponseSupplier")
+    public void streamingResponsesAreNotBuffered(String contentType, boolean useStreamingContext) {
+        byte[] data = "streaming response".getBytes(StandardCharsets.UTF_8);
+        AtomicInteger bufferCount = new AtomicInteger();
+        HttpRequest request = new HttpRequest(HttpMethod.GET, "https://test.com/streamingResponsesAreNotBuffered");
+        HttpHeaders responseHeaders = new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, contentType)
+            .set(HttpHeaderName.CONTENT_LENGTH, Integer.toString(data.length));
+
+        HttpPipeline pipeline = new HttpPipelineBuilder()
+            .policies(new HttpLoggingPolicy(new HttpLogOptions().setLogLevel(HttpLogDetailLevel.BODY)))
+            .httpClient(ignored -> Mono.just(new BufferTrackingHttpResponse(ignored, responseHeaders,
+                Flux.just(ByteBuffer.wrap(data)), bufferCount)))
+            .build();
+
+        Context context = getCallerMethodContext("streamingResponsesAreNotBuffered", LogLevel.INFORMATIONAL);
+        if (useStreamingContext) {
+            context = context.addData(HttpUtils.AZURE_PRESERVE_RESPONSE_BODY_AS_STREAM, true);
+        }
+
+        try (HttpResponse response = pipeline.send(request, context).block()) {
+            assertNotNull(response);
+            assertArraysEqual(data, response.getBodyAsBinaryData().toBytes());
+        }
+
+        try (HttpResponse response = pipeline.sendSync(request, context)) {
+            assertArraysEqual(data, response.getBodyAsBinaryData().toBytes());
+        }
+
+        assertEquals(0, bufferCount.get());
+        assertFalse(convertOutputStreamToString(logCaptureStream).contains(new String(data, StandardCharsets.UTF_8)));
+    }
+
+    private static Stream<Arguments> streamingResponseSupplier() {
+        return Stream.of(Arguments.of("Text/Event-Stream; charset=utf-8", false),
+            Arguments.of(ContentType.APPLICATION_JSON, true));
+    }
+
     private static Stream<Arguments> validateLoggingDoesNotConsumeSupplierSync() {
         byte[] data = "this is a test".getBytes(StandardCharsets.UTF_8);
 
@@ -348,6 +388,22 @@ public class HttpLoggingPolicyTests {
         @Override
         public Mono<String> getBodyAsString(Charset charset) {
             return getBodyAsByteArray().map(bytes -> new String(bytes, charset));
+        }
+    }
+
+    private static final class BufferTrackingHttpResponse extends MockHttpResponse {
+        private final AtomicInteger bufferCount;
+
+        private BufferTrackingHttpResponse(HttpRequest request, HttpHeaders headers, Flux<ByteBuffer> body,
+            AtomicInteger bufferCount) {
+            super(request, headers, body);
+            this.bufferCount = bufferCount;
+        }
+
+        @Override
+        public HttpResponse buffer() {
+            bufferCount.incrementAndGet();
+            return super.buffer();
         }
     }
 

--- a/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/HttpUtilsTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/HttpUtilsTests.java
@@ -16,8 +16,23 @@ public class HttpUtilsTests {
     }
 
     @Test
+    public void acceptsTextEventStreamRequiresValidPositiveQuality() {
+        assertTrue(HttpUtils.acceptsTextEventStream("text/event-stream;q=0.001"));
+        assertTrue(HttpUtils.acceptsTextEventStream("text/event-stream;q=1.000"));
+        assertTrue(HttpUtils.acceptsTextEventStream("text/event-stream;q=1."));
+        assertFalse(HttpUtils.acceptsTextEventStream("text/event-stream;q=0.000"));
+        assertFalse(HttpUtils.acceptsTextEventStream("text/event-stream;q=1.001"));
+        assertFalse(HttpUtils.acceptsTextEventStream("text/event-stream;q=0.0000"));
+        assertFalse(HttpUtils.acceptsTextEventStream("text/event-stream;q=invalid"));
+        assertFalse(HttpUtils.acceptsTextEventStream("text/event-stream;q = 0.5"));
+    }
+
+    @Test
     public void textEventStreamContentTypeRequiresSingleMediaType() {
         assertTrue(HttpUtils.isTextEventStreamContentType("Text/Event-Stream; charset=utf-8"));
+        assertTrue(HttpUtils.isTextEventStreamContentType("text/event-stream; charset=\"UTF-8\""));
+        assertFalse(HttpUtils.isTextEventStreamContentType("text/event-stream; charset=iso-8859-1"));
+        assertFalse(HttpUtils.isTextEventStreamContentType("text/event-stream; charset=utf-16"));
         assertFalse(HttpUtils.isTextEventStreamContentType("application/json, text/event-stream"));
     }
 }

--- a/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/HttpUtilsTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/HttpUtilsTests.java
@@ -25,6 +25,8 @@ public class HttpUtilsTests {
         assertFalse(HttpUtils.acceptsTextEventStream("text/event-stream;q=0.0000"));
         assertFalse(HttpUtils.acceptsTextEventStream("text/event-stream;q=invalid"));
         assertFalse(HttpUtils.acceptsTextEventStream("text/event-stream;q = 0.5"));
+        assertFalse(HttpUtils.acceptsTextEventStream("application/json; note=\"text/event-stream, q=1\""));
+        assertTrue(HttpUtils.acceptsTextEventStream("text/event-stream; note=\"x,y;q=0.5\"; q=0.5"));
     }
 
     @Test
@@ -34,5 +36,7 @@ public class HttpUtilsTests {
         assertFalse(HttpUtils.isTextEventStreamContentType("text/event-stream; charset=iso-8859-1"));
         assertFalse(HttpUtils.isTextEventStreamContentType("text/event-stream; charset=utf-16"));
         assertFalse(HttpUtils.isTextEventStreamContentType("application/json, text/event-stream"));
+        assertTrue(HttpUtils.isTextEventStreamContentType("text/event-stream; note=\"x,y;z\""));
+        assertFalse(HttpUtils.isTextEventStreamContentType("text/event-stream; note=\"unterminated"));
     }
 }

--- a/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/HttpUtilsTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/HttpUtilsTests.java
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.implementation.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HttpUtilsTests {
+    @Test
+    public void acceptsTextEventStreamIgnoresDisabledMediaRange() {
+        assertFalse(HttpUtils.acceptsTextEventStream("text/event-stream;q=0"));
+        assertTrue(HttpUtils.acceptsTextEventStream("application/json, text/event-stream;q=0.5"));
+    }
+
+    @Test
+    public void textEventStreamContentTypeRequiresSingleMediaType() {
+        assertTrue(HttpUtils.isTextEventStreamContentType("Text/Event-Stream; charset=utf-8"));
+        assertFalse(HttpUtils.isTextEventStreamContentType("application/json, text/event-stream"));
+    }
+}

--- a/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
@@ -1,0 +1,649 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.implementation.util;
+
+import com.azure.core.http.ServerSentEvent;
+import com.azure.core.http.ServerSentEventListener;
+import com.azure.core.util.BinaryData;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ServerSentEventStreamTests {
+    @Test
+    public void syncReconnectsWithMetadataOnlyState() {
+        BinaryData firstBody
+            = BinaryData.fromString("id: first\nretry: 0\ndata: one\n\n" + "id: reconnect\nretry: invalid\n\n");
+        List<ServerSentEvent<String>> events = new ArrayList<>();
+        AtomicReference<String> reconnectEventId = new AtomicReference<>();
+        AtomicInteger reconnectCount = new AtomicInteger();
+
+        ServerSentEventStream.process(response(firstBody), eventId -> {
+            reconnectEventId.set(eventId);
+            reconnectCount.incrementAndGet();
+            return response(BinaryData.fromString("data: [DONE]\n\n"));
+        }, (event, data) -> data, event -> "[DONE]".equals(event.getData()), events::add);
+
+        assertEquals(1, reconnectCount.get());
+        assertEquals("reconnect", reconnectEventId.get());
+        assertEquals(2, events.size());
+        assertEquals("one", events.get(0).getData());
+        assertEquals("reconnect", events.get(1).getId());
+        assertEquals(Duration.ZERO, events.get(1).getRetryAfter());
+    }
+
+    @Test
+    public void asyncReconnectsSeriallyWithRetainedState() {
+        BinaryData firstBody = BinaryData.fromString("id: first\nretry: 0\ndata: one\n\nid: second\n\n");
+        AtomicInteger reconnectCount = new AtomicInteger();
+        AtomicReference<String> reconnectEventId = new AtomicReference<>();
+
+        StepVerifier.create(ServerSentEventStream.decode(response(firstBody), eventId -> {
+            reconnectEventId.set(eventId);
+            reconnectCount.incrementAndGet();
+            return Mono.just(response(BinaryData.fromString("data: [DONE]\n\n")));
+        }, (event, data) -> data).takeUntil(event -> "[DONE]".equals(event.getData())))
+            .assertNext(event -> assertEquals("one", event.getData()))
+            .assertNext(event -> {
+                assertEquals("[DONE]", event.getData());
+                assertEquals("second", event.getId());
+                assertEquals(Duration.ZERO, event.getRetryAfter());
+            })
+            .verifyComplete();
+
+        assertEquals(1, reconnectCount.get());
+        assertEquals("second", reconnectEventId.get());
+    }
+
+    @Test
+    public void emptyIdOmitsLastEventIdOnReconnect() {
+        BinaryData firstBody = BinaryData.fromString("id: first\nretry: 0\ndata: one\n\nid:\n\n");
+        AtomicReference<String> reconnectEventId = new AtomicReference<>("not-called");
+
+        ServerSentEventStream.process(response(firstBody), eventId -> {
+            reconnectEventId.set(eventId);
+            return response(BinaryData.fromString("data: [DONE]\n\n"));
+        }, (event, data) -> data, event -> "[DONE]".equals(event.getData()), event -> {
+        });
+
+        assertNull(reconnectEventId.get());
+    }
+
+    @Test
+    public void cleanCompletionWithoutRetryDoesNotReconnect() {
+        AtomicInteger reconnectCount = new AtomicInteger();
+
+        ServerSentEventStream.process(response(BinaryData.fromString("data: one\n\n")), eventId -> {
+            reconnectCount.incrementAndGet();
+            return response(BinaryData.fromString("data: unexpected\n\n"));
+        }, (event, data) -> data, event -> false, event -> {
+        });
+
+        assertEquals(0, reconnectCount.get());
+    }
+
+    @Test
+    public void asyncBodyErrorReconnectsWithRetainedRetry() {
+        IOException disconnect = new IOException("connection closed");
+        byte[] prefix = "retry: 0\ndata: one\n\n".getBytes(StandardCharsets.UTF_8);
+        BinaryData body
+            = BinaryData.fromFlux(Flux.concat(Flux.just(ByteBuffer.wrap(prefix)), Flux.error(disconnect)), null, false)
+                .block();
+        AtomicInteger reconnectCount = new AtomicInteger();
+
+        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
+            reconnectCount.incrementAndGet();
+            return Mono.just(response(BinaryData.fromString("data: [DONE]\n\n")));
+        }, (event, data) -> data).takeUntil(event -> "[DONE]".equals(event.getData())))
+            .assertNext(event -> assertEquals("one", event.getData()))
+            .assertNext(event -> assertEquals("[DONE]", event.getData()))
+            .verifyComplete();
+
+        assertEquals(1, reconnectCount.get());
+    }
+
+    @Test
+    public void syncBodyErrorReconnectsWithRetainedRetry() {
+        IOException disconnect = new IOException("connection closed");
+        byte[] prefix = "retry: 0\ndata: one\n\n".getBytes(StandardCharsets.UTF_8);
+        BinaryData body
+            = BinaryData.fromFlux(Flux.concat(Flux.just(ByteBuffer.wrap(prefix)), Flux.error(disconnect)), null, false)
+                .block();
+        AtomicInteger reconnectCount = new AtomicInteger();
+        List<String> events = new ArrayList<>();
+
+        ServerSentEventStream.process(response(body), eventId -> {
+            reconnectCount.incrementAndGet();
+            return response(BinaryData.fromString("data: [DONE]\n\n"));
+        }, (event, data) -> data, event -> "[DONE]".equals(event.getData()), event -> events.add(event.getData()));
+
+        assertEquals(1, reconnectCount.get());
+        assertEquals(2, events.size());
+        assertEquals("one", events.get(0));
+        assertEquals("[DONE]", events.get(1));
+    }
+
+    @Test
+    public void bodyErrorWithoutRetryTerminatesAsyncStream() {
+        IOException disconnect = new IOException("connection closed");
+        BinaryData body = BinaryData
+            .fromFlux(Flux.concat(Flux.just(ByteBuffer.wrap("data: one\n\n".getBytes(StandardCharsets.UTF_8))),
+                Flux.error(disconnect)), null, false)
+            .block();
+        AtomicInteger reconnectCount = new AtomicInteger();
+
+        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
+            reconnectCount.incrementAndGet();
+            return Mono.just(response(BinaryData.fromString("data: unexpected\n\n")));
+        }, (event, data) -> data))
+            .assertNext(event -> assertEquals("one", event.getData()))
+            .expectErrorMatches(error -> error == disconnect)
+            .verify();
+
+        assertEquals(0, reconnectCount.get());
+    }
+
+    @Test
+    public void deserializerErrorDoesNotReconnectAsyncStream() {
+        RuntimeException deserializerError = new IllegalStateException("deserialization failed");
+        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
+        AtomicInteger reconnectCount = new AtomicInteger();
+
+        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
+            reconnectCount.incrementAndGet();
+            return Mono.just(response(BinaryData.fromString("data: unexpected\n\n")));
+        }, (event, data) -> {
+            throw deserializerError;
+        })).expectErrorMatches(error -> error == deserializerError).verify();
+
+        assertEquals(0, reconnectCount.get());
+    }
+
+    @Test
+    public void asyncReconnectsWithoutGrowingPublisherDepth() {
+        int eventCount = 10_000;
+        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
+        AtomicInteger reconnectCount = new AtomicInteger();
+
+        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
+            reconnectCount.incrementAndGet();
+            return Mono.just(response(BinaryData.fromString("data: one\n\n")));
+        }, (event, data) -> data).take(eventCount)).expectNextCount(eventCount).verifyComplete();
+
+        assertEquals(eventCount - 1, reconnectCount.get());
+    }
+
+    @Test
+    public void zeroRetryUsesAsyncSchedulingBoundary() {
+        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
+        Thread subscriptionThread = Thread.currentThread();
+        AtomicReference<Thread> reconnectThread = new AtomicReference<>();
+
+        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
+            reconnectThread.set(Thread.currentThread());
+            return Mono.just(response(BinaryData.fromString("data: [DONE]\n\n")));
+        }, (event, data) -> data).takeUntil(event -> "[DONE]".equals(event.getData())))
+            .expectNextCount(2)
+            .verifyComplete();
+
+        assertNotSame(subscriptionThread, reconnectThread.get());
+    }
+
+    @Test
+    public void reconnectRequestErrorTerminatesAsyncStream() {
+        RuntimeException requestError = new IllegalStateException("reconnect failed");
+        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
+        AtomicInteger reconnectCount = new AtomicInteger();
+
+        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
+            reconnectCount.incrementAndGet();
+            return Mono.error(requestError);
+        }, (event, data) -> data))
+            .assertNext(event -> assertEquals("one", event.getData()))
+            .expectErrorMatches(error -> error == requestError)
+            .verify();
+
+        assertEquals(1, reconnectCount.get());
+    }
+
+    @Test
+    public void listenerErrorDoesNotReconnect() {
+        RuntimeException listenerError = new IllegalStateException("listener failed");
+        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
+        AtomicInteger reconnectCount = new AtomicInteger();
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+
+        RuntimeException exception
+            = assertThrows(RuntimeException.class, () -> ServerSentEventStream.process(response(body), eventId -> {
+                reconnectCount.incrementAndGet();
+                return response(BinaryData.fromString("data: unexpected\n\n"));
+            }, (event, data) -> data, event -> false, new ServerSentEventListener<String>() {
+                @Override
+                public void onEvent(ServerSentEvent<String> event) {
+                    throw listenerError;
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    reportedError.set(error);
+                }
+            }));
+
+        assertSame(listenerError, exception);
+        assertSame(listenerError, reportedError.get());
+        assertEquals(0, reconnectCount.get());
+    }
+
+    @Test
+    public void asyncCancellationDuringRetryDelayPreventsReconnect() {
+        BinaryData body = BinaryData.fromString("retry: 60000\ndata: one\n\n");
+        AtomicInteger reconnectCount = new AtomicInteger();
+
+        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
+            reconnectCount.incrementAndGet();
+            return Mono.just(response(BinaryData.fromString("data: unexpected\n\n")));
+        }, (event, data) -> data)).assertNext(event -> assertEquals("one", event.getData())).thenCancel().verify();
+
+        assertEquals(0, reconnectCount.get());
+    }
+
+    @Test
+    public void maximumRetryValueDoesNotOverflowAsyncDelay() {
+        BinaryData body = BinaryData.fromString("retry: 9223372036854775807\ndata: one\n\n");
+        AtomicInteger reconnectCount = new AtomicInteger();
+
+        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
+            reconnectCount.incrementAndGet();
+            return Mono.just(response(BinaryData.fromString("data: unexpected\n\n")));
+        }, (event, data) -> data))
+            .assertNext(event -> assertEquals(Duration.ofMillis(Long.MAX_VALUE), event.getRetryAfter()))
+            .thenCancel()
+            .verify();
+
+        assertEquals(0, reconnectCount.get());
+    }
+
+    @Test
+    public void syncInterruptionDuringRetryDelayIsPropagated() {
+        BinaryData body = BinaryData.fromString("retry: 60000\n\n");
+        AtomicReference<Throwable> listenerError = new AtomicReference<>();
+        AtomicBoolean closed = new AtomicBoolean();
+        ServerSentEventListener<String> listener = new ServerSentEventListener<String>() {
+            @Override
+            public void onEvent(ServerSentEvent<String> event) {
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                listenerError.set(error);
+            }
+
+            @Override
+            public void onClose() {
+                closed.set(true);
+            }
+        };
+
+        Thread.currentThread().interrupt();
+        try {
+            RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> ServerSentEventStream.process(response(body),
+                    eventId -> response(BinaryData.fromString("data: unexpected\n\n")), (event, data) -> data,
+                    event -> false, listener));
+
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertSame(exception, listenerError.get());
+            assertTrue(closed.get());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void syncInterruptionBeforeZeroDelayReconnectIsPropagated() {
+        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
+        AtomicReference<Throwable> listenerError = new AtomicReference<>();
+        AtomicInteger reconnectCount = new AtomicInteger();
+        AtomicInteger eventCount = new AtomicInteger();
+        ServerSentEventListener<String> listener = new ServerSentEventListener<String>() {
+            @Override
+            public void onEvent(ServerSentEvent<String> event) {
+                eventCount.incrementAndGet();
+                Thread.currentThread().interrupt();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                listenerError.set(error);
+            }
+        };
+
+        try {
+            RuntimeException exception
+                = assertThrows(RuntimeException.class, () -> ServerSentEventStream.process(response(body), eventId -> {
+                    reconnectCount.incrementAndGet();
+                    return response(BinaryData.fromString("data: unexpected\n\n"));
+                }, (event, data) -> data, event -> false, listener));
+
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertSame(exception, listenerError.get());
+            assertEquals(1, eventCount.get());
+            assertEquals(0, reconnectCount.get());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void syncInterruptionAfterReconnectClosesAcquiredResponse() {
+        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
+        AtomicBoolean acquiredResponseClosed = new AtomicBoolean();
+        AtomicReference<Throwable> listenerError = new AtomicReference<>();
+        ServerSentEventListener<String> listener = new ServerSentEventListener<String>() {
+            @Override
+            public void onEvent(ServerSentEvent<String> event) {
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                listenerError.set(error);
+            }
+        };
+
+        try {
+            RuntimeException exception
+                = assertThrows(RuntimeException.class, () -> ServerSentEventStream.process(response(body), eventId -> {
+                    Thread.currentThread().interrupt();
+                    return new ServerSentEventStreamResponse(200, BinaryData.fromString("data: unexpected\n\n"),
+                        () -> acquiredResponseClosed.set(true));
+                }, (event, data) -> data, event -> false, listener));
+
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertSame(exception, listenerError.get());
+            assertTrue(acquiredResponseClosed.get());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    public void processParsesSupportedFields() {
+        BinaryData body = BinaryData.fromString("\uFEFF: comment\nid: 42\nevent: stockUpdate\nretry: 2000\n"
+            + "ignored: value\ndata: first\ndata: second\n\n");
+        List<ServerSentEvent<String>> events = new ArrayList<>();
+
+        ServerSentEventStream.process(body, (event, data) -> data, events::add);
+
+        assertEquals(1, events.size());
+        ServerSentEvent<String> event = events.get(0);
+        assertEquals("42", event.getId());
+        assertEquals("stockUpdate", event.getEvent());
+        assertEquals("first\nsecond", event.getData());
+        assertEquals("comment", event.getComment());
+        assertEquals(Duration.ofSeconds(2), event.getRetryAfter());
+    }
+
+    @Test
+    public void processSkipsBlocksWithoutDataAndUsesDefaultEvent() {
+        BinaryData body
+            = BinaryData.fromString(": keep alive\nretry: invalid\n\nid: contains\0null\nevent:\ndata: payload\n\n");
+        AtomicReference<ServerSentEvent<String>> eventReference = new AtomicReference<>();
+
+        ServerSentEventStream.process(body, (event, data) -> data, eventReference::set);
+
+        ServerSentEvent<String> event = eventReference.get();
+        assertNull(event.getId());
+        assertEquals("message", event.getEvent());
+        assertEquals("payload", event.getData());
+        assertNull(event.getComment());
+        assertNull(event.getRetryAfter());
+    }
+
+    @Test
+    public void protocolMetadataPersistsAcrossEvents() {
+        BinaryData body = BinaryData.fromString("id: 42\nretry: 2000\n\ndata: first\n\ndata: second\n\n");
+        List<ServerSentEvent<String>> syncEvents = new ArrayList<>();
+
+        ServerSentEventStream.process(body, (event, data) -> data, syncEvents::add);
+
+        assertPersistentMetadata(syncEvents);
+        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data).collectList())
+            .assertNext(ServerSentEventStreamTests::assertPersistentMetadata)
+            .verifyComplete();
+    }
+
+    @Test
+    public void protocolEmptyIdResetsPersistentState() {
+        BinaryData body = BinaryData.fromString("id: 42\ndata: first\n\nid:\ndata: second\n\n");
+
+        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data))
+            .assertNext(event -> assertEquals("42", event.getId()))
+            .assertNext(event -> assertEquals("", event.getId()))
+            .verifyComplete();
+    }
+
+    @Test
+    public void protocolFinalMetadataOnlyBlockDoesNotEmitState() {
+        BinaryData body = BinaryData.fromString("id: 1\nretry: 1000\ndata: first\n\nid: 2\nretry: 2000\n\n");
+        List<ServerSentEvent<String>> syncEvents = new ArrayList<>();
+
+        ServerSentEventStream.process(body, (event, data) -> data, syncEvents::add);
+
+        assertEquals(1, syncEvents.size());
+        assertInitialMetadata(syncEvents.get(0));
+        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data))
+            .assertNext(ServerSentEventStreamTests::assertInitialMetadata)
+            .verifyComplete();
+    }
+
+    @Test
+    public void processDeserializesTypedEventData() {
+        BinaryData body = BinaryData.fromString("id: 42\nevent: number\ndata: 123\n\n");
+        AtomicReference<ServerSentEvent<Integer>> eventReference = new AtomicReference<>();
+
+        ServerSentEventStream.process(body, (eventName, data) -> {
+            assertEquals("number", eventName);
+            return Integer.parseInt(data);
+        }, eventReference::set);
+
+        ServerSentEvent<Integer> event = eventReference.get();
+        assertEquals("42", event.getId());
+        assertEquals("number", event.getEvent());
+        assertEquals(123, event.getData());
+    }
+
+    @Test
+    public void protocolDecodeParsesFragmentedUtf8AndLineEndings() {
+        byte[] bytes = ("\uFEFF: comment\rid: 42\r\nevent: greeting\nretry: 2000\ndata: caf\u00e9\r\ndata: second\n\n")
+            .getBytes(StandardCharsets.UTF_8);
+        List<ByteBuffer> buffers = new ArrayList<>();
+        for (byte value : bytes) {
+            buffers.add(ByteBuffer.wrap(new byte[] { value }));
+        }
+        BinaryData body = BinaryData.fromFlux(Flux.fromIterable(buffers), null, false).block();
+
+        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data)).assertNext(event -> {
+            assertEquals("42", event.getId());
+            assertEquals("greeting", event.getEvent());
+            assertEquals("caf\u00e9\nsecond", event.getData());
+            assertEquals("comment", event.getComment());
+            assertEquals(Duration.ofSeconds(2), event.getRetryAfter());
+        }).verifyComplete();
+    }
+
+    @Test
+    public void protocolDecodeDiscardsFinalEventWithoutDelimiter() {
+        BinaryData body
+            = BinaryData
+                .fromFlux(Flux.just(ByteBuffer.wrap("event: final\ndata: payload".getBytes(StandardCharsets.UTF_8))),
+                    null, false)
+                .block();
+
+        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data)).verifyComplete();
+
+        AtomicBoolean eventReceived = new AtomicBoolean();
+        ServerSentEventStream.process(body, (event, data) -> data, event -> eventReceived.set(true));
+        assertFalse(eventReceived.get());
+    }
+
+    @Test
+    public void protocolDecodeDoesNotDispatchPartialEventAfterNetworkError() {
+        IOException disconnect = new IOException("connection closed");
+        Flux<ByteBuffer> content
+            = Flux.concat(Flux.just(ByteBuffer.wrap("event: partial\ndata: pay".getBytes(StandardCharsets.UTF_8))),
+                Flux.error(disconnect));
+        BinaryData body = BinaryData.fromFlux(content, null, false).block();
+
+        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data))
+            .expectErrorMatches(error -> error == disconnect)
+            .verify();
+    }
+
+    @Test
+    public void processNotifiesAndRethrowsNetworkError() {
+        IOException disconnect = new IOException("connection closed");
+        Flux<ByteBuffer> content = Flux.concat(
+            Flux.just(ByteBuffer.wrap("data: first\n\n".getBytes(StandardCharsets.UTF_8))), Flux.error(disconnect));
+        BinaryData body = BinaryData.fromFlux(content, null, false).block();
+        AtomicReference<Throwable> listenerError = new AtomicReference<>();
+        AtomicBoolean closed = new AtomicBoolean();
+
+        UncheckedIOException exception = assertThrows(UncheckedIOException.class,
+            () -> ServerSentEventStream.process(body, (event, data) -> data, new ServerSentEventListener<String>() {
+                @Override
+                public void onEvent(ServerSentEvent<String> event) {
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    listenerError.set(error);
+                }
+
+                @Override
+                public void onClose() {
+                    closed.set(true);
+                }
+            }));
+
+        assertSame(disconnect, exception.getCause());
+        assertSame(disconnect, listenerError.get());
+        assertTrue(closed.get());
+    }
+
+    @Test
+    public void processRethrowsDeserializerRuntimeException() {
+        UncheckedIOException deserializationError = new UncheckedIOException(new IOException("invalid event"));
+        BinaryData body = BinaryData.fromString("data: invalid\n\n");
+
+        UncheckedIOException exception
+            = assertThrows(UncheckedIOException.class, () -> ServerSentEventStream.process(body, (event, data) -> {
+                throw deserializationError;
+            }, ignored -> {
+            }));
+
+        assertSame(deserializationError, exception);
+    }
+
+    @Test
+    public void processNotifiesAndRethrowsListenerRuntimeException() {
+        RuntimeException listenerFailure = new IllegalStateException("listener failed");
+        AtomicReference<Throwable> listenerError = new AtomicReference<>();
+        AtomicBoolean closed = new AtomicBoolean();
+        BinaryData body = BinaryData.fromString("data: event\n\n");
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+            () -> ServerSentEventStream.process(body, (event, data) -> data, new ServerSentEventListener<String>() {
+                @Override
+                public void onEvent(ServerSentEvent<String> event) {
+                    throw listenerFailure;
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    listenerError.set(error);
+                }
+
+                @Override
+                public void onClose() {
+                    closed.set(true);
+                }
+            }));
+
+        assertSame(listenerFailure, exception);
+        assertSame(listenerFailure, listenerError.get());
+        assertTrue(closed.get());
+    }
+
+    @Test
+    public void protocolDecodeCancellationCancelsFluxBackedBody() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        byte[] eventBytes = "data: payload\n\n".getBytes(StandardCharsets.UTF_8);
+        Flux<ByteBuffer> content
+            = Flux.concat(Flux.just(ByteBuffer.wrap(eventBytes)), Flux.never()).doOnCancel(() -> cancelled.set(true));
+        BinaryData body = BinaryData.fromFlux(content, null, false).block();
+
+        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data))
+            .assertNext(event -> assertEquals("payload", event.getData()))
+            .thenCancel()
+            .verify();
+
+        assertTrue(cancelled.get());
+    }
+
+    @Test
+    public void protocolSyncAndAsyncDecodingHaveMatchingFraming() {
+        String content = "event: first\ndata: one\r\n\r\nevent: second\ndata: two\n\n";
+        List<ServerSentEvent<String>> syncEvents = new ArrayList<>();
+        ServerSentEventStream.process(BinaryData.fromString(content), (event, data) -> data, syncEvents::add);
+
+        List<ServerSentEvent<String>> asyncEvents
+            = ServerSentEventStream.decode(BinaryData.fromString(content), (event, data) -> data).collectList().block();
+
+        assertEquals(2, asyncEvents.size());
+        assertEquals(Arrays.asList(syncEvents.get(0).getEvent(), syncEvents.get(1).getEvent()),
+            Arrays.asList(asyncEvents.get(0).getEvent(), asyncEvents.get(1).getEvent()));
+        assertEquals(Arrays.asList(syncEvents.get(0).getData(), syncEvents.get(1).getData()),
+            Arrays.asList(asyncEvents.get(0).getData(), asyncEvents.get(1).getData()));
+    }
+
+    private static void assertPersistentMetadata(List<ServerSentEvent<String>> events) {
+        assertEquals(2, events.size());
+        assertEquals(Arrays.asList("first", "second"), Arrays.asList(events.get(0).getData(), events.get(1).getData()));
+        for (ServerSentEvent<String> event : events) {
+            assertEquals("42", event.getId());
+            assertEquals(Duration.ofSeconds(2), event.getRetryAfter());
+        }
+    }
+
+    private static void assertInitialMetadata(ServerSentEvent<String> event) {
+        assertEquals("1", event.getId());
+        assertEquals(Duration.ofSeconds(1), event.getRetryAfter());
+    }
+
+    private static ServerSentEventStreamResponse response(BinaryData body) {
+        return new ServerSentEventStreamResponse(200, body, () -> {
+        });
+    }
+}

--- a/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
@@ -275,6 +275,190 @@ public class ServerSentEventStreamTests {
         assertTrue(response.closed.get());
     }
 
+    @Test
+    public void toFluxEmitsTerminalEventAndCancelsRemainingBody() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        AtomicReference<Integer> conversionCount = new AtomicReference<>(0);
+        BinaryData body
+            = BinaryData
+                .fromFlux(Flux.concat(
+                    Flux.just(ByteBuffer
+                        .wrap("data: one\n\ndata: [DONE]\n\ndata: ignored\n\n".getBytes(StandardCharsets.UTF_8))),
+                    Flux.never()).doOnCancel(() -> cancelled.set(true)), null, false)
+                .block();
+        TestResponse response = response(200, body);
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> {
+            conversionCount.set(conversionCount.get() + 1);
+            return data;
+        }, event -> "[DONE]".equals(event.getData())))
+            .assertNext(event -> assertEquals("one", event.getData()))
+            .assertNext(event -> assertEquals("[DONE]", event.getData()))
+            .verifyComplete();
+
+        assertEquals(2, conversionCount.get());
+        assertTrue(cancelled.get());
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxFailsOnEofBeforeTerminalEvent() {
+        TestResponse response = response(200, BinaryData.fromString("data: one\n\n"));
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data, event -> false))
+            .assertNext(event -> assertEquals("one", event.getData()))
+            .expectErrorMessage("The server-sent event stream ended before a terminal event.")
+            .verify();
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxFailsOnMetadataOnlyEofBeforeTerminalEvent() {
+        TestResponse response = response(200, BinaryData.fromString("retry: 1000\n\n"));
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data, event -> false))
+            .expectErrorMessage("The server-sent event stream ended before a terminal event.")
+            .verify();
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxCancellationBeforeTerminalDoesNotCreateEofError() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        BinaryData body = BinaryData.fromFlux(
+            Flux.concat(Flux.just(ByteBuffer.wrap("data: one\n\n".getBytes(StandardCharsets.UTF_8))), Flux.never())
+                .doOnCancel(() -> cancelled.set(true)),
+            null, false).block();
+        TestResponse response = response(200, body);
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data, event -> false))
+            .assertNext(event -> assertEquals("one", event.getData()))
+            .thenCancel()
+            .verify();
+
+        assertTrue(cancelled.get());
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxNoContentDoesNotInvokeTerminalPredicate() {
+        AtomicBoolean predicateInvoked = new AtomicBoolean();
+        TestResponse response = response(204, null);
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data, event -> {
+            predicateInvoked.set(true);
+            return false;
+        })).verifyComplete();
+
+        assertFalse(predicateInvoked.get());
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxPropagatesTerminalPredicateFailureAndClosesResponse() {
+        RuntimeException failure = new IllegalStateException("predicate failed");
+        TestResponse response = response(200, BinaryData.fromString("data: one\n\n"));
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data, event -> {
+            throw failure;
+        }))
+            .assertNext(event -> assertEquals("one", event.getData()))
+            .expectErrorMatches(error -> error == failure)
+            .verify();
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void listenDeliversTerminalEventAndSkipsBufferedEventsAfterIt() {
+        TestResponse response = response(200, BinaryData.fromString("data: one\n\ndata: [DONE]\n\ndata: ignored\n\n"));
+        List<String> events = new ArrayList<>();
+        AtomicReference<Integer> conversionCount = new AtomicReference<>(0);
+
+        ServerSentEventStreams.listen(response, (event, data) -> {
+            conversionCount.set(conversionCount.get() + 1);
+            return data;
+        }, event -> "[DONE]".equals(event.getData()), event -> events.add(event.getData()));
+
+        assertEquals(2, events.size());
+        assertEquals("[DONE]", events.get(1));
+        assertEquals(2, conversionCount.get());
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void listenFailsOnEofBeforeTerminalEventAndNotifiesListener() {
+        TestResponse response = response(200, BinaryData.fromString("data: one\n\n"));
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        List<String> events = new ArrayList<>();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> ServerSentEventStreams
+            .listen(response, (event, data) -> data, event -> false, new ServerSentEventListener<String>() {
+                @Override
+                public void onEvent(ServerSentEvent<String> event) {
+                    events.add(event.getData());
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    reportedError.set(error);
+                }
+            }));
+
+        assertEquals(1, events.size());
+        assertSame(exception, reportedError.get());
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void listenNoContentDoesNotInvokeTerminalPredicate() {
+        AtomicBoolean predicateInvoked = new AtomicBoolean();
+        TestResponse response = response(204, null);
+
+        ServerSentEventStreams.listen(response, (event, data) -> data, event -> {
+            predicateInvoked.set(true);
+            return false;
+        }, event -> {
+        });
+
+        assertFalse(predicateInvoked.get());
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void listenPropagatesTerminalPredicateFailureAndClosesResponse() {
+        RuntimeException failure = new IllegalStateException("predicate failed");
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        AtomicBoolean closed = new AtomicBoolean();
+        TestResponse response = response(200, BinaryData.fromString("data: one\n\n"));
+
+        RuntimeException exception = assertThrows(RuntimeException.class,
+            () -> ServerSentEventStreams.listen(response, (event, data) -> data, event -> {
+                throw failure;
+            }, new ServerSentEventListener<String>() {
+                @Override
+                public void onEvent(ServerSentEvent<String> event) {
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    reportedError.set(error);
+                }
+
+                @Override
+                public void onClose() {
+                    closed.set(true);
+                }
+            }));
+
+        assertSame(failure, exception);
+        assertSame(failure, reportedError.get());
+        assertTrue(closed.get());
+        assertTrue(response.closed.get());
+    }
+
     private static TestResponse response(int statusCode, BinaryData body) {
         return response(statusCode, body, "text/event-stream");
     }

--- a/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
@@ -124,6 +124,39 @@ public class ServerSentEventStreamTests {
     }
 
     @Test
+    public void toFluxRejectsUnsupportedStatusAndClosesResponse() {
+        TestResponse response = response(201, BinaryData.fromString("data: one\n\n"));
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data))
+            .expectErrorMessage("Expected a server-sent event response to have status code 200 or 204.")
+            .verify();
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxDoesNotClaimOrCloseResponseBeforeSubscription() {
+        TestResponse response = response(200, BinaryData.fromString("data: one\n\n"));
+
+        ServerSentEventStreams.toFlux(response, (event, data) -> data);
+
+        assertFalse(response.closed.get());
+    }
+
+    @Test
+    public void toFluxAllowsOnlyOneSubscription() {
+        TestResponse response = response(200, BinaryData.fromString("data: one\n\n"));
+        Flux<ServerSentEvent<String>> events = ServerSentEventStreams.toFlux(response, (event, data) -> data);
+
+        StepVerifier.create(events).expectNextCount(1).verifyComplete();
+        StepVerifier.create(events)
+            .expectErrorMessage("This server-sent event stream supports only one subscription.")
+            .verify();
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
     public void toFluxCancellationClosesResponse() {
         AtomicBoolean cancelled = new AtomicBoolean();
         BinaryData body = BinaryData.fromFlux(
@@ -284,6 +317,38 @@ public class ServerSentEventStreamTests {
     }
 
     @Test
+    public void toFluxCloseFailureFailsNormalCompletion() {
+        IOException closeFailure = new IOException("close failed");
+        TestResponse response
+            = response(200, BinaryData.fromString("data: one\n\n"), "text/event-stream", closeFailure);
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data))
+            .assertNext(event -> assertEquals("one", event.getData()))
+            .expectErrorMatches(
+                error -> error instanceof java.io.UncheckedIOException && error.getCause() == closeFailure)
+            .verify();
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxPrioritizesCloseFailureWhenBodyAndCloseFail() {
+        IOException bodyFailure = new IOException("body failed");
+        IOException closeFailure = new IOException("close failed");
+        BinaryData body = BinaryData.fromFlux(Flux.error(bodyFailure), null, false).block();
+        TestResponse response = response(200, body, "text/event-stream", closeFailure);
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data))
+            .expectErrorMatches(error -> error instanceof java.io.UncheckedIOException
+                && error.getCause() == closeFailure
+                && error.getSuppressed().length == 1
+                && error.getSuppressed()[0] == bodyFailure)
+            .verify();
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
     public void toFluxPropagatesConverterFailureAndClosesResponse() {
         RuntimeException failure = new IllegalStateException("invalid event");
         TestResponse response = response(200, BinaryData.fromString("data: invalid\n\n"));
@@ -370,7 +435,7 @@ public class ServerSentEventStreamTests {
         StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data, event -> {
             predicateInvoked.set(true);
             return false;
-        })).verifyComplete();
+        })).expectErrorMessage("The server-sent event stream ended before a terminal event.").verify();
 
         assertFalse(predicateInvoked.get());
         assertTrue(response.closed.get());
@@ -435,15 +500,26 @@ public class ServerSentEventStreamTests {
     @Test
     public void listenNoContentDoesNotInvokeTerminalPredicate() {
         AtomicBoolean predicateInvoked = new AtomicBoolean();
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
         TestResponse response = response(204, null);
 
-        ServerSentEventStreams.listen(response, (event, data) -> data, event -> {
-            predicateInvoked.set(true);
-            return false;
-        }, event -> {
-        });
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> ServerSentEventStreams.listen(response, (event, data) -> data, event -> {
+                predicateInvoked.set(true);
+                return false;
+            }, new ServerSentEventListener<String>() {
+                @Override
+                public void onEvent(ServerSentEvent<String> event) {
+                }
+
+                @Override
+                public void onError(Throwable error) {
+                    reportedError.set(error);
+                }
+            }));
 
         assertFalse(predicateInvoked.get());
+        assertSame(exception, reportedError.get());
         assertTrue(response.closed.get());
     }
 
@@ -484,19 +560,34 @@ public class ServerSentEventStreamTests {
     }
 
     private static TestResponse response(int statusCode, BinaryData body, String contentType) {
-        return new TestResponse(statusCode, new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, contentType), body);
+        return response(statusCode, body, contentType, null);
+    }
+
+    private static TestResponse response(int statusCode, BinaryData body, String contentType,
+        IOException closeFailure) {
+        return new TestResponse(statusCode, new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, contentType), body,
+            closeFailure);
     }
 
     private static final class TestResponse extends ResponseBase<Object, BinaryData> implements Closeable {
         private final AtomicBoolean closed = new AtomicBoolean();
+        private final IOException closeFailure;
 
         private TestResponse(int statusCode, HttpHeaders headers, BinaryData value) {
+            this(statusCode, headers, value, null);
+        }
+
+        private TestResponse(int statusCode, HttpHeaders headers, BinaryData value, IOException closeFailure) {
             super(null, statusCode, headers, value, null);
+            this.closeFailure = closeFailure;
         }
 
         @Override
         public void close() throws IOException {
             closed.set(true);
+            if (closeFailure != null) {
+                throw closeFailure;
+            }
         }
     }
 }

--- a/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -151,6 +152,36 @@ public class ServerSentEventStreamTests {
         StepVerifier.create(events).expectNextCount(1).verifyComplete();
         StepVerifier.create(events)
             .expectErrorMessage("This server-sent event stream supports only one subscription.")
+            .verify();
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxRejectsOversizedPendingLineAndClosesResponse() {
+        byte[] body = new byte[ServerSentEventStream.MAX_PENDING_EVENT_BYTES + 1];
+        Arrays.fill(body, (byte) 'a');
+        TestResponse response = response(200, BinaryData.fromBytes(body));
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data))
+            .expectErrorMessage("The server-sent event exceeds the maximum supported size of 16 MiB.")
+            .verify();
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxRejectsOversizedPendingDataAndClosesResponse() {
+        byte[] dataLine = "data:\n".getBytes(StandardCharsets.UTF_8);
+        int lineCount = ServerSentEventStream.MAX_PENDING_EVENT_BYTES / (dataLine.length - 1) + 1;
+        byte[] body = new byte[lineCount * dataLine.length];
+        for (int offset = 0; offset < body.length; offset += dataLine.length) {
+            System.arraycopy(dataLine, 0, body, offset, dataLine.length);
+        }
+        TestResponse response = response(200, BinaryData.fromBytes(body));
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data))
+            .expectErrorMessage("The server-sent event exceeds the maximum supported size of 16 MiB.")
             .verify();
 
         assertTrue(response.closed.get());

--- a/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
@@ -3,246 +3,158 @@
 
 package com.azure.core.implementation.util;
 
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpHeaders;
 import com.azure.core.http.ServerSentEvent;
 import com.azure.core.http.ServerSentEventListener;
+import com.azure.core.http.ServerSentEventStreams;
+import com.azure.core.http.rest.ResponseBase;
 import com.azure.core.util.BinaryData;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.io.Closeable;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ServerSentEventStreamTests {
     @Test
-    public void syncReconnectsWithMetadataOnlyState() {
-        BinaryData firstBody
-            = BinaryData.fromString("id: first\nretry: 0\ndata: one\n\n" + "id: reconnect\nretry: invalid\n\n");
-        List<ServerSentEvent<String>> events = new ArrayList<>();
-        AtomicReference<String> reconnectEventId = new AtomicReference<>();
-        AtomicInteger reconnectCount = new AtomicInteger();
+    public void toFluxParsesFragmentedEventMetadata() {
+        byte[] bytes = ("\uFEFF: comment\rid: 42\r\nevent: greeting\nretry: 2000\ndata: caf\u00e9\r\ndata: second\n\n")
+            .getBytes(StandardCharsets.UTF_8);
+        List<ByteBuffer> buffers = new ArrayList<>();
+        for (byte value : bytes) {
+            buffers.add(ByteBuffer.wrap(new byte[] { value }));
+        }
 
-        ServerSentEventStream.process(response(firstBody), eventId -> {
-            reconnectEventId.set(eventId);
-            reconnectCount.incrementAndGet();
-            return response(BinaryData.fromString("data: [DONE]\n\n"));
-        }, (event, data) -> data, event -> "[DONE]".equals(event.getData()), events::add);
+        TestResponse response = response(200, BinaryData.fromFlux(Flux.fromIterable(buffers), null, false).block());
 
-        assertEquals(1, reconnectCount.get());
-        assertEquals("reconnect", reconnectEventId.get());
-        assertEquals(2, events.size());
-        assertEquals("one", events.get(0).getData());
-        assertEquals("reconnect", events.get(1).getId());
-        assertEquals(Duration.ZERO, events.get(1).getRetryAfter());
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data)).assertNext(event -> {
+            assertEquals("42", event.getId());
+            assertEquals("greeting", event.getEvent());
+            assertEquals("caf\u00e9\nsecond", event.getData());
+            assertEquals("comment", event.getComment());
+            assertEquals(Duration.ofSeconds(2), event.getRetryAfter());
+        }).verifyComplete();
+
+        assertTrue(response.closed.get());
     }
 
     @Test
-    public void asyncReconnectsSeriallyWithRetainedState() {
-        BinaryData firstBody = BinaryData.fromString("id: first\nretry: 0\ndata: one\n\nid: second\n\n");
-        AtomicInteger reconnectCount = new AtomicInteger();
-        AtomicReference<String> reconnectEventId = new AtomicReference<>();
+    public void toFluxCompletesOnEofWithoutReconnecting() {
+        TestResponse response = response(200, BinaryData.fromString("id: 1\nretry: 0\ndata: one\n\n"));
 
-        StepVerifier.create(ServerSentEventStream.decode(response(firstBody), eventId -> {
-            reconnectEventId.set(eventId);
-            reconnectCount.incrementAndGet();
-            return Mono.just(response(BinaryData.fromString("data: [DONE]\n\n")));
-        }, (event, data) -> data).takeUntil(event -> "[DONE]".equals(event.getData())))
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data))
             .assertNext(event -> assertEquals("one", event.getData()))
-            .assertNext(event -> {
-                assertEquals("[DONE]", event.getData());
-                assertEquals("second", event.getId());
-                assertEquals(Duration.ZERO, event.getRetryAfter());
-            })
             .verifyComplete();
 
-        assertEquals(1, reconnectCount.get());
-        assertEquals("second", reconnectEventId.get());
+        assertTrue(response.closed.get());
     }
 
     @Test
-    public void emptyIdOmitsLastEventIdOnReconnect() {
-        BinaryData firstBody = BinaryData.fromString("id: first\nretry: 0\ndata: one\n\nid:\n\n");
-        AtomicReference<String> reconnectEventId = new AtomicReference<>("not-called");
+    public void toFluxReturnsEmptyForNoContent() {
+        TestResponse response = response(204, null);
 
-        ServerSentEventStream.process(response(firstBody), eventId -> {
-            reconnectEventId.set(eventId);
-            return response(BinaryData.fromString("data: [DONE]\n\n"));
-        }, (event, data) -> data, event -> "[DONE]".equals(event.getData()), event -> {
-        });
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data)).verifyComplete();
 
-        assertNull(reconnectEventId.get());
+        assertTrue(response.closed.get());
     }
 
     @Test
-    public void cleanCompletionWithoutRetryDoesNotReconnect() {
-        AtomicInteger reconnectCount = new AtomicInteger();
+    public void toFluxRejectsInvalidContentTypeAndClosesResponse() {
+        TestResponse response = response(200, BinaryData.fromString("data: one\n\n"), "application/json");
 
-        ServerSentEventStream.process(response(BinaryData.fromString("data: one\n\n")), eventId -> {
-            reconnectCount.incrementAndGet();
-            return response(BinaryData.fromString("data: unexpected\n\n"));
-        }, (event, data) -> data, event -> false, event -> {
-        });
+        assertThrows(IllegalStateException.class,
+            () -> ServerSentEventStreams.toFlux(response, (event, data) -> data).blockLast());
 
-        assertEquals(0, reconnectCount.get());
+        assertTrue(response.closed.get());
     }
 
     @Test
-    public void asyncBodyErrorReconnectsWithRetainedRetry() {
-        IOException disconnect = new IOException("connection closed");
-        byte[] prefix = "retry: 0\ndata: one\n\n".getBytes(StandardCharsets.UTF_8);
-        BinaryData body
-            = BinaryData.fromFlux(Flux.concat(Flux.just(ByteBuffer.wrap(prefix)), Flux.error(disconnect)), null, false)
-                .block();
-        AtomicInteger reconnectCount = new AtomicInteger();
+    public void toFluxRejectsMissingContentTypeAndClosesResponse() {
+        TestResponse response = new TestResponse(200, new HttpHeaders(), BinaryData.fromString("data: one\n\n"));
 
-        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
-            reconnectCount.incrementAndGet();
-            return Mono.just(response(BinaryData.fromString("data: [DONE]\n\n")));
-        }, (event, data) -> data).takeUntil(event -> "[DONE]".equals(event.getData())))
+        assertThrows(IllegalStateException.class,
+            () -> ServerSentEventStreams.toFlux(response, (event, data) -> data).blockLast());
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxRejectsNullBodyAndClosesResponse() {
+        TestResponse response = response(200, null);
+
+        assertThrows(NullPointerException.class,
+            () -> ServerSentEventStreams.toFlux(response, (event, data) -> data).blockLast());
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxCancellationClosesResponse() {
+        AtomicBoolean cancelled = new AtomicBoolean();
+        BinaryData body = BinaryData.fromFlux(
+            Flux.concat(Flux.just(ByteBuffer.wrap("data: one\n\n".getBytes(StandardCharsets.UTF_8))), Flux.never())
+                .doOnCancel(() -> cancelled.set(true)),
+            null, false).block();
+        TestResponse response = response(200, body);
+
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data))
             .assertNext(event -> assertEquals("one", event.getData()))
-            .assertNext(event -> assertEquals("[DONE]", event.getData()))
-            .verifyComplete();
+            .thenCancel()
+            .verify();
 
-        assertEquals(1, reconnectCount.get());
+        assertTrue(cancelled.get());
+        assertTrue(response.closed.get());
     }
 
     @Test
-    public void syncBodyErrorReconnectsWithRetainedRetry() {
-        IOException disconnect = new IOException("connection closed");
-        byte[] prefix = "retry: 0\ndata: one\n\n".getBytes(StandardCharsets.UTF_8);
-        BinaryData body
-            = BinaryData.fromFlux(Flux.concat(Flux.just(ByteBuffer.wrap(prefix)), Flux.error(disconnect)), null, false)
-                .block();
-        AtomicInteger reconnectCount = new AtomicInteger();
+    public void listenCompletesOnEofAndNotifiesLifecycleOnce() {
+        TestResponse response = response(200, BinaryData.fromString("data: one\n\ndata: two\n\n"));
         List<String> events = new ArrayList<>();
+        AtomicBoolean closed = new AtomicBoolean();
 
-        ServerSentEventStream.process(response(body), eventId -> {
-            reconnectCount.incrementAndGet();
-            return response(BinaryData.fromString("data: [DONE]\n\n"));
-        }, (event, data) -> data, event -> "[DONE]".equals(event.getData()), event -> events.add(event.getData()));
+        ServerSentEventStreams.listen(response, (event, data) -> data, new ServerSentEventListener<String>() {
+            @Override
+            public void onEvent(ServerSentEvent<String> event) {
+                events.add(event.getData());
+            }
 
-        assertEquals(1, reconnectCount.get());
+            @Override
+            public void onClose() {
+                assertFalse(closed.getAndSet(true));
+            }
+        });
+
         assertEquals(2, events.size());
-        assertEquals("one", events.get(0));
-        assertEquals("[DONE]", events.get(1));
+        assertTrue(closed.get());
+        assertTrue(response.closed.get());
     }
 
     @Test
-    public void bodyErrorWithoutRetryTerminatesAsyncStream() {
-        IOException disconnect = new IOException("connection closed");
-        BinaryData body = BinaryData
-            .fromFlux(Flux.concat(Flux.just(ByteBuffer.wrap("data: one\n\n".getBytes(StandardCharsets.UTF_8))),
-                Flux.error(disconnect)), null, false)
-            .block();
-        AtomicInteger reconnectCount = new AtomicInteger();
-
-        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
-            reconnectCount.incrementAndGet();
-            return Mono.just(response(BinaryData.fromString("data: unexpected\n\n")));
-        }, (event, data) -> data))
-            .assertNext(event -> assertEquals("one", event.getData()))
-            .expectErrorMatches(error -> error == disconnect)
-            .verify();
-
-        assertEquals(0, reconnectCount.get());
-    }
-
-    @Test
-    public void deserializerErrorDoesNotReconnectAsyncStream() {
-        RuntimeException deserializerError = new IllegalStateException("deserialization failed");
-        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
-        AtomicInteger reconnectCount = new AtomicInteger();
-
-        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
-            reconnectCount.incrementAndGet();
-            return Mono.just(response(BinaryData.fromString("data: unexpected\n\n")));
-        }, (event, data) -> {
-            throw deserializerError;
-        })).expectErrorMatches(error -> error == deserializerError).verify();
-
-        assertEquals(0, reconnectCount.get());
-    }
-
-    @Test
-    public void asyncReconnectsWithoutGrowingPublisherDepth() {
-        int eventCount = 10_000;
-        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
-        AtomicInteger reconnectCount = new AtomicInteger();
-
-        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
-            reconnectCount.incrementAndGet();
-            return Mono.just(response(BinaryData.fromString("data: one\n\n")));
-        }, (event, data) -> data).take(eventCount)).expectNextCount(eventCount).verifyComplete();
-
-        assertEquals(eventCount - 1, reconnectCount.get());
-    }
-
-    @Test
-    public void zeroRetryUsesAsyncSchedulingBoundary() {
-        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
-        Thread subscriptionThread = Thread.currentThread();
-        AtomicReference<Thread> reconnectThread = new AtomicReference<>();
-
-        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
-            reconnectThread.set(Thread.currentThread());
-            return Mono.just(response(BinaryData.fromString("data: [DONE]\n\n")));
-        }, (event, data) -> data).takeUntil(event -> "[DONE]".equals(event.getData())))
-            .expectNextCount(2)
-            .verifyComplete();
-
-        assertNotSame(subscriptionThread, reconnectThread.get());
-    }
-
-    @Test
-    public void reconnectRequestErrorTerminatesAsyncStream() {
-        RuntimeException requestError = new IllegalStateException("reconnect failed");
-        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
-        AtomicInteger reconnectCount = new AtomicInteger();
-
-        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
-            reconnectCount.incrementAndGet();
-            return Mono.error(requestError);
-        }, (event, data) -> data))
-            .assertNext(event -> assertEquals("one", event.getData()))
-            .expectErrorMatches(error -> error == requestError)
-            .verify();
-
-        assertEquals(1, reconnectCount.get());
-    }
-
-    @Test
-    public void listenerErrorDoesNotReconnect() {
-        RuntimeException listenerError = new IllegalStateException("listener failed");
-        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
-        AtomicInteger reconnectCount = new AtomicInteger();
+    public void listenNotifiesErrorAndClosesResponse() {
+        RuntimeException failure = new IllegalStateException("listener failed");
         AtomicReference<Throwable> reportedError = new AtomicReference<>();
+        TestResponse response = response(200, BinaryData.fromString("data: one\n\n"));
 
-        RuntimeException exception
-            = assertThrows(RuntimeException.class, () -> ServerSentEventStream.process(response(body), eventId -> {
-                reconnectCount.incrementAndGet();
-                return response(BinaryData.fromString("data: unexpected\n\n"));
-            }, (event, data) -> data, event -> false, new ServerSentEventListener<String>() {
+        RuntimeException exception = assertThrows(RuntimeException.class,
+            () -> ServerSentEventStreams.listen(response, (event, data) -> data, new ServerSentEventListener<String>() {
                 @Override
                 public void onEvent(ServerSentEvent<String> event) {
-                    throw listenerError;
+                    throw failure;
                 }
 
                 @Override
@@ -251,399 +163,136 @@ public class ServerSentEventStreamTests {
                 }
             }));
 
-        assertSame(listenerError, exception);
-        assertSame(listenerError, reportedError.get());
-        assertEquals(0, reconnectCount.get());
+        assertSame(failure, exception);
+        assertSame(failure, reportedError.get());
+        assertTrue(response.closed.get());
     }
 
     @Test
-    public void asyncCancellationDuringRetryDelayPreventsReconnect() {
-        BinaryData body = BinaryData.fromString("retry: 60000\ndata: one\n\n");
-        AtomicInteger reconnectCount = new AtomicInteger();
+    public void listenStopsDeliveringBufferedEventsAfterInterruption() {
+        TestResponse response = response(200, BinaryData.fromString("data: one\n\ndata: two\n\n"));
+        List<String> events = new ArrayList<>();
+        AtomicReference<Throwable> reportedError = new AtomicReference<>();
 
-        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
-            reconnectCount.incrementAndGet();
-            return Mono.just(response(BinaryData.fromString("data: unexpected\n\n")));
-        }, (event, data) -> data)).assertNext(event -> assertEquals("one", event.getData())).thenCancel().verify();
-
-        assertEquals(0, reconnectCount.get());
-    }
-
-    @Test
-    public void maximumRetryValueDoesNotOverflowAsyncDelay() {
-        BinaryData body = BinaryData.fromString("retry: 9223372036854775807\ndata: one\n\n");
-        AtomicInteger reconnectCount = new AtomicInteger();
-
-        StepVerifier.create(ServerSentEventStream.decode(response(body), eventId -> {
-            reconnectCount.incrementAndGet();
-            return Mono.just(response(BinaryData.fromString("data: unexpected\n\n")));
-        }, (event, data) -> data))
-            .assertNext(event -> assertEquals(Duration.ofMillis(Long.MAX_VALUE), event.getRetryAfter()))
-            .thenCancel()
-            .verify();
-
-        assertEquals(0, reconnectCount.get());
-    }
-
-    @Test
-    public void syncInterruptionDuringRetryDelayIsPropagated() {
-        BinaryData body = BinaryData.fromString("retry: 60000\n\n");
-        AtomicReference<Throwable> listenerError = new AtomicReference<>();
-        AtomicBoolean closed = new AtomicBoolean();
-        ServerSentEventListener<String> listener = new ServerSentEventListener<String>() {
-            @Override
-            public void onEvent(ServerSentEvent<String> event) {
-            }
-
-            @Override
-            public void onError(Throwable error) {
-                listenerError.set(error);
-            }
-
-            @Override
-            public void onClose() {
-                closed.set(true);
-            }
-        };
-
-        Thread.currentThread().interrupt();
         try {
-            RuntimeException exception = assertThrows(RuntimeException.class,
-                () -> ServerSentEventStream.process(response(body),
-                    eventId -> response(BinaryData.fromString("data: unexpected\n\n")), (event, data) -> data,
-                    event -> false, listener));
+            RuntimeException exception = assertThrows(RuntimeException.class, () -> ServerSentEventStreams
+                .listen(response, (event, data) -> data, new ServerSentEventListener<String>() {
+                    @Override
+                    public void onEvent(ServerSentEvent<String> event) {
+                        events.add(event.getData());
+                        Thread.currentThread().interrupt();
+                    }
+
+                    @Override
+                    public void onError(Throwable error) {
+                        reportedError.set(error);
+                    }
+                }));
 
             assertTrue(Thread.currentThread().isInterrupted());
-            assertSame(exception, listenerError.get());
-            assertTrue(closed.get());
+            assertSame(exception, reportedError.get());
+            assertEquals(1, events.size());
+            assertTrue(response.closed.get());
         } finally {
             Thread.interrupted();
         }
     }
 
     @Test
-    public void syncInterruptionBeforeZeroDelayReconnectIsPropagated() {
-        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
-        AtomicReference<Throwable> listenerError = new AtomicReference<>();
-        AtomicInteger reconnectCount = new AtomicInteger();
-        AtomicInteger eventCount = new AtomicInteger();
-        ServerSentEventListener<String> listener = new ServerSentEventListener<String>() {
-            @Override
-            public void onEvent(ServerSentEvent<String> event) {
-                eventCount.incrementAndGet();
-                Thread.currentThread().interrupt();
-            }
+    public void idAndRetryAreMetadataOnly() {
+        TestResponse response = response(200, BinaryData.fromString("id: 42\nretry: 1000\ndata: one\n\n"));
 
-            @Override
-            public void onError(Throwable error) {
-                listenerError.set(error);
-            }
-        };
-
-        try {
-            RuntimeException exception
-                = assertThrows(RuntimeException.class, () -> ServerSentEventStream.process(response(body), eventId -> {
-                    reconnectCount.incrementAndGet();
-                    return response(BinaryData.fromString("data: unexpected\n\n"));
-                }, (event, data) -> data, event -> false, listener));
-
-            assertTrue(Thread.currentThread().isInterrupted());
-            assertSame(exception, listenerError.get());
-            assertEquals(1, eventCount.get());
-            assertEquals(0, reconnectCount.get());
-        } finally {
-            Thread.interrupted();
-        }
-    }
-
-    @Test
-    public void syncInterruptionAfterReconnectClosesAcquiredResponse() {
-        BinaryData body = BinaryData.fromString("retry: 0\ndata: one\n\n");
-        AtomicBoolean acquiredResponseClosed = new AtomicBoolean();
-        AtomicReference<Throwable> listenerError = new AtomicReference<>();
-        ServerSentEventListener<String> listener = new ServerSentEventListener<String>() {
-            @Override
-            public void onEvent(ServerSentEvent<String> event) {
-            }
-
-            @Override
-            public void onError(Throwable error) {
-                listenerError.set(error);
-            }
-        };
-
-        try {
-            RuntimeException exception
-                = assertThrows(RuntimeException.class, () -> ServerSentEventStream.process(response(body), eventId -> {
-                    Thread.currentThread().interrupt();
-                    return new ServerSentEventStreamResponse(200, BinaryData.fromString("data: unexpected\n\n"),
-                        () -> acquiredResponseClosed.set(true));
-                }, (event, data) -> data, event -> false, listener));
-
-            assertTrue(Thread.currentThread().isInterrupted());
-            assertSame(exception, listenerError.get());
-            assertTrue(acquiredResponseClosed.get());
-        } finally {
-            Thread.interrupted();
-        }
-    }
-
-    @Test
-    public void processParsesSupportedFields() {
-        BinaryData body = BinaryData.fromString("\uFEFF: comment\nid: 42\nevent: stockUpdate\nretry: 2000\n"
-            + "ignored: value\ndata: first\ndata: second\n\n");
-        List<ServerSentEvent<String>> events = new ArrayList<>();
-
-        ServerSentEventStream.process(body, (event, data) -> data, events::add);
-
-        assertEquals(1, events.size());
-        ServerSentEvent<String> event = events.get(0);
-        assertEquals("42", event.getId());
-        assertEquals("stockUpdate", event.getEvent());
-        assertEquals("first\nsecond", event.getData());
-        assertEquals("comment", event.getComment());
-        assertEquals(Duration.ofSeconds(2), event.getRetryAfter());
-    }
-
-    @Test
-    public void processSkipsBlocksWithoutDataAndUsesDefaultEvent() {
-        BinaryData body
-            = BinaryData.fromString(": keep alive\nretry: invalid\n\nid: contains\0null\nevent:\ndata: payload\n\n");
-        AtomicReference<ServerSentEvent<String>> eventReference = new AtomicReference<>();
-
-        ServerSentEventStream.process(body, (event, data) -> data, eventReference::set);
-
-        ServerSentEvent<String> event = eventReference.get();
-        assertNull(event.getId());
-        assertEquals("message", event.getEvent());
-        assertEquals("payload", event.getData());
-        assertNull(event.getComment());
-        assertNull(event.getRetryAfter());
-    }
-
-    @Test
-    public void protocolMetadataPersistsAcrossEvents() {
-        BinaryData body = BinaryData.fromString("id: 42\nretry: 2000\n\ndata: first\n\ndata: second\n\n");
-        List<ServerSentEvent<String>> syncEvents = new ArrayList<>();
-
-        ServerSentEventStream.process(body, (event, data) -> data, syncEvents::add);
-
-        assertPersistentMetadata(syncEvents);
-        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data).collectList())
-            .assertNext(ServerSentEventStreamTests::assertPersistentMetadata)
-            .verifyComplete();
-    }
-
-    @Test
-    public void protocolEmptyIdResetsPersistentState() {
-        BinaryData body = BinaryData.fromString("id: 42\ndata: first\n\nid:\ndata: second\n\n");
-
-        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data))
-            .assertNext(event -> assertEquals("42", event.getId()))
-            .assertNext(event -> assertEquals("", event.getId()))
-            .verifyComplete();
-    }
-
-    @Test
-    public void protocolFinalMetadataOnlyBlockDoesNotEmitState() {
-        BinaryData body = BinaryData.fromString("id: 1\nretry: 1000\ndata: first\n\nid: 2\nretry: 2000\n\n");
-        List<ServerSentEvent<String>> syncEvents = new ArrayList<>();
-
-        ServerSentEventStream.process(body, (event, data) -> data, syncEvents::add);
-
-        assertEquals(1, syncEvents.size());
-        assertInitialMetadata(syncEvents.get(0));
-        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data))
-            .assertNext(ServerSentEventStreamTests::assertInitialMetadata)
-            .verifyComplete();
-    }
-
-    @Test
-    public void processDeserializesTypedEventData() {
-        BinaryData body = BinaryData.fromString("id: 42\nevent: number\ndata: 123\n\n");
-        AtomicReference<ServerSentEvent<Integer>> eventReference = new AtomicReference<>();
-
-        ServerSentEventStream.process(body, (eventName, data) -> {
-            assertEquals("number", eventName);
-            return Integer.parseInt(data);
-        }, eventReference::set);
-
-        ServerSentEvent<Integer> event = eventReference.get();
-        assertEquals("42", event.getId());
-        assertEquals("number", event.getEvent());
-        assertEquals(123, event.getData());
-    }
-
-    @Test
-    public void protocolDecodeParsesFragmentedUtf8AndLineEndings() {
-        byte[] bytes = ("\uFEFF: comment\rid: 42\r\nevent: greeting\nretry: 2000\ndata: caf\u00e9\r\ndata: second\n\n")
-            .getBytes(StandardCharsets.UTF_8);
-        List<ByteBuffer> buffers = new ArrayList<>();
-        for (byte value : bytes) {
-            buffers.add(ByteBuffer.wrap(new byte[] { value }));
-        }
-        BinaryData body = BinaryData.fromFlux(Flux.fromIterable(buffers), null, false).block();
-
-        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data)).assertNext(event -> {
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data)).assertNext(event -> {
             assertEquals("42", event.getId());
-            assertEquals("greeting", event.getEvent());
-            assertEquals("caf\u00e9\nsecond", event.getData());
-            assertEquals("comment", event.getComment());
-            assertEquals(Duration.ofSeconds(2), event.getRetryAfter());
+            assertEquals(Duration.ofSeconds(1), event.getRetryAfter());
         }).verifyComplete();
     }
 
     @Test
-    public void protocolDecodeDiscardsFinalEventWithoutDelimiter() {
-        BinaryData body
-            = BinaryData
-                .fromFlux(Flux.just(ByteBuffer.wrap("event: final\ndata: payload".getBytes(StandardCharsets.UTF_8))),
-                    null, false)
-                .block();
+    public void parserSkipsMetadataOnlyBlocksAndPersistsMetadata() {
+        TestResponse response
+            = response(200, BinaryData.fromString("id: 42\nretry: 1000\n\ndata: one\n\ndata: two\n\n"));
 
-        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data)).verifyComplete();
-
-        AtomicBoolean eventReceived = new AtomicBoolean();
-        ServerSentEventStream.process(body, (event, data) -> data, event -> eventReceived.set(true));
-        assertFalse(eventReceived.get());
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data).collectList())
+            .assertNext(events -> {
+                assertEquals(2, events.size());
+                for (ServerSentEvent<String> event : events) {
+                    assertEquals("42", event.getId());
+                    assertEquals(Duration.ofSeconds(1), event.getRetryAfter());
+                }
+            })
+            .verifyComplete();
     }
 
     @Test
-    public void protocolDecodeDoesNotDispatchPartialEventAfterNetworkError() {
-        IOException disconnect = new IOException("connection closed");
-        Flux<ByteBuffer> content
-            = Flux.concat(Flux.just(ByteBuffer.wrap("event: partial\ndata: pay".getBytes(StandardCharsets.UTF_8))),
-                Flux.error(disconnect));
-        BinaryData body = BinaryData.fromFlux(content, null, false).block();
+    public void parserResetsIdAndUsesDefaultEvent() {
+        TestResponse response = response(200, BinaryData.fromString("id: 42\ndata: one\n\nid:\nevent:\ndata: two\n\n"));
 
-        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data))
-            .expectErrorMatches(error -> error == disconnect)
-            .verify();
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data))
+            .assertNext(event -> assertEquals("42", event.getId()))
+            .assertNext(event -> {
+                assertEquals("", event.getId());
+                assertEquals("message", event.getEvent());
+            })
+            .verifyComplete();
     }
 
     @Test
-    public void processNotifiesAndRethrowsNetworkError() {
-        IOException disconnect = new IOException("connection closed");
-        Flux<ByteBuffer> content = Flux.concat(
-            Flux.just(ByteBuffer.wrap("data: first\n\n".getBytes(StandardCharsets.UTF_8))), Flux.error(disconnect));
-        BinaryData body = BinaryData.fromFlux(content, null, false).block();
-        AtomicReference<Throwable> listenerError = new AtomicReference<>();
-        AtomicBoolean closed = new AtomicBoolean();
+    public void parserDiscardsUnterminatedEventAtEof() {
+        TestResponse response = response(200, BinaryData.fromString("event: partial\ndata: payload"));
 
-        UncheckedIOException exception = assertThrows(UncheckedIOException.class,
-            () -> ServerSentEventStream.process(body, (event, data) -> data, new ServerSentEventListener<String>() {
-                @Override
-                public void onEvent(ServerSentEvent<String> event) {
-                }
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data)).verifyComplete();
 
-                @Override
-                public void onError(Throwable error) {
-                    listenerError.set(error);
-                }
-
-                @Override
-                public void onClose() {
-                    closed.set(true);
-                }
-            }));
-
-        assertSame(disconnect, exception.getCause());
-        assertSame(disconnect, listenerError.get());
-        assertTrue(closed.get());
+        assertTrue(response.closed.get());
     }
 
     @Test
-    public void processRethrowsDeserializerRuntimeException() {
-        UncheckedIOException deserializationError = new UncheckedIOException(new IOException("invalid event"));
-        BinaryData body = BinaryData.fromString("data: invalid\n\n");
+    public void toFluxPropagatesBodyFailureAndClosesResponse() {
+        IOException failure = new IOException("connection closed");
+        BinaryData body = BinaryData
+            .fromFlux(Flux.concat(Flux.just(ByteBuffer.wrap("data: one\n\n".getBytes(StandardCharsets.UTF_8))),
+                Flux.error(failure)), null, false)
+            .block();
+        TestResponse response = response(200, body);
 
-        UncheckedIOException exception
-            = assertThrows(UncheckedIOException.class, () -> ServerSentEventStream.process(body, (event, data) -> {
-                throw deserializationError;
-            }, ignored -> {
-            }));
-
-        assertSame(deserializationError, exception);
-    }
-
-    @Test
-    public void processNotifiesAndRethrowsListenerRuntimeException() {
-        RuntimeException listenerFailure = new IllegalStateException("listener failed");
-        AtomicReference<Throwable> listenerError = new AtomicReference<>();
-        AtomicBoolean closed = new AtomicBoolean();
-        BinaryData body = BinaryData.fromString("data: event\n\n");
-
-        RuntimeException exception = assertThrows(RuntimeException.class,
-            () -> ServerSentEventStream.process(body, (event, data) -> data, new ServerSentEventListener<String>() {
-                @Override
-                public void onEvent(ServerSentEvent<String> event) {
-                    throw listenerFailure;
-                }
-
-                @Override
-                public void onError(Throwable error) {
-                    listenerError.set(error);
-                }
-
-                @Override
-                public void onClose() {
-                    closed.set(true);
-                }
-            }));
-
-        assertSame(listenerFailure, exception);
-        assertSame(listenerFailure, listenerError.get());
-        assertTrue(closed.get());
-    }
-
-    @Test
-    public void protocolDecodeCancellationCancelsFluxBackedBody() {
-        AtomicBoolean cancelled = new AtomicBoolean();
-        byte[] eventBytes = "data: payload\n\n".getBytes(StandardCharsets.UTF_8);
-        Flux<ByteBuffer> content
-            = Flux.concat(Flux.just(ByteBuffer.wrap(eventBytes)), Flux.never()).doOnCancel(() -> cancelled.set(true));
-        BinaryData body = BinaryData.fromFlux(content, null, false).block();
-
-        StepVerifier.create(ServerSentEventStream.decode(body, (event, data) -> data))
-            .assertNext(event -> assertEquals("payload", event.getData()))
-            .thenCancel()
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> data))
+            .assertNext(event -> assertEquals("one", event.getData()))
+            .expectErrorMatches(error -> error == failure)
             .verify();
 
-        assertTrue(cancelled.get());
+        assertTrue(response.closed.get());
     }
 
     @Test
-    public void protocolSyncAndAsyncDecodingHaveMatchingFraming() {
-        String content = "event: first\ndata: one\r\n\r\nevent: second\ndata: two\n\n";
-        List<ServerSentEvent<String>> syncEvents = new ArrayList<>();
-        ServerSentEventStream.process(BinaryData.fromString(content), (event, data) -> data, syncEvents::add);
+    public void toFluxPropagatesConverterFailureAndClosesResponse() {
+        RuntimeException failure = new IllegalStateException("invalid event");
+        TestResponse response = response(200, BinaryData.fromString("data: invalid\n\n"));
 
-        List<ServerSentEvent<String>> asyncEvents
-            = ServerSentEventStream.decode(BinaryData.fromString(content), (event, data) -> data).collectList().block();
+        StepVerifier.create(ServerSentEventStreams.toFlux(response, (event, data) -> {
+            throw failure;
+        })).expectErrorMatches(error -> error == failure).verify();
 
-        assertEquals(2, asyncEvents.size());
-        assertEquals(Arrays.asList(syncEvents.get(0).getEvent(), syncEvents.get(1).getEvent()),
-            Arrays.asList(asyncEvents.get(0).getEvent(), asyncEvents.get(1).getEvent()));
-        assertEquals(Arrays.asList(syncEvents.get(0).getData(), syncEvents.get(1).getData()),
-            Arrays.asList(asyncEvents.get(0).getData(), asyncEvents.get(1).getData()));
+        assertTrue(response.closed.get());
     }
 
-    private static void assertPersistentMetadata(List<ServerSentEvent<String>> events) {
-        assertEquals(2, events.size());
-        assertEquals(Arrays.asList("first", "second"), Arrays.asList(events.get(0).getData(), events.get(1).getData()));
-        for (ServerSentEvent<String> event : events) {
-            assertEquals("42", event.getId());
-            assertEquals(Duration.ofSeconds(2), event.getRetryAfter());
+    private static TestResponse response(int statusCode, BinaryData body) {
+        return response(statusCode, body, "text/event-stream");
+    }
+
+    private static TestResponse response(int statusCode, BinaryData body, String contentType) {
+        return new TestResponse(statusCode, new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, contentType), body);
+    }
+
+    private static final class TestResponse extends ResponseBase<Object, BinaryData> implements Closeable {
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private TestResponse(int statusCode, HttpHeaders headers, BinaryData value) {
+            super(null, statusCode, headers, value, null);
         }
-    }
 
-    private static void assertInitialMetadata(ServerSentEvent<String> event) {
-        assertEquals("1", event.getId());
-        assertEquals(Duration.ofSeconds(1), event.getRetryAfter());
-    }
-
-    private static ServerSentEventStreamResponse response(BinaryData body) {
-        return new ServerSentEventStreamResponse(200, body, () -> {
-        });
+        @Override
+        public void close() throws IOException {
+            closed.set(true);
+        }
     }
 }

--- a/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/implementation/util/ServerSentEventStreamTests.java
@@ -84,6 +84,26 @@ public class ServerSentEventStreamTests {
     }
 
     @Test
+    public void toFluxRejectsIncompatibleCharsetAndClosesResponse() {
+        TestResponse response
+            = response(200, BinaryData.fromString("data: one\n\n"), "text/event-stream; charset=utf-16");
+
+        assertThrows(IllegalStateException.class,
+            () -> ServerSentEventStreams.toFlux(response, (event, data) -> data).blockLast());
+
+        assertTrue(response.closed.get());
+    }
+
+    @Test
+    public void toFluxRejectsNonCloseableResponseBeforeValidatingContentType() {
+        ResponseBase<Object, BinaryData> response
+            = new ResponseBase<>(null, 200, new HttpHeaders(), BinaryData.fromString("data: one\n\n"), null);
+
+        assertThrows(IllegalArgumentException.class,
+            () -> ServerSentEventStreams.toFlux(response, (event, data) -> data).blockLast());
+    }
+
+    @Test
     public void toFluxRejectsMissingContentTypeAndClosesResponse() {
         TestResponse response = new TestResponse(200, new HttpHeaders(), BinaryData.fromString("data: one\n\n"));
 


### PR DESCRIPTION
## Summary

Adds minimal, single-response server-sent events support to `azure-core`, based on #50081.

- Adds `ServerSentEvent<T>`, `ServerSentEventListener<T>`, and `ServerSentEventStreams` for synchronous listener and asynchronous `Flux` consumption.
- Incrementally parses `text/event-stream` responses and supports optional service-defined terminal-event predicates.
- Preserves live response bodies through REST proxy decoding and returns a closeable `Response<BinaryData>` implementation for streaming responses.
- Prevents `HttpLoggingPolicy` from buffering SSE response bodies.
- Closes the physical response on completion, failure, interruption, terminal events, or Reactor cancellation.
- Bounds incomplete events to 16 MiB and uses a single data buffer to prevent unbounded heap growth.

## Scope

This PR intentionally handles one established HTTP response. It does not reconnect, replay requests, or send `Last-Event-Id`. Search client APIs, generated models, and emitter work remain separate.

## Contract

Response overloads require a closeable HTTP 200 or 204 response. Non-204 responses require exactly one `text/event-stream` content type and reject an explicit non-UTF-8 charset. Existing overloads complete on EOF or HTTP 204; predicate overloads require and inclusively deliver a matching terminal event.

## Validation

- Full `azure-core` test suite: 11,881 tests, 0 failures, 3 skipped
- Checkstyle: 0 violations
- SpotBugs: 0 findings