### PR TITLE
Update Resources TypeSpec source commit

### DIFF
--- a/sdk/resources/azure-resourcemanager-resources/tsp-location.yaml
+++ b/sdk/resources/azure-resourcemanager-resources/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/resources/resource-manager/Microsoft.Resources/resources
-commit: 8e1ccf713f549ade0d4bdf53f022585aa04fc723
+commit: eff5b0c137f2a0e303b60f5928f4879804b81796
 repo: Azure/azure-rest-api-specs
 additionalDirectories:


### PR DESCRIPTION
Updates the Resources package's `tsp-location.yaml` to the merged TypeSpec migration commit on `Azure/azure-rest-api-specs` main.

Related to #49803.
