### PR TITLE
[Service Bus] Prepare azure-messaging-servicebus 7.18.0-beta.3 release

### DIFF
--- a/sdk/servicebus/azure-messaging-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-messaging-servicebus/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Release History
 
-## 7.18.0-beta.3 (Unreleased)
+## 7.18.0-beta.3 (2026-08-21)
 
 ### Features Added
 
 - Added `listSessions()` and `listSessions(OffsetDateTime sessionStateUpdatedAfter)` to `ServiceBusSessionReceiverAsyncClient` (returning `PagedFlux<String>`) and `ServiceBusSessionReceiverClient` (returning `PagedIterable<String>`). The no-arg overload returns sessions with active messages; the `sessionStateUpdatedAfter` overload returns sessions whose session state was updated after the given timestamp. Implements the `com.microsoft:get-message-sessions` AMQP management operation. ([#48956](https://github.com/Azure/azure-sdk-for-java/pull/48956))
 - Added `getSqlFilterCount()` and `getCorrelationFilterCount()` to `TopicRuntimeProperties`, exposing the total number of SQL filters and correlation filters across all of a topic's subscriptions.
 - Added `ServiceBusServiceVersion.V2024_05` and made it the latest version. The administration client now uses `api-version=2024-05` by default, which is required for the topic filter counts above.
-
-### Breaking Changes
 
 ### Bugs Fixed
 

--- a/sdk/servicebus/azure-messaging-servicebus/README.md
+++ b/sdk/servicebus/azure-messaging-servicebus/README.md
@@ -70,7 +70,7 @@ add the direct dependency to your project as follows.
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-messaging-servicebus</artifactId>
-    <version>7.18.0-beta.2</version>
+    <version>7.18.0-beta.3</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})


### PR DESCRIPTION
## Summary

Prepares `azure-messaging-servicebus` `7.18.0-beta.3` for the planned
August 21, 2026 release.

## Changes

- `sdk/servicebus/azure-messaging-servicebus/CHANGELOG.md`
- `sdk/servicebus/azure-messaging-servicebus/README.md`

Updates the README dependency example to the release version. No product code
changes.

## Cross-SDK release set

| SDK | Package | Version | PR |
|-----|---------|---------|----|
| .NET | `Azure.Messaging.ServiceBus` | `7.21.0-beta.1` | [#62282](https://github.com/Azure/azure-sdk-for-net/pull/62282) |
| Java | `azure-messaging-servicebus` | `7.18.0-beta.3` | [#50198](https://github.com/Azure/azure-sdk-for-java/pull/50198) |
| JavaScript | `@azure/service-bus` | `7.10.0-beta.5` | [#39672](https://github.com/Azure/azure-sdk-for-js/pull/39672) |
| Go | `sdk/messaging/azservicebus` | `1.11.0-beta.1` | [#27420](https://github.com/Azure/azure-sdk-for-go/pull/27420) |
| Python | `azure-servicebus` | `7.15.0b2` | [#48649](https://github.com/Azure/azure-sdk-for-python/pull/48649) |

## Validation

- `./eng/common/scripts/Prepare-Release.ps1 -PackageName azure-messaging-servicebus -ServiceDirectory servicebus -GroupId com.azure -ReleaseDate '08/21/2026'`
- `git diff --check`
- Metadata-only change; no product tests required.

## Release controls

- Release tracking: [22249 - Java - Service Bus - 7.18](https://dev.azure.com/azure-sdk/Release/_workitems/edit/22249/)
- Release pipeline: Not queued by this PR.
