### PR TITLE
Fix credential headers on cross-authority redirects

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Prevented key credential headers from being forwarded when a redirect changes the request authority.
+  ([#50215](https://github.com/Azure/azure-sdk-for-java/issues/50215))
+
 ### Other Changes
 
 ## 1.59.0 (2026-08-12)

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/policy/KeyCredentialPolicy.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/policy/KeyCredentialPolicy.java
@@ -23,6 +23,9 @@ import java.util.Objects;
  * <p>This class is useful when you need to authorize requests with a key. It ensures that the requests are sent over
  * HTTPS to prevent the key from being leaked. The key is set in the header of the HTTP request.</p>
  *
+ * <p>When used with {@link RedirectPolicy}, the key is not included in a redirected request if the redirect changes
+ * the request authority.</p>
+ *
  * <p><strong>Code sample:</strong></p>
  *
  * <p>In this example, a {@code KeyCredentialPolicy} is created with a key and a header name. The policy can then be
@@ -100,7 +103,7 @@ public class KeyCredentialPolicy implements HttpPipelinePolicy {
                 new IllegalStateException("Key credentials require HTTPS to prevent leaking the key."));
         }
 
-        setCredential(context.getHttpRequest().getHeaders());
+        setCredential(context);
         return next.process();
     }
 
@@ -111,8 +114,16 @@ public class KeyCredentialPolicy implements HttpPipelinePolicy {
                 new IllegalStateException("Key credentials require HTTPS to prevent leaking the key."));
         }
 
-        setCredential(context.getHttpRequest().getHeaders());
+        setCredential(context);
         return next.processSync();
+    }
+
+    private void setCredential(HttpPipelineCallContext context) {
+        if (RedirectPolicy.shouldSetSensitiveHeader(context, name)) {
+            setCredential(context.getHttpRequest().getHeaders());
+        } else {
+            context.getHttpRequest().getHeaders().remove(name);
+        }
     }
 
     void setCredential(HttpHeaders headers) {

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/policy/RedirectPolicy.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/policy/RedirectPolicy.java
@@ -11,7 +11,10 @@ import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import reactor.core.publisher.Mono;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -23,6 +26,9 @@ import java.util.Set;
  * <p>This class is useful when you need to handle HTTP redirects in a pipeline. It uses a {@link RedirectStrategy} to
  * decide if a request should be redirected. By default, it uses the {@link DefaultRedirectStrategy}, which redirects
  * the request based on the HTTP status code of the response.</p>
+ *
+ * <p>When a redirect changes the request authority, credential headers added by Azure Core credential policies are
+ * removed from the redirected request.</p>
  *
  * <p><strong>Code sample:</strong></p>
  *
@@ -45,6 +51,8 @@ import java.util.Set;
  * @see com.azure.core.http.policy.DefaultRedirectStrategy
  */
 public final class RedirectPolicy implements HttpPipelinePolicy {
+    private static final String SENSITIVE_HEADERS_CONTEXT_KEY
+        = "com.azure.core.http.policy.RedirectPolicy.sensitiveHeaders";
     private final RedirectStrategy redirectStrategy;
 
     /**
@@ -89,7 +97,7 @@ public final class RedirectPolicy implements HttpPipelinePolicy {
 
         return next.clone().process().flatMap(httpResponse -> {
             if (redirectStrategy.shouldAttemptRedirect(context, httpResponse, redirectAttempt, attemptedRedirectUrls)) {
-                HttpRequest redirectRequestCopy = createRedirectRequest(httpResponse);
+                HttpRequest redirectRequestCopy = createRedirectRequest(context, httpResponse);
                 return attemptRedirect(context, next, redirectRequestCopy, redirectAttempt + 1, attemptedRedirectUrls);
             } else {
                 return Mono.just(httpResponse);
@@ -110,20 +118,57 @@ public final class RedirectPolicy implements HttpPipelinePolicy {
         HttpResponse httpResponse = next.clone().processSync();
 
         if (redirectStrategy.shouldAttemptRedirect(context, httpResponse, redirectAttempt, attemptedRedirectUrls)) {
-            HttpRequest redirectRequestCopy = createRedirectRequest(httpResponse);
+            HttpRequest redirectRequestCopy = createRedirectRequest(context, httpResponse);
             return attemptRedirectSync(context, next, redirectRequestCopy, redirectAttempt + 1, attemptedRedirectUrls);
         } else {
             return httpResponse;
         }
     }
 
-    private HttpRequest createRedirectRequest(HttpResponse redirectResponse) {
-        // Clear the authorization header to avoid the client to be redirected to an untrusted third party server
-        // causing it to leak your authorization token to.
-        redirectResponse.getRequest().getHeaders().remove(HttpHeaderName.AUTHORIZATION);
+    private HttpRequest createRedirectRequest(HttpPipelineCallContext context, HttpResponse redirectResponse) {
         HttpRequest redirectRequestCopy = redirectStrategy.createRedirectRequest(redirectResponse);
+        removeSensitiveHeaders(context, redirectRequestCopy);
         redirectResponse.close();
 
         return redirectRequestCopy;
+    }
+
+    private static void removeSensitiveHeaders(HttpPipelineCallContext context, HttpRequest redirectRequest) {
+        // Authorization has historically been removed on every redirect.
+        redirectRequest.getHeaders().remove(HttpHeaderName.AUTHORIZATION);
+
+        String redirectAuthority = getAuthority(redirectRequest);
+        getSensitiveHeaders(context).forEach((headerName, authority) -> {
+            if (!authority.equals(redirectAuthority)) {
+                redirectRequest.getHeaders().remove(headerName);
+            }
+        });
+    }
+
+    static boolean shouldSetSensitiveHeader(HttpPipelineCallContext context, HttpHeaderName headerName) {
+        Map<HttpHeaderName, String> sensitiveHeaders = getSensitiveHeaders(context);
+        String authority = getAuthority(context.getHttpRequest());
+        String originalAuthority = sensitiveHeaders.get(headerName);
+        if (originalAuthority == null) {
+            sensitiveHeaders.put(headerName, authority);
+            context.setData(SENSITIVE_HEADERS_CONTEXT_KEY, sensitiveHeaders);
+            return true;
+        }
+
+        return originalAuthority.equals(authority);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<HttpHeaderName, String> getSensitiveHeaders(HttpPipelineCallContext context) {
+        return (Map<HttpHeaderName, String>) context.getData(SENSITIVE_HEADERS_CONTEXT_KEY).orElseGet(HashMap::new);
+    }
+
+    private static String getAuthority(HttpRequest request) {
+        int port = request.getUrl().getPort();
+        if (port == -1) {
+            port = request.getUrl().getDefaultPort();
+        }
+        return (request.getUrl().getProtocol() + "://" + request.getUrl().getHost() + ":" + port)
+            .toLowerCase(Locale.ROOT);
     }
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/core/http/policy/RedirectPolicy.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/core/http/policy/RedirectPolicy.java
@@ -126,6 +126,9 @@ public final class RedirectPolicy implements HttpPipelinePolicy {
     }
 
     private HttpRequest createRedirectRequest(HttpPipelineCallContext context, HttpResponse redirectResponse) {
+        // Clear authorization before invoking the redirect strategy to avoid exposing it to custom strategies.
+        redirectResponse.getRequest().getHeaders().remove(HttpHeaderName.AUTHORIZATION);
+
         HttpRequest redirectRequestCopy = redirectStrategy.createRedirectRequest(redirectResponse);
         removeSensitiveHeaders(context, redirectRequestCopy);
         redirectResponse.close();

--- a/sdk/core/azure-core/src/test/java/com/azure/core/http/policy/RedirectPolicyTest.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/core/http/policy/RedirectPolicyTest.java
@@ -5,6 +5,7 @@ package com.azure.core.http.policy;
 
 import com.azure.core.SyncAsyncExtension;
 import com.azure.core.SyncAsyncTest;
+import com.azure.core.credential.AzureKeyCredential;
 import com.azure.core.http.HttpClient;
 import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpHeaders;
@@ -328,6 +329,57 @@ public class RedirectPolicyTest {
             () -> sendRequest(pipeline, HttpMethod.GET))) {
             assertEquals(200, response.getStatusCode());
             assertNull(response.getRequest().getHeaders().getValue(HttpHeaderName.AUTHORIZATION));
+        }
+    }
+
+    @SyncAsyncTest
+    public void crossAuthorityRedirectClearsKeyCredentialHeader() throws Exception {
+        assertCrossAuthorityRedirectClearsKeyCredentialHeader(new RedirectPolicy(),
+            new AzureKeyCredentialPolicy("api-key", new AzureKeyCredential("credential")));
+    }
+
+    @SyncAsyncTest
+    public void crossAuthorityRedirectClearsKeyCredentialHeaderWhenCredentialPolicyRunsFirst() throws Exception {
+        assertCrossAuthorityRedirectClearsKeyCredentialHeader(
+            new AzureKeyCredentialPolicy("api-key", new AzureKeyCredential("credential")), new RedirectPolicy());
+    }
+
+    @SyncAsyncTest
+    public void sameAuthorityRedirectPreservesKeyCredentialHeader() throws Exception {
+        RecordingHttpClient httpClient = new RecordingHttpClient(request -> {
+            if (request.getUrl().getPath().equals("/")) {
+                return Mono.just(new MockHttpResponse(request, 308,
+                    new HttpHeaders().set(HttpHeaderName.LOCATION, "https://localhost/redirected")));
+            }
+            return Mono.just(new MockHttpResponse(request, 200));
+        });
+        HttpPipeline pipeline = new HttpPipelineBuilder().httpClient(httpClient)
+            .policies(new RedirectPolicy(),
+                new AzureKeyCredentialPolicy("api-key", new AzureKeyCredential("credential")))
+            .build();
+
+        try (HttpResponse response = SyncAsyncExtension.execute(
+            () -> pipeline.sendSync(new HttpRequest(HttpMethod.GET, createUrl("https://localhost/")), Context.NONE),
+            () -> pipeline.send(new HttpRequest(HttpMethod.GET, createUrl("https://localhost/"))))) {
+            assertEquals("credential", response.getRequest().getHeaders().getValue("api-key"));
+        }
+    }
+
+    private static void assertCrossAuthorityRedirectClearsKeyCredentialHeader(HttpPipelinePolicy... policies)
+        throws Exception {
+        RecordingHttpClient httpClient = new RecordingHttpClient(request -> {
+            if (request.getUrl().getHost().equals("localhost")) {
+                return Mono.just(new MockHttpResponse(request, 308,
+                    new HttpHeaders().set(HttpHeaderName.LOCATION, "https://redirecthost/")));
+            }
+            return Mono.just(new MockHttpResponse(request, 200));
+        });
+        HttpPipeline pipeline = new HttpPipelineBuilder().httpClient(httpClient).policies(policies).build();
+
+        try (HttpResponse response = SyncAsyncExtension.execute(
+            () -> pipeline.sendSync(new HttpRequest(HttpMethod.GET, createUrl("https://localhost/")), Context.NONE),
+            () -> pipeline.send(new HttpRequest(HttpMethod.GET, createUrl("https://localhost/"))))) {
+            assertNull(response.getRequest().getHeaders().getValue("api-key"));
         }
     }
 


### PR DESCRIPTION
# Description

Fixes credential leakage across cross-authority HTTP redirects in `azure-core`.

`RedirectPolicy` previously removed only the `Authorization` header. Custom credential headers added by `KeyCredentialPolicy` or `AzureKeyCredentialPolicy`, such as `api-key`, could be forwarded or reapplied when a redirect changed the request authority.

This pull request:

- Tracks key credential headers and their originating authority.
- Removes these headers when a redirect changes the scheme, host, or effective port.
- Prevents credential policies from reapplying the headers to an untrusted redirect destination.
- Preserves credentials for same-authority redirects.
- Preserves the existing behavior of removing `Authorization` on redirects.
- Adds synchronous and asynchronous coverage for both policy orderings and same-authority redirects.
- Documents the behavior in JavaDoc and the `azure-core` CHANGELOG.

Fixes #50215

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
