### PR TITLE
WIP Demo Java APIView snapshots for agent review

### DIFF
--- a/eng/common/scripts/Export-APIViewMarkdown.ps1
+++ b/eng/common/scripts/Export-APIViewMarkdown.ps1
@@ -17,14 +17,11 @@ Required. Path to the input APIView token JSON file.
 Required. Path to write the output markdown file. If a directory is given, the file will be
 named api.md inside that directory.
 
-.PARAMETER ExcludeDocumentation
-Optional. Excludes lines whose tokens are all marked as documentation.
-
 .EXAMPLE
 ./Export-APIViewMarkdown.ps1 -TokenJsonPath ./azure-core_python.json -OutputPath ./api.md
 
 .EXAMPLE
-./Export-APIViewMarkdown.ps1 -TokenJsonPath ./azure-sdk_java.json -OutputPath ./output/ -ExcludeDocumentation
+./Export-APIViewMarkdown.ps1 -TokenJsonPath ./azure-sdk_java.json -OutputPath ./output/
 #>
 
 [CmdletBinding()]
@@ -33,9 +30,7 @@ param(
     [string]$TokenJsonPath,
 
     [Parameter(Mandatory = $true)]
-    [string]$OutputPath,
-
-    [switch]$ExcludeDocumentation
+    [string]$OutputPath
 )
 
 Set-StrictMode -Version 3
@@ -48,10 +43,8 @@ function Render-Token {
     #>
     param([PSCustomObject]$Token)
 
-    $prefixSpace = $Token.PSObject.Properties.Item('HasPrefixSpace')
-    $suffixSpace = $Token.PSObject.Properties.Item('HasSuffixSpace')
-    $prefix = if ($null -ne $prefixSpace -and $prefixSpace.Value -eq $true) { " " } else { "" }
-    $suffix = if ($null -eq $suffixSpace -or $suffixSpace.Value -eq $true) { " " } else { "" }
+    $prefix = if ($Token.HasPrefixSpace -eq $true) { " " } else { "" }
+    $suffix = if ($Token.HasSuffixSpace -eq $true) { " " } else { "" }
     return "$prefix$($Token.Value)$suffix"
 }
 
@@ -70,16 +63,6 @@ function Render-ReviewLines {
 
     foreach ($line in $ReviewLines) {
         $tokens = @($line.Tokens)
-
-        if ($ExcludeDocumentation -and $tokens.Count -gt 0) {
-            $documentationTokens = @($tokens | Where-Object {
-                $documentationProperty = $_.PSObject.Properties.Item('IsDocumentation')
-                $null -ne $documentationProperty -and $documentationProperty.Value -eq $true
-            })
-            if ($documentationTokens.Count -eq $tokens.Count) {
-                continue
-            }
-        }
 
         if ($tokens.Count -eq 0) {
             # Blank line

--- a/eng/common/scripts/Export-APIViewMarkdown.ps1
+++ b/eng/common/scripts/Export-APIViewMarkdown.ps1
@@ -17,11 +17,14 @@ Required. Path to the input APIView token JSON file.
 Required. Path to write the output markdown file. If a directory is given, the file will be
 named api.md inside that directory.
 
+.PARAMETER ExcludeDocumentation
+Optional. Excludes lines whose tokens are all marked as documentation.
+
 .EXAMPLE
 ./Export-APIViewMarkdown.ps1 -TokenJsonPath ./azure-core_python.json -OutputPath ./api.md
 
 .EXAMPLE
-./Export-APIViewMarkdown.ps1 -TokenJsonPath ./azure-sdk_java.json -OutputPath ./output/
+./Export-APIViewMarkdown.ps1 -TokenJsonPath ./azure-sdk_java.json -OutputPath ./output/ -ExcludeDocumentation
 #>
 
 [CmdletBinding()]
@@ -30,7 +33,9 @@ param(
     [string]$TokenJsonPath,
 
     [Parameter(Mandatory = $true)]
-    [string]$OutputPath
+    [string]$OutputPath,
+
+    [switch]$ExcludeDocumentation
 )
 
 Set-StrictMode -Version 3
@@ -43,8 +48,10 @@ function Render-Token {
     #>
     param([PSCustomObject]$Token)
 
-    $prefix = if ($Token.HasPrefixSpace -eq $true) { " " } else { "" }
-    $suffix = if ($Token.HasSuffixSpace -eq $true) { " " } else { "" }
+    $prefixSpace = $Token.PSObject.Properties.Item('HasPrefixSpace')
+    $suffixSpace = $Token.PSObject.Properties.Item('HasSuffixSpace')
+    $prefix = if ($null -ne $prefixSpace -and $prefixSpace.Value -eq $true) { " " } else { "" }
+    $suffix = if ($null -eq $suffixSpace -or $suffixSpace.Value -eq $true) { " " } else { "" }
     return "$prefix$($Token.Value)$suffix"
 }
 
@@ -63,6 +70,16 @@ function Render-ReviewLines {
 
     foreach ($line in $ReviewLines) {
         $tokens = @($line.Tokens)
+
+        if ($ExcludeDocumentation -and $tokens.Count -gt 0) {
+            $documentationTokens = @($tokens | Where-Object {
+                $documentationProperty = $_.PSObject.Properties.Item('IsDocumentation')
+                $null -ne $documentationProperty -and $documentationProperty.Value -eq $true
+            })
+            if ($documentationTokens.Count -eq $tokens.Count) {
+                continue
+            }
+        }
 
         if ($tokens.Count -eq 0) {
             # Blank line

--- a/sdk/core/azure-core/api.md
+++ b/sdk/core/azure-core/api.md
@@ -212,7 +212,7 @@ package com.azure.core.annotation {
     public @annotation ServiceClient {
         Class<?> builder()
         boolean isAsync() default false
-        Class<?>[] serviceInterfaces() default {  }
+        Class<?>[] serviceInterfaces() default { }
     }
     @Retention(RUNTIME)
     @Target(TYPE)
@@ -239,7 +239,7 @@ package com.azure.core.annotation {
     @Target(METHOD)
     public @annotation UnexpectedResponseExceptionType {
         Class<? extends HttpResponseException> value()
-        int[] code() default {  }
+        int[] code() default { }
     }
     @Retention(RUNTIME)
     @Target(METHOD)

--- a/sdk/core/azure-core/api.md
+++ b/sdk/core/azure-core/api.md
@@ -11,7 +11,6 @@ maven {
     name : Microsoft Azure Java Core Library
     description : This package contains core types for Azure Java clients.
     dependencies {
-        // compile scope
         com.azure:azure-json 1.5.1
         com.azure:azure-xml 1.2.1
         com.fasterxml.jackson.core:jackson-annotations 2.18.9
@@ -20,7 +19,6 @@ maven {
         com.fasterxml.jackson.datatype:jackson-datatype-jsr310 2.18.9
         org.slf4j:slf4j-api 1.7.36
         io.projectreactor:reactor-core 3.7.19
-        // provided scope
         com.google.code.findbugs:jsr305 3.0.2
     }
 }
@@ -99,7 +97,6 @@ package com.azure.core.annotation {
     @Retention(SOURCE)
     @Target(TYPE)
     public @annotation Fluent {
-        // This annotation does not declare any members.
     }
     @Retention(RUNTIME)
     @Target(PARAMETER)
@@ -110,7 +107,6 @@ package com.azure.core.annotation {
     @Retention(SOURCE)
     @Target({ METHOD, CONSTRUCTOR, FIELD })
     public @annotation Generated {
-        // This annotation does not declare any members.
     }
     @Retention(RUNTIME)
     @Target(METHOD)
@@ -151,12 +147,10 @@ package com.azure.core.annotation {
     @Retention(SOURCE)
     @Target(TYPE)
     public @annotation Immutable {
-        // This annotation does not declare any members.
     }
     @Retention(RUNTIME)
     @Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD })
     public @annotation JsonFlatten {
-        // This annotation does not declare any members.
     }
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
@@ -195,7 +189,6 @@ package com.azure.core.annotation {
     @Retention(RUNTIME)
     @Target(METHOD)
     public @annotation ResumeOperation {
-        // This annotation does not declare any members.
     }
     public enum ReturnType {
         SINGLE,
@@ -304,7 +297,6 @@ package com.azure.core.credential {
     }
     @Immutable
     public final class AzureNamedKey {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public String getKey()
         public String getName()
     }
@@ -451,7 +443,6 @@ package com.azure.core.http {
         public static final String APPLICATION_JSON = "application/json";
         public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
         public static final String APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded";
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
     }
     @Immutable
     public final class HttpAuthorization {
@@ -598,7 +589,6 @@ package com.azure.core.http {
         CONNECT;
     }
     public final class HttpPipeline {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public HttpClient getHttpClient()
         public HttpPipelinePolicy getPolicy(int index)
         public int getPolicyCount()
@@ -617,7 +607,6 @@ package com.azure.core.http {
         public HttpPipeline build()
     }
     public final class HttpPipelineCallContext {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Context getContext()
         public Optional<Object> getData(String key)
         public void setData(String key, Object value)
@@ -625,12 +614,10 @@ package com.azure.core.http {
         public HttpPipelineCallContext setHttpRequest(HttpRequest request)
     }
     public class HttpPipelineNextPolicy {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Override public HttpPipelineNextPolicy clone()
         public Mono<HttpResponse> process()
     }
     public class HttpPipelineNextSyncPolicy {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Override public HttpPipelineNextSyncPolicy clone()
         public HttpResponse processSync()
     }
@@ -745,7 +732,6 @@ package com.azure.core.http.policy {
         @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
     }
     public interface AfterRetryPolicyProvider extends HttpPolicyProvider {
-        // This interface does not declare any API.
     }
     public final class AzureKeyCredentialPolicy extends KeyCredentialPolicy {
         public AzureKeyCredentialPolicy(String name, AzureKeyCredential credential)
@@ -769,7 +755,6 @@ package com.azure.core.http.policy {
         @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
     }
     public interface BeforeRetryPolicyProvider extends HttpPolicyProvider {
-        // This interface does not declare any API.
     }
     public class CookiePolicy implements HttpPipelinePolicy {
         public CookiePolicy()
@@ -875,7 +860,6 @@ package com.azure.core.http.policy {
         HttpPipelinePolicy create()
     }
     public final class HttpPolicyProviders {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static void addAfterRetryPolicies(List<HttpPipelinePolicy> policies)
         public static void addBeforeRetryPolicies(List<HttpPipelinePolicy> policies)
     }
@@ -886,7 +870,6 @@ package com.azure.core.http.policy {
         default void logRequestSync(ClientLogger logger, HttpRequestLoggingContext loggingOptions)
     }
     public final class HttpRequestLoggingContext {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Context getContext()
         public HttpRequest getHttpRequest()
         public Integer getTryCount()
@@ -898,7 +881,6 @@ package com.azure.core.http.policy {
         default HttpResponse logResponseSync(ClientLogger logger, HttpResponseLoggingContext loggingOptions)
     }
     public final class HttpResponseLoggingContext {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Context getContext()
         public HttpResponse getHttpResponse()
         public Duration getResponseDuration()
@@ -938,7 +920,6 @@ package com.azure.core.http.policy {
         @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
     }
     public final class RequestRetryCondition {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public HttpResponse getResponse()
         public List<Throwable> getRetriedThrowables()
         public Throwable getThrowable()
@@ -1060,7 +1041,6 @@ package com.azure.core.http.rest {
         @Override public T getValue()
     }
     public final class RestProxy implements InvocationHandler {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static <A> A create(Class<A> swaggerInterface)
         public static <A> A create(Class<A> swaggerInterface, HttpPipeline httpPipeline)
         public static <A> A create(Class<A> swaggerInterface, HttpPipeline httpPipeline, SerializerAdapter serializer)
@@ -1319,7 +1299,6 @@ package com.azure.core.util {
         @Override public String toString()
     }
     public final class Base64Util {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static byte[] decode(byte[] encoded)
         public static byte[] decodeString(String encoded)
         public static byte[] decodeURL(byte[] src)
@@ -1328,7 +1307,6 @@ package com.azure.core.util {
         public static byte[] encodeURLWithoutPadding(byte[] src)
     }
     public final class BinaryData {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static BinaryData fromByteBuffer(ByteBuffer data)
         public static BinaryData fromBytes(byte[] data)
         public static BinaryData fromFile(Path file)
@@ -1442,7 +1420,6 @@ package com.azure.core.util {
         public Configuration buildSection(String path)
     }
     public final class ConfigurationProperty<T> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Iterable<String> getAliases()
         public Function<String, T> getConverter()
         public T getDefaultValue()
@@ -1482,7 +1459,6 @@ package com.azure.core.util {
         public Map<Object, Object> getValues()
     }
     public final class Contexts {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Context getContext()
         public static Contexts empty()
         public ProgressReporter getHttpRequestProgressReporter()
@@ -1490,7 +1466,6 @@ package com.azure.core.util {
         public static Contexts with(Context context)
     }
     public final class CoreUtils {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static Thread addShutdownHookSafely(Thread shutdownThread)
         public static ExecutorService addShutdownHookSafely(ExecutorService executorService, Duration shutdownTimeout)
         public static String getApplicationId(ClientOptions clientOptions, HttpLogOptions logOptions)
@@ -1548,7 +1523,6 @@ package com.azure.core.util {
         protected static <T extends ExpandableStringEnum<T>> Collection<T> values(Class<T> clazz)
     }
     public final class FluxUtil {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static Flux<ByteBuffer> addProgressReporting(Flux<ByteBuffer> flux, ProgressReporter progressReporter)
         public static byte[] byteBufferToArray(ByteBuffer byteBuffer)
         public static Mono<byte[]> collectBytesFromNetworkResponse(Flux<ByteBuffer> stream, HttpHeaders headers)
@@ -1646,7 +1620,6 @@ package com.azure.core.util {
         void handleProgress(long progress)
     }
     public final class ProgressReporter {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public ProgressReporter createChild()
         public void reportProgress(long progress)
         public void reset()
@@ -1660,7 +1633,6 @@ package com.azure.core.util {
         String getVersion()
     }
     public final class SharedExecutorService implements ScheduledExecutorService {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Override public boolean awaitTermination(long timeout, TimeUnit unit)
         @Override public void execute(Runnable command)
         public ScheduledExecutorService getExecutorService()
@@ -1685,7 +1657,6 @@ package com.azure.core.util {
     }
     @Immutable
     public interface TelemetryAttributes {
-        // This interface does not declare any API.
     }
     public class TracingOptions {
         public TracingOptions()
@@ -1720,26 +1691,22 @@ package com.azure.core.util {
         public URL toUrl() throws MalformedURLException
     }
     public class UserAgentProperties {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public String getName()
         public String getVersion()
     }
     public final class UserAgentUtil {
         public static final String DEFAULT_USER_AGENT_HEADER = "azsdk-java";
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static String toUserAgentString(String applicationId, String sdkName, String sdkVersion, Configuration configuration)
     }
 }
 package com.azure.core.util.builder {
     public final class ClientBuilderUtil {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static HttpPipelinePolicy validateAndGetRetryPolicy(HttpPipelinePolicy retryPolicy, RetryOptions retryOptions)
         public static HttpPipelinePolicy validateAndGetRetryPolicy(HttpPipelinePolicy retryPolicy, RetryOptions retryOptions, HttpPipelinePolicy defaultPolicy)
     }
 }
 package com.azure.core.util.io {
     public final class IOUtils {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static AsynchronousByteChannel toAsynchronousByteChannel(AsynchronousFileChannel fileChannel, long position)
         public static void transfer(ReadableByteChannel source, WritableByteChannel destination) throws IOException
         public static void transfer(ReadableByteChannel source, WritableByteChannel destination, Long estimatedSourceSize) throws IOException
@@ -1787,7 +1754,6 @@ package com.azure.core.util.logging {
     }
     @Fluent
     public final class LoggingEventBuilder {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public LoggingEventBuilder addKeyValue(String key, String value)
         public LoggingEventBuilder addKeyValue(String key, Object value)
         public LoggingEventBuilder addKeyValue(String key, boolean value)
@@ -1880,7 +1846,6 @@ package com.azure.core.util.paging {
 }
 package com.azure.core.util.polling {
     public final class AsyncPollResponse<T, U> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Mono<T> cancelOperation()
         public Mono<U> getFinalResult()
         public LongRunningOperationStatus getStatus()
@@ -1939,7 +1904,6 @@ package com.azure.core.util.polling {
     }
     @Immutable
     public final class PollOperationDetails implements JsonSerializable<PollOperationDetails> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public ResponseError getError()
         public String getOperationId()
     }
@@ -1961,7 +1925,6 @@ package com.azure.core.util.polling {
         public SyncPoller<T, U> getSyncPoller()
     }
     public final class PollingContext<T> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public PollResponse<T> getActivationResponse()
         public String getData(String name)
         public PollingContext<T> setData(String name, String value)
@@ -2106,7 +2069,6 @@ package com.azure.core.util.serializer {
         JsonSerializer createInstance()
     }
     public final class JsonSerializerProviders {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static JsonSerializer createInstance()
         public static JsonSerializer createInstance(boolean useDefaultIfAbsent)
     }
@@ -2117,7 +2079,6 @@ package com.azure.core.util.serializer {
         MemberNameConverter createInstance()
     }
     public final class MemberNameConverterProviders {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static MemberNameConverter createInstance()
     }
     public interface ObjectSerializer {
@@ -2223,7 +2184,6 @@ package com.azure.core.util.tracing {
     }
     @Deprecated
     public final class TracerProxy {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static void setAttribute(String key, String value, Context context)
         public static void end(int responseCode, Throwable error, Context context)
         public static Context setSpanName(String spanName, Context context)

--- a/sdk/core/azure-core/api.md
+++ b/sdk/core/azure-core/api.md
@@ -1,0 +1,2242 @@
+```java
+maven {
+    parent : com.azure:azure-client-sdk-parent:1.7.0
+    properties : com.azure:azure-core:1.60.0-beta.1
+    configuration {
+        jacoco {
+            min-line-coverage : 0.6
+            min-branch-coverage : 0.6
+        }
+    }
+    name : Microsoft Azure Java Core Library
+    description : This package contains core types for Azure Java clients.
+    dependencies {
+        // compile scope
+        com.azure:azure-json 1.5.1
+        com.azure:azure-xml 1.2.1
+        com.fasterxml.jackson.core:jackson-annotations 2.18.9
+        com.fasterxml.jackson.core:jackson-core 2.18.9
+        com.fasterxml.jackson.core:jackson-databind 2.18.9
+        com.fasterxml.jackson.datatype:jackson-datatype-jsr310 2.18.9
+        org.slf4j:slf4j-api 1.7.36
+        io.projectreactor:reactor-core 3.7.19
+        // provided scope
+        com.google.code.findbugs:jsr305 3.0.2
+    }
+}
+module com.azure.core {
+    requires transitive com.azure.json;
+    requires transitive com.azure.xml;
+    requires transitive reactor.core;
+    requires transitive org.reactivestreams;
+    requires transitive org.slf4j;
+    requires transitive com.fasterxml.jackson.annotation;
+    requires transitive com.fasterxml.jackson.core;
+    requires transitive com.fasterxml.jackson.databind;
+    requires transitive com.fasterxml.jackson.datatype.jsr310;
+    exports com.azure.core.annotation;
+    exports com.azure.core.client.traits;
+    exports com.azure.core.credential;
+    exports com.azure.core.cryptography;
+    exports com.azure.core.exception;
+    exports com.azure.core.http;
+    exports com.azure.core.http.policy;
+    exports com.azure.core.http.rest;
+    exports com.azure.core.models;
+    exports com.azure.core.util;
+    exports com.azure.core.util.builder;
+    exports com.azure.core.util.io;
+    exports com.azure.core.util.logging;
+    exports com.azure.core.util.paging;
+    exports com.azure.core.util.polling;
+    exports com.azure.core.util.serializer;
+    exports com.azure.core.util.tracing;
+    exports com.azure.core.util.metrics;
+    exports com.azure.core.implementation to com.azure.core.serializer.json.jackson, com.azure.core.serializer.json.gson, com.azure.core.experimental, com.azure.core.http.vertx;
+    exports com.azure.core.implementation.jackson to com.azure.core.management, com.azure.core.serializer.json.jackson;
+    exports com.azure.core.implementation.util to com.azure.http.netty, com.azure.core.http.okhttp, com.azure.core.http.jdk.httpclient, com.azure.core.http.vertx, com.azure.core.serializer.json.jackson;
+    exports com.azure.core.util.polling.implementation to com.azure.core.experimental;
+    opens com.azure.core.credential to com.fasterxml.jackson.databind;
+    opens com.azure.core.http to com.fasterxml.jackson.databind;
+    opens com.azure.core.models to com.fasterxml.jackson.databind;
+    opens com.azure.core.util to com.fasterxml.jackson.databind;
+    opens com.azure.core.util.logging to com.fasterxml.jackson.databind;
+    opens com.azure.core.util.polling to com.fasterxml.jackson.databind;
+    opens com.azure.core.util.polling.implementation to com.fasterxml.jackson.databind;
+    opens com.azure.core.util.serializer to com.fasterxml.jackson.databind;
+    opens com.azure.core.implementation to com.fasterxml.jackson.databind;
+    opens com.azure.core.implementation.logging to com.fasterxml.jackson.databind;
+    opens com.azure.core.implementation.serializer to com.fasterxml.jackson.databind;
+    opens com.azure.core.implementation.jackson to com.fasterxml.jackson.databind;
+    opens com.azure.core.implementation.util to com.fasterxml.jackson.databind;
+    opens com.azure.core.implementation.http.rest to com.fasterxml.jackson.databind;
+    opens com.azure.core.http.rest to com.fasterxml.jackson.databind;
+    uses com.azure.core.http.HttpClientProvider;
+    uses com.azure.core.http.policy.BeforeRetryPolicyProvider;
+    uses com.azure.core.http.policy.AfterRetryPolicyProvider;
+    uses com.azure.core.util.serializer.JsonSerializerProvider;
+    uses com.azure.core.util.serializer.MemberNameConverterProvider;
+    uses com.azure.core.util.tracing.Tracer;
+    uses com.azure.core.util.metrics.MeterProvider;
+    uses com.azure.core.util.tracing.TracerProvider;
+}
+package com.azure.core.annotation {
+    @Retention(RUNTIME)
+    @Target(PARAMETER)
+    public @annotation BodyParam {
+        String value()
+    }
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation Delete {
+        String value()
+    }
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation ExpectedResponses {
+        int[] value()
+    }
+    @Retention(SOURCE)
+    @Target(TYPE)
+    public @annotation Fluent {
+        // This annotation does not declare any members.
+    }
+    @Retention(RUNTIME)
+    @Target(PARAMETER)
+    public @annotation FormParam {
+        String value()
+        boolean encoded() default false
+    }
+    @Retention(SOURCE)
+    @Target({ METHOD, CONSTRUCTOR, FIELD })
+    public @annotation Generated {
+        // This annotation does not declare any members.
+    }
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation Get {
+        String value()
+    }
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation Head {
+        String value()
+    }
+    @Retention(RUNTIME)
+    @Target(FIELD)
+    public @annotation HeaderCollection {
+        String value()
+    }
+    @Retention(RUNTIME)
+    @Target(PARAMETER)
+    public @annotation HeaderParam {
+        String value()
+    }
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation Headers {
+        String[] value()
+    }
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    public @annotation Host {
+        String value() default ""
+    }
+    @Retention(RUNTIME)
+    @Target(PARAMETER)
+    public @annotation HostParam {
+        String value()
+        boolean encoded() default true
+    }
+    @Retention(SOURCE)
+    @Target(TYPE)
+    public @annotation Immutable {
+        // This annotation does not declare any members.
+    }
+    @Retention(RUNTIME)
+    @Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD })
+    public @annotation JsonFlatten {
+        // This annotation does not declare any members.
+    }
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @annotation Options {
+        String value()
+    }
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation Patch {
+        String value()
+    }
+    @Retention(RUNTIME)
+    @Target(PARAMETER)
+    public @annotation PathParam {
+        String value()
+        boolean encoded() default false
+    }
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation Post {
+        String value()
+    }
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation Put {
+        String value()
+    }
+    @Retention(RUNTIME)
+    @Target(PARAMETER)
+    public @annotation QueryParam {
+        String value()
+        boolean encoded() default false
+        boolean multipleQueryParams() default false
+    }
+    @Deprecated
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation ResumeOperation {
+        // This annotation does not declare any members.
+    }
+    public enum ReturnType {
+        SINGLE,
+        COLLECTION,
+        LONG_RUNNING_OPERATION;
+    }
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation ReturnValueWireType {
+        Class<?> value()
+    }
+    @Retention(CLASS)
+    @Target(TYPE)
+    public @annotation ServiceClient {
+        Class<?> builder()
+        boolean isAsync() default false
+        Class<?>[] serviceInterfaces() default {  }
+    }
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    public @annotation ServiceClientBuilder {
+        Class<?>[] serviceClients()
+        ServiceClientProtocol protocol() default ServiceClientProtocol.HTTP
+    }
+    public enum ServiceClientProtocol {
+        HTTP,
+        AMQP;
+    }
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    public @annotation ServiceInterface {
+        String name()
+    }
+    @Retention(CLASS)
+    @Target(METHOD)
+    public @annotation ServiceMethod {
+        ReturnType returns()
+    }
+    @Repeatable(UnexpectedResponseExceptionTypes)
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation UnexpectedResponseExceptionType {
+        Class<? extends HttpResponseException> value()
+        int[] code() default {  }
+    }
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    public @annotation UnexpectedResponseExceptionTypes {
+        UnexpectedResponseExceptionType[] value()
+    }
+}
+package com.azure.core.client.traits {
+    public interface AzureKeyCredentialTrait<T extends AzureKeyCredentialTrait<T>> {
+        T credential(AzureKeyCredential credential)
+    }
+    public interface AzureNamedKeyCredentialTrait<T extends AzureNamedKeyCredentialTrait<T>> {
+        T credential(AzureNamedKeyCredential credential)
+    }
+    public interface AzureSasCredentialTrait<T extends AzureSasCredentialTrait<T>> {
+        T credential(AzureSasCredential credential)
+    }
+    public interface ConfigurationTrait<T extends ConfigurationTrait<T>> {
+        T configuration(Configuration configuration)
+    }
+    public interface ConnectionStringTrait<T extends ConnectionStringTrait<T>> {
+        T connectionString(String connectionString)
+    }
+    public interface EndpointTrait<T extends EndpointTrait<T>> {
+        T endpoint(String endpoint)
+    }
+    public interface HttpTrait<T extends HttpTrait<T>> {
+        T addPolicy(HttpPipelinePolicy pipelinePolicy)
+        T clientOptions(ClientOptions clientOptions)
+        T httpClient(HttpClient httpClient)
+        T httpLogOptions(HttpLogOptions logOptions)
+        T pipeline(HttpPipeline pipeline)
+        T retryOptions(RetryOptions retryOptions)
+    }
+    public interface KeyCredentialTrait<T> {
+        T credential(KeyCredential credential)
+    }
+    public interface TokenCredentialTrait<T extends TokenCredentialTrait<T>> {
+        T credential(TokenCredential credential)
+    }
+}
+package com.azure.core.credential {
+    public class AccessToken {
+        public AccessToken(String token, OffsetDateTime expiresAt)
+        public AccessToken(String token, OffsetDateTime expiresAt, OffsetDateTime refreshAt)
+        public AccessToken(String token, OffsetDateTime expiresAt, OffsetDateTime refreshAt, String tokenType)
+        public Duration getDurationUntilExpiration()
+        public boolean isExpired()
+        public OffsetDateTime getExpiresAt()
+        public OffsetDateTime getRefreshAt()
+        public String getToken()
+        public String getTokenType()
+    }
+    public final class AccessTokenCache {
+        public AccessTokenCache(TokenCredential tokenCredential)
+        public Mono<AccessToken> getToken(TokenRequestContext tokenRequestContext, boolean refreshOnContextChange)
+        public AccessToken getTokenSync(TokenRequestContext tokenRequestContext, boolean refreshOnContextChange)
+    }
+    public final class AzureKeyCredential extends KeyCredential {
+        public AzureKeyCredential(String key)
+        @Override public AzureKeyCredential update(String key)
+    }
+    @Immutable
+    public final class AzureNamedKey {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public String getKey()
+        public String getName()
+    }
+    public final class AzureNamedKeyCredential {
+        public AzureNamedKeyCredential(String name, String key)
+        public AzureNamedKey getAzureNamedKey()
+        public AzureNamedKeyCredential update(String name, String key)
+    }
+    public final class AzureSasCredential {
+        public AzureSasCredential(String signature)
+        public AzureSasCredential(String signature, Function<String, String> signatureEncoder)
+        public String getSignature()
+        public AzureSasCredential update(String signature)
+    }
+    public class BasicAuthenticationCredential implements TokenCredential {
+        public BasicAuthenticationCredential(String username, String password)
+        @Override public Mono<AccessToken> getToken(TokenRequestContext request)
+        @Override public AccessToken getTokenSync(TokenRequestContext request)
+    }
+    public class KeyCredential {
+        public KeyCredential(String key)
+        public String getKey()
+        public KeyCredential update(String key)
+    }
+    public class ProofOfPossessionOptions {
+        public ProofOfPossessionOptions()
+        public String getProofOfPossessionNonce()
+        public ProofOfPossessionOptions setProofOfPossessionNonce(String proofOfPossessionNonce)
+        public HttpMethod getRequestMethod()
+        public ProofOfPossessionOptions setRequestMethod(HttpMethod requestMethod)
+        public URL getRequestUrl()
+        public ProofOfPossessionOptions setRequestUrl(URL requestUrl)
+    }
+    public class SimpleTokenCache {
+        public SimpleTokenCache(Supplier<Mono<AccessToken>> tokenSupplier)
+        public Mono<AccessToken> getToken()
+    }
+    @FunctionalInterface
+    public interface TokenCredential {
+        Mono<AccessToken> getToken(TokenRequestContext request)
+        default AccessToken getTokenSync(TokenRequestContext request)
+    }
+    public class TokenRequestContext {
+        public TokenRequestContext()
+        public TokenRequestContext addScopes(String... scopes)
+        public boolean isCaeEnabled()
+        public TokenRequestContext setCaeEnabled(boolean enableCae)
+        public String getClaims()
+        public TokenRequestContext setClaims(String claims)
+        public ProofOfPossessionOptions getProofOfPossessionOptions()
+        public TokenRequestContext setProofOfPossessionOptions(ProofOfPossessionOptions proofOfPossessionOptions)
+        public List<String> getScopes()
+        public TokenRequestContext setScopes(List<String> scopes)
+        public String getTenantId()
+        public TokenRequestContext setTenantId(String tenantId)
+    }
+}
+package com.azure.core.cryptography {
+    public interface AsyncKeyEncryptionKey {
+        Mono<String> getKeyId()
+        Mono<byte[]> unwrapKey(String algorithm, byte[] encryptedKey)
+        Mono<byte[]> wrapKey(String algorithm, byte[] key)
+    }
+    public interface AsyncKeyEncryptionKeyResolver {
+        Mono<? extends AsyncKeyEncryptionKey> buildAsyncKeyEncryptionKey(String keyId)
+    }
+    public interface KeyEncryptionKey {
+        String getKeyId()
+        byte[] unwrapKey(String algorithm, byte[] encryptedKey)
+        byte[] wrapKey(String algorithm, byte[] key)
+    }
+    public interface KeyEncryptionKeyResolver {
+        KeyEncryptionKey buildKeyEncryptionKey(String keyId)
+    }
+}
+package com.azure.core.exception {
+    public class AzureException extends RuntimeException {
+        public AzureException()
+        public AzureException(String message)
+        public AzureException(Throwable cause)
+        public AzureException(String message, Throwable cause)
+        public AzureException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace)
+    }
+    public class ClientAuthenticationException extends HttpResponseException {
+        public ClientAuthenticationException(String message, HttpResponse response)
+        public ClientAuthenticationException(String message, HttpResponse response, Object value)
+        public ClientAuthenticationException(String message, HttpResponse response, Throwable cause)
+    }
+    public class DecodeException extends HttpResponseException {
+        public DecodeException(String message, HttpResponse response)
+        public DecodeException(String message, HttpResponse response, Object value)
+        public DecodeException(String message, HttpResponse response, Throwable cause)
+    }
+    public class HttpRequestException extends AzureException {
+        public HttpRequestException(HttpRequest request)
+        public HttpRequestException(String message, HttpRequest request)
+        public HttpRequestException(HttpRequest request, Throwable cause)
+        public HttpRequestException(String message, HttpRequest request, Throwable cause)
+        public HttpRequestException(String message, HttpRequest request, Throwable cause, boolean enableSuppression, boolean writableStackTrace)
+        public HttpRequest getRequest()
+    }
+    public class HttpResponseException extends AzureException {
+        public HttpResponseException(HttpResponse response)
+        public HttpResponseException(String message, HttpResponse response)
+        public HttpResponseException(HttpResponse response, Throwable cause)
+        public HttpResponseException(String message, HttpResponse response, Object value)
+        public HttpResponseException(String message, HttpResponse response, Throwable cause)
+        public HttpResponseException(String message, HttpResponse response, Throwable cause, boolean enableSuppression, boolean writableStackTrace)
+        public HttpResponse getResponse()
+        public Object getValue()
+    }
+    public class ResourceExistsException extends HttpResponseException {
+        public ResourceExistsException(String message, HttpResponse response)
+        public ResourceExistsException(String message, HttpResponse response, Object value)
+        public ResourceExistsException(String message, HttpResponse response, Throwable cause)
+    }
+    public class ResourceModifiedException extends HttpResponseException {
+        public ResourceModifiedException(String message, HttpResponse response)
+        public ResourceModifiedException(String message, HttpResponse response, Object value)
+        public ResourceModifiedException(String message, HttpResponse response, Throwable cause)
+    }
+    public class ResourceNotFoundException extends HttpResponseException {
+        public ResourceNotFoundException(String message, HttpResponse response)
+        public ResourceNotFoundException(String message, HttpResponse response, Object value)
+        public ResourceNotFoundException(String message, HttpResponse response, Throwable cause)
+    }
+    public class ServiceResponseException extends AzureException {
+        public ServiceResponseException(String message)
+        public ServiceResponseException(String message, Throwable cause)
+    }
+    public class TooManyRedirectsException extends HttpResponseException {
+        public TooManyRedirectsException(String message, HttpResponse response)
+        public TooManyRedirectsException(String message, HttpResponse response, Object value)
+        public TooManyRedirectsException(String message, HttpResponse response, Throwable cause)
+    }
+    public final class UnexpectedLengthException extends IllegalStateException {
+        public UnexpectedLengthException(String message, long bytesRead, long bytesExpected)
+        public long getBytesExpected()
+        public long getBytesRead()
+    }
+}
+package com.azure.core.http {
+    public final class ContentType {
+        public static final String APPLICATION_JSON = "application/json";
+        public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+        public static final String APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded";
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+    }
+    @Immutable
+    public final class HttpAuthorization {
+        public HttpAuthorization(String scheme, String parameter)
+        public String getParameter()
+        public String getScheme()
+        @Override public String toString()
+    }
+    public interface HttpClient {
+        static HttpClient createDefault()
+        static HttpClient createDefault(HttpClientOptions clientOptions)
+        Mono<HttpResponse> send(HttpRequest request)
+        default Mono<HttpResponse> send(HttpRequest request, Context context)
+        default HttpResponse sendSync(HttpRequest request, Context context)
+    }
+    @FunctionalInterface
+    public interface HttpClientProvider {
+        HttpClient createInstance()
+        default HttpClient createInstance(HttpClientOptions clientOptions)
+    }
+    public class HttpHeader extends Header {
+        public HttpHeader(String name, String value)
+        public HttpHeader(String name, List<String> values)
+    }
+    public final class HttpHeaderName extends ExpandableStringEnum<HttpHeaderName> {
+        public static final HttpHeaderName ACCEPT = fromString("Accept");
+        public static final HttpHeaderName ACCEPT_CHARSET = fromString("Accept-Charset");
+        public static final HttpHeaderName ACCESS_CONTROL_ALLOW_CREDENTIALS = fromString("Access-Control-Allow-Credentials");
+        public static final HttpHeaderName ACCESS_CONTROL_ALLOW_HEADERS = fromString("Access-Control-Allow-Headers");
+        public static final HttpHeaderName ACCESS_CONTROL_ALLOW_METHODS = fromString("Access-Control-Allow-Methods");
+        public static final HttpHeaderName ACCESS_CONTROL_ALLOW_ORIGIN = fromString("Access-Control-Allow-Origin");
+        public static final HttpHeaderName ACCESS_CONTROL_EXPOSE_HEADERS = fromString("Access-Control-Expose-Headers");
+        public static final HttpHeaderName ACCESS_CONTROL_MAX_AGE = fromString("Access-Control-Max-Age");
+        public static final HttpHeaderName ACCEPT_DATETIME = fromString("Accept-Datetime");
+        public static final HttpHeaderName ACCEPT_ENCODING = fromString("Accept-Encoding");
+        public static final HttpHeaderName ACCEPT_LANGUAGE = fromString("Accept-Language");
+        public static final HttpHeaderName ACCEPT_PATCH = fromString("Accept-Patch");
+        public static final HttpHeaderName ACCEPT_RANGES = fromString("Accept-Ranges");
+        public static final HttpHeaderName AGE = fromString("Age");
+        public static final HttpHeaderName ALLOW = fromString("Allow");
+        public static final HttpHeaderName AUTHORIZATION = fromString("Authorization");
+        public static final HttpHeaderName AZURE_ASYNCOPERATION = fromString("Azure-AsyncOperation");
+        public static final HttpHeaderName CACHE_CONTROL = fromString("Cache-Control");
+        public static final HttpHeaderName CONNECTION = fromString("Connection");
+        public static final HttpHeaderName CONTENT_DISPOSITION = fromString("Content-Disposition");
+        public static final HttpHeaderName CONTENT_ENCODING = fromString("Content-Encoding");
+        public static final HttpHeaderName CONTENT_LANGUAGE = fromString("Content-Language");
+        public static final HttpHeaderName CONTENT_LENGTH = fromString("Content-Length");
+        public static final HttpHeaderName CONTENT_LOCATION = fromString("Content-Location");
+        public static final HttpHeaderName CONTENT_MD5 = fromString("Content-MD5");
+        public static final HttpHeaderName CONTENT_RANGE = fromString("Content-Range");
+        public static final HttpHeaderName CONTENT_TYPE = fromString("Content-Type");
+        public static final HttpHeaderName COOKIE = fromString("Cookie");
+        public static final HttpHeaderName DATE = fromString("Date");
+        public static final HttpHeaderName ETAG = fromString("ETag");
+        public static final HttpHeaderName EXPECT = fromString("Expect");
+        public static final HttpHeaderName EXPIRES = fromString("Expires");
+        public static final HttpHeaderName FORWARDED = fromString("Forwarded");
+        public static final HttpHeaderName FROM = fromString("From");
+        public static final HttpHeaderName HOST = fromString("Host");
+        public static final HttpHeaderName HTTP2_SETTINGS = fromString("HTTP2-Settings");
+        public static final HttpHeaderName IF_MATCH = fromString("If-Match");
+        public static final HttpHeaderName IF_MODIFIED_SINCE = fromString("If-Modified-Since");
+        public static final HttpHeaderName IF_NONE_MATCH = fromString("If-None-Match");
+        public static final HttpHeaderName IF_RANGE = fromString("If-Range");
+        public static final HttpHeaderName IF_UNMODIFIED_SINCE = fromString("If-Unmodified-Since");
+        public static final HttpHeaderName LAST_MODIFIED = fromString("Last-Modified");
+        public static final HttpHeaderName LINK = fromString("Link");
+        public static final HttpHeaderName LOCATION = fromString("Location");
+        public static final HttpHeaderName MAX_FORWARDS = fromString("Max-Forwards");
+        public static final HttpHeaderName OPERATION_LOCATION = fromString("Operation-Location");
+        public static final HttpHeaderName ORIGIN = fromString("Origin");
+        public static final HttpHeaderName PRAGMA = fromString("Pragma");
+        public static final HttpHeaderName PREFER = fromString("Prefer");
+        public static final HttpHeaderName PREFERENCE_APPLIED = fromString("Preference-Applied");
+        public static final HttpHeaderName PROXY_AUTHENTICATE = fromString("Proxy-Authenticate");
+        public static final HttpHeaderName PROXY_AUTHORIZATION = fromString("Proxy-Authorization");
+        public static final HttpHeaderName RANGE = fromString("Range");
+        public static final HttpHeaderName REFERER = fromString("Referer");
+        public static final HttpHeaderName RETRY_AFTER = fromString("Retry-After");
+        public static final HttpHeaderName RETRY_AFTER_MS = fromString("retry-after-ms");
+        public static final HttpHeaderName SERVER = fromString("Server");
+        public static final HttpHeaderName SET_COOKIE = fromString("Set-Cookie");
+        public static final HttpHeaderName STRICT_TRANSPORT_SECURITY = fromString("Strict-Transport-Security");
+        public static final HttpHeaderName TE = fromString("TE");
+        public static final HttpHeaderName TRAILER = fromString("Trailer");
+        public static final HttpHeaderName TRANSFER_ENCODING = fromString("Transfer-Encoding");
+        public static final HttpHeaderName USER_AGENT = fromString("User-Agent");
+        public static final HttpHeaderName UPGRADE = fromString("Upgrade");
+        public static final HttpHeaderName VARY = fromString("Vary");
+        public static final HttpHeaderName VIA = fromString("Via");
+        public static final HttpHeaderName WARNING = fromString("Warning");
+        public static final HttpHeaderName WWW_AUTHENTICATE = fromString("WWW-Authenticate");
+        public static final HttpHeaderName X_MS_CLIENT_ID = fromString("x-ms-client-id");
+        public static final HttpHeaderName X_MS_CLIENT_REQUEST_ID = fromString("x-ms-client-request-id");
+        public static final HttpHeaderName X_MS_DATE = fromString("x-ms-date");
+        public static final HttpHeaderName X_MS_REQUEST_ID = fromString("x-ms-request-id");
+        public static final HttpHeaderName X_MS_RETRY_AFTER_MS = fromString("x-ms-retry-after-ms");
+        public static final HttpHeaderName TRACEPARENT = fromString("traceparent");
+        @Deprecated public HttpHeaderName()
+        public String getCaseInsensitiveName()
+        public String getCaseSensitiveName()
+        @Override public boolean equals(Object obj)
+        public static HttpHeaderName fromString(String name)
+        @Override public int hashCode()
+    }
+    public class HttpHeaders implements Iterable<HttpHeader> {
+        public HttpHeaders()
+        public HttpHeaders(Map<String, String> headers)
+        public HttpHeaders(Iterable<HttpHeader> headers)
+        public HttpHeaders(int initialCapacity)
+        @Deprecated public HttpHeader get(String name)
+        public HttpHeader get(HttpHeaderName name)
+        @Deprecated public HttpHeaders set(String name, String value)
+        public HttpHeaders set(HttpHeaderName name, String value)
+        @Deprecated public HttpHeaders set(String name, List<String> values)
+        public HttpHeaders set(HttpHeaderName name, List<String> values)
+        @Deprecated public HttpHeaders add(String name, String value)
+        public HttpHeaders add(HttpHeaderName name, String value)
+        public HttpHeaders setAll(Map<String, List<String>> headers)
+        public HttpHeaders setAllHttpHeaders(HttpHeaders headers)
+        @Override public Iterator<HttpHeader> iterator()
+        @Deprecated public HttpHeaders put(String name, String value)
+        @Deprecated public HttpHeader remove(String name)
+        public HttpHeader remove(HttpHeaderName name)
+        public int getSize()
+        public Stream<HttpHeader> stream()
+        public Map<String, String> toMap()
+        @Override public String toString()
+        @Deprecated public String getValue(String name)
+        public String getValue(HttpHeaderName name)
+        @Deprecated public String[] getValues(String name)
+        public String[] getValues(HttpHeaderName name)
+    }
+    public enum HttpMethod {
+        GET,
+        PUT,
+        POST,
+        PATCH,
+        DELETE,
+        HEAD,
+        OPTIONS,
+        TRACE,
+        CONNECT;
+    }
+    public final class HttpPipeline {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public HttpClient getHttpClient()
+        public HttpPipelinePolicy getPolicy(int index)
+        public int getPolicyCount()
+        public Mono<HttpResponse> send(HttpRequest request)
+        public Mono<HttpResponse> send(HttpPipelineCallContext context)
+        public Mono<HttpResponse> send(HttpRequest request, Context data)
+        public HttpResponse sendSync(HttpRequest request, Context data)
+        public Tracer getTracer()
+    }
+    public class HttpPipelineBuilder {
+        public HttpPipelineBuilder()
+        public HttpPipelineBuilder clientOptions(ClientOptions clientOptions)
+        public HttpPipelineBuilder httpClient(HttpClient httpClient)
+        public HttpPipelineBuilder policies(HttpPipelinePolicy... policies)
+        public HttpPipelineBuilder tracer(Tracer tracer)
+        public HttpPipeline build()
+    }
+    public final class HttpPipelineCallContext {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public Context getContext()
+        public Optional<Object> getData(String key)
+        public void setData(String key, Object value)
+        public HttpRequest getHttpRequest()
+        public HttpPipelineCallContext setHttpRequest(HttpRequest request)
+    }
+    public class HttpPipelineNextPolicy {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Override public HttpPipelineNextPolicy clone()
+        public Mono<HttpResponse> process()
+    }
+    public class HttpPipelineNextSyncPolicy {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Override public HttpPipelineNextSyncPolicy clone()
+        public HttpResponse processSync()
+    }
+    public enum HttpPipelinePosition {
+        PER_CALL,
+        PER_RETRY;
+    }
+    @Immutable
+    public final class HttpRange {
+        public HttpRange(long offset)
+        public HttpRange(long offset, Long length)
+        @Override public boolean equals(Object obj)
+        @Override public int hashCode()
+        public Long getLength()
+        public long getOffset()
+        @Override public String toString()
+    }
+    public class HttpRequest {
+        public HttpRequest(HttpMethod httpMethod, URL url)
+        public HttpRequest(HttpMethod httpMethod, String url)
+        public HttpRequest(HttpMethod httpMethod, URL url, HttpHeaders headers)
+        public HttpRequest(HttpMethod httpMethod, URL url, HttpHeaders headers, Flux<ByteBuffer> body)
+        public HttpRequest(HttpMethod httpMethod, URL url, HttpHeaders headers, BinaryData body)
+        public Flux<ByteBuffer> getBody()
+        public HttpRequest setBody(String content)
+        public HttpRequest setBody(byte[] content)
+        public HttpRequest setBody(Flux<ByteBuffer> content)
+        public HttpRequest setBody(BinaryData content)
+        public BinaryData getBodyAsBinaryData()
+        public HttpRequest copy()
+        @Deprecated public HttpRequest setHeader(String name, String value)
+        public HttpRequest setHeader(HttpHeaderName headerName, String value)
+        public HttpHeaders getHeaders()
+        public HttpRequest setHeaders(HttpHeaders headers)
+        public HttpMethod getHttpMethod()
+        public HttpRequest setHttpMethod(HttpMethod httpMethod)
+        public URL getUrl()
+        public HttpRequest setUrl(URL url)
+        public HttpRequest setUrl(String url)
+    }
+    public abstract class HttpResponse implements Closeable {
+        protected HttpResponse(HttpRequest request)
+        public abstract Flux<ByteBuffer> getBody()
+        public BinaryData getBodyAsBinaryData()
+        public abstract Mono<byte[]> getBodyAsByteArray()
+        public Mono<InputStream> getBodyAsInputStream()
+        public InputStream getBodyAsInputStreamSync()
+        public abstract Mono<String> getBodyAsString()
+        public abstract Mono<String> getBodyAsString(Charset charset)
+        public HttpResponse buffer()
+        @Override public void close()
+        public abstract HttpHeaders getHeaders()
+        @Deprecated public abstract String getHeaderValue(String name)
+        public String getHeaderValue(HttpHeaderName headerName)
+        public final HttpRequest getRequest()
+        public abstract int getStatusCode()
+        public void writeBodyTo(WritableByteChannel channel) throws IOException
+        public Mono<Void> writeBodyToAsync(AsynchronousByteChannel channel)
+    }
+    @Fluent
+    public class MatchConditions {
+        public MatchConditions()
+        public String getIfMatch()
+        public MatchConditions setIfMatch(String ifMatch)
+        public String getIfNoneMatch()
+        public MatchConditions setIfNoneMatch(String ifNoneMatch)
+    }
+    public class ProxyOptions {
+        public ProxyOptions(Type type, InetSocketAddress address)
+        public InetSocketAddress getAddress()
+        public ProxyOptions setCredentials(String username, String password)
+        public static ProxyOptions fromConfiguration(Configuration configuration)
+        public static ProxyOptions fromConfiguration(Configuration configuration, boolean createUnresolved)
+        public String getNonProxyHosts()
+        public ProxyOptions setNonProxyHosts(String nonProxyHosts)
+        public String getPassword()
+        public Type getType()
+        public String getUsername()
+        public enum Type {
+            HTTP(Proxy.Type.HTTP),
+            SOCKS4(Proxy.Type.SOCKS),
+            SOCKS5(Proxy.Type.SOCKS);
+            public Proxy.Type toProxyType()
+        }
+    }
+    @Fluent
+    public class RequestConditions extends MatchConditions {
+        public RequestConditions()
+        @Override public RequestConditions setIfMatch(String ifMatch)
+        public OffsetDateTime getIfModifiedSince()
+        public RequestConditions setIfModifiedSince(OffsetDateTime ifModifiedSince)
+        @Override public RequestConditions setIfNoneMatch(String ifNoneMatch)
+        public OffsetDateTime getIfUnmodifiedSince()
+        public RequestConditions setIfUnmodifiedSince(OffsetDateTime ifUnmodifiedSince)
+    }
+}
+package com.azure.core.http.policy {
+    public class AddDatePolicy implements HttpPipelinePolicy {
+        public AddDatePolicy()
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public class AddHeadersFromContextPolicy implements HttpPipelinePolicy {
+        public static final String AZURE_REQUEST_HTTP_HEADERS_KEY = "azure-http-headers-key";
+        public AddHeadersFromContextPolicy()
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public class AddHeadersPolicy implements HttpPipelinePolicy {
+        public AddHeadersPolicy(HttpHeaders headers)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public interface AfterRetryPolicyProvider extends HttpPolicyProvider {
+        // This interface does not declare any API.
+    }
+    public final class AzureKeyCredentialPolicy extends KeyCredentialPolicy {
+        public AzureKeyCredentialPolicy(String name, AzureKeyCredential credential)
+        public AzureKeyCredentialPolicy(String name, AzureKeyCredential credential, String prefix)
+    }
+    public final class AzureSasCredentialPolicy implements HttpPipelinePolicy {
+        public AzureSasCredentialPolicy(AzureSasCredential credential)
+        public AzureSasCredentialPolicy(AzureSasCredential credential, boolean requireHttps)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public class BearerTokenAuthenticationPolicy implements HttpPipelinePolicy {
+        public BearerTokenAuthenticationPolicy(TokenCredential credential, String... scopes)
+        public Mono<Void> setAuthorizationHeader(HttpPipelineCallContext context, TokenRequestContext tokenRequestContext)
+        public void setAuthorizationHeaderSync(HttpPipelineCallContext context, TokenRequestContext tokenRequestContext)
+        public Mono<Void> authorizeRequest(HttpPipelineCallContext context)
+        public Mono<Boolean> authorizeRequestOnChallenge(HttpPipelineCallContext context, HttpResponse response)
+        public boolean authorizeRequestOnChallengeSync(HttpPipelineCallContext context, HttpResponse response)
+        public void authorizeRequestSync(HttpPipelineCallContext context)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public interface BeforeRetryPolicyProvider extends HttpPolicyProvider {
+        // This interface does not declare any API.
+    }
+    public class CookiePolicy implements HttpPipelinePolicy {
+        public CookiePolicy()
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public final class DefaultRedirectStrategy implements RedirectStrategy {
+        public DefaultRedirectStrategy()
+        public DefaultRedirectStrategy(int maxAttempts)
+        public DefaultRedirectStrategy(int maxAttempts, String locationHeader, Set<HttpMethod> allowedMethods)
+        @Override public HttpRequest createRedirectRequest(HttpResponse httpResponse)
+        @Override public int getMaxAttempts()
+        @Override public boolean shouldAttemptRedirect(HttpPipelineCallContext context, HttpResponse httpResponse, int tryCount, Set<String> attemptedRedirectUrls)
+    }
+    public class ExponentialBackoff implements RetryStrategy {
+        public ExponentialBackoff()
+        public ExponentialBackoff(ExponentialBackoffOptions options)
+        public ExponentialBackoff(int maxRetries, Duration baseDelay, Duration maxDelay)
+        @Override public Duration calculateRetryDelay(int retryAttempts)
+        @Override public int getMaxRetries()
+        @Override public boolean shouldRetryCondition(RequestRetryCondition requestRetryCondition)
+    }
+    public class ExponentialBackoffOptions {
+        public ExponentialBackoffOptions()
+        public Duration getBaseDelay()
+        public ExponentialBackoffOptions setBaseDelay(Duration baseDelay)
+        public Duration getMaxDelay()
+        public ExponentialBackoffOptions setMaxDelay(Duration maxDelay)
+        public Integer getMaxRetries()
+        public ExponentialBackoffOptions setMaxRetries(Integer maxRetries)
+    }
+    public class FixedDelay implements RetryStrategy {
+        public FixedDelay(FixedDelayOptions fixedDelayOptions)
+        public FixedDelay(int maxRetries, Duration delay)
+        @Override public Duration calculateRetryDelay(int retryAttempts)
+        @Override public int getMaxRetries()
+        @Override public boolean shouldRetryCondition(RequestRetryCondition requestRetryCondition)
+    }
+    public class FixedDelayOptions {
+        public FixedDelayOptions(int maxRetries, Duration delay)
+        public Duration getDelay()
+        public int getMaxRetries()
+    }
+    public class HostPolicy implements HttpPipelinePolicy {
+        public HostPolicy(String host)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public enum HttpLogDetailLevel {
+        NONE,
+        BASIC,
+        HEADERS,
+        BODY,
+        BODY_AND_HEADERS;
+        public boolean shouldLogBody()
+        public boolean shouldLogHeaders()
+        public boolean shouldLogUrl()
+    }
+    public class HttpLogOptions {
+        public HttpLogOptions()
+        @Deprecated public HttpLogOptions addAllowedHeaderName(String allowedHeaderName)
+        public HttpLogOptions addAllowedHttpHeaderName(HttpHeaderName allowedHeaderName)
+        public HttpLogOptions addAllowedQueryParamName(String allowedQueryParamName)
+        @Deprecated public Set<String> getAllowedHeaderNames()
+        @Deprecated public HttpLogOptions setAllowedHeaderNames(Set<String> allowedHeaderNames)
+        public Set<HttpHeaderName> getAllowedHttpHeaderNames()
+        public HttpLogOptions setAllowedHttpHeaderNames(Set<HttpHeaderName> allowedHttpHeaderNames)
+        public Set<String> getAllowedQueryParamNames()
+        public HttpLogOptions setAllowedQueryParamNames(Set<String> allowedQueryParamNames)
+        @Deprecated public String getApplicationId()
+        @Deprecated public HttpLogOptions setApplicationId(String applicationId)
+        public HttpLogOptions disableRedactedHeaderLogging(boolean disableRedactedHeaderLogging)
+        public HttpLogDetailLevel getLogLevel()
+        public HttpLogOptions setLogLevel(HttpLogDetailLevel logLevel)
+        @Deprecated public boolean isPrettyPrintBody()
+        @Deprecated public HttpLogOptions setPrettyPrintBody(boolean prettyPrintBody)
+        public boolean isRedactedHeaderLoggingDisabled()
+        public HttpRequestLogger getRequestLogger()
+        public HttpLogOptions setRequestLogger(HttpRequestLogger requestLogger)
+        public HttpResponseLogger getResponseLogger()
+        public HttpLogOptions setResponseLogger(HttpResponseLogger responseLogger)
+    }
+    public class HttpLoggingPolicy implements HttpPipelinePolicy {
+        public static final String RETRY_COUNT_CONTEXT = "requestRetryCount";
+        public HttpLoggingPolicy(HttpLogOptions httpLogOptions)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    @FunctionalInterface
+    public interface HttpPipelinePolicy {
+        default HttpPipelinePosition getPipelinePosition()
+        Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        default HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public class HttpPipelineSyncPolicy implements HttpPipelinePolicy {
+        public HttpPipelineSyncPolicy()
+        protected HttpResponse afterReceivedResponse(HttpPipelineCallContext context, HttpResponse response)
+        protected void beforeSendingRequest(HttpPipelineCallContext context)
+        @Override public final Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public final HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public interface HttpPolicyProvider {
+        HttpPipelinePolicy create()
+    }
+    public final class HttpPolicyProviders {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static void addAfterRetryPolicies(List<HttpPipelinePolicy> policies)
+        public static void addBeforeRetryPolicies(List<HttpPipelinePolicy> policies)
+    }
+    @FunctionalInterface
+    public interface HttpRequestLogger {
+        default LogLevel getLogLevel(HttpRequestLoggingContext loggingOptions)
+        Mono<Void> logRequest(ClientLogger logger, HttpRequestLoggingContext loggingOptions)
+        default void logRequestSync(ClientLogger logger, HttpRequestLoggingContext loggingOptions)
+    }
+    public final class HttpRequestLoggingContext {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public Context getContext()
+        public HttpRequest getHttpRequest()
+        public Integer getTryCount()
+    }
+    @FunctionalInterface
+    public interface HttpResponseLogger {
+        default LogLevel getLogLevel(HttpResponseLoggingContext loggingOptions)
+        Mono<HttpResponse> logResponse(ClientLogger logger, HttpResponseLoggingContext loggingOptions)
+        default HttpResponse logResponseSync(ClientLogger logger, HttpResponseLoggingContext loggingOptions)
+    }
+    public final class HttpResponseLoggingContext {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public Context getContext()
+        public HttpResponse getHttpResponse()
+        public Duration getResponseDuration()
+        public Integer getTryCount()
+    }
+    public class KeyCredentialPolicy implements HttpPipelinePolicy {
+        public KeyCredentialPolicy(String name, KeyCredential credential)
+        public KeyCredentialPolicy(String name, KeyCredential credential, String prefix)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public class PortPolicy implements HttpPipelinePolicy {
+        public PortPolicy(int port, boolean overwrite)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public class ProtocolPolicy implements HttpPipelinePolicy {
+        public ProtocolPolicy(String protocol, boolean overwrite)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public final class RedirectPolicy implements HttpPipelinePolicy {
+        public RedirectPolicy()
+        public RedirectPolicy(RedirectStrategy redirectStrategy)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public interface RedirectStrategy {
+        HttpRequest createRedirectRequest(HttpResponse httpResponse)
+        int getMaxAttempts()
+        boolean shouldAttemptRedirect(HttpPipelineCallContext context, HttpResponse httpResponse, int tryCount, Set<String> attemptedRedirectUrls)
+    }
+    public class RequestIdPolicy implements HttpPipelinePolicy {
+        public RequestIdPolicy()
+        public RequestIdPolicy(String requestIdHeaderName)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public final class RequestRetryCondition {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public HttpResponse getResponse()
+        public List<Throwable> getRetriedThrowables()
+        public Throwable getThrowable()
+        public int getTryCount()
+    }
+    public class RetryOptions {
+        public RetryOptions(ExponentialBackoffOptions exponentialBackoffOptions)
+        public RetryOptions(FixedDelayOptions fixedDelayOptions)
+        public ExponentialBackoffOptions getExponentialBackoffOptions()
+        public FixedDelayOptions getFixedDelayOptions()
+        public Predicate<RequestRetryCondition> getShouldRetryCondition()
+        public RetryOptions setShouldRetryCondition(Predicate<RequestRetryCondition> shouldRetryCondition)
+    }
+    public class RetryPolicy implements HttpPipelinePolicy {
+        public RetryPolicy()
+        public RetryPolicy(RetryStrategy retryStrategy)
+        public RetryPolicy(RetryOptions retryOptions)
+        public RetryPolicy(String retryAfterHeader, ChronoUnit retryAfterTimeUnit)
+        public RetryPolicy(RetryStrategy retryStrategy, String retryAfterHeader, ChronoUnit retryAfterTimeUnit)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+    public interface RetryStrategy {
+        int HTTP_STATUS_TOO_MANY_REQUESTS = 429;
+        Duration calculateRetryDelay(int retryAttempts)
+        default Duration calculateRetryDelay(RequestRetryCondition requestRetryCondition)
+        int getMaxRetries()
+        default boolean shouldRetry(HttpResponse httpResponse)
+        default boolean shouldRetryCondition(RequestRetryCondition requestRetryCondition)
+        default boolean shouldRetryException(Throwable throwable)
+    }
+    @Deprecated
+    public class TimeoutPolicy implements HttpPipelinePolicy {
+        public TimeoutPolicy(Duration timeoutDuration)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+    }
+    public class UserAgentPolicy implements HttpPipelinePolicy {
+        public static final String OVERRIDE_USER_AGENT_CONTEXT_KEY = "Override-User-Agent";
+        public static final String APPEND_USER_AGENT_CONTEXT_KEY = "Append-User-Agent";
+        public UserAgentPolicy()
+        public UserAgentPolicy(String userAgent)
+        public UserAgentPolicy(String applicationId, String sdkName, String sdkVersion, Configuration configuration)
+        @Deprecated public UserAgentPolicy(String sdkName, String sdkVersion, Configuration configuration, ServiceVersion version)
+        @Override public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next)
+        @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
+    }
+}
+package com.azure.core.http.rest {
+    public interface Page<T> extends ContinuablePage<String, T> {
+        @Deprecated default List<T> getItems()
+    }
+    public class PagedFlux<T> extends PagedFluxBase<T, PagedResponse<T>> {
+        public PagedFlux(Supplier<Mono<PagedResponse<T>>> firstPageRetriever)
+        public PagedFlux(Function<Integer, Mono<PagedResponse<T>>> firstPageRetriever)
+        public PagedFlux(Supplier<Mono<PagedResponse<T>>> firstPageRetriever, Function<String, Mono<PagedResponse<T>>> nextPageRetriever)
+        public PagedFlux(Function<Integer, Mono<PagedResponse<T>>> firstPageRetriever, BiFunction<String, Integer, Mono<PagedResponse<T>>> nextPageRetriever)
+        public static <T> PagedFlux<T> create(Supplier<PageRetriever<String, PagedResponse<T>>> provider)
+        @Deprecated public <S> PagedFlux<S> mapPage(Function<T, S> mapper)
+    }
+    @Deprecated
+    public class PagedFluxBase<T, P extends PagedResponse<T>> extends ContinuablePagedFluxCore<String, T, P> {
+        public PagedFluxBase(Supplier<Mono<P>> firstPageRetriever)
+        public PagedFluxBase(Supplier<Mono<P>> firstPageRetriever, Function<String, Mono<P>> nextPageRetriever)
+        public Flux<P> byPage()
+        public Flux<P> byPage(String continuationToken)
+        @Override public void subscribe(CoreSubscriber<? super T> coreSubscriber)
+    }
+    public class PagedIterable<T> extends PagedIterableBase<T, PagedResponse<T>> {
+        public PagedIterable(PagedFlux<T> pagedFlux)
+        public PagedIterable(Supplier<PagedResponse<T>> firstPageRetriever)
+        public PagedIterable(Function<Integer, PagedResponse<T>> firstPageRetriever)
+        public PagedIterable(Supplier<PagedResponse<T>> firstPageRetriever, Function<String, PagedResponse<T>> nextPageRetriever)
+        public PagedIterable(Function<Integer, PagedResponse<T>> firstPageRetriever, BiFunction<String, Integer, PagedResponse<T>> nextPageRetriever)
+        public <S> PagedIterable<S> mapPage(Function<T, S> mapper)
+    }
+    public class PagedIterableBase<T, P extends PagedResponse<T>> extends ContinuablePagedIterable<String, T, P> {
+        public PagedIterableBase(PagedFluxBase<T, P> pagedFluxBase)
+        public PagedIterableBase(Supplier<PageRetrieverSync<String, P>> provider)
+    }
+    public interface PagedResponse<T> extends Page<T> , Response<List<T>> , Closeable {
+        default List<T> getValue()
+    }
+    public class PagedResponseBase<H, T> implements PagedResponse<T> {
+        public PagedResponseBase(HttpRequest request, int statusCode, HttpHeaders headers, Page<T> page, H deserializedHeaders)
+        public PagedResponseBase(HttpRequest request, int statusCode, HttpHeaders headers, List<T> items, String continuationToken, H deserializedHeaders)
+        @Override public void close()
+        @Override public String getContinuationToken()
+        public H getDeserializedHeaders()
+        @Override public IterableStream<T> getElements()
+        @Override public HttpHeaders getHeaders()
+        @Override public HttpRequest getRequest()
+        @Override public int getStatusCode()
+    }
+    public final class RequestOptions {
+        public RequestOptions()
+        @Deprecated public RequestOptions addHeader(String header, String value)
+        public RequestOptions addHeader(HttpHeaderName header, String value)
+        public RequestOptions addQueryParam(String parameterName, String value)
+        public RequestOptions addQueryParam(String parameterName, String value, boolean encoded)
+        public RequestOptions addRequestCallback(Consumer<HttpRequest> requestCallback)
+        public RequestOptions setBody(BinaryData requestBody)
+        public Context getContext()
+        public RequestOptions setContext(Context context)
+        @Deprecated public RequestOptions setHeader(String header, String value)
+        public RequestOptions setHeader(HttpHeaderName header, String value)
+    }
+    public interface Response<T> {
+        HttpHeaders getHeaders()
+        HttpRequest getRequest()
+        int getStatusCode()
+        T getValue()
+    }
+    public class ResponseBase<H, T> implements Response<T> {
+        public ResponseBase(HttpRequest request, int statusCode, HttpHeaders headers, T value, H deserializedHeaders)
+        public H getDeserializedHeaders()
+        @Override public HttpHeaders getHeaders()
+        @Override public HttpRequest getRequest()
+        @Override public int getStatusCode()
+        @Override public T getValue()
+    }
+    public final class RestProxy implements InvocationHandler {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static <A> A create(Class<A> swaggerInterface)
+        public static <A> A create(Class<A> swaggerInterface, HttpPipeline httpPipeline)
+        public static <A> A create(Class<A> swaggerInterface, HttpPipeline httpPipeline, SerializerAdapter serializer)
+        @Override public Object invoke(Object proxy, Method method, Object[] args)
+        public Mono<HttpResponse> send(HttpRequest request, Context contextData)
+    }
+    public class SimpleResponse<T> implements Response<T> {
+        public SimpleResponse(Response<?> response, T value)
+        public SimpleResponse(HttpRequest request, int statusCode, HttpHeaders headers, T value)
+        @Override public HttpHeaders getHeaders()
+        @Override public HttpRequest getRequest()
+        @Override public int getStatusCode()
+        @Override public T getValue()
+    }
+    public final class StreamResponse extends SimpleResponse<Flux<ByteBuffer>> implements Closeable {
+        public StreamResponse(HttpResponse response)
+        @Deprecated public StreamResponse(HttpRequest request, int statusCode, HttpHeaders headers, Flux<ByteBuffer> value)
+        @Override public void close()
+        @Override public Flux<ByteBuffer> getValue()
+        public void writeValueTo(WritableByteChannel channel)
+        public Mono<Void> writeValueToAsync(AsynchronousByteChannel channel)
+    }
+}
+package com.azure.core.models {
+    public final class AzureCloud extends ExpandableStringEnum<AzureCloud> {
+        public static final AzureCloud AZURE_PUBLIC_CLOUD = fromString("AZURE_PUBLIC_CLOUD");
+        public static final AzureCloud AZURE_CHINA_CLOUD = fromString("AZURE_CHINA_CLOUD");
+        public static final AzureCloud AZURE_US_GOVERNMENT_CLOUD = fromString("AZURE_US_GOVERNMENT");
+        @Deprecated public AzureCloud()
+        public static AzureCloud fromString(String cloudName)
+    }
+    @Fluent
+    public final class CloudEvent implements JsonSerializable<CloudEvent> {
+        public CloudEvent(String source, String type, BinaryData data, CloudEventDataFormat format, String dataContentType)
+        public CloudEvent addExtensionAttribute(String name, Object value)
+        public BinaryData getData()
+        public String getDataContentType()
+        public String getDataSchema()
+        public CloudEvent setDataSchema(String dataSchema)
+        public Map<String, Object> getExtensionAttributes()
+        public static List<CloudEvent> fromString(String cloudEventsJson)
+        public static List<CloudEvent> fromString(String cloudEventsJson, boolean skipValidation)
+        public String getId()
+        public CloudEvent setId(String id)
+        public String getSource()
+        public String getSubject()
+        public CloudEvent setSubject(String subject)
+        public OffsetDateTime getTime()
+        public CloudEvent setTime(OffsetDateTime time)
+        public String getType()
+    }
+    public final class CloudEventDataFormat extends ExpandableStringEnum<CloudEventDataFormat> {
+        public static final CloudEventDataFormat BYTES = fromString("BYTES", CloudEventDataFormat.class);
+        public static final CloudEventDataFormat JSON = fromString("JSON", CloudEventDataFormat.class);
+        @Deprecated public CloudEventDataFormat()
+        public static CloudEventDataFormat fromString(String name)
+    }
+    @Immutable
+    public final class GeoBoundingBox implements JsonSerializable<GeoBoundingBox> {
+        public GeoBoundingBox(double west, double south, double east, double north)
+        public GeoBoundingBox(double west, double south, double east, double north, double minAltitude, double maxAltitude)
+        public double getEast()
+        @Override public boolean equals(Object obj)
+        @Override public int hashCode()
+        public Double getMaxAltitude()
+        public Double getMinAltitude()
+        public double getNorth()
+        public double getSouth()
+        @Override public String toString()
+        public double getWest()
+    }
+    @Immutable
+    public final class GeoCollection extends GeoObject {
+        public GeoCollection(List<GeoObject> geometries)
+        public GeoCollection(List<GeoObject> geometries, GeoBoundingBox boundingBox, Map<String, Object> customProperties)
+        @Override public boolean equals(Object obj)
+        public static GeoCollection fromJson(JsonReader jsonReader) throws IOException
+        public List<GeoObject> getGeometries()
+        @Override public int hashCode()
+        @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Override public GeoObjectType getType()
+    }
+    @Immutable
+    public final class GeoLineString extends GeoObject {
+        public GeoLineString(List<GeoPosition> positions)
+        public GeoLineString(List<GeoPosition> positions, GeoBoundingBox boundingBox, Map<String, Object> customProperties)
+        public List<GeoPosition> getCoordinates()
+        @Override public boolean equals(Object obj)
+        public static GeoLineString fromJson(JsonReader jsonReader) throws IOException
+        @Override public int hashCode()
+        @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Override public GeoObjectType getType()
+    }
+    @Immutable
+    public final class GeoLineStringCollection extends GeoObject {
+        public GeoLineStringCollection(List<GeoLineString> lines)
+        public GeoLineStringCollection(List<GeoLineString> lines, GeoBoundingBox boundingBox, Map<String, Object> customProperties)
+        @Override public boolean equals(Object obj)
+        public static GeoLineStringCollection fromJson(JsonReader jsonReader) throws IOException
+        @Override public int hashCode()
+        public List<GeoLineString> getLines()
+        @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Override public GeoObjectType getType()
+    }
+    @Immutable
+    public final class GeoLinearRing implements JsonSerializable<GeoLinearRing> {
+        public GeoLinearRing(List<GeoPosition> coordinates)
+        public List<GeoPosition> getCoordinates()
+        @Override public boolean equals(Object obj)
+        @Override public int hashCode()
+    }
+    @Immutable
+    public abstract class GeoObject implements JsonSerializable<GeoObject> {
+        protected GeoObject(GeoBoundingBox boundingBox, Map<String, Object> customProperties)
+        public final GeoBoundingBox getBoundingBox()
+        public final Map<String, Object> getCustomProperties()
+        @Override public boolean equals(Object obj)
+        @Override public int hashCode()
+        public abstract GeoObjectType getType()
+    }
+    public final class GeoObjectType extends ExpandableStringEnum<GeoObjectType> {
+        public static final GeoObjectType POINT = fromString("Point");
+        public static final GeoObjectType MULTI_POINT = fromString("MultiPoint");
+        public static final GeoObjectType POLYGON = fromString("Polygon");
+        public static final GeoObjectType MULTI_POLYGON = fromString("MultiPolygon");
+        public static final GeoObjectType LINE_STRING = fromString("LineString");
+        public static final GeoObjectType MULTI_LINE_STRING = fromString("MultiLineString");
+        public static final GeoObjectType GEOMETRY_COLLECTION = fromString("GeometryCollection");
+        @Deprecated public GeoObjectType()
+        public static GeoObjectType fromString(String name)
+        public static Collection<GeoObjectType> values()
+    }
+    @Immutable
+    public final class GeoPoint extends GeoObject {
+        public GeoPoint(GeoPosition position)
+        public GeoPoint(double longitude, double latitude)
+        public GeoPoint(double longitude, double latitude, Double altitude)
+        public GeoPoint(GeoPosition position, GeoBoundingBox boundingBox, Map<String, Object> customProperties)
+        public GeoPosition getCoordinates()
+        @Override public boolean equals(Object obj)
+        public static GeoPoint fromJson(JsonReader jsonReader) throws IOException
+        @Override public int hashCode()
+        @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Override public GeoObjectType getType()
+    }
+    @Immutable
+    public final class GeoPointCollection extends GeoObject {
+        public GeoPointCollection(List<GeoPoint> points)
+        public GeoPointCollection(List<GeoPoint> points, GeoBoundingBox boundingBox, Map<String, Object> customProperties)
+        @Override public boolean equals(Object obj)
+        public static GeoPointCollection fromJson(JsonReader jsonReader) throws IOException
+        @Override public int hashCode()
+        public List<GeoPoint> getPoints()
+        @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Override public GeoObjectType getType()
+    }
+    @Immutable
+    public final class GeoPolygon extends GeoObject {
+        public GeoPolygon(GeoLinearRing ring)
+        public GeoPolygon(List<GeoLinearRing> rings)
+        public GeoPolygon(GeoLinearRing ring, GeoBoundingBox boundingBox, Map<String, Object> customProperties)
+        public GeoPolygon(List<GeoLinearRing> rings, GeoBoundingBox boundingBox, Map<String, Object> customProperties)
+        @Override public boolean equals(Object obj)
+        public static GeoPolygon fromJson(JsonReader jsonReader) throws IOException
+        @Override public int hashCode()
+        public GeoLinearRing getOuterRing()
+        public List<GeoLinearRing> getRings()
+        @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Override public GeoObjectType getType()
+    }
+    @Immutable
+    public final class GeoPolygonCollection extends GeoObject {
+        public GeoPolygonCollection(List<GeoPolygon> polygons)
+        public GeoPolygonCollection(List<GeoPolygon> polygons, GeoBoundingBox boundingBox, Map<String, Object> customProperties)
+        @Override public boolean equals(Object obj)
+        public static GeoPolygonCollection fromJson(JsonReader jsonReader) throws IOException
+        @Override public int hashCode()
+        public List<GeoPolygon> getPolygons()
+        @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Override public GeoObjectType getType()
+    }
+    @Immutable
+    public final class GeoPosition implements JsonSerializable<GeoPosition> {
+        public GeoPosition(double longitude, double latitude)
+        public GeoPosition(double longitude, double latitude, Double altitude)
+        public Double getAltitude()
+        public int count()
+        @Override public boolean equals(Object obj)
+        @Override public int hashCode()
+        public double getLatitude()
+        public double getLongitude()
+        @Override public String toString()
+    }
+    public final class JsonPatchDocument implements JsonSerializable<JsonPatchDocument> {
+        public JsonPatchDocument()
+        public JsonPatchDocument(JsonSerializer serializer)
+        public JsonPatchDocument appendAdd(String path, Object value)
+        public JsonPatchDocument appendAddRaw(String path, String rawJson)
+        public JsonPatchDocument appendCopy(String from, String path)
+        public JsonPatchDocument appendMove(String from, String path)
+        public JsonPatchDocument appendRemove(String path)
+        public JsonPatchDocument appendReplace(String path, Object value)
+        public JsonPatchDocument appendReplaceRaw(String path, String rawJson)
+        public JsonPatchDocument appendTest(String path, Object value)
+        public JsonPatchDocument appendTestRaw(String path, String rawJson)
+        @Override public String toString()
+    }
+    @Fluent
+    public class MessageContent {
+        public MessageContent()
+        public BinaryData getBodyAsBinaryData()
+        public MessageContent setBodyAsBinaryData(BinaryData binaryData)
+        public String getContentType()
+        public MessageContent setContentType(String contentType)
+    }
+    public final class ResponseError implements JsonSerializable<ResponseError> {
+        public ResponseError(String code, String message)
+        public String getCode()
+        public String getMessage()
+    }
+}
+package com.azure.core.util {
+    public interface AsyncCloseable {
+        Mono<Void> closeAsync()
+    }
+    public final class AuthenticateChallenge {
+        public AuthenticateChallenge(String scheme)
+        public AuthenticateChallenge(String scheme, String token68)
+        public AuthenticateChallenge(String scheme, Map<String, String> parameters)
+        public Map<String, String> getParameters()
+        public String getScheme()
+        public String getToken68()
+    }
+    public class AuthorizationChallengeHandler {
+        public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
+        public static final String PROXY_AUTHENTICATE = "Proxy-Authenticate";
+        public static final String AUTHORIZATION = "Authorization";
+        public static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
+        public static final String AUTHENTICATION_INFO = "Authentication-Info";
+        public static final String PROXY_AUTHENTICATION_INFO = "Proxy-Authentication-Info";
+        public AuthorizationChallengeHandler(String username, String password)
+        public final String attemptToPipelineAuthorization(String method, String uri, Supplier<byte[]> entityBodySupplier)
+        public final void consumeAuthenticationInfoHeader(Map<String, String> authenticationInfoMap)
+        public final String handleBasic()
+        public final String handleDigest(String method, String uri, List<Map<String, String>> challenges, Supplier<byte[]> entityBodySupplier)
+        public static Map<String, String> parseAuthenticationOrAuthorizationHeader(String header)
+    }
+    public final class Base64Url {
+        public Base64Url(String string)
+        public Base64Url(byte[] bytes)
+        public byte[] decodedBytes()
+        public static Base64Url encode(byte[] bytes)
+        public byte[] encodedBytes()
+        @Override public boolean equals(Object obj)
+        @Override public int hashCode()
+        @Override public String toString()
+    }
+    public final class Base64Util {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static byte[] decode(byte[] encoded)
+        public static byte[] decodeString(String encoded)
+        public static byte[] decodeURL(byte[] src)
+        public static byte[] encode(byte[] src)
+        public static String encodeToString(byte[] src)
+        public static byte[] encodeURLWithoutPadding(byte[] src)
+    }
+    public final class BinaryData {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static BinaryData fromByteBuffer(ByteBuffer data)
+        public static BinaryData fromBytes(byte[] data)
+        public static BinaryData fromFile(Path file)
+        public static BinaryData fromFile(Path file, int chunkSize)
+        public static BinaryData fromFile(Path file, Long position, Long length)
+        public static BinaryData fromFile(Path file, Long position, Long length, int chunkSize)
+        public static Mono<BinaryData> fromFlux(Flux<ByteBuffer> data)
+        public static Mono<BinaryData> fromFlux(Flux<ByteBuffer> data, Long length)
+        public static Mono<BinaryData> fromFlux(Flux<ByteBuffer> data, Long length, boolean bufferContent)
+        public static BinaryData fromListByteBuffer(List<ByteBuffer> data)
+        public static BinaryData fromObject(Object data)
+        public static BinaryData fromObject(Object data, ObjectSerializer serializer)
+        public static Mono<BinaryData> fromObjectAsync(Object data)
+        public static Mono<BinaryData> fromObjectAsync(Object data, ObjectSerializer serializer)
+        public static BinaryData fromStream(InputStream inputStream)
+        public static BinaryData fromStream(InputStream inputStream, Long length)
+        public static Mono<BinaryData> fromStreamAsync(InputStream inputStream)
+        public static Mono<BinaryData> fromStreamAsync(InputStream inputStream, Long length)
+        public static BinaryData fromString(String data)
+        public Long getLength()
+        public boolean isReplayable()
+        public ByteBuffer toByteBuffer()
+        public byte[] toBytes()
+        public Flux<ByteBuffer> toFluxByteBuffer()
+        public <T> T toObject(Class<T> clazz)
+        public <T> T toObject(TypeReference<T> typeReference)
+        public <T> T toObject(Class<T> clazz, ObjectSerializer serializer)
+        public <T> T toObject(TypeReference<T> typeReference, ObjectSerializer serializer)
+        public <T> Mono<T> toObjectAsync(Class<T> clazz)
+        public <T> Mono<T> toObjectAsync(TypeReference<T> typeReference)
+        public <T> Mono<T> toObjectAsync(Class<T> clazz, ObjectSerializer serializer)
+        public <T> Mono<T> toObjectAsync(TypeReference<T> typeReference, ObjectSerializer serializer)
+        public BinaryData toReplayableBinaryData()
+        public Mono<BinaryData> toReplayableBinaryDataAsync()
+        public InputStream toStream()
+        public String toString()
+        public void writeTo(OutputStream outputStream) throws IOException
+        public void writeTo(WritableByteChannel channel) throws IOException
+        public Mono<Void> writeTo(AsynchronousByteChannel channel)
+        public void writeTo(JsonWriter jsonWriter) throws IOException
+    }
+    @Fluent
+    public class ClientOptions {
+        public ClientOptions()
+        public String getApplicationId()
+        public ClientOptions setApplicationId(String applicationId)
+        public Iterable<Header> getHeaders()
+        public ClientOptions setHeaders(Iterable<Header> headers)
+        public MetricsOptions getMetricsOptions()
+        public ClientOptions setMetricsOptions(MetricsOptions metricsOptions)
+        public TracingOptions getTracingOptions()
+        public ClientOptions setTracingOptions(TracingOptions tracingOptions)
+    }
+    public class Configuration implements Cloneable {
+        public static final String PROPERTY_HTTP_PROXY = "HTTP_PROXY";
+        public static final String PROPERTY_HTTPS_PROXY = "HTTPS_PROXY";
+        public static final String PROPERTY_IDENTITY_ENDPOINT = "IDENTITY_ENDPOINT";
+        public static final String PROPERTY_IDENTITY_HEADER = "IDENTITY_HEADER";
+        public static final String PROPERTY_NO_PROXY = "NO_PROXY";
+        public static final String PROPERTY_MSI_ENDPOINT = "MSI_ENDPOINT";
+        public static final String PROPERTY_MSI_SECRET = "MSI_SECRET";
+        public static final String PROPERTY_AZURE_SUBSCRIPTION_ID = "AZURE_SUBSCRIPTION_ID";
+        public static final String PROPERTY_AZURE_USERNAME = "AZURE_USERNAME";
+        public static final String PROPERTY_AZURE_PASSWORD = "AZURE_PASSWORD";
+        public static final String PROPERTY_AZURE_CLIENT_ID = "AZURE_CLIENT_ID";
+        public static final String PROPERTY_AZURE_CLIENT_SECRET = "AZURE_CLIENT_SECRET";
+        public static final String PROPERTY_AZURE_TENANT_ID = "AZURE_TENANT_ID";
+        public static final String PROPERTY_AZURE_CLIENT_CERTIFICATE_PATH = "AZURE_CLIENT_CERTIFICATE_PATH";
+        public static final String PROPERTY_AZURE_CLIENT_CERTIFICATE_PASSWORD = "AZURE_CLIENT_CERTIFICATE_PASSWORD";
+        public static final String PROPERTY_AZURE_CLIENT_SEND_CERTIFICATE_CHAIN = "AZURE_CLIENT_SEND_CERTIFICATE_CHAIN";
+        public static final String PROPERTY_AZURE_IDENTITY_DISABLE_CP1 = "AZURE_IDENTITY_DISABLE_CP1";
+        public static final String PROPERTY_AZURE_POD_IDENTITY_TOKEN_URL = "AZURE_POD_IDENTITY_TOKEN_URL";
+        public static final String PROPERTY_AZURE_REGIONAL_AUTHORITY_NAME = "AZURE_REGIONAL_AUTHORITY_NAME";
+        public static final String PROPERTY_AZURE_RESOURCE_GROUP = "AZURE_RESOURCE_GROUP";
+        public static final String PROPERTY_AZURE_CLOUD = "AZURE_CLOUD";
+        public static final String PROPERTY_AZURE_AUTHORITY_HOST = "AZURE_AUTHORITY_HOST";
+        public static final String PROPERTY_AZURE_TELEMETRY_DISABLED = "AZURE_TELEMETRY_DISABLED";
+        public static final String PROPERTY_AZURE_LOG_LEVEL = "AZURE_LOG_LEVEL";
+        public static final String PROPERTY_AZURE_HTTP_LOG_DETAIL_LEVEL = "AZURE_HTTP_LOG_DETAIL_LEVEL";
+        public static final String PROPERTY_AZURE_TRACING_DISABLED = "AZURE_TRACING_DISABLED";
+        public static final String PROPERTY_AZURE_TRACING_IMPLEMENTATION = "AZURE_TRACING_IMPLEMENTATION";
+        public static final String PROPERTY_AZURE_METRICS_DISABLED = "AZURE_METRICS_DISABLED";
+        public static final String PROPERTY_AZURE_METRICS_IMPLEMENTATION = "AZURE_METRICS_IMPLEMENTATION";
+        public static final String PROPERTY_AZURE_REQUEST_RETRY_COUNT = "AZURE_REQUEST_RETRY_COUNT";
+        public static final String PROPERTY_AZURE_REQUEST_CONNECT_TIMEOUT = "AZURE_REQUEST_CONNECT_TIMEOUT";
+        public static final String PROPERTY_AZURE_REQUEST_WRITE_TIMEOUT = "AZURE_REQUEST_WRITE_TIMEOUT";
+        public static final String PROPERTY_AZURE_REQUEST_RESPONSE_TIMEOUT = "AZURE_REQUEST_RESPONSE_TIMEOUT";
+        public static final String PROPERTY_AZURE_REQUEST_READ_TIMEOUT = "AZURE_REQUEST_READ_TIMEOUT";
+        public static final String PROPERTY_AZURE_HTTP_CLIENT_IMPLEMENTATION = "AZURE_HTTP_CLIENT_IMPLEMENTATION";
+        public static final Configuration NONE = new NoopConfiguration ( /* Elided */ ) ;
+        @Deprecated public Configuration()
+        public String get(String name)
+        public <T> T get(ConfigurationProperty<T> property)
+        public <T> T get(String name, T defaultValue)
+        public <T> T get(String name, Function<String, T> converter)
+        @Deprecated public Configuration clone()
+        public boolean contains(String name)
+        public boolean contains(ConfigurationProperty<?> property)
+        public static Configuration getGlobalConfiguration()
+        @Deprecated public Configuration put(String name, String value)
+        @Deprecated public String remove(String name)
+    }
+    @Fluent
+    public final class ConfigurationBuilder {
+        public ConfigurationBuilder()
+        public ConfigurationBuilder(ConfigurationSource source)
+        public ConfigurationBuilder(ConfigurationSource source, ConfigurationSource systemPropertiesConfigurationSource, ConfigurationSource environmentConfigurationSource)
+        public ConfigurationBuilder putProperty(String name, String value)
+        public ConfigurationBuilder root(String rootPath)
+        public Configuration build()
+        public Configuration buildSection(String path)
+    }
+    public final class ConfigurationProperty<T> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public Iterable<String> getAliases()
+        public Function<String, T> getConverter()
+        public T getDefaultValue()
+        public String getEnvironmentVariableName()
+        public String getName()
+        public boolean isRequired()
+        public boolean isShared()
+        public String getSystemPropertyName()
+        public Function<String, String> getValueSanitizer()
+    }
+    public final class ConfigurationPropertyBuilder<T> {
+        public ConfigurationPropertyBuilder(String name, Function<String, T> converter)
+        public ConfigurationPropertyBuilder<T> aliases(String... aliases)
+        public ConfigurationPropertyBuilder<T> defaultValue(T defaultValue)
+        public ConfigurationPropertyBuilder<T> environmentVariableName(String environmentVariableName)
+        public ConfigurationPropertyBuilder<T> logValue(boolean logValue)
+        public static ConfigurationPropertyBuilder<Boolean> ofBoolean(String name)
+        public static ConfigurationPropertyBuilder<Duration> ofDuration(String name)
+        public static ConfigurationPropertyBuilder<Integer> ofInteger(String name)
+        public static ConfigurationPropertyBuilder<String> ofString(String name)
+        public ConfigurationPropertyBuilder<T> required(boolean required)
+        public ConfigurationPropertyBuilder<T> shared(boolean shared)
+        public ConfigurationPropertyBuilder<T> systemPropertyName(String systemPropertyName)
+        public ConfigurationProperty<T> build()
+    }
+    @FunctionalInterface
+    public interface ConfigurationSource {
+        Map<String, String> getProperties(String source)
+    }
+    @Immutable
+    public class Context {
+        public static final Context NONE ;
+        public Context(Object key, Object value)
+        public Context addData(Object key, Object value)
+        public Optional<Object> getData(Object key)
+        public static Context of(Map<Object, Object> keyValues)
+        public Map<Object, Object> getValues()
+    }
+    public final class Contexts {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public Context getContext()
+        public static Contexts empty()
+        public ProgressReporter getHttpRequestProgressReporter()
+        public Contexts setHttpRequestProgressReporter(ProgressReporter progressReporter)
+        public static Contexts with(Context context)
+    }
+    public final class CoreUtils {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static Thread addShutdownHookSafely(Thread shutdownThread)
+        public static ExecutorService addShutdownHookSafely(ExecutorService executorService, Duration shutdownTimeout)
+        public static String getApplicationId(ClientOptions clientOptions, HttpLogOptions logOptions)
+        public static <T> String arrayToString(T[] array, Function<T, String> mapper)
+        public static String bomAwareToString(byte[] bytes, String contentType)
+        public static String bytesToHexString(byte[] bytes)
+        public static byte[] clone(byte[] source)
+        public static int[] clone(int[] source)
+        public static <T> T[] clone(T[] source)
+        public static HttpHeaders createHttpHeadersFromClientOptions(ClientOptions clientOptions)
+        public static Duration getDefaultTimeoutFromEnvironment(Configuration configuration, String timeoutPropertyName, Duration defaultTimeout, ClientLogger logger)
+        public static String durationToStringWithDays(Duration duration)
+        @Deprecated public static <T> Publisher<T> extractAndFetch(PagedResponse<T> page, Context context, BiFunction<String, Context, Publisher<T>> content)
+        public static long extractSizeFromContentRange(String contentRange)
+        public static <T> T findFirstOfType(Object[] args, Class<T> clazz)
+        public static Context mergeContexts(Context into, Context from)
+        public static boolean isNullOrEmpty(Object[] array)
+        public static boolean isNullOrEmpty(Collection<?> collection)
+        public static boolean isNullOrEmpty(Map<?, ?> map)
+        public static boolean isNullOrEmpty(CharSequence charSequence)
+        public static List<AuthenticateChallenge> parseAuthenticateHeader(String authenticateHeader)
+        public static OffsetDateTime parseBestOffsetDateTime(String dateString)
+        public static Iterator<Map.Entry<String, String>> parseQueryParameters(String queryParameters)
+        public static Map<String, String> getProperties(String propertiesFileName)
+        public static UUID randomUuid()
+        public static <T> T getResultWithTimeout(Future<T> future, Duration timeout) throws InterruptedException, ExecutionException, TimeoutException
+        public static String stringJoin(String delimiter, List<String> values)
+    }
+    public final class DateTimeRfc1123 {
+        public DateTimeRfc1123(OffsetDateTime dateTime)
+        public DateTimeRfc1123(String formattedString)
+        public OffsetDateTime getDateTime()
+        @Override public boolean equals(Object obj)
+        @Override public int hashCode()
+        public static String toRfc1123String(OffsetDateTime dateTime)
+        @Override public String toString()
+    }
+    public final class ETag {
+        public static final ETag ALL = new ETag ( /* Elided */ ) ;
+        public ETag(String eTag)
+        @Override public boolean equals(Object o)
+        @Override public int hashCode()
+        @Override public String toString()
+    }
+    public interface ExpandableEnum<T> {
+        T getValue()
+    }
+    public abstract class ExpandableStringEnum<T extends ExpandableStringEnum<T>> implements ExpandableEnum<String> {
+        @Deprecated public ExpandableStringEnum()
+        @Override public boolean equals(Object obj)
+        protected static <T extends ExpandableStringEnum<T>> T fromString(String name, Class<T> clazz)
+        @Override public int hashCode()
+        @Override public String toString()
+        @Override public String getValue()
+        protected static <T extends ExpandableStringEnum<T>> Collection<T> values(Class<T> clazz)
+    }
+    public final class FluxUtil {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static Flux<ByteBuffer> addProgressReporting(Flux<ByteBuffer> flux, ProgressReporter progressReporter)
+        public static byte[] byteBufferToArray(ByteBuffer byteBuffer)
+        public static Mono<byte[]> collectBytesFromNetworkResponse(Flux<ByteBuffer> stream, HttpHeaders headers)
+        public static Mono<byte[]> collectBytesInByteBufferStream(Flux<ByteBuffer> stream)
+        public static Mono<byte[]> collectBytesInByteBufferStream(Flux<ByteBuffer> stream, int sizeHint)
+        public static Flux<ByteBuffer> createRetriableDownloadFlux(Supplier<Flux<ByteBuffer>> downloadSupplier, BiFunction<Throwable, Long, Flux<ByteBuffer>> onDownloadErrorResume, int maxRetries)
+        public static Flux<ByteBuffer> createRetriableDownloadFlux(Supplier<Flux<ByteBuffer>> downloadSupplier, BiFunction<Throwable, Long, Flux<ByteBuffer>> onDownloadErrorResume, int maxRetries, long position)
+        public static Flux<ByteBuffer> createRetriableDownloadFlux(Supplier<Flux<ByteBuffer>> downloadSupplier, BiFunction<Throwable, Long, Flux<ByteBuffer>> onDownloadErrorResume, RetryOptions retryOptions, long position)
+        public static boolean isFluxByteBuffer(Type entityType)
+        public static <T> Flux<T> fluxContext(Function<Context, Flux<T>> serviceCall)
+        public static <T> Flux<T> fluxError(ClientLogger logger, RuntimeException ex)
+        public static <T> Mono<T> monoError(ClientLogger logger, RuntimeException ex)
+        public static <T> Mono<T> monoError(LoggingEventBuilder logBuilder, RuntimeException ex)
+        public static <T> PagedFlux<T> pagedFluxError(ClientLogger logger, RuntimeException ex)
+        public static Flux<ByteBuffer> readFile(AsynchronousFileChannel fileChannel)
+        public static Flux<ByteBuffer> readFile(AsynchronousFileChannel fileChannel, long offset, long length)
+        public static Flux<ByteBuffer> readFile(AsynchronousFileChannel fileChannel, int chunkSize, long offset, long length)
+        public static Flux<ByteBuffer> toFluxByteBuffer(InputStream inputStream)
+        public static Flux<ByteBuffer> toFluxByteBuffer(InputStream inputStream, int chunkSize)
+        public static <T> Mono<T> toMono(Response<T> response)
+        public static reactor.util.context.Context toReactorContext(Context context)
+        public static <T> Mono<T> withContext(Function<Context, Mono<T>> serviceCall)
+        public static <T> Mono<T> withContext(Function<Context, Mono<T>> serviceCall, Map<String, String> contextAttributes)
+        public static Mono<Void> writeFile(Flux<ByteBuffer> content, AsynchronousFileChannel outFile)
+        public static Mono<Void> writeFile(Flux<ByteBuffer> content, AsynchronousFileChannel outFile, long position)
+        public static Mono<Void> writeToAsynchronousByteChannel(Flux<ByteBuffer> content, AsynchronousByteChannel channel)
+        public static Mono<Void> writeToOutputStream(Flux<ByteBuffer> content, OutputStream stream)
+        public static Mono<Void> writeToWritableByteChannel(Flux<ByteBuffer> content, WritableByteChannel channel)
+    }
+    public class Header {
+        public Header(String name, String value)
+        public Header(String name, String... values)
+        public Header(String name, List<String> values)
+        public void addValue(String value)
+        public String getName()
+        @Override public String toString()
+        public String getValue()
+        public String[] getValues()
+        public List<String> getValuesList()
+    }
+    @Fluent
+    public final class HttpClientOptions extends ClientOptions {
+        public HttpClientOptions()
+        @Override public HttpClientOptions setApplicationId(String applicationId)
+        public Configuration getConfiguration()
+        public HttpClientOptions setConfiguration(Configuration configuration)
+        public Duration getConnectionIdleTimeout()
+        public HttpClientOptions setConnectionIdleTimeout(Duration connectionIdleTimeout)
+        public Duration getConnectTimeout()
+        public HttpClientOptions setConnectTimeout(Duration connectTimeout)
+        @Override public HttpClientOptions setHeaders(Iterable<Header> headers)
+        public Class<? extends HttpClientProvider> getHttpClientProvider()
+        public HttpClientOptions setHttpClientProvider(Class<? extends HttpClientProvider> httpClientProvider)
+        public Integer getMaximumConnectionPoolSize()
+        public HttpClientOptions setMaximumConnectionPoolSize(Integer maximumConnectionPoolSize)
+        public ProxyOptions getProxyOptions()
+        public HttpClientOptions setProxyOptions(ProxyOptions proxyOptions)
+        public Duration getReadTimeout()
+        public HttpClientOptions readTimeout(Duration readTimeout)
+        public HttpClientOptions setReadTimeout(Duration readTimeout)
+        public Duration getResponseTimeout()
+        public HttpClientOptions responseTimeout(Duration responseTimeout)
+        public HttpClientOptions setResponseTimeout(Duration responseTimeout)
+        public Duration getWriteTimeout()
+        public HttpClientOptions setWriteTimeout(Duration writeTimeout)
+    }
+    public class IterableStream<T> implements Iterable<T> {
+        public IterableStream(Flux<T> flux)
+        public IterableStream(Iterable<T> iterable)
+        @Override public Iterator<T> iterator()
+        public static <T> IterableStream<T> of(Iterable<T> iterable)
+        public Stream<T> stream()
+    }
+    @Fluent
+    public final class LibraryTelemetryOptions {
+        public LibraryTelemetryOptions(String libraryName)
+        public String getLibraryName()
+        public String getLibraryVersion()
+        public LibraryTelemetryOptions setLibraryVersion(String libraryVersion)
+        public String getResourceProviderNamespace()
+        public LibraryTelemetryOptions setResourceProviderNamespace(String rpNamespace)
+        public String getSchemaUrl()
+        public LibraryTelemetryOptions setSchemaUrl(String schemaUrl)
+    }
+    public class MetricsOptions {
+        public MetricsOptions()
+        protected MetricsOptions(Class<? extends MeterProvider> meterProvider)
+        public boolean isEnabled()
+        public MetricsOptions setEnabled(boolean enabled)
+        public static MetricsOptions fromConfiguration(Configuration configuration)
+        public Class<? extends MeterProvider> getMeterProvider()
+    }
+    @FunctionalInterface
+    public interface ProgressListener {
+        void handleProgress(long progress)
+    }
+    public final class ProgressReporter {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public ProgressReporter createChild()
+        public void reportProgress(long progress)
+        public void reset()
+        public static ProgressReporter withProgressListener(ProgressListener progressListener)
+    }
+    public interface ReferenceManager {
+        ReferenceManager INSTANCE = new ReferenceManagerImpl ( /* Elided */ ) ;
+        void register(Object object, Runnable cleanupAction)
+    }
+    public interface ServiceVersion {
+        String getVersion()
+    }
+    public final class SharedExecutorService implements ScheduledExecutorService {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Override public boolean awaitTermination(long timeout, TimeUnit unit)
+        @Override public void execute(Runnable command)
+        public ScheduledExecutorService getExecutorService()
+        public void setExecutorService(ScheduledExecutorService executorService)
+        public static SharedExecutorService getInstance()
+        @Override public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException
+        @Override public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException
+        @Override public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException
+        @Override public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException
+        public void reset()
+        @Override public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit)
+        @Override public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit)
+        @Override public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit)
+        @Override public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit)
+        @Override public boolean isShutdown()
+        @Override public void shutdown()
+        @Override public List<Runnable> shutdownNow()
+        @Override public <T> Future<T> submit(Callable<T> task)
+        @Override public Future<?> submit(Runnable task)
+        @Override public <T> Future<T> submit(Runnable task, T result)
+        @Override public boolean isTerminated()
+    }
+    @Immutable
+    public interface TelemetryAttributes {
+        // This interface does not declare any API.
+    }
+    public class TracingOptions {
+        public TracingOptions()
+        protected TracingOptions(Class<? extends TracerProvider> tracerProvider)
+        public Set<String> getAllowedTracingQueryParamNames()
+        public TracingOptions setAllowedTracingQueryParamNames(Set<String> allowedQueryParamNames)
+        public boolean isEnabled()
+        public TracingOptions setEnabled(boolean enabled)
+        public static TracingOptions fromConfiguration(Configuration configuration)
+        public Class<? extends TracerProvider> getTracerProvider()
+    }
+    public final class UrlBuilder {
+        public UrlBuilder()
+        public UrlBuilder addQueryParameter(String queryParameterName, String queryParameterEncodedValue)
+        public UrlBuilder clearQuery()
+        public String getHost()
+        public UrlBuilder setHost(String host)
+        public static UrlBuilder parse(String url)
+        public static UrlBuilder parse(URL url)
+        public String getPath()
+        public UrlBuilder setPath(String path)
+        public Integer getPort()
+        public UrlBuilder setPort(String port)
+        public UrlBuilder setPort(int port)
+        public Map<String, String> getQuery()
+        public UrlBuilder setQuery(String query)
+        public UrlBuilder setQueryParameter(String queryParameterName, String queryParameterEncodedValue)
+        public String getQueryString()
+        public String getScheme()
+        public UrlBuilder setScheme(String scheme)
+        @Override public String toString()
+        public URL toUrl() throws MalformedURLException
+    }
+    public class UserAgentProperties {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public String getName()
+        public String getVersion()
+    }
+    public final class UserAgentUtil {
+        public static final String DEFAULT_USER_AGENT_HEADER = "azsdk-java";
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static String toUserAgentString(String applicationId, String sdkName, String sdkVersion, Configuration configuration)
+    }
+}
+package com.azure.core.util.builder {
+    public final class ClientBuilderUtil {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static HttpPipelinePolicy validateAndGetRetryPolicy(HttpPipelinePolicy retryPolicy, RetryOptions retryOptions)
+        public static HttpPipelinePolicy validateAndGetRetryPolicy(HttpPipelinePolicy retryPolicy, RetryOptions retryOptions, HttpPipelinePolicy defaultPolicy)
+    }
+}
+package com.azure.core.util.io {
+    public final class IOUtils {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static AsynchronousByteChannel toAsynchronousByteChannel(AsynchronousFileChannel fileChannel, long position)
+        public static void transfer(ReadableByteChannel source, WritableByteChannel destination) throws IOException
+        public static void transfer(ReadableByteChannel source, WritableByteChannel destination, Long estimatedSourceSize) throws IOException
+        public static Mono<Void> transferAsync(ReadableByteChannel source, AsynchronousByteChannel destination)
+        public static Mono<Void> transferAsync(ReadableByteChannel source, AsynchronousByteChannel destination, Long estimatedSourceSize)
+        public static Mono<Void> transferStreamResponseToAsynchronousByteChannel(AsynchronousByteChannel targetChannel, StreamResponse sourceResponse, BiFunction<Throwable, Long, Mono<StreamResponse>> onErrorResume, ProgressReporter progressReporter, int maxRetries)
+    }
+}
+package com.azure.core.util.logging {
+    public class ClientLogger {
+        public ClientLogger(Class<?> clazz)
+        public ClientLogger(String className)
+        public ClientLogger(Class<?> clazz, Map<String, Object> context)
+        public ClientLogger(String className, Map<String, Object> context)
+        public LoggingEventBuilder atError()
+        public LoggingEventBuilder atInfo()
+        public LoggingEventBuilder atLevel(LogLevel level)
+        public LoggingEventBuilder atVerbose()
+        public LoggingEventBuilder atWarning()
+        public boolean canLogAtLevel(LogLevel logLevel)
+        public void error(String message)
+        public void error(String format, Object... args)
+        public void info(String message)
+        public void info(String format, Object... args)
+        public void log(LogLevel logLevel, Supplier<String> message)
+        public void log(LogLevel logLevel, Supplier<String> message, Throwable throwable)
+        public RuntimeException logExceptionAsError(RuntimeException runtimeException)
+        public RuntimeException logExceptionAsWarning(RuntimeException runtimeException)
+        @Deprecated public <T extends Throwable> T logThowableAsWarning(T throwable)
+        public <T extends Throwable> T logThrowableAsError(T throwable)
+        public <T extends Throwable> T logThrowableAsWarning(T throwable)
+        public void verbose(String message)
+        public void verbose(String format, Object... args)
+        public void warning(String message)
+        public void warning(String format, Object... args)
+    }
+    public enum LogLevel {
+        VERBOSE(1, "1", "verbose", "debug"),
+        INFORMATIONAL(2, "2", "info", "information", "informational"),
+        WARNING(3, "3", "warn", "warning"),
+        ERROR(4, "4", "err", "error"),
+        NOT_SET(5, "5");
+        public static LogLevel fromString(String logLevelVal)
+        public int getLogLevel()
+    }
+    @Fluent
+    public final class LoggingEventBuilder {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public LoggingEventBuilder addKeyValue(String key, String value)
+        public LoggingEventBuilder addKeyValue(String key, Object value)
+        public LoggingEventBuilder addKeyValue(String key, boolean value)
+        public LoggingEventBuilder addKeyValue(String key, long value)
+        public LoggingEventBuilder addKeyValue(String key, Supplier<String> valueSupplier)
+        public void log(String message)
+        public void log(Supplier<String> messageSupplier)
+        public Throwable log(Throwable throwable)
+        public RuntimeException log(RuntimeException runtimeException)
+        public void log(Supplier<String> messageSupplier, Throwable throwable)
+        public void log(String format, Object... args)
+    }
+}
+package com.azure.core.util.metrics {
+    public interface DoubleHistogram {
+        boolean isEnabled()
+        void record(double value, TelemetryAttributes attributes, Context context)
+    }
+    public interface LongCounter {
+        void add(long value, TelemetryAttributes attributes, Context context)
+        boolean isEnabled()
+    }
+    public interface LongGauge {
+        boolean isEnabled()
+        AutoCloseable registerCallback(Supplier<Long> valueSupplier, TelemetryAttributes attributes)
+    }
+    public interface Meter extends AutoCloseable {
+        @Override void close()
+        TelemetryAttributes createAttributes(Map<String, Object> attributeMap)
+        DoubleHistogram createDoubleHistogram(String name, String description, String unit)
+        LongCounter createLongCounter(String name, String description, String unit)
+        default LongGauge createLongGauge(String name, String description, String unit)
+        LongCounter createLongUpDownCounter(String name, String description, String unit)
+        boolean isEnabled()
+    }
+    public interface MeterProvider {
+        default Meter createMeter(LibraryTelemetryOptions libraryOptions, MetricsOptions applicationOptions)
+        Meter createMeter(String libraryName, String libraryVersion, MetricsOptions applicationOptions)
+        static MeterProvider getDefaultProvider()
+    }
+}
+package com.azure.core.util.paging {
+    public interface ContinuablePage<C, T> {
+        C getContinuationToken()
+        IterableStream<T> getElements()
+    }
+    public abstract class ContinuablePagedFlux<C, T, P extends ContinuablePage<C, T>> extends Flux<T> {
+        public ContinuablePagedFlux()
+        protected ContinuablePagedFlux(Predicate<C> continuationPredicate)
+        public abstract Flux<P> byPage()
+        public abstract Flux<P> byPage(C continuationToken)
+        public abstract Flux<P> byPage(int preferredPageSize)
+        public abstract Flux<P> byPage(C continuationToken, int preferredPageSize)
+        protected final Predicate<C> getContinuationPredicate()
+    }
+    public abstract class ContinuablePagedFluxCore<C, T, P extends ContinuablePage<C, T>> extends ContinuablePagedFlux<C, T, P> {
+        protected ContinuablePagedFluxCore(Supplier<PageRetriever<C, P>> pageRetrieverProvider)
+        protected ContinuablePagedFluxCore(Supplier<PageRetriever<C, P>> pageRetrieverProvider, int pageSize)
+        protected ContinuablePagedFluxCore(Supplier<PageRetriever<C, P>> pageRetrieverProvider, Integer pageSize, Predicate<C> continuationPredicate)
+        @Override public Flux<P> byPage()
+        @Override public Flux<P> byPage(C continuationToken)
+        @Override public Flux<P> byPage(int preferredPageSize)
+        @Override public Flux<P> byPage(C continuationToken, int preferredPageSize)
+        public Integer getPageSize()
+        @Override public void subscribe(CoreSubscriber<? super T> coreSubscriber)
+    }
+    public class ContinuablePagedIterable<C, T, P extends ContinuablePage<C, T>> extends IterableStream<T> {
+        public ContinuablePagedIterable(ContinuablePagedFlux<C, T, P> pagedFlux)
+        public ContinuablePagedIterable(ContinuablePagedFlux<C, T, P> pagedFlux, int batchSize)
+        public ContinuablePagedIterable(Supplier<PageRetrieverSync<C, P>> pageRetrieverSyncProvider, Integer pageSize, Predicate<C> continuationPredicate)
+        public Iterable<P> iterableByPage()
+        public Iterable<P> iterableByPage(C continuationToken)
+        public Iterable<P> iterableByPage(int preferredPageSize)
+        public Iterable<P> iterableByPage(C continuationToken, int preferredPageSize)
+        @Override public Iterator<T> iterator()
+        @Override public Stream<T> stream()
+        public Stream<P> streamByPage()
+        public Stream<P> streamByPage(C continuationToken)
+        public Stream<P> streamByPage(int preferredPageSize)
+        public Stream<P> streamByPage(C continuationToken, int preferredPageSize)
+    }
+    @FunctionalInterface
+    public interface PageRetriever<C, P> {
+        Flux<P> get(C continuationToken, Integer pageSize)
+    }
+    @FunctionalInterface
+    public interface PageRetrieverSync<C, P> {
+        P getPage(C continuationToken, Integer pageSize)
+    }
+}
+package com.azure.core.util.polling {
+    public final class AsyncPollResponse<T, U> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public Mono<T> cancelOperation()
+        public Mono<U> getFinalResult()
+        public LongRunningOperationStatus getStatus()
+        public T getValue()
+    }
+    public final class ChainedPollingStrategy<T, U> implements PollingStrategy<T, U> {
+        public ChainedPollingStrategy(List<PollingStrategy<T, U>> strategies)
+        @Override public Mono<T> cancel(PollingContext<T> pollingContext, PollResponse<T> initialResponse)
+        @Override public Mono<Boolean> canPoll(Response<?> initialResponse)
+        @Override public Mono<PollResponse<T>> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public Mono<PollResponse<T>> poll(PollingContext<T> context, TypeReference<T> pollResponseType)
+        @Override public Mono<U> getResult(PollingContext<T> context, TypeReference<U> resultType)
+    }
+    public final class DefaultPollingStrategy<T, U> implements PollingStrategy<T, U> {
+        public DefaultPollingStrategy(HttpPipeline httpPipeline)
+        public DefaultPollingStrategy(PollingStrategyOptions pollingStrategyOptions)
+        public DefaultPollingStrategy(HttpPipeline httpPipeline, JsonSerializer serializer)
+        public DefaultPollingStrategy(HttpPipeline httpPipeline, JsonSerializer serializer, Context context)
+        public DefaultPollingStrategy(HttpPipeline httpPipeline, String endpoint, JsonSerializer serializer, Context context)
+        @Override public Mono<Boolean> canPoll(Response<?> initialResponse)
+        @Override public Mono<PollResponse<T>> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public Mono<PollResponse<T>> poll(PollingContext<T> context, TypeReference<T> pollResponseType)
+        @Override public Mono<U> getResult(PollingContext<T> context, TypeReference<U> resultType)
+    }
+    public class LocationPollingStrategy<T, U> implements PollingStrategy<T, U> {
+        public LocationPollingStrategy(HttpPipeline httpPipeline)
+        public LocationPollingStrategy(PollingStrategyOptions pollingStrategyOptions)
+        public LocationPollingStrategy(HttpPipeline httpPipeline, ObjectSerializer serializer)
+        public LocationPollingStrategy(HttpPipeline httpPipeline, ObjectSerializer serializer, Context context)
+        public LocationPollingStrategy(HttpPipeline httpPipeline, String endpoint, ObjectSerializer serializer, Context context)
+        @Override public Mono<Boolean> canPoll(Response<?> initialResponse)
+        @Override public Mono<PollResponse<T>> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public Mono<PollResponse<T>> poll(PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public Mono<U> getResult(PollingContext<T> pollingContext, TypeReference<U> resultType)
+    }
+    public final class LongRunningOperationStatus extends ExpandableStringEnum<LongRunningOperationStatus> {
+        public static final LongRunningOperationStatus NOT_STARTED = fromString("NOT_STARTED", false);
+        public static final LongRunningOperationStatus IN_PROGRESS = fromString("IN_PROGRESS", false);
+        public static final LongRunningOperationStatus SUCCESSFULLY_COMPLETED = fromString("SUCCESSFULLY_COMPLETED", true);
+        public static final LongRunningOperationStatus FAILED = fromString("FAILED", true);
+        public static final LongRunningOperationStatus USER_CANCELLED = fromString("USER_CANCELLED", true);
+        @Deprecated public LongRunningOperationStatus()
+        public boolean isComplete()
+        public static LongRunningOperationStatus fromString(String name, boolean isComplete)
+    }
+    public class OperationResourcePollingStrategy<T, U> implements PollingStrategy<T, U> {
+        public OperationResourcePollingStrategy(HttpPipeline httpPipeline)
+        public OperationResourcePollingStrategy(HttpHeaderName operationLocationHeaderName, PollingStrategyOptions pollingStrategyOptions)
+        public OperationResourcePollingStrategy(HttpPipeline httpPipeline, ObjectSerializer serializer, String operationLocationHeaderName)
+        public OperationResourcePollingStrategy(HttpPipeline httpPipeline, ObjectSerializer serializer, String operationLocationHeaderName, Context context)
+        public OperationResourcePollingStrategy(HttpPipeline httpPipeline, String endpoint, ObjectSerializer serializer, String operationLocationHeaderName, Context context)
+        @Override public Mono<Boolean> canPoll(Response<?> initialResponse)
+        @Override public Mono<PollResponse<T>> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public Mono<PollResponse<T>> poll(PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public Mono<U> getResult(PollingContext<T> pollingContext, TypeReference<U> resultType)
+    }
+    @Immutable
+    public final class PollOperationDetails implements JsonSerializable<PollOperationDetails> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public ResponseError getError()
+        public String getOperationId()
+    }
+    public final class PollResponse<T> {
+        public PollResponse(LongRunningOperationStatus status, T value)
+        public PollResponse(LongRunningOperationStatus status, T value, Duration retryAfter)
+        public Duration getRetryAfter()
+        public LongRunningOperationStatus getStatus()
+        public T getValue()
+    }
+    public final class PollerFlux<T, U> extends Flux<AsyncPollResponse<T, U>> {
+        public PollerFlux(Duration pollInterval, Function<PollingContext<T>, Mono<T>> activationOperation, Function<PollingContext<T>, Mono<PollResponse<T>>> pollOperation, BiFunction<PollingContext<T>, PollResponse<T>, Mono<T>> cancelOperation, Function<PollingContext<T>, Mono<U>> fetchResultOperation)
+        public static <T, U> PollerFlux<T, U> create(Duration pollInterval, Function<PollingContext<T>, Mono<PollResponse<T>>> activationOperation, Function<PollingContext<T>, Mono<PollResponse<T>>> pollOperation, BiFunction<PollingContext<T>, PollResponse<T>, Mono<T>> cancelOperation, Function<PollingContext<T>, Mono<U>> fetchResultOperation)
+        public static <T, U> PollerFlux<T, U> create(Duration pollInterval, Supplier<Mono<? extends Response<?>>> initialOperation, PollingStrategy<T, U> strategy, TypeReference<T> pollResponseType, TypeReference<U> resultType)
+        public static <T, U> PollerFlux<T, U> error(Exception ex)
+        public Duration getPollInterval()
+        public PollerFlux<T, U> setPollInterval(Duration pollInterval)
+        @Override public void subscribe(CoreSubscriber<? super AsyncPollResponse<T, U>> actual)
+        public SyncPoller<T, U> getSyncPoller()
+    }
+    public final class PollingContext<T> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public PollResponse<T> getActivationResponse()
+        public String getData(String name)
+        public PollingContext<T> setData(String name, String value)
+        public PollResponse<T> getLatestResponse()
+    }
+    public interface PollingStrategy<T, U> {
+        default Mono<T> cancel(PollingContext<T> pollingContext, PollResponse<T> initialResponse)
+        Mono<Boolean> canPoll(Response<?> initialResponse)
+        Mono<PollResponse<T>> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        Mono<PollResponse<T>> poll(PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        Mono<U> getResult(PollingContext<T> pollingContext, TypeReference<U> resultType)
+    }
+    @Fluent
+    public final class PollingStrategyOptions {
+        public PollingStrategyOptions(HttpPipeline httpPipeline)
+        public Context getContext()
+        public PollingStrategyOptions setContext(Context context)
+        public String getEndpoint()
+        public PollingStrategyOptions setEndpoint(String endpoint)
+        public HttpPipeline getHttpPipeline()
+        public ObjectSerializer getSerializer()
+        public PollingStrategyOptions setSerializer(ObjectSerializer serializer)
+        public String getServiceVersion()
+        public PollingStrategyOptions setServiceVersion(String serviceVersion)
+    }
+    public class StatusCheckPollingStrategy<T, U> implements PollingStrategy<T, U> {
+        public StatusCheckPollingStrategy()
+        public StatusCheckPollingStrategy(ObjectSerializer serializer)
+        @Override public Mono<Boolean> canPoll(Response<?> initialResponse)
+        @Override public Mono<PollResponse<T>> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public Mono<PollResponse<T>> poll(PollingContext<T> context, TypeReference<T> pollResponseType)
+        @Override public Mono<U> getResult(PollingContext<T> pollingContext, TypeReference<U> resultType)
+    }
+    public final class SyncChainedPollingStrategy<T, U> implements SyncPollingStrategy<T, U> {
+        public SyncChainedPollingStrategy(List<SyncPollingStrategy<T, U>> strategies)
+        @Override public T cancel(PollingContext<T> pollingContext, PollResponse<T> initialResponse)
+        @Override public boolean canPoll(Response<?> initialResponse)
+        @Override public PollResponse<T> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public PollResponse<T> poll(PollingContext<T> context, TypeReference<T> pollResponseType)
+        @Override public U getResult(PollingContext<T> context, TypeReference<U> resultType)
+    }
+    public final class SyncDefaultPollingStrategy<T, U> implements SyncPollingStrategy<T, U> {
+        public SyncDefaultPollingStrategy(HttpPipeline httpPipeline)
+        public SyncDefaultPollingStrategy(PollingStrategyOptions pollingStrategyOptions)
+        public SyncDefaultPollingStrategy(HttpPipeline httpPipeline, JsonSerializer serializer)
+        public SyncDefaultPollingStrategy(HttpPipeline httpPipeline, JsonSerializer serializer, Context context)
+        public SyncDefaultPollingStrategy(HttpPipeline httpPipeline, String endpoint, JsonSerializer serializer, Context context)
+        @Override public T cancel(PollingContext<T> pollingContext, PollResponse<T> initialResponse)
+        @Override public boolean canPoll(Response<?> initialResponse)
+        @Override public PollResponse<T> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public PollResponse<T> poll(PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public U getResult(PollingContext<T> pollingContext, TypeReference<U> resultType)
+    }
+    public class SyncLocationPollingStrategy<T, U> implements SyncPollingStrategy<T, U> {
+        public SyncLocationPollingStrategy(HttpPipeline httpPipeline)
+        public SyncLocationPollingStrategy(PollingStrategyOptions pollingStrategyOptions)
+        public SyncLocationPollingStrategy(HttpPipeline httpPipeline, ObjectSerializer serializer)
+        public SyncLocationPollingStrategy(HttpPipeline httpPipeline, ObjectSerializer serializer, Context context)
+        public SyncLocationPollingStrategy(HttpPipeline httpPipeline, String endpoint, ObjectSerializer serializer, Context context)
+        @Override public boolean canPoll(Response<?> initialResponse)
+        @Override public PollResponse<T> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public PollResponse<T> poll(PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public U getResult(PollingContext<T> pollingContext, TypeReference<U> resultType)
+    }
+    public class SyncOperationResourcePollingStrategy<T, U> implements SyncPollingStrategy<T, U> {
+        public SyncOperationResourcePollingStrategy(HttpPipeline httpPipeline)
+        public SyncOperationResourcePollingStrategy(HttpHeaderName operationLocationHeaderName, PollingStrategyOptions pollingStrategyOptions)
+        public SyncOperationResourcePollingStrategy(HttpPipeline httpPipeline, ObjectSerializer serializer, String operationLocationHeaderName)
+        public SyncOperationResourcePollingStrategy(HttpPipeline httpPipeline, ObjectSerializer serializer, String operationLocationHeaderName, Context context)
+        public SyncOperationResourcePollingStrategy(HttpPipeline httpPipeline, String endpoint, ObjectSerializer serializer, String operationLocationHeaderName, Context context)
+        @Override public boolean canPoll(Response<?> initialResponse)
+        @Override public PollResponse<T> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public PollResponse<T> poll(PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public U getResult(PollingContext<T> pollingContext, TypeReference<U> resultType)
+    }
+    public interface SyncPoller<T, U> {
+        void cancelOperation()
+        static <T, U> SyncPoller<T, U> createPoller(Duration pollInterval, Function<PollingContext<T>, PollResponse<T>> syncActivationOperation, Function<PollingContext<T>, PollResponse<T>> pollOperation, BiFunction<PollingContext<T>, PollResponse<T>, T> cancelOperation, Function<PollingContext<T>, U> fetchResultOperation)
+        static <T, U> SyncPoller<T, U> createPoller(Duration pollInterval, Supplier<Response<?>> initialOperation, SyncPollingStrategy<T, U> strategy, TypeReference<T> pollResponseType, TypeReference<U> resultType)
+        U getFinalResult()
+        default U getFinalResult(Duration timeout)
+        PollResponse<T> poll()
+        default SyncPoller<T, U> setPollInterval(Duration pollInterval)
+        PollResponse<T> waitForCompletion()
+        PollResponse<T> waitForCompletion(Duration timeout)
+        PollResponse<T> waitUntil(LongRunningOperationStatus statusToWaitFor)
+        PollResponse<T> waitUntil(Duration timeout, LongRunningOperationStatus statusToWaitFor)
+    }
+    public interface SyncPollingStrategy<T, U> {
+        default T cancel(PollingContext<T> pollingContext, PollResponse<T> initialResponse)
+        boolean canPoll(Response<?> initialResponse)
+        PollResponse<T> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        PollResponse<T> poll(PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        U getResult(PollingContext<T> pollingContext, TypeReference<U> resultType)
+    }
+    public class SyncStatusCheckPollingStrategy<T, U> implements SyncPollingStrategy<T, U> {
+        public SyncStatusCheckPollingStrategy()
+        public SyncStatusCheckPollingStrategy(ObjectSerializer serializer)
+        @Override public boolean canPoll(Response<?> initialResponse)
+        @Override public PollResponse<T> onInitialResponse(Response<?> response, PollingContext<T> pollingContext, TypeReference<T> pollResponseType)
+        @Override public PollResponse<T> poll(PollingContext<T> context, TypeReference<T> pollResponseType)
+        @Override public U getResult(PollingContext<T> pollingContext, TypeReference<U> resultType)
+    }
+}
+package com.azure.core.util.serializer {
+    public enum CollectionFormat {
+        CSV(","),
+        SSV(" "),
+        TSV("\t"),
+        PIPES("|"),
+        MULTI("&");
+        public String getDelimiter()
+    }
+    public class JacksonAdapter implements SerializerAdapter {
+        public JacksonAdapter()
+        @Deprecated public JacksonAdapter(BiConsumer<ObjectMapper, ObjectMapper> configureSerialization)
+        public static SerializerAdapter createDefaultSerializerAdapter()
+        @Override public <T> T deserialize(HttpHeaders headers, Type deserializedHeadersType) throws IOException
+        @Override public <T> T deserialize(String value, Type type, SerializerEncoding encoding) throws IOException
+        @Override public <T> T deserialize(byte[] bytes, Type type, SerializerEncoding encoding) throws IOException
+        @Override public <T> T deserialize(InputStream inputStream, Type type, SerializerEncoding encoding) throws IOException
+        @Override public <T> T deserializeHeader(Header header, Type type) throws IOException
+        @Override public String serialize(Object object, SerializerEncoding encoding) throws IOException
+        @Override public void serialize(Object object, SerializerEncoding encoding, OutputStream outputStream) throws IOException
+        @Override public String serializeList(List<?> list, CollectionFormat format)
+        @Deprecated public ObjectMapper serializer()
+        @Override public String serializeRaw(Object object)
+        @Override public byte[] serializeToBytes(Object object, SerializerEncoding encoding) throws IOException
+        @Deprecated protected ObjectMapper simpleMapper()
+    }
+    public interface JsonSerializer extends ObjectSerializer {
+        @Override <T> T deserialize(InputStream stream, TypeReference<T> typeReference)
+        @Override <T> Mono<T> deserializeAsync(InputStream stream, TypeReference<T> typeReference)
+        @Override default <T> T deserializeFromBytes(byte[] data, TypeReference<T> typeReference)
+        @Override default <T> Mono<T> deserializeFromBytesAsync(byte[] data, TypeReference<T> typeReference)
+        @Override void serialize(OutputStream stream, Object value)
+        @Override Mono<Void> serializeAsync(OutputStream stream, Object value)
+        @Override default byte[] serializeToBytes(Object value)
+        @Override default Mono<byte[]> serializeToBytesAsync(Object value)
+    }
+    public interface JsonSerializerProvider {
+        JsonSerializer createInstance()
+    }
+    public final class JsonSerializerProviders {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static JsonSerializer createInstance()
+        public static JsonSerializer createInstance(boolean useDefaultIfAbsent)
+    }
+    public interface MemberNameConverter {
+        String convertMemberName(Member member)
+    }
+    public interface MemberNameConverterProvider {
+        MemberNameConverter createInstance()
+    }
+    public final class MemberNameConverterProviders {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static MemberNameConverter createInstance()
+    }
+    public interface ObjectSerializer {
+        <T> T deserialize(InputStream stream, TypeReference<T> typeReference)
+        <T> Mono<T> deserializeAsync(InputStream stream, TypeReference<T> typeReference)
+        default <T> T deserializeFromBytes(byte[] data, TypeReference<T> typeReference)
+        default <T> Mono<T> deserializeFromBytesAsync(byte[] data, TypeReference<T> typeReference)
+        void serialize(OutputStream stream, Object value)
+        Mono<Void> serializeAsync(OutputStream stream, Object value)
+        default byte[] serializeToBytes(Object value)
+        default Mono<byte[]> serializeToBytesAsync(Object value)
+    }
+    public interface SerializerAdapter {
+        <T> T deserialize(HttpHeaders headers, Type type) throws IOException
+        <T> T deserialize(String value, Type type, SerializerEncoding encoding) throws IOException
+        default <T> T deserialize(byte[] bytes, Type type, SerializerEncoding encoding) throws IOException
+        default <T> T deserialize(InputStream inputStream, Type type, SerializerEncoding encoding) throws IOException
+        default <T> T deserializeHeader(Header header, Type type) throws IOException
+        String serialize(Object object, SerializerEncoding encoding) throws IOException
+        default void serialize(Object object, SerializerEncoding encoding, OutputStream outputStream) throws IOException
+        default String serializeIterable(Iterable<?> iterable, CollectionFormat format)
+        String serializeList(List<?> list, CollectionFormat format)
+        String serializeRaw(Object object)
+        default byte[] serializeToBytes(Object object, SerializerEncoding encoding) throws IOException
+    }
+    public enum SerializerEncoding {
+        JSON,
+        XML,
+        TEXT;
+        public static SerializerEncoding fromHeaders(HttpHeaders headers)
+    }
+    public abstract class TypeReference<T> {
+        public TypeReference()
+        public static <T> TypeReference<T> createInstance(Class<T> clazz)
+        public Class<T> getJavaClass()
+        public Type getJavaType()
+    }
+}
+package com.azure.core.util.tracing {
+    @Deprecated
+    public enum ProcessKind {
+        SEND,
+        MESSAGE,
+        PROCESS;
+    }
+    public enum SpanKind {
+        INTERNAL,
+        CLIENT,
+        SERVER,
+        PRODUCER,
+        CONSUMER;
+    }
+    @Fluent
+    public final class StartSpanOptions {
+        public StartSpanOptions(SpanKind kind)
+        public StartSpanOptions addLink(TracingLink link)
+        public StartSpanOptions setAttribute(String key, Object value)
+        public Map<String, Object> getAttributes()
+        public List<TracingLink> getLinks()
+        public Context getRemoteParent()
+        public StartSpanOptions setRemoteParent(Context parent)
+        public SpanKind getSpanKind()
+        public Instant getStartTimestamp()
+        public StartSpanOptions setStartTimestamp(Instant timestamp)
+    }
+    public interface Tracer {
+        @Deprecated String PARENT_SPAN_KEY = "parent-span";
+        String PARENT_TRACE_CONTEXT_KEY = "trace-context";
+        @Deprecated String USER_SPAN_NAME_KEY = "user-span-name";
+        String ENTITY_PATH_KEY = "entity-path";
+        String HOST_NAME_KEY = "hostname";
+        String SPAN_CONTEXT_KEY = "span-context";
+        @Deprecated String DIAGNOSTIC_ID_KEY = "Diagnostic-Id";
+        @Deprecated String SCOPE_KEY = "scope";
+        @Deprecated String AZ_TRACING_NAMESPACE_KEY = "az.namespace";
+        @Deprecated String SPAN_BUILDER_KEY = "builder";
+        @Deprecated String MESSAGE_ENQUEUED_TIME = "x-opt-enqueued-time";
+        String DISABLE_TRACING_KEY = "disable-tracing";
+        @Deprecated default void addEvent(String name, Map<String, Object> attributes, OffsetDateTime timestamp)
+        default void addEvent(String name, Map<String, Object> attributes, OffsetDateTime timestamp, Context context)
+        @Deprecated default void addLink(Context context)
+        void setAttribute(String key, String value, Context context)
+        default void setAttribute(String key, long value, Context context)
+        default void setAttribute(String key, Object value, Context context)
+        default boolean isEnabled()
+        @Deprecated default void end(int responseCode, Throwable error, Context context)
+        void end(String errorMessage, Throwable throwable, Context context)
+        default Context extractContext(Function<String, String> headerGetter)
+        @Deprecated default Context extractContext(String diagnosticId, Context context)
+        default void injectContext(BiConsumer<String, String> headerSetter, Context context)
+        default AutoCloseable makeSpanCurrent(Context context)
+        default boolean isRecording(Context span)
+        @Deprecated default Context getSharedSpanBuilder(String spanName, Context context)
+        @Deprecated default Context setSpanName(String spanName, Context context)
+        Context start(String methodName, Context context)
+        default Context start(String methodName, StartSpanOptions options, Context context)
+        @Deprecated default Context start(String spanName, Context context, ProcessKind processKind)
+    }
+    public interface TracerProvider {
+        default Tracer createTracer(LibraryTelemetryOptions libraryOptions, TracingOptions options)
+        Tracer createTracer(String libraryName, String libraryVersion, String azNamespace, TracingOptions options)
+        static TracerProvider getDefaultProvider()
+    }
+    @Deprecated
+    public final class TracerProxy {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static void setAttribute(String key, String value, Context context)
+        public static void end(int responseCode, Throwable error, Context context)
+        public static Context setSpanName(String spanName, Context context)
+        public static Context start(String methodName, Context context)
+        public static Context start(String methodName, StartSpanOptions spanOptions, Context context)
+        public static boolean isTracingEnabled()
+    }
+    @Immutable
+    public class TracingLink {
+        public TracingLink(Context context)
+        public TracingLink(Context context, Map<String, Object> attributes)
+        public Map<String, Object> getAttributes()
+        public Context getContext()
+    }
+}
+```

--- a/sdk/core/azure-core/api.md
+++ b/sdk/core/azure-core/api.md
@@ -11,6 +11,7 @@ maven {
     name : Microsoft Azure Java Core Library
     description : This package contains core types for Azure Java clients.
     dependencies {
+        // compile scope
         com.azure:azure-json 1.5.1
         com.azure:azure-xml 1.2.1
         com.fasterxml.jackson.core:jackson-annotations 2.18.9
@@ -19,6 +20,7 @@ maven {
         com.fasterxml.jackson.datatype:jackson-datatype-jsr310 2.18.9
         org.slf4j:slf4j-api 1.7.36
         io.projectreactor:reactor-core 3.7.19
+        // provided scope
         com.google.code.findbugs:jsr305 3.0.2
     }
 }
@@ -97,6 +99,7 @@ package com.azure.core.annotation {
     @Retention(SOURCE)
     @Target(TYPE)
     public @annotation Fluent {
+        // This annotation does not declare any members.
     }
     @Retention(RUNTIME)
     @Target(PARAMETER)
@@ -107,6 +110,7 @@ package com.azure.core.annotation {
     @Retention(SOURCE)
     @Target({ METHOD, CONSTRUCTOR, FIELD })
     public @annotation Generated {
+        // This annotation does not declare any members.
     }
     @Retention(RUNTIME)
     @Target(METHOD)
@@ -147,10 +151,12 @@ package com.azure.core.annotation {
     @Retention(SOURCE)
     @Target(TYPE)
     public @annotation Immutable {
+        // This annotation does not declare any members.
     }
     @Retention(RUNTIME)
     @Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.FIELD })
     public @annotation JsonFlatten {
+        // This annotation does not declare any members.
     }
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
@@ -189,6 +195,7 @@ package com.azure.core.annotation {
     @Retention(RUNTIME)
     @Target(METHOD)
     public @annotation ResumeOperation {
+        // This annotation does not declare any members.
     }
     public enum ReturnType {
         SINGLE,
@@ -297,6 +304,7 @@ package com.azure.core.credential {
     }
     @Immutable
     public final class AzureNamedKey {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public String getKey()
         public String getName()
     }
@@ -443,6 +451,7 @@ package com.azure.core.http {
         public static final String APPLICATION_JSON = "application/json";
         public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
         public static final String APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded";
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
     }
     @Immutable
     public final class HttpAuthorization {
@@ -589,6 +598,7 @@ package com.azure.core.http {
         CONNECT;
     }
     public final class HttpPipeline {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public HttpClient getHttpClient()
         public HttpPipelinePolicy getPolicy(int index)
         public int getPolicyCount()
@@ -607,6 +617,7 @@ package com.azure.core.http {
         public HttpPipeline build()
     }
     public final class HttpPipelineCallContext {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Context getContext()
         public Optional<Object> getData(String key)
         public void setData(String key, Object value)
@@ -614,10 +625,12 @@ package com.azure.core.http {
         public HttpPipelineCallContext setHttpRequest(HttpRequest request)
     }
     public class HttpPipelineNextPolicy {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Override public HttpPipelineNextPolicy clone()
         public Mono<HttpResponse> process()
     }
     public class HttpPipelineNextSyncPolicy {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Override public HttpPipelineNextSyncPolicy clone()
         public HttpResponse processSync()
     }
@@ -732,6 +745,7 @@ package com.azure.core.http.policy {
         @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
     }
     public interface AfterRetryPolicyProvider extends HttpPolicyProvider {
+        // This interface does not declare any API.
     }
     public final class AzureKeyCredentialPolicy extends KeyCredentialPolicy {
         public AzureKeyCredentialPolicy(String name, AzureKeyCredential credential)
@@ -755,6 +769,7 @@ package com.azure.core.http.policy {
         @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
     }
     public interface BeforeRetryPolicyProvider extends HttpPolicyProvider {
+        // This interface does not declare any API.
     }
     public class CookiePolicy implements HttpPipelinePolicy {
         public CookiePolicy()
@@ -860,6 +875,7 @@ package com.azure.core.http.policy {
         HttpPipelinePolicy create()
     }
     public final class HttpPolicyProviders {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static void addAfterRetryPolicies(List<HttpPipelinePolicy> policies)
         public static void addBeforeRetryPolicies(List<HttpPipelinePolicy> policies)
     }
@@ -870,6 +886,7 @@ package com.azure.core.http.policy {
         default void logRequestSync(ClientLogger logger, HttpRequestLoggingContext loggingOptions)
     }
     public final class HttpRequestLoggingContext {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Context getContext()
         public HttpRequest getHttpRequest()
         public Integer getTryCount()
@@ -881,6 +898,7 @@ package com.azure.core.http.policy {
         default HttpResponse logResponseSync(ClientLogger logger, HttpResponseLoggingContext loggingOptions)
     }
     public final class HttpResponseLoggingContext {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Context getContext()
         public HttpResponse getHttpResponse()
         public Duration getResponseDuration()
@@ -920,6 +938,7 @@ package com.azure.core.http.policy {
         @Override public HttpResponse processSync(HttpPipelineCallContext context, HttpPipelineNextSyncPolicy next)
     }
     public final class RequestRetryCondition {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public HttpResponse getResponse()
         public List<Throwable> getRetriedThrowables()
         public Throwable getThrowable()
@@ -1041,6 +1060,7 @@ package com.azure.core.http.rest {
         @Override public T getValue()
     }
     public final class RestProxy implements InvocationHandler {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static <A> A create(Class<A> swaggerInterface)
         public static <A> A create(Class<A> swaggerInterface, HttpPipeline httpPipeline)
         public static <A> A create(Class<A> swaggerInterface, HttpPipeline httpPipeline, SerializerAdapter serializer)
@@ -1299,6 +1319,7 @@ package com.azure.core.util {
         @Override public String toString()
     }
     public final class Base64Util {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static byte[] decode(byte[] encoded)
         public static byte[] decodeString(String encoded)
         public static byte[] decodeURL(byte[] src)
@@ -1307,6 +1328,7 @@ package com.azure.core.util {
         public static byte[] encodeURLWithoutPadding(byte[] src)
     }
     public final class BinaryData {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static BinaryData fromByteBuffer(ByteBuffer data)
         public static BinaryData fromBytes(byte[] data)
         public static BinaryData fromFile(Path file)
@@ -1420,6 +1442,7 @@ package com.azure.core.util {
         public Configuration buildSection(String path)
     }
     public final class ConfigurationProperty<T> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Iterable<String> getAliases()
         public Function<String, T> getConverter()
         public T getDefaultValue()
@@ -1459,6 +1482,7 @@ package com.azure.core.util {
         public Map<Object, Object> getValues()
     }
     public final class Contexts {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Context getContext()
         public static Contexts empty()
         public ProgressReporter getHttpRequestProgressReporter()
@@ -1466,6 +1490,7 @@ package com.azure.core.util {
         public static Contexts with(Context context)
     }
     public final class CoreUtils {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static Thread addShutdownHookSafely(Thread shutdownThread)
         public static ExecutorService addShutdownHookSafely(ExecutorService executorService, Duration shutdownTimeout)
         public static String getApplicationId(ClientOptions clientOptions, HttpLogOptions logOptions)
@@ -1523,6 +1548,7 @@ package com.azure.core.util {
         protected static <T extends ExpandableStringEnum<T>> Collection<T> values(Class<T> clazz)
     }
     public final class FluxUtil {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static Flux<ByteBuffer> addProgressReporting(Flux<ByteBuffer> flux, ProgressReporter progressReporter)
         public static byte[] byteBufferToArray(ByteBuffer byteBuffer)
         public static Mono<byte[]> collectBytesFromNetworkResponse(Flux<ByteBuffer> stream, HttpHeaders headers)
@@ -1620,6 +1646,7 @@ package com.azure.core.util {
         void handleProgress(long progress)
     }
     public final class ProgressReporter {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public ProgressReporter createChild()
         public void reportProgress(long progress)
         public void reset()
@@ -1633,6 +1660,7 @@ package com.azure.core.util {
         String getVersion()
     }
     public final class SharedExecutorService implements ScheduledExecutorService {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Override public boolean awaitTermination(long timeout, TimeUnit unit)
         @Override public void execute(Runnable command)
         public ScheduledExecutorService getExecutorService()
@@ -1657,6 +1685,7 @@ package com.azure.core.util {
     }
     @Immutable
     public interface TelemetryAttributes {
+        // This interface does not declare any API.
     }
     public class TracingOptions {
         public TracingOptions()
@@ -1691,22 +1720,26 @@ package com.azure.core.util {
         public URL toUrl() throws MalformedURLException
     }
     public class UserAgentProperties {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public String getName()
         public String getVersion()
     }
     public final class UserAgentUtil {
         public static final String DEFAULT_USER_AGENT_HEADER = "azsdk-java";
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static String toUserAgentString(String applicationId, String sdkName, String sdkVersion, Configuration configuration)
     }
 }
 package com.azure.core.util.builder {
     public final class ClientBuilderUtil {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static HttpPipelinePolicy validateAndGetRetryPolicy(HttpPipelinePolicy retryPolicy, RetryOptions retryOptions)
         public static HttpPipelinePolicy validateAndGetRetryPolicy(HttpPipelinePolicy retryPolicy, RetryOptions retryOptions, HttpPipelinePolicy defaultPolicy)
     }
 }
 package com.azure.core.util.io {
     public final class IOUtils {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static AsynchronousByteChannel toAsynchronousByteChannel(AsynchronousFileChannel fileChannel, long position)
         public static void transfer(ReadableByteChannel source, WritableByteChannel destination) throws IOException
         public static void transfer(ReadableByteChannel source, WritableByteChannel destination, Long estimatedSourceSize) throws IOException
@@ -1754,6 +1787,7 @@ package com.azure.core.util.logging {
     }
     @Fluent
     public final class LoggingEventBuilder {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public LoggingEventBuilder addKeyValue(String key, String value)
         public LoggingEventBuilder addKeyValue(String key, Object value)
         public LoggingEventBuilder addKeyValue(String key, boolean value)
@@ -1846,6 +1880,7 @@ package com.azure.core.util.paging {
 }
 package com.azure.core.util.polling {
     public final class AsyncPollResponse<T, U> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public Mono<T> cancelOperation()
         public Mono<U> getFinalResult()
         public LongRunningOperationStatus getStatus()
@@ -1904,6 +1939,7 @@ package com.azure.core.util.polling {
     }
     @Immutable
     public final class PollOperationDetails implements JsonSerializable<PollOperationDetails> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public ResponseError getError()
         public String getOperationId()
     }
@@ -1925,6 +1961,7 @@ package com.azure.core.util.polling {
         public SyncPoller<T, U> getSyncPoller()
     }
     public final class PollingContext<T> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public PollResponse<T> getActivationResponse()
         public String getData(String name)
         public PollingContext<T> setData(String name, String value)
@@ -2069,6 +2106,7 @@ package com.azure.core.util.serializer {
         JsonSerializer createInstance()
     }
     public final class JsonSerializerProviders {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static JsonSerializer createInstance()
         public static JsonSerializer createInstance(boolean useDefaultIfAbsent)
     }
@@ -2079,6 +2117,7 @@ package com.azure.core.util.serializer {
         MemberNameConverter createInstance()
     }
     public final class MemberNameConverterProviders {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static MemberNameConverter createInstance()
     }
     public interface ObjectSerializer {
@@ -2184,6 +2223,7 @@ package com.azure.core.util.tracing {
     }
     @Deprecated
     public final class TracerProxy {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static void setAttribute(String key, String value, Context context)
         public static void end(int responseCode, Throwable error, Context context)
         public static Context setSpanName(String spanName, Context context)

--- a/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
+++ b/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
@@ -1,2360 +1,2360 @@
 ```java
-maven { 
-    parent : com.azure:azure-client-sdk-parent:1.7.0 
-    properties : com.azure:azure-analytics-planetarycomputer:1.1.0-beta.1 
-    configuration { 
-        jacoco { 
-            min-line-coverage : 0.2 
-            min-branch-coverage : 0.05 
-        } 
-    } 
-    name : Microsoft Azure SDK for Planetary Computer 
-    description : This package contains Microsoft Azure Planetary Computer client library. 
-    dependencies { 
-        // compile scope 
-        com.azure:azure-core 1.59.0 
-        com.azure:azure-core-http-netty 1.16.6 
-    } 
-} 
-module com.azure.analytics.planetarycomputer { 
+maven {
+    parent : com.azure:azure-client-sdk-parent:1.7.0
+    properties : com.azure:azure-analytics-planetarycomputer:1.1.0-beta.1
+    configuration {
+        jacoco {
+            min-line-coverage : 0.2
+            min-branch-coverage : 0.05
+        }
+    }
+    name : Microsoft Azure SDK for Planetary Computer
+    description : This package contains Microsoft Azure Planetary Computer client library.
+    dependencies {
+        // compile scope
+        com.azure:azure-core 1.59.0
+        com.azure:azure-core-http-netty 1.16.6
+    }
+}
+module com.azure.analytics.planetarycomputer {
     requires transitive com.azure.core;
     exports com.azure.analytics.planetarycomputer;
     exports com.azure.analytics.planetarycomputer.models;
     opens com.azure.analytics.planetarycomputer.models to com.azure.core;
     opens com.azure.analytics.planetarycomputer.implementation.models to com.azure.core;
-} 
-package com.azure.analytics.planetarycomputer { 
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true) 
-    public final class DataAsyncClient { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        // Service Methods: 
-        @Generated public Mono<ClassMapLegendResponse> getClassMapLegend(String classmapName) 
-        @Generated public Mono<ClassMapLegendResponse> getClassMapLegend(String classmapName, Integer trimStart, Integer trimEnd) 
-        @Generated public Mono<Response<BinaryData>> getClassMapLegendWithResponse(String classmapName, RequestOptions requestOptions) 
-        @Generated public Mono<List<BinaryData>> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy) 
-        @Generated public Mono<List<BinaryData>> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
-        @Generated public Mono<Response<BinaryData>> getCollectionAssetsForBboxWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions) 
-        @Generated public Mono<List<BinaryData>> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y) 
-        @Generated public Mono<List<BinaryData>> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId) 
-        @Generated public Mono<Response<BinaryData>> getCollectionAssetsForTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public Mono<List<TilerAssetGeoJson>> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y) 
-        @Generated public Mono<List<TilerAssetGeoJson>> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getCollectionAssetsForTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format) 
-        @Generated public Mono<BinaryData> getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
-        @Generated public Mono<BinaryData> getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
-        @Generated public Mono<BinaryData> getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
-        @Generated public Mono<Response<BinaryData>> getCollectionBboxCropWithDimensionsWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getCollectionBboxCropWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
-        @Generated public Mono<TilerStacSearchRegistration> getCollectionInfo(String collectionId) 
-        @Generated public Mono<Response<BinaryData>> getCollectionInfoWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<TilerCoreModelsResponsesPoint> getCollectionPoint(String collectionId, double longitude, double latitude) 
-        @Generated public Mono<TilerCoreModelsResponsesPoint> getCollectionPoint(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling) 
-        @Generated public Mono<List<StacItemPointAsset>> getCollectionPointAssets(String collectionId, double longitude, double latitude) 
-        @Generated public Mono<List<StacItemPointAsset>> getCollectionPointAssets(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
-        @Generated public Mono<Response<BinaryData>> getCollectionPointAssetsWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getCollectionPointWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions) 
-        @Generated public Mono<TileJsonMetadata> getCollectionTileJson(String collectionId) 
-        @Generated public Mono<TileJsonMetadata> getCollectionTileJson(String collectionId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTileJsonWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<TileJsonMetadata> getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId) 
-        @Generated public Mono<TileJsonMetadata> getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTileJsonWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getCollectionTileNoTms(String collectionId, double z, double x, double y) 
-        @Generated public Mono<BinaryData> getCollectionTileNoTms(String collectionId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<BinaryData> getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format) 
-        @Generated public Mono<BinaryData> getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsByFormatWithResponse(String collectionId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale) 
-        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format) 
-        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsByScaleAndFormatWithResponse(String collectionId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsByScaleWithResponse(String collectionId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public Mono<TileSetMetadata> getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId) 
-        @Generated public Mono<TileSetMetadata> getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTilesetMetadataWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public Mono<TileSetList> getCollectionTilesets(String collectionId) 
-        @Generated public Mono<TileSetList> getCollectionTilesets(String collectionId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTilesetsWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y) 
-        @Generated public Mono<BinaryData> getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<BinaryData> getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format) 
-        @Generated public Mono<BinaryData> getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsByFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale) 
-        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
-        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsByScaleAndFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsByScaleWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public Mono<byte[]> getCollectionWmtsCapabilities(String collectionId) 
-        @Generated public Mono<byte[]> getCollectionWmtsCapabilities(String collectionId, String ids, String bbox, String query, String sortby, String datetime, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
-        @Generated public Mono<Response<BinaryData>> getCollectionWmtsCapabilitiesWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<byte[]> getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId) 
-        @Generated public Mono<byte[]> getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
-        @Generated public Mono<Response<BinaryData>> getCollectionWmtsCapabilitiesWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> cropCollectionFeature(String collectionId, GeoJsonFeature body) 
-        @Generated public Mono<BinaryData> cropCollectionFeature(String collectionId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format) 
-        @Generated public Mono<BinaryData> cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body) 
-        @Generated public Mono<BinaryData> cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
-        @Generated public Mono<Response<BinaryData>> cropCollectionFeatureByFormatWithResponse(String collectionId, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body) 
-        @Generated public Mono<BinaryData> cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
-        @Generated public Mono<Response<BinaryData>> cropCollectionFeatureWidthByHeightWithResponse(String collectionId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> cropCollectionFeatureWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> cropFeature(String collectionId, String itemId, GeoJsonFeature body) 
-        @Generated public Mono<BinaryData> cropFeature(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TilerImageFormat format) 
-        @Generated public Mono<BinaryData> cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body) 
-        @Generated public Mono<BinaryData> cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> cropFeatureByFormatWithResponse(String collectionId, String itemId, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body) 
-        @Generated public Mono<BinaryData> cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> cropFeatureWidthByHeightWithResponse(String collectionId, String itemId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> cropFeatureWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> cropSearchFeature(String searchId, GeoJsonFeature body) 
-        @Generated public Mono<BinaryData> cropSearchFeature(String searchId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format) 
-        @Generated public Mono<BinaryData> cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body) 
-        @Generated public Mono<BinaryData> cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
-        @Generated public Mono<Response<BinaryData>> cropSearchFeatureByFormatWithResponse(String searchId, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body) 
-        @Generated public Mono<BinaryData> cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
-        @Generated public Mono<Response<BinaryData>> cropSearchFeatureWidthByHeightWithResponse(String searchId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> cropSearchFeatureWithResponse(String searchId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<List<List<List<Long>>>> getIntervalLegend(String classmapName) 
-        @Generated public Mono<List<List<List<Long>>>> getIntervalLegend(String classmapName, Integer trimStart, Integer trimEnd) 
-        @Generated public Mono<Response<BinaryData>> getIntervalLegendWithResponse(String classmapName, RequestOptions requestOptions) 
-        @Generated public Mono<AssetStatisticsResponse> getItemAssetStatistics(String collectionId, String itemId) 
-        @Generated public Mono<AssetStatisticsResponse> getItemAssetStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, List<String> assetBandIndices, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assetExpression, Integer height, Integer width) 
-        @Generated public Mono<Response<BinaryData>> getItemAssetStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Mono<List<String>> getItemAvailableAssets(String collectionId, String itemId) 
-        @Generated public Mono<List<String>> getItemAvailableAssets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getItemAvailableAssetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format) 
-        @Generated public Mono<BinaryData> getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<BinaryData> getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
-        @Generated public Mono<BinaryData> getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getItemBboxCropWithDimensionsWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getItemBboxCropWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
-        @Generated public Mono<StacItemBounds> getItemBounds(String collectionId, String itemId) 
-        @Generated public Mono<StacItemBounds> getItemBounds(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getItemBoundsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Mono<StacItemStatisticsGeoJson> getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body) 
-        @Generated public Mono<StacItemStatisticsGeoJson> getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width) 
-        @Generated public Mono<Response<BinaryData>> getItemFeatureStatisticsWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<TilerInfoMapResponse> getItemInfo(String collectionId, String itemId) 
-        @Generated public Mono<TilerInfoMapResponse> getItemInfo(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets) 
-        @Generated public Mono<TilerInfoGeoJsonFeature> getItemInfoGeoJson(String collectionId, String itemId) 
-        @Generated public Mono<TilerInfoGeoJsonFeature> getItemInfoGeoJson(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets) 
-        @Generated public Mono<Response<BinaryData>> getItemInfoGeoJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getItemInfoWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Mono<TilerCoreModelsResponsesPoint> getItemPoint(String collectionId, String itemId, double longitude, double latitude) 
-        @Generated public Mono<TilerCoreModelsResponsesPoint> getItemPoint(String collectionId, String itemId, double longitude, double latitude, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem, Resampling resampling) 
-        @Generated public Mono<Response<BinaryData>> getItemPointWithResponse(String collectionId, String itemId, double longitude, double latitude, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getItemPreview(String collectionId, String itemId) 
-        @Generated public Mono<BinaryData> getItemPreview(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<BinaryData> getItemPreviewWithFormat(String collectionId, String itemId, String format) 
-        @Generated public Mono<BinaryData> getItemPreviewWithFormat(String collectionId, String itemId, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getItemPreviewWithFormatWithResponse(String collectionId, String itemId, String format, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getItemPreviewWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Mono<TilerStacItemStatistics> getItemStatistics(String collectionId, String itemId) 
-        @Generated public Mono<TilerStacItemStatistics> getItemStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width) 
-        @Generated public Mono<Response<BinaryData>> getItemStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Mono<TileJsonMetadata> getItemTileJson(String collectionId, String itemId) 
-        @Generated public Mono<TileJsonMetadata> getItemTileJson(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getItemTileJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Mono<TileJsonMetadata> getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId) 
-        @Generated public Mono<TileJsonMetadata> getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getItemTileJsonWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public Mono<byte[]> getItemWmtsCapabilities(String collectionId, String itemId) 
-        @Generated public Mono<byte[]> getItemWmtsCapabilities(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getItemWmtsCapabilitiesWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Mono<byte[]> getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId) 
-        @Generated public Mono<byte[]> getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getItemWmtsCapabilitiesWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getLegend(String colorMapName) 
-        @Generated public Mono<BinaryData> getLegend(String colorMapName, Double height, Double width, Integer trimStart, Integer trimEnd) 
-        @Generated public Mono<Response<BinaryData>> getLegendWithResponse(String colorMapName, RequestOptions requestOptions) 
-        @Generated public Mono<TilerMosaicSearchRegistrationResponse> registerMosaicsSearch(RegisterMosaicsSearchOptions options) 
-        @Generated public Mono<Response<BinaryData>> registerMosaicsSearchWithResponse(BinaryData registerMosaicsSearchRequest, RequestOptions requestOptions) 
-        @Generated public Mono<List<BinaryData>> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y) 
-        @Generated public Mono<List<BinaryData>> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId) 
-        @Generated public Mono<Response<BinaryData>> getSearchAssetsForTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public Mono<List<TilerAssetGeoJson>> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y) 
-        @Generated public Mono<List<TilerAssetGeoJson>> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getSearchAssetsForTileWithTmsWithResponse(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public Mono<List<BinaryData>> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy) 
-        @Generated public Mono<List<BinaryData>> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
-        @Generated public Mono<Response<BinaryData>> getSearchBboxAssetsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format) 
-        @Generated public Mono<BinaryData> getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
-        @Generated public Mono<BinaryData> getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
-        @Generated public Mono<BinaryData> getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
-        @Generated public Mono<Response<BinaryData>> getSearchBboxCropWithDimensionsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getSearchBboxCropWithResponse(String searchId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
-        @Generated public Mono<TilerStacSearchRegistration> getSearchInfo(String searchId) 
-        @Generated public Mono<Response<BinaryData>> getSearchInfoWithResponse(String searchId, RequestOptions requestOptions) 
-        @Generated public Mono<TilerCoreModelsResponsesPoint> getSearchPoint(String searchId, double longitude, double latitude) 
-        @Generated public Mono<TilerCoreModelsResponsesPoint> getSearchPoint(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling) 
-        @Generated public Mono<List<StacItemPointAsset>> getSearchPointWithAssets(String searchId, double longitude, double latitude) 
-        @Generated public Mono<List<StacItemPointAsset>> getSearchPointWithAssets(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
-        @Generated public Mono<Response<BinaryData>> getSearchPointWithAssetsWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getSearchPointWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions) 
-        @Generated public Mono<TileJsonMetadata> getSearchTileJson(String searchId) 
-        @Generated public Mono<TileJsonMetadata> getSearchTileJson(String searchId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Integer padding, Double buffer, String colorFormula, String collectionId, Resampling resampling, PixelSelection pixelSelection, TerrainAlgorithm algorithm, String algorithmParams, List<String> rescale, ColorMapNames colormapName, String colormap, Boolean returnMask) 
-        @Generated public Mono<Response<BinaryData>> getSearchTileJsonWithResponse(String searchId, RequestOptions requestOptions) 
-        @Generated public Mono<TileJsonMetadata> getSearchTileJsonWithTms(String searchId, String tileMatrixSetId) 
-        @Generated public Mono<TileJsonMetadata> getSearchTileJsonWithTms(String searchId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer minZoom, Integer maxZoom, TilerImageFormat tileFormat, Integer tileScale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<Response<BinaryData>> getSearchTileJsonWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getSearchTileNoTms(String searchId, double z, double x, double y) 
-        @Generated public Mono<BinaryData> getSearchTileNoTms(String searchId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<BinaryData> getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format) 
-        @Generated public Mono<BinaryData> getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsByFormatWithResponse(String searchId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale) 
-        @Generated public Mono<BinaryData> getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<BinaryData> getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format) 
-        @Generated public Mono<BinaryData> getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsByScaleAndFormatWithResponse(String searchId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsByScaleWithResponse(String searchId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public Mono<TileSetMetadata> getSearchTilesetMetadata(String searchId, String tileMatrixSetId) 
-        @Generated public Mono<TileSetMetadata> getSearchTilesetMetadata(String searchId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getSearchTilesetMetadataWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public Mono<TileSetList> getSearchTilesets(String searchId) 
-        @Generated public Mono<TileSetList> getSearchTilesets(String searchId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getSearchTilesetsWithResponse(String searchId, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y) 
-        @Generated public Mono<BinaryData> getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<BinaryData> getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format) 
-        @Generated public Mono<BinaryData> getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsByFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale) 
-        @Generated public Mono<BinaryData> getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<BinaryData> getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
-        @Generated public Mono<BinaryData> getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsByScaleAndFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsByScaleWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public Mono<byte[]> getSearchWmtsCapabilities(String searchId) 
-        @Generated public Mono<byte[]> getSearchWmtsCapabilities(String searchId, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
-        @Generated public Mono<Response<BinaryData>> getSearchWmtsCapabilitiesWithResponse(String searchId, RequestOptions requestOptions) 
-        @Generated public Mono<byte[]> getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId) 
-        @Generated public Mono<byte[]> getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
-        @Generated public Mono<Response<BinaryData>> getSearchWmtsCapabilitiesWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public Mono<List<String>> getTileMatrices() 
-        @Generated public Mono<Response<BinaryData>> getTileMatricesWithResponse(RequestOptions requestOptions) 
-        @Generated public Mono<TileMatrixSet> getTileMatrixDefinitions(String tileMatrixSetId) 
-        @Generated public Mono<Response<BinaryData>> getTileMatrixDefinitionsWithResponse(String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getTileNoTms(String collectionId, String itemId, double z, double x, double y) 
-        @Generated public Mono<BinaryData> getTileNoTms(String collectionId, String itemId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<BinaryData> getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format) 
-        @Generated public Mono<BinaryData> getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getTileNoTmsByFormatWithResponse(String collectionId, String itemId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale) 
-        @Generated public Mono<BinaryData> getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<BinaryData> getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format) 
-        @Generated public Mono<BinaryData> getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getTileNoTmsByScaleAndFormatWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getTileNoTmsByScaleWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getTileNoTmsWithResponse(String collectionId, String itemId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public Mono<TileSetMetadata> getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId) 
-        @Generated public Mono<TileSetMetadata> getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getTilesetMetadataWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public Mono<TileSetList> getTilesets(String collectionId, String itemId) 
-        @Generated public Mono<TileSetList> getTilesets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getTilesetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y) 
-        @Generated public Mono<BinaryData> getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<BinaryData> getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format) 
-        @Generated public Mono<BinaryData> getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getTileWithTmsByFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale) 
-        @Generated public Mono<BinaryData> getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<BinaryData> getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
-        @Generated public Mono<BinaryData> getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Mono<Response<BinaryData>> getTileWithTmsByScaleAndFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getTileWithTmsByScaleWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getTileWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
-    } 
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder) 
-    public final class DataClient { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        // Service Methods: 
-        @Generated public ClassMapLegendResponse getClassMapLegend(String classmapName) 
-        @Generated public ClassMapLegendResponse getClassMapLegend(String classmapName, Integer trimStart, Integer trimEnd) 
-        @Generated public Response<BinaryData> getClassMapLegendWithResponse(String classmapName, RequestOptions requestOptions) 
-        @Generated public List<BinaryData> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy) 
-        @Generated public List<BinaryData> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
-        @Generated public Response<BinaryData> getCollectionAssetsForBboxWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions) 
-        @Generated public List<BinaryData> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y) 
-        @Generated public List<BinaryData> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId) 
-        @Generated public Response<BinaryData> getCollectionAssetsForTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public List<TilerAssetGeoJson> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y) 
-        @Generated public List<TilerAssetGeoJson> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getCollectionAssetsForTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public BinaryData getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format) 
-        @Generated public BinaryData getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
-        @Generated public BinaryData getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
-        @Generated public BinaryData getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
-        @Generated public Response<BinaryData> getCollectionBboxCropWithDimensionsWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getCollectionBboxCropWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
-        @Generated public TilerStacSearchRegistration getCollectionInfo(String collectionId) 
-        @Generated public Response<BinaryData> getCollectionInfoWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public TilerCoreModelsResponsesPoint getCollectionPoint(String collectionId, double longitude, double latitude) 
-        @Generated public TilerCoreModelsResponsesPoint getCollectionPoint(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling) 
-        @Generated public List<StacItemPointAsset> getCollectionPointAssets(String collectionId, double longitude, double latitude) 
-        @Generated public List<StacItemPointAsset> getCollectionPointAssets(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
-        @Generated public Response<BinaryData> getCollectionPointAssetsWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getCollectionPointWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions) 
-        @Generated public TileJsonMetadata getCollectionTileJson(String collectionId) 
-        @Generated public TileJsonMetadata getCollectionTileJson(String collectionId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Response<BinaryData> getCollectionTileJsonWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public TileJsonMetadata getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId) 
-        @Generated public TileJsonMetadata getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Response<BinaryData> getCollectionTileJsonWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public BinaryData getCollectionTileNoTms(String collectionId, double z, double x, double y) 
-        @Generated public BinaryData getCollectionTileNoTms(String collectionId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public BinaryData getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format) 
-        @Generated public BinaryData getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Response<BinaryData> getCollectionTileNoTmsByFormatWithResponse(String collectionId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public BinaryData getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale) 
-        @Generated public BinaryData getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public BinaryData getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format) 
-        @Generated public BinaryData getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Response<BinaryData> getCollectionTileNoTmsByScaleAndFormatWithResponse(String collectionId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getCollectionTileNoTmsByScaleWithResponse(String collectionId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getCollectionTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public TileSetMetadata getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId) 
-        @Generated public TileSetMetadata getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getCollectionTilesetMetadataWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public TileSetList getCollectionTilesets(String collectionId) 
-        @Generated public TileSetList getCollectionTilesets(String collectionId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getCollectionTilesetsWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public BinaryData getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y) 
-        @Generated public BinaryData getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public BinaryData getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format) 
-        @Generated public BinaryData getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Response<BinaryData> getCollectionTileWithTmsByFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public BinaryData getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale) 
-        @Generated public BinaryData getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public BinaryData getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
-        @Generated public BinaryData getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Response<BinaryData> getCollectionTileWithTmsByScaleAndFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getCollectionTileWithTmsByScaleWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getCollectionTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public byte[] getCollectionWmtsCapabilities(String collectionId) 
-        @Generated public byte[] getCollectionWmtsCapabilities(String collectionId, String ids, String bbox, String query, String sortby, String datetime, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
-        @Generated public Response<BinaryData> getCollectionWmtsCapabilitiesWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public byte[] getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId) 
-        @Generated public byte[] getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
-        @Generated public Response<BinaryData> getCollectionWmtsCapabilitiesWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public BinaryData cropCollectionFeature(String collectionId, GeoJsonFeature body) 
-        @Generated public BinaryData cropCollectionFeature(String collectionId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format) 
-        @Generated public BinaryData cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body) 
-        @Generated public BinaryData cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
-        @Generated public Response<BinaryData> cropCollectionFeatureByFormatWithResponse(String collectionId, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public BinaryData cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body) 
-        @Generated public BinaryData cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
-        @Generated public Response<BinaryData> cropCollectionFeatureWidthByHeightWithResponse(String collectionId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> cropCollectionFeatureWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public BinaryData cropFeature(String collectionId, String itemId, GeoJsonFeature body) 
-        @Generated public BinaryData cropFeature(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TilerImageFormat format) 
-        @Generated public BinaryData cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body) 
-        @Generated public BinaryData cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> cropFeatureByFormatWithResponse(String collectionId, String itemId, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public BinaryData cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body) 
-        @Generated public BinaryData cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> cropFeatureWidthByHeightWithResponse(String collectionId, String itemId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> cropFeatureWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public BinaryData cropSearchFeature(String searchId, GeoJsonFeature body) 
-        @Generated public BinaryData cropSearchFeature(String searchId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format) 
-        @Generated public BinaryData cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body) 
-        @Generated public BinaryData cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
-        @Generated public Response<BinaryData> cropSearchFeatureByFormatWithResponse(String searchId, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public BinaryData cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body) 
-        @Generated public BinaryData cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
-        @Generated public Response<BinaryData> cropSearchFeatureWidthByHeightWithResponse(String searchId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> cropSearchFeatureWithResponse(String searchId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public List<List<List<Long>>> getIntervalLegend(String classmapName) 
-        @Generated public List<List<List<Long>>> getIntervalLegend(String classmapName, Integer trimStart, Integer trimEnd) 
-        @Generated public Response<BinaryData> getIntervalLegendWithResponse(String classmapName, RequestOptions requestOptions) 
-        @Generated public AssetStatisticsResponse getItemAssetStatistics(String collectionId, String itemId) 
-        @Generated public AssetStatisticsResponse getItemAssetStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, List<String> assetBandIndices, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assetExpression, Integer height, Integer width) 
-        @Generated public Response<BinaryData> getItemAssetStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public List<String> getItemAvailableAssets(String collectionId, String itemId) 
-        @Generated public List<String> getItemAvailableAssets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getItemAvailableAssetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public BinaryData getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format) 
-        @Generated public BinaryData getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public BinaryData getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
-        @Generated public BinaryData getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getItemBboxCropWithDimensionsWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getItemBboxCropWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
-        @Generated public StacItemBounds getItemBounds(String collectionId, String itemId) 
-        @Generated public StacItemBounds getItemBounds(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getItemBoundsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public StacItemStatisticsGeoJson getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body) 
-        @Generated public StacItemStatisticsGeoJson getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width) 
-        @Generated public Response<BinaryData> getItemFeatureStatisticsWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public TilerInfoMapResponse getItemInfo(String collectionId, String itemId) 
-        @Generated public TilerInfoMapResponse getItemInfo(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets) 
-        @Generated public TilerInfoGeoJsonFeature getItemInfoGeoJson(String collectionId, String itemId) 
-        @Generated public TilerInfoGeoJsonFeature getItemInfoGeoJson(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets) 
-        @Generated public Response<BinaryData> getItemInfoGeoJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getItemInfoWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public TilerCoreModelsResponsesPoint getItemPoint(String collectionId, String itemId, double longitude, double latitude) 
-        @Generated public TilerCoreModelsResponsesPoint getItemPoint(String collectionId, String itemId, double longitude, double latitude, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem, Resampling resampling) 
-        @Generated public Response<BinaryData> getItemPointWithResponse(String collectionId, String itemId, double longitude, double latitude, RequestOptions requestOptions) 
-        @Generated public BinaryData getItemPreview(String collectionId, String itemId) 
-        @Generated public BinaryData getItemPreview(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public BinaryData getItemPreviewWithFormat(String collectionId, String itemId, String format) 
-        @Generated public BinaryData getItemPreviewWithFormat(String collectionId, String itemId, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getItemPreviewWithFormatWithResponse(String collectionId, String itemId, String format, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getItemPreviewWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public TilerStacItemStatistics getItemStatistics(String collectionId, String itemId) 
-        @Generated public TilerStacItemStatistics getItemStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width) 
-        @Generated public Response<BinaryData> getItemStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public TileJsonMetadata getItemTileJson(String collectionId, String itemId) 
-        @Generated public TileJsonMetadata getItemTileJson(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getItemTileJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public TileJsonMetadata getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId) 
-        @Generated public TileJsonMetadata getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getItemTileJsonWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public byte[] getItemWmtsCapabilities(String collectionId, String itemId) 
-        @Generated public byte[] getItemWmtsCapabilities(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getItemWmtsCapabilitiesWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public byte[] getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId) 
-        @Generated public byte[] getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getItemWmtsCapabilitiesWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public BinaryData getLegend(String colorMapName) 
-        @Generated public BinaryData getLegend(String colorMapName, Double height, Double width, Integer trimStart, Integer trimEnd) 
-        @Generated public Response<BinaryData> getLegendWithResponse(String colorMapName, RequestOptions requestOptions) 
-        @Generated public TilerMosaicSearchRegistrationResponse registerMosaicsSearch(RegisterMosaicsSearchOptions options) 
-        @Generated public Response<BinaryData> registerMosaicsSearchWithResponse(BinaryData registerMosaicsSearchRequest, RequestOptions requestOptions) 
-        @Generated public List<BinaryData> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y) 
-        @Generated public List<BinaryData> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId) 
-        @Generated public Response<BinaryData> getSearchAssetsForTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public List<TilerAssetGeoJson> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y) 
-        @Generated public List<TilerAssetGeoJson> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getSearchAssetsForTileWithTmsWithResponse(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public List<BinaryData> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy) 
-        @Generated public List<BinaryData> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
-        @Generated public Response<BinaryData> getSearchBboxAssetsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions) 
-        @Generated public BinaryData getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format) 
-        @Generated public BinaryData getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
-        @Generated public BinaryData getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
-        @Generated public BinaryData getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
-        @Generated public Response<BinaryData> getSearchBboxCropWithDimensionsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getSearchBboxCropWithResponse(String searchId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
-        @Generated public TilerStacSearchRegistration getSearchInfo(String searchId) 
-        @Generated public Response<BinaryData> getSearchInfoWithResponse(String searchId, RequestOptions requestOptions) 
-        @Generated public TilerCoreModelsResponsesPoint getSearchPoint(String searchId, double longitude, double latitude) 
-        @Generated public TilerCoreModelsResponsesPoint getSearchPoint(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling) 
-        @Generated public List<StacItemPointAsset> getSearchPointWithAssets(String searchId, double longitude, double latitude) 
-        @Generated public List<StacItemPointAsset> getSearchPointWithAssets(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
-        @Generated public Response<BinaryData> getSearchPointWithAssetsWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getSearchPointWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions) 
-        @Generated public TileJsonMetadata getSearchTileJson(String searchId) 
-        @Generated public TileJsonMetadata getSearchTileJson(String searchId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Integer padding, Double buffer, String colorFormula, String collectionId, Resampling resampling, PixelSelection pixelSelection, TerrainAlgorithm algorithm, String algorithmParams, List<String> rescale, ColorMapNames colormapName, String colormap, Boolean returnMask) 
-        @Generated public Response<BinaryData> getSearchTileJsonWithResponse(String searchId, RequestOptions requestOptions) 
-        @Generated public TileJsonMetadata getSearchTileJsonWithTms(String searchId, String tileMatrixSetId) 
-        @Generated public TileJsonMetadata getSearchTileJsonWithTms(String searchId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer minZoom, Integer maxZoom, TilerImageFormat tileFormat, Integer tileScale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Response<BinaryData> getSearchTileJsonWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public BinaryData getSearchTileNoTms(String searchId, double z, double x, double y) 
-        @Generated public BinaryData getSearchTileNoTms(String searchId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public BinaryData getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format) 
-        @Generated public BinaryData getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Response<BinaryData> getSearchTileNoTmsByFormatWithResponse(String searchId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public BinaryData getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale) 
-        @Generated public BinaryData getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public BinaryData getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format) 
-        @Generated public BinaryData getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Response<BinaryData> getSearchTileNoTmsByScaleAndFormatWithResponse(String searchId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getSearchTileNoTmsByScaleWithResponse(String searchId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getSearchTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public TileSetMetadata getSearchTilesetMetadata(String searchId, String tileMatrixSetId) 
-        @Generated public TileSetMetadata getSearchTilesetMetadata(String searchId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getSearchTilesetMetadataWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public TileSetList getSearchTilesets(String searchId) 
-        @Generated public TileSetList getSearchTilesets(String searchId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getSearchTilesetsWithResponse(String searchId, RequestOptions requestOptions) 
-        @Generated public BinaryData getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y) 
-        @Generated public BinaryData getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public BinaryData getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format) 
-        @Generated public BinaryData getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Response<BinaryData> getSearchTileWithTmsByFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public BinaryData getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale) 
-        @Generated public BinaryData getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public BinaryData getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
-        @Generated public BinaryData getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
-        @Generated public Response<BinaryData> getSearchTileWithTmsByScaleAndFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getSearchTileWithTmsByScaleWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getSearchTileWithTmsWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public byte[] getSearchWmtsCapabilities(String searchId) 
-        @Generated public byte[] getSearchWmtsCapabilities(String searchId, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
-        @Generated public Response<BinaryData> getSearchWmtsCapabilitiesWithResponse(String searchId, RequestOptions requestOptions) 
-        @Generated public byte[] getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId) 
-        @Generated public byte[] getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
-        @Generated public Response<BinaryData> getSearchWmtsCapabilitiesWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public List<String> getTileMatrices() 
-        @Generated public Response<BinaryData> getTileMatricesWithResponse(RequestOptions requestOptions) 
-        @Generated public TileMatrixSet getTileMatrixDefinitions(String tileMatrixSetId) 
-        @Generated public Response<BinaryData> getTileMatrixDefinitionsWithResponse(String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public BinaryData getTileNoTms(String collectionId, String itemId, double z, double x, double y) 
-        @Generated public BinaryData getTileNoTms(String collectionId, String itemId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public BinaryData getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format) 
-        @Generated public BinaryData getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getTileNoTmsByFormatWithResponse(String collectionId, String itemId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public BinaryData getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale) 
-        @Generated public BinaryData getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public BinaryData getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format) 
-        @Generated public BinaryData getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getTileNoTmsByScaleAndFormatWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getTileNoTmsByScaleWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getTileNoTmsWithResponse(String collectionId, String itemId, double z, double x, double y, RequestOptions requestOptions) 
-        @Generated public TileSetMetadata getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId) 
-        @Generated public TileSetMetadata getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getTilesetMetadataWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
-        @Generated public TileSetList getTilesets(String collectionId, String itemId) 
-        @Generated public TileSetList getTilesets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getTilesetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public BinaryData getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y) 
-        @Generated public BinaryData getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public BinaryData getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format) 
-        @Generated public BinaryData getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getTileWithTmsByFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
-        @Generated public BinaryData getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale) 
-        @Generated public BinaryData getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public BinaryData getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
-        @Generated public BinaryData getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
-        @Generated public Response<BinaryData> getTileWithTmsByScaleAndFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getTileWithTmsByScaleWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getTileWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
-    } 
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true) 
-    public final class IngestionAsyncClient { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        // Service Methods: 
-        @Generated public Mono<IngestionDefinition> get(String collectionId, String ingestionId) 
-        @Generated public PollerFlux<Operation, Void> beginDelete(String collectionId, String ingestionId) 
-        @Generated public PollerFlux<BinaryData, Void> beginDelete(String collectionId, String ingestionId, RequestOptions requestOptions) 
-        @Generated public Mono<Void> cancelAllOperations() 
-        @Generated public Mono<Response<Void>> cancelAllOperationsWithResponse(RequestOptions requestOptions) 
-        @Generated public Mono<Void> cancelOperation(String operationId) 
-        @Generated public Mono<Response<Void>> cancelOperationWithResponse(String operationId, RequestOptions requestOptions) 
-        @Generated public Mono<IngestionDefinition> create(String collectionId, IngestionDefinition body) 
-        @Generated public Mono<IngestionRun> createRun(String collectionId, String ingestionId) 
-        @Generated public Mono<Response<BinaryData>> createRunWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions) 
-        @Generated public Mono<IngestionSource> createSource(IngestionSource body) 
-        @Generated public Mono<Response<BinaryData>> createSourceWithResponse(BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> createWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<Void> deleteSource(String id) 
-        @Generated public Mono<Response<Void>> deleteSourceWithResponse(String id, RequestOptions requestOptions) 
-        @Generated public PagedFlux<IngestionDefinition> list(String collectionId) 
-        @Generated public PagedFlux<BinaryData> list(String collectionId, RequestOptions requestOptions) 
-        @Generated public PagedFlux<IngestionDefinition> list(String collectionId, Integer top, Integer skip) 
-        @Generated public PagedFlux<ManagedIdentityMetadata> listManagedIdentities() 
-        @Generated public PagedFlux<BinaryData> listManagedIdentities(RequestOptions requestOptions) 
-        @Generated public PagedFlux<Operation> listOperations() 
-        @Generated public PagedFlux<BinaryData> listOperations(RequestOptions requestOptions) 
-        @Generated public PagedFlux<Operation> listOperations(Integer top, Integer skip, String collectionId, OperationStatus status) 
-        @Generated public PagedFlux<IngestionRun> listRuns(String collectionId, String ingestionId) 
-        @Generated public PagedFlux<BinaryData> listRuns(String collectionId, String ingestionId, RequestOptions requestOptions) 
-        @Generated public PagedFlux<IngestionRun> listRuns(String collectionId, String ingestionId, Integer top, Integer skip) 
-        @Generated public PagedFlux<IngestionSourceSummary> listSources() 
-        @Generated public PagedFlux<BinaryData> listSources(RequestOptions requestOptions) 
-        @Generated public PagedFlux<IngestionSourceSummary> listSources(Integer top, Integer skip) 
-        @Generated public Mono<Operation> getOperation(String operationId) 
-        @Generated public Mono<Response<BinaryData>> getOperationWithResponse(String operationId, RequestOptions requestOptions) 
-        @Generated public Mono<IngestionSource> replaceSource(String id, IngestionSource body) 
-        @Generated public Mono<Response<BinaryData>> replaceSourceWithResponse(String id, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<IngestionRun> getRun(String collectionId, String ingestionId, String runId) 
-        @Generated public Mono<Response<BinaryData>> getRunWithResponse(String collectionId, String ingestionId, String runId, RequestOptions requestOptions) 
-        @Generated public Mono<IngestionSource> getSource(String id) 
-        @Generated public Mono<Response<BinaryData>> getSourceWithResponse(String id, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> updateWithResponse(String collectionId, String ingestionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions) 
-    } 
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder) 
-    public final class IngestionClient { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        // Service Methods: 
-        @Generated public IngestionDefinition get(String collectionId, String ingestionId) 
-        @Generated public SyncPoller<Operation, Void> beginDelete(String collectionId, String ingestionId) 
-        @Generated public SyncPoller<BinaryData, Void> beginDelete(String collectionId, String ingestionId, RequestOptions requestOptions) 
-        @Generated public void cancelAllOperations() 
-        @Generated public Response<Void> cancelAllOperationsWithResponse(RequestOptions requestOptions) 
-        @Generated public void cancelOperation(String operationId) 
-        @Generated public Response<Void> cancelOperationWithResponse(String operationId, RequestOptions requestOptions) 
-        @Generated public IngestionDefinition create(String collectionId, IngestionDefinition body) 
-        @Generated public IngestionRun createRun(String collectionId, String ingestionId) 
-        @Generated public Response<BinaryData> createRunWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions) 
-        @Generated public IngestionSource createSource(IngestionSource body) 
-        @Generated public Response<BinaryData> createSourceWithResponse(BinaryData body, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> createWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public void deleteSource(String id) 
-        @Generated public Response<Void> deleteSourceWithResponse(String id, RequestOptions requestOptions) 
-        @Generated public PagedIterable<IngestionDefinition> list(String collectionId) 
-        @Generated public PagedIterable<BinaryData> list(String collectionId, RequestOptions requestOptions) 
-        @Generated public PagedIterable<IngestionDefinition> list(String collectionId, Integer top, Integer skip) 
-        @Generated public PagedIterable<ManagedIdentityMetadata> listManagedIdentities() 
-        @Generated public PagedIterable<BinaryData> listManagedIdentities(RequestOptions requestOptions) 
-        @Generated public PagedIterable<Operation> listOperations() 
-        @Generated public PagedIterable<BinaryData> listOperations(RequestOptions requestOptions) 
-        @Generated public PagedIterable<Operation> listOperations(Integer top, Integer skip, String collectionId, OperationStatus status) 
-        @Generated public PagedIterable<IngestionRun> listRuns(String collectionId, String ingestionId) 
-        @Generated public PagedIterable<BinaryData> listRuns(String collectionId, String ingestionId, RequestOptions requestOptions) 
-        @Generated public PagedIterable<IngestionRun> listRuns(String collectionId, String ingestionId, Integer top, Integer skip) 
-        @Generated public PagedIterable<IngestionSourceSummary> listSources() 
-        @Generated public PagedIterable<BinaryData> listSources(RequestOptions requestOptions) 
-        @Generated public PagedIterable<IngestionSourceSummary> listSources(Integer top, Integer skip) 
-        @Generated public Operation getOperation(String operationId) 
-        @Generated public Response<BinaryData> getOperationWithResponse(String operationId, RequestOptions requestOptions) 
-        @Generated public IngestionSource replaceSource(String id, IngestionSource body) 
-        @Generated public Response<BinaryData> replaceSourceWithResponse(String id, BinaryData body, RequestOptions requestOptions) 
-        @Generated public IngestionRun getRun(String collectionId, String ingestionId, String runId) 
-        @Generated public Response<BinaryData> getRunWithResponse(String collectionId, String ingestionId, String runId, RequestOptions requestOptions) 
-        @Generated public IngestionSource getSource(String id) 
-        @Generated public Response<BinaryData> getSourceWithResponse(String id, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> updateWithResponse(String collectionId, String ingestionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions) 
-    } 
-    @ServiceClientBuilder(serviceClients  =  { IngestionClient, StacClient, DataClient, SharedAccessSignatureClient, IngestionAsyncClient, StacAsyncClient, DataAsyncClient, SharedAccessSignatureAsyncClient }) 
-    public final class PlanetaryComputerProClientBuilder implements HttpTrait<PlanetaryComputerProClientBuilder> , ConfigurationTrait<PlanetaryComputerProClientBuilder> , TokenCredentialTrait<PlanetaryComputerProClientBuilder> , EndpointTrait<PlanetaryComputerProClientBuilder> { 
-        @Generated public PlanetaryComputerProClientBuilder() 
-        @Generated @Override public PlanetaryComputerProClientBuilder addPolicy(HttpPipelinePolicy customPolicy) 
-        @Generated @Override public PlanetaryComputerProClientBuilder clientOptions(ClientOptions clientOptions) 
-        @Generated @Override public PlanetaryComputerProClientBuilder configuration(Configuration configuration) 
-        @Generated @Override public PlanetaryComputerProClientBuilder credential(TokenCredential tokenCredential) 
-        @Generated @Override public PlanetaryComputerProClientBuilder endpoint(String endpoint) 
-        @Generated @Override public PlanetaryComputerProClientBuilder httpClient(HttpClient httpClient) 
-        @Generated @Override public PlanetaryComputerProClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) 
-        @Generated @Override public PlanetaryComputerProClientBuilder pipeline(HttpPipeline pipeline) 
-        @Generated @Override public PlanetaryComputerProClientBuilder retryOptions(RetryOptions retryOptions) 
-        @Generated public PlanetaryComputerProClientBuilder retryPolicy(RetryPolicy retryPolicy) 
-        @Generated public PlanetaryComputerProClientBuilder serviceVersion(PlanetaryComputerServiceVersion serviceVersion) 
-        @Generated public DataAsyncClient buildDataAsyncClient() 
-        @Generated public DataClient buildDataClient() 
-        @Generated public IngestionAsyncClient buildIngestionAsyncClient() 
-        @Generated public IngestionClient buildIngestionClient() 
-        @Generated public SharedAccessSignatureAsyncClient buildSharedAccessSignatureAsyncClient() 
-        @Generated public SharedAccessSignatureClient buildSharedAccessSignatureClient() 
-        @Generated public StacAsyncClient buildStacAsyncClient() 
-        @Generated public StacClient buildStacClient() 
-    } 
-    public enum PlanetaryComputerServiceVersion implements ServiceVersion { 
-        V2026_04_15("2026-04-15"); 
-        public static PlanetaryComputerServiceVersion getLatest(// returns V2026_04_15 ) 
-        @Override public String getVersion() 
-    } 
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true) 
-    public final class SharedAccessSignatureAsyncClient { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        // Service Methods: 
-        @Generated public Mono<Void> revokeToken() 
-        @Generated public Mono<Void> revokeToken(Integer durationInMinutes) 
-        @Generated public Mono<Response<Void>> revokeTokenWithResponse(RequestOptions requestOptions) 
-        @Generated public Mono<SharedAccessSignatureToken> getToken(String collectionId) 
-        @Generated public Mono<SharedAccessSignatureToken> getToken(String collectionId, Integer durationInMinutes) 
-        @Generated public Mono<Response<BinaryData>> getTokenWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<SharedAccessSignatureSignedLink> getUrl(String href) 
-        @Generated public Mono<SharedAccessSignatureSignedLink> getUrl(String href, Integer durationInMinutes) 
-        @Generated public Mono<Response<BinaryData>> getUrlWithResponse(String href, RequestOptions requestOptions) 
-    } 
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder) 
-    public final class SharedAccessSignatureClient { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        // Service Methods: 
-        @Generated public void revokeToken() 
-        @Generated public void revokeToken(Integer durationInMinutes) 
-        @Generated public Response<Void> revokeTokenWithResponse(RequestOptions requestOptions) 
-        @Generated public SharedAccessSignatureToken getToken(String collectionId) 
-        @Generated public SharedAccessSignatureToken getToken(String collectionId, Integer durationInMinutes) 
-        @Generated public Response<BinaryData> getTokenWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public SharedAccessSignatureSignedLink getUrl(String href) 
-        @Generated public SharedAccessSignatureSignedLink getUrl(String href, Integer durationInMinutes) 
-        @Generated public Response<BinaryData> getUrlWithResponse(String href, RequestOptions requestOptions) 
-    } 
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true) 
-    public final class StacAsyncClient { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        // Service Methods: 
-        @Generated public Mono<StacMosaic> addMosaic(String collectionId, StacMosaic body) 
-        @Generated public Mono<Response<BinaryData>> addMosaicWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public PollerFlux<Operation, Void> beginCreateCollection(StacCollection body) 
-        @Generated public PollerFlux<BinaryData, BinaryData> beginCreateCollection(BinaryData body, RequestOptions requestOptions) 
-        @Generated public PollerFlux<Operation, Void> beginCreateItem(String collectionId, StacItemOrStacItemCollection body) 
-        @Generated public PollerFlux<BinaryData, BinaryData> beginCreateItem(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public PollerFlux<Operation, Void> beginDeleteCollection(String collectionId) 
-        @Generated public PollerFlux<BinaryData, Void> beginDeleteCollection(String collectionId, RequestOptions requestOptions) 
-        @Generated public PollerFlux<Operation, Void> beginDeleteItem(String collectionId, String itemId) 
-        @Generated public PollerFlux<BinaryData, Void> beginDeleteItem(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public PollerFlux<Operation, Void> beginReplaceItem(String collectionId, String itemId, StacItem body) 
-        @Generated public PollerFlux<BinaryData, BinaryData> beginReplaceItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public PollerFlux<BinaryData, BinaryData> beginUpdateItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<StacCollection> getCollection(String collectionId) 
-        @Generated public Mono<StacCollection> getCollection(String collectionId, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
-        @Generated public Mono<UserCollectionSettings> getCollectionConfiguration(String collectionId) 
-        @Generated public Mono<Response<BinaryData>> getCollectionConfigurationWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<QueryableDefinitionsResponse> getCollectionQueryables(String collectionId) 
-        @Generated public Mono<Response<BinaryData>> getCollectionQueryablesWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<StacCatalogCollections> getCollections() 
-        @Generated public Mono<StacCatalogCollections> getCollections(StacAssetUrlSigningMode sign, Integer durationInMinutes) 
-        @Generated public Mono<Response<BinaryData>> getCollectionsWithResponse(RequestOptions requestOptions) 
-        @Generated public Mono<BinaryData> getCollectionThumbnail(String collectionId) 
-        @Generated public Mono<Response<BinaryData>> getCollectionThumbnailWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getCollectionWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<StacConformanceClasses> getConformanceClasses() 
-        @Generated public Mono<Response<BinaryData>> getConformanceClassesWithResponse(RequestOptions requestOptions) 
-        @Generated public Mono<StacCollection> createCollectionAsset(String collectionId, StacAssetData body) 
-        @Generated public Mono<List<StacQueryable>> createQueryables(String collectionId, List<StacQueryable> body) 
-        @Generated public Mono<Response<BinaryData>> createQueryablesWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<RenderOption> createRenderOption(String collectionId, RenderOption body) 
-        @Generated public Mono<Response<BinaryData>> createRenderOptionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<StacCollection> deleteCollectionAsset(String collectionId, String assetId) 
-        @Generated public Mono<Response<BinaryData>> deleteCollectionAssetWithResponse(String collectionId, String assetId, RequestOptions requestOptions) 
-        @Generated public Mono<Void> deleteMosaic(String collectionId, String mosaicId) 
-        @Generated public Mono<Response<Void>> deleteMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions) 
-        @Generated public Mono<Void> deleteQueryable(String collectionId, String queryableName) 
-        @Generated public Mono<Response<Void>> deleteQueryableWithResponse(String collectionId, String queryableName, RequestOptions requestOptions) 
-        @Generated public Mono<Void> deleteRenderOption(String collectionId, String renderOptionId) 
-        @Generated public Mono<Response<Void>> deleteRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions) 
-        @Generated public Mono<StacItem> getItem(String collectionId, String itemId) 
-        @Generated public Mono<StacItem> getItem(String collectionId, String itemId, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
-        @Generated public Mono<StacItemCollection> getItemCollection(String collectionId) 
-        @Generated public Mono<StacItemCollection> getItemCollection(String collectionId, Integer limit, List<String> boundingBox, String datetime, StacAssetUrlSigningMode sign, Integer durationInMinutes, String token) 
-        @Generated public Mono<Response<BinaryData>> getItemCollectionWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getItemWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public Mono<StacLandingPage> getLandingPage() 
-        @Generated public Mono<Response<BinaryData>> getLandingPageWithResponse(RequestOptions requestOptions) 
-        @Generated public Mono<StacMosaic> getMosaic(String collectionId, String mosaicId) 
-        @Generated public Mono<List<StacMosaic>> getMosaics(String collectionId) 
-        @Generated public Mono<Response<BinaryData>> getMosaicsWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions) 
-        @Generated public Mono<PartitionType> getPartitionType(String collectionId) 
-        @Generated public Mono<Response<BinaryData>> getPartitionTypeWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<QueryableDefinitionsResponse> getQueryables() 
-        @Generated public Mono<Response<BinaryData>> getQueryablesWithResponse(RequestOptions requestOptions) 
-        @Generated public Mono<RenderOption> getRenderOption(String collectionId, String renderOptionId) 
-        @Generated public Mono<List<RenderOption>> getRenderOptions(String collectionId) 
-        @Generated public Mono<Response<BinaryData>> getRenderOptionsWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Mono<Response<BinaryData>> getRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions) 
-        @Generated public Mono<StacCollection> replaceCollection(String collectionId, StacCollection body) 
-        @Generated public Mono<StacCollection> replaceCollectionAsset(String collectionId, String assetId, StacAssetData body) 
-        @Generated public Mono<Response<BinaryData>> replaceCollectionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<StacMosaic> replaceMosaic(String collectionId, String mosaicId, StacMosaic body) 
-        @Generated public Mono<Response<BinaryData>> replaceMosaicWithResponse(String collectionId, String mosaicId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<Void> replacePartitionType(String collectionId, PartitionType body) 
-        @Generated public Mono<Response<Void>> replacePartitionTypeWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<StacQueryable> replaceQueryable(String collectionId, String queryableName, StacQueryable body) 
-        @Generated public Mono<Response<BinaryData>> replaceQueryableWithResponse(String collectionId, String queryableName, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<RenderOption> replaceRenderOption(String collectionId, String renderOptionId, RenderOption body) 
-        @Generated public Mono<Response<BinaryData>> replaceRenderOptionWithResponse(String collectionId, String renderOptionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<TileSettings> replaceTileSettings(String collectionId, TileSettings body) 
-        @Generated public Mono<Response<BinaryData>> replaceTileSettingsWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<StacItemCollection> search(StacSearchParameters body) 
-        @Generated public Mono<StacItemCollection> search(StacSearchParameters body, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
-        @Generated public Mono<Response<BinaryData>> searchWithResponse(BinaryData body, RequestOptions requestOptions) 
-        @Generated public Mono<TileSettings> getTileSettings(String collectionId) 
-        @Generated public Mono<Response<BinaryData>> getTileSettingsWithResponse(String collectionId, RequestOptions requestOptions) 
-    } 
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder) 
-    public final class StacClient { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        // Service Methods: 
-        @Generated public StacMosaic addMosaic(String collectionId, StacMosaic body) 
-        @Generated public Response<BinaryData> addMosaicWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public SyncPoller<Operation, Void> beginCreateCollection(StacCollection body) 
-        @Generated public SyncPoller<BinaryData, BinaryData> beginCreateCollection(BinaryData body, RequestOptions requestOptions) 
-        @Generated public SyncPoller<Operation, Void> beginCreateItem(String collectionId, StacItemOrStacItemCollection body) 
-        @Generated public SyncPoller<BinaryData, BinaryData> beginCreateItem(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public SyncPoller<Operation, Void> beginDeleteCollection(String collectionId) 
-        @Generated public SyncPoller<BinaryData, Void> beginDeleteCollection(String collectionId, RequestOptions requestOptions) 
-        @Generated public SyncPoller<Operation, Void> beginDeleteItem(String collectionId, String itemId) 
-        @Generated public SyncPoller<BinaryData, Void> beginDeleteItem(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public SyncPoller<Operation, Void> beginReplaceItem(String collectionId, String itemId, StacItem body) 
-        @Generated public SyncPoller<BinaryData, BinaryData> beginReplaceItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public SyncPoller<BinaryData, BinaryData> beginUpdateItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public StacCollection getCollection(String collectionId) 
-        @Generated public StacCollection getCollection(String collectionId, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
-        @Generated public UserCollectionSettings getCollectionConfiguration(String collectionId) 
-        @Generated public Response<BinaryData> getCollectionConfigurationWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public QueryableDefinitionsResponse getCollectionQueryables(String collectionId) 
-        @Generated public Response<BinaryData> getCollectionQueryablesWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public StacCatalogCollections getCollections() 
-        @Generated public StacCatalogCollections getCollections(StacAssetUrlSigningMode sign, Integer durationInMinutes) 
-        @Generated public Response<BinaryData> getCollectionsWithResponse(RequestOptions requestOptions) 
-        @Generated public BinaryData getCollectionThumbnail(String collectionId) 
-        @Generated public Response<BinaryData> getCollectionThumbnailWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getCollectionWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public StacConformanceClasses getConformanceClasses() 
-        @Generated public Response<BinaryData> getConformanceClassesWithResponse(RequestOptions requestOptions) 
-        @Generated public StacCollection createCollectionAsset(String collectionId, StacAssetData body) 
-        @Generated public List<StacQueryable> createQueryables(String collectionId, List<StacQueryable> body) 
-        @Generated public Response<BinaryData> createQueryablesWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public RenderOption createRenderOption(String collectionId, RenderOption body) 
-        @Generated public Response<BinaryData> createRenderOptionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public StacCollection deleteCollectionAsset(String collectionId, String assetId) 
-        @Generated public Response<BinaryData> deleteCollectionAssetWithResponse(String collectionId, String assetId, RequestOptions requestOptions) 
-        @Generated public void deleteMosaic(String collectionId, String mosaicId) 
-        @Generated public Response<Void> deleteMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions) 
-        @Generated public void deleteQueryable(String collectionId, String queryableName) 
-        @Generated public Response<Void> deleteQueryableWithResponse(String collectionId, String queryableName, RequestOptions requestOptions) 
-        @Generated public void deleteRenderOption(String collectionId, String renderOptionId) 
-        @Generated public Response<Void> deleteRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions) 
-        @Generated public StacItem getItem(String collectionId, String itemId) 
-        @Generated public StacItem getItem(String collectionId, String itemId, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
-        @Generated public StacItemCollection getItemCollection(String collectionId) 
-        @Generated public StacItemCollection getItemCollection(String collectionId, Integer limit, List<String> boundingBox, String datetime, StacAssetUrlSigningMode sign, Integer durationInMinutes, String token) 
-        @Generated public Response<BinaryData> getItemCollectionWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getItemWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
-        @Generated public StacLandingPage getLandingPage() 
-        @Generated public Response<BinaryData> getLandingPageWithResponse(RequestOptions requestOptions) 
-        @Generated public StacMosaic getMosaic(String collectionId, String mosaicId) 
-        @Generated public List<StacMosaic> getMosaics(String collectionId) 
-        @Generated public Response<BinaryData> getMosaicsWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions) 
-        @Generated public PartitionType getPartitionType(String collectionId) 
-        @Generated public Response<BinaryData> getPartitionTypeWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public QueryableDefinitionsResponse getQueryables() 
-        @Generated public Response<BinaryData> getQueryablesWithResponse(RequestOptions requestOptions) 
-        @Generated public RenderOption getRenderOption(String collectionId, String renderOptionId) 
-        @Generated public List<RenderOption> getRenderOptions(String collectionId) 
-        @Generated public Response<BinaryData> getRenderOptionsWithResponse(String collectionId, RequestOptions requestOptions) 
-        @Generated public Response<BinaryData> getRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions) 
-        @Generated public StacCollection replaceCollection(String collectionId, StacCollection body) 
-        @Generated public StacCollection replaceCollectionAsset(String collectionId, String assetId, StacAssetData body) 
-        @Generated public Response<BinaryData> replaceCollectionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public StacMosaic replaceMosaic(String collectionId, String mosaicId, StacMosaic body) 
-        @Generated public Response<BinaryData> replaceMosaicWithResponse(String collectionId, String mosaicId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public void replacePartitionType(String collectionId, PartitionType body) 
-        @Generated public Response<Void> replacePartitionTypeWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public StacQueryable replaceQueryable(String collectionId, String queryableName, StacQueryable body) 
-        @Generated public Response<BinaryData> replaceQueryableWithResponse(String collectionId, String queryableName, BinaryData body, RequestOptions requestOptions) 
-        @Generated public RenderOption replaceRenderOption(String collectionId, String renderOptionId, RenderOption body) 
-        @Generated public Response<BinaryData> replaceRenderOptionWithResponse(String collectionId, String renderOptionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public TileSettings replaceTileSettings(String collectionId, TileSettings body) 
-        @Generated public Response<BinaryData> replaceTileSettingsWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
-        @Generated public StacItemCollection search(StacSearchParameters body) 
-        @Generated public StacItemCollection search(StacSearchParameters body, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
-        @Generated public Response<BinaryData> searchWithResponse(BinaryData body, RequestOptions requestOptions) 
-        @Generated public TileSettings getTileSettings(String collectionId) 
-        @Generated public Response<BinaryData> getTileSettingsWithResponse(String collectionId, RequestOptions requestOptions) 
-    } 
-} 
-package com.azure.analytics.planetarycomputer.models { 
+}
+package com.azure.analytics.planetarycomputer {
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
+    public final class DataAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        @Generated public Mono<ClassMapLegendResponse> getClassMapLegend(String classmapName)
+        @Generated public Mono<ClassMapLegendResponse> getClassMapLegend(String classmapName, Integer trimStart, Integer trimEnd)
+        @Generated public Mono<Response<BinaryData>> getClassMapLegendWithResponse(String classmapName, RequestOptions requestOptions)
+        @Generated public Mono<List<BinaryData>> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy)
+        @Generated public Mono<List<BinaryData>> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem)
+        @Generated public Mono<Response<BinaryData>> getCollectionAssetsForBboxWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions)
+        @Generated public Mono<List<BinaryData>> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y)
+        @Generated public Mono<List<BinaryData>> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId)
+        @Generated public Mono<Response<BinaryData>> getCollectionAssetsForTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public Mono<List<TilerAssetGeoJson>> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y)
+        @Generated public Mono<List<TilerAssetGeoJson>> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getCollectionAssetsForTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format)
+        @Generated public Mono<BinaryData> getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask)
+        @Generated public Mono<BinaryData> getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format)
+        @Generated public Mono<BinaryData> getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask)
+        @Generated public Mono<Response<BinaryData>> getCollectionBboxCropWithDimensionsWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getCollectionBboxCropWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions)
+        @Generated public Mono<TilerStacSearchRegistration> getCollectionInfo(String collectionId)
+        @Generated public Mono<Response<BinaryData>> getCollectionInfoWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getCollectionPoint(String collectionId, double longitude, double latitude)
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getCollectionPoint(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling)
+        @Generated public Mono<List<StacItemPointAsset>> getCollectionPointAssets(String collectionId, double longitude, double latitude)
+        @Generated public Mono<List<StacItemPointAsset>> getCollectionPointAssets(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem)
+        @Generated public Mono<Response<BinaryData>> getCollectionPointAssetsWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getCollectionPointWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions)
+        @Generated public Mono<TileJsonMetadata> getCollectionTileJson(String collectionId)
+        @Generated public Mono<TileJsonMetadata> getCollectionTileJson(String collectionId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<Response<BinaryData>> getCollectionTileJsonWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<TileJsonMetadata> getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId)
+        @Generated public Mono<TileJsonMetadata> getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<Response<BinaryData>> getCollectionTileJsonWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getCollectionTileNoTms(String collectionId, double z, double x, double y)
+        @Generated public Mono<BinaryData> getCollectionTileNoTms(String collectionId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format)
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsByFormatWithResponse(String collectionId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale)
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format)
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsByScaleAndFormatWithResponse(String collectionId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsByScaleWithResponse(String collectionId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public Mono<TileSetMetadata> getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId)
+        @Generated public Mono<TileSetMetadata> getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getCollectionTilesetMetadataWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public Mono<TileSetList> getCollectionTilesets(String collectionId)
+        @Generated public Mono<TileSetList> getCollectionTilesets(String collectionId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getCollectionTilesetsWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y)
+        @Generated public Mono<BinaryData> getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format)
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsByFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale)
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format)
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsByScaleAndFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsByScaleWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public Mono<byte[]> getCollectionWmtsCapabilities(String collectionId)
+        @Generated public Mono<byte[]> getCollectionWmtsCapabilities(String collectionId, String ids, String bbox, String query, String sortby, String datetime, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject)
+        @Generated public Mono<Response<BinaryData>> getCollectionWmtsCapabilitiesWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<byte[]> getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId)
+        @Generated public Mono<byte[]> getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject)
+        @Generated public Mono<Response<BinaryData>> getCollectionWmtsCapabilitiesWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> cropCollectionFeature(String collectionId, GeoJsonFeature body)
+        @Generated public Mono<BinaryData> cropCollectionFeature(String collectionId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format)
+        @Generated public Mono<BinaryData> cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body)
+        @Generated public Mono<BinaryData> cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs)
+        @Generated public Mono<Response<BinaryData>> cropCollectionFeatureByFormatWithResponse(String collectionId, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body)
+        @Generated public Mono<BinaryData> cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs)
+        @Generated public Mono<Response<BinaryData>> cropCollectionFeatureWidthByHeightWithResponse(String collectionId, int width, int height, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> cropCollectionFeatureWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> cropFeature(String collectionId, String itemId, GeoJsonFeature body)
+        @Generated public Mono<BinaryData> cropFeature(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TilerImageFormat format)
+        @Generated public Mono<BinaryData> cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body)
+        @Generated public Mono<BinaryData> cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> cropFeatureByFormatWithResponse(String collectionId, String itemId, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body)
+        @Generated public Mono<BinaryData> cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> cropFeatureWidthByHeightWithResponse(String collectionId, String itemId, int width, int height, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> cropFeatureWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> cropSearchFeature(String searchId, GeoJsonFeature body)
+        @Generated public Mono<BinaryData> cropSearchFeature(String searchId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format)
+        @Generated public Mono<BinaryData> cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body)
+        @Generated public Mono<BinaryData> cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs)
+        @Generated public Mono<Response<BinaryData>> cropSearchFeatureByFormatWithResponse(String searchId, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body)
+        @Generated public Mono<BinaryData> cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs)
+        @Generated public Mono<Response<BinaryData>> cropSearchFeatureWidthByHeightWithResponse(String searchId, int width, int height, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> cropSearchFeatureWithResponse(String searchId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<List<List<List<Long>>>> getIntervalLegend(String classmapName)
+        @Generated public Mono<List<List<List<Long>>>> getIntervalLegend(String classmapName, Integer trimStart, Integer trimEnd)
+        @Generated public Mono<Response<BinaryData>> getIntervalLegendWithResponse(String classmapName, RequestOptions requestOptions)
+        @Generated public Mono<AssetStatisticsResponse> getItemAssetStatistics(String collectionId, String itemId)
+        @Generated public Mono<AssetStatisticsResponse> getItemAssetStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, List<String> assetBandIndices, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assetExpression, Integer height, Integer width)
+        @Generated public Mono<Response<BinaryData>> getItemAssetStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Mono<List<String>> getItemAvailableAssets(String collectionId, String itemId)
+        @Generated public Mono<List<String>> getItemAvailableAssets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getItemAvailableAssetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format)
+        @Generated public Mono<BinaryData> getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<BinaryData> getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format)
+        @Generated public Mono<BinaryData> getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getItemBboxCropWithDimensionsWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getItemBboxCropWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions)
+        @Generated public Mono<StacItemBounds> getItemBounds(String collectionId, String itemId)
+        @Generated public Mono<StacItemBounds> getItemBounds(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getItemBoundsWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Mono<StacItemStatisticsGeoJson> getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body)
+        @Generated public Mono<StacItemStatisticsGeoJson> getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width)
+        @Generated public Mono<Response<BinaryData>> getItemFeatureStatisticsWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<TilerInfoMapResponse> getItemInfo(String collectionId, String itemId)
+        @Generated public Mono<TilerInfoMapResponse> getItemInfo(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets)
+        @Generated public Mono<TilerInfoGeoJsonFeature> getItemInfoGeoJson(String collectionId, String itemId)
+        @Generated public Mono<TilerInfoGeoJsonFeature> getItemInfoGeoJson(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets)
+        @Generated public Mono<Response<BinaryData>> getItemInfoGeoJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getItemInfoWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getItemPoint(String collectionId, String itemId, double longitude, double latitude)
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getItemPoint(String collectionId, String itemId, double longitude, double latitude, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem, Resampling resampling)
+        @Generated public Mono<Response<BinaryData>> getItemPointWithResponse(String collectionId, String itemId, double longitude, double latitude, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getItemPreview(String collectionId, String itemId)
+        @Generated public Mono<BinaryData> getItemPreview(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<BinaryData> getItemPreviewWithFormat(String collectionId, String itemId, String format)
+        @Generated public Mono<BinaryData> getItemPreviewWithFormat(String collectionId, String itemId, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getItemPreviewWithFormatWithResponse(String collectionId, String itemId, String format, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getItemPreviewWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Mono<TilerStacItemStatistics> getItemStatistics(String collectionId, String itemId)
+        @Generated public Mono<TilerStacItemStatistics> getItemStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width)
+        @Generated public Mono<Response<BinaryData>> getItemStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Mono<TileJsonMetadata> getItemTileJson(String collectionId, String itemId)
+        @Generated public Mono<TileJsonMetadata> getItemTileJson(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getItemTileJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Mono<TileJsonMetadata> getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId)
+        @Generated public Mono<TileJsonMetadata> getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getItemTileJsonWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public Mono<byte[]> getItemWmtsCapabilities(String collectionId, String itemId)
+        @Generated public Mono<byte[]> getItemWmtsCapabilities(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getItemWmtsCapabilitiesWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Mono<byte[]> getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId)
+        @Generated public Mono<byte[]> getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getItemWmtsCapabilitiesWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getLegend(String colorMapName)
+        @Generated public Mono<BinaryData> getLegend(String colorMapName, Double height, Double width, Integer trimStart, Integer trimEnd)
+        @Generated public Mono<Response<BinaryData>> getLegendWithResponse(String colorMapName, RequestOptions requestOptions)
+        @Generated public Mono<TilerMosaicSearchRegistrationResponse> registerMosaicsSearch(RegisterMosaicsSearchOptions options)
+        @Generated public Mono<Response<BinaryData>> registerMosaicsSearchWithResponse(BinaryData registerMosaicsSearchRequest, RequestOptions requestOptions)
+        @Generated public Mono<List<BinaryData>> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y)
+        @Generated public Mono<List<BinaryData>> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId)
+        @Generated public Mono<Response<BinaryData>> getSearchAssetsForTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public Mono<List<TilerAssetGeoJson>> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y)
+        @Generated public Mono<List<TilerAssetGeoJson>> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getSearchAssetsForTileWithTmsWithResponse(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public Mono<List<BinaryData>> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy)
+        @Generated public Mono<List<BinaryData>> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem)
+        @Generated public Mono<Response<BinaryData>> getSearchBboxAssetsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format)
+        @Generated public Mono<BinaryData> getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask)
+        @Generated public Mono<BinaryData> getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format)
+        @Generated public Mono<BinaryData> getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask)
+        @Generated public Mono<Response<BinaryData>> getSearchBboxCropWithDimensionsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getSearchBboxCropWithResponse(String searchId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions)
+        @Generated public Mono<TilerStacSearchRegistration> getSearchInfo(String searchId)
+        @Generated public Mono<Response<BinaryData>> getSearchInfoWithResponse(String searchId, RequestOptions requestOptions)
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getSearchPoint(String searchId, double longitude, double latitude)
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getSearchPoint(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling)
+        @Generated public Mono<List<StacItemPointAsset>> getSearchPointWithAssets(String searchId, double longitude, double latitude)
+        @Generated public Mono<List<StacItemPointAsset>> getSearchPointWithAssets(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem)
+        @Generated public Mono<Response<BinaryData>> getSearchPointWithAssetsWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getSearchPointWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions)
+        @Generated public Mono<TileJsonMetadata> getSearchTileJson(String searchId)
+        @Generated public Mono<TileJsonMetadata> getSearchTileJson(String searchId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Integer padding, Double buffer, String colorFormula, String collectionId, Resampling resampling, PixelSelection pixelSelection, TerrainAlgorithm algorithm, String algorithmParams, List<String> rescale, ColorMapNames colormapName, String colormap, Boolean returnMask)
+        @Generated public Mono<Response<BinaryData>> getSearchTileJsonWithResponse(String searchId, RequestOptions requestOptions)
+        @Generated public Mono<TileJsonMetadata> getSearchTileJsonWithTms(String searchId, String tileMatrixSetId)
+        @Generated public Mono<TileJsonMetadata> getSearchTileJsonWithTms(String searchId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer minZoom, Integer maxZoom, TilerImageFormat tileFormat, Integer tileScale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<Response<BinaryData>> getSearchTileJsonWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getSearchTileNoTms(String searchId, double z, double x, double y)
+        @Generated public Mono<BinaryData> getSearchTileNoTms(String searchId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format)
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsByFormatWithResponse(String searchId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale)
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format)
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsByScaleAndFormatWithResponse(String searchId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsByScaleWithResponse(String searchId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public Mono<TileSetMetadata> getSearchTilesetMetadata(String searchId, String tileMatrixSetId)
+        @Generated public Mono<TileSetMetadata> getSearchTilesetMetadata(String searchId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getSearchTilesetMetadataWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public Mono<TileSetList> getSearchTilesets(String searchId)
+        @Generated public Mono<TileSetList> getSearchTilesets(String searchId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getSearchTilesetsWithResponse(String searchId, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y)
+        @Generated public Mono<BinaryData> getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format)
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsByFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale)
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format)
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsByScaleAndFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsByScaleWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public Mono<byte[]> getSearchWmtsCapabilities(String searchId)
+        @Generated public Mono<byte[]> getSearchWmtsCapabilities(String searchId, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject)
+        @Generated public Mono<Response<BinaryData>> getSearchWmtsCapabilitiesWithResponse(String searchId, RequestOptions requestOptions)
+        @Generated public Mono<byte[]> getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId)
+        @Generated public Mono<byte[]> getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject)
+        @Generated public Mono<Response<BinaryData>> getSearchWmtsCapabilitiesWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public Mono<List<String>> getTileMatrices()
+        @Generated public Mono<Response<BinaryData>> getTileMatricesWithResponse(RequestOptions requestOptions)
+        @Generated public Mono<TileMatrixSet> getTileMatrixDefinitions(String tileMatrixSetId)
+        @Generated public Mono<Response<BinaryData>> getTileMatrixDefinitionsWithResponse(String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getTileNoTms(String collectionId, String itemId, double z, double x, double y)
+        @Generated public Mono<BinaryData> getTileNoTms(String collectionId, String itemId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<BinaryData> getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format)
+        @Generated public Mono<BinaryData> getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getTileNoTmsByFormatWithResponse(String collectionId, String itemId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale)
+        @Generated public Mono<BinaryData> getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<BinaryData> getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format)
+        @Generated public Mono<BinaryData> getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getTileNoTmsByScaleAndFormatWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getTileNoTmsByScaleWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getTileNoTmsWithResponse(String collectionId, String itemId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public Mono<TileSetMetadata> getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId)
+        @Generated public Mono<TileSetMetadata> getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getTilesetMetadataWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public Mono<TileSetList> getTilesets(String collectionId, String itemId)
+        @Generated public Mono<TileSetList> getTilesets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getTilesetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y)
+        @Generated public Mono<BinaryData> getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<BinaryData> getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format)
+        @Generated public Mono<BinaryData> getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getTileWithTmsByFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale)
+        @Generated public Mono<BinaryData> getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<BinaryData> getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format)
+        @Generated public Mono<BinaryData> getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Mono<Response<BinaryData>> getTileWithTmsByScaleAndFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getTileWithTmsByScaleWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getTileWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions)
+    }
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
+    public final class DataClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        @Generated public ClassMapLegendResponse getClassMapLegend(String classmapName)
+        @Generated public ClassMapLegendResponse getClassMapLegend(String classmapName, Integer trimStart, Integer trimEnd)
+        @Generated public Response<BinaryData> getClassMapLegendWithResponse(String classmapName, RequestOptions requestOptions)
+        @Generated public List<BinaryData> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy)
+        @Generated public List<BinaryData> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem)
+        @Generated public Response<BinaryData> getCollectionAssetsForBboxWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions)
+        @Generated public List<BinaryData> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y)
+        @Generated public List<BinaryData> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId)
+        @Generated public Response<BinaryData> getCollectionAssetsForTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public List<TilerAssetGeoJson> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y)
+        @Generated public List<TilerAssetGeoJson> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getCollectionAssetsForTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public BinaryData getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format)
+        @Generated public BinaryData getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask)
+        @Generated public BinaryData getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format)
+        @Generated public BinaryData getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask)
+        @Generated public Response<BinaryData> getCollectionBboxCropWithDimensionsWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getCollectionBboxCropWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions)
+        @Generated public TilerStacSearchRegistration getCollectionInfo(String collectionId)
+        @Generated public Response<BinaryData> getCollectionInfoWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public TilerCoreModelsResponsesPoint getCollectionPoint(String collectionId, double longitude, double latitude)
+        @Generated public TilerCoreModelsResponsesPoint getCollectionPoint(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling)
+        @Generated public List<StacItemPointAsset> getCollectionPointAssets(String collectionId, double longitude, double latitude)
+        @Generated public List<StacItemPointAsset> getCollectionPointAssets(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem)
+        @Generated public Response<BinaryData> getCollectionPointAssetsWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getCollectionPointWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions)
+        @Generated public TileJsonMetadata getCollectionTileJson(String collectionId)
+        @Generated public TileJsonMetadata getCollectionTileJson(String collectionId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Response<BinaryData> getCollectionTileJsonWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public TileJsonMetadata getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId)
+        @Generated public TileJsonMetadata getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Response<BinaryData> getCollectionTileJsonWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public BinaryData getCollectionTileNoTms(String collectionId, double z, double x, double y)
+        @Generated public BinaryData getCollectionTileNoTms(String collectionId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public BinaryData getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format)
+        @Generated public BinaryData getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Response<BinaryData> getCollectionTileNoTmsByFormatWithResponse(String collectionId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public BinaryData getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale)
+        @Generated public BinaryData getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public BinaryData getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format)
+        @Generated public BinaryData getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Response<BinaryData> getCollectionTileNoTmsByScaleAndFormatWithResponse(String collectionId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getCollectionTileNoTmsByScaleWithResponse(String collectionId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getCollectionTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public TileSetMetadata getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId)
+        @Generated public TileSetMetadata getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getCollectionTilesetMetadataWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public TileSetList getCollectionTilesets(String collectionId)
+        @Generated public TileSetList getCollectionTilesets(String collectionId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getCollectionTilesetsWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public BinaryData getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y)
+        @Generated public BinaryData getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public BinaryData getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format)
+        @Generated public BinaryData getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Response<BinaryData> getCollectionTileWithTmsByFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public BinaryData getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale)
+        @Generated public BinaryData getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public BinaryData getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format)
+        @Generated public BinaryData getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Response<BinaryData> getCollectionTileWithTmsByScaleAndFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getCollectionTileWithTmsByScaleWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getCollectionTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public byte[] getCollectionWmtsCapabilities(String collectionId)
+        @Generated public byte[] getCollectionWmtsCapabilities(String collectionId, String ids, String bbox, String query, String sortby, String datetime, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject)
+        @Generated public Response<BinaryData> getCollectionWmtsCapabilitiesWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public byte[] getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId)
+        @Generated public byte[] getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject)
+        @Generated public Response<BinaryData> getCollectionWmtsCapabilitiesWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public BinaryData cropCollectionFeature(String collectionId, GeoJsonFeature body)
+        @Generated public BinaryData cropCollectionFeature(String collectionId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format)
+        @Generated public BinaryData cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body)
+        @Generated public BinaryData cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs)
+        @Generated public Response<BinaryData> cropCollectionFeatureByFormatWithResponse(String collectionId, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public BinaryData cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body)
+        @Generated public BinaryData cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs)
+        @Generated public Response<BinaryData> cropCollectionFeatureWidthByHeightWithResponse(String collectionId, int width, int height, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> cropCollectionFeatureWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public BinaryData cropFeature(String collectionId, String itemId, GeoJsonFeature body)
+        @Generated public BinaryData cropFeature(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TilerImageFormat format)
+        @Generated public BinaryData cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body)
+        @Generated public BinaryData cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> cropFeatureByFormatWithResponse(String collectionId, String itemId, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public BinaryData cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body)
+        @Generated public BinaryData cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> cropFeatureWidthByHeightWithResponse(String collectionId, String itemId, int width, int height, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> cropFeatureWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions)
+        @Generated public BinaryData cropSearchFeature(String searchId, GeoJsonFeature body)
+        @Generated public BinaryData cropSearchFeature(String searchId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format)
+        @Generated public BinaryData cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body)
+        @Generated public BinaryData cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs)
+        @Generated public Response<BinaryData> cropSearchFeatureByFormatWithResponse(String searchId, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public BinaryData cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body)
+        @Generated public BinaryData cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs)
+        @Generated public Response<BinaryData> cropSearchFeatureWidthByHeightWithResponse(String searchId, int width, int height, String format, BinaryData body, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> cropSearchFeatureWithResponse(String searchId, BinaryData body, RequestOptions requestOptions)
+        @Generated public List<List<List<Long>>> getIntervalLegend(String classmapName)
+        @Generated public List<List<List<Long>>> getIntervalLegend(String classmapName, Integer trimStart, Integer trimEnd)
+        @Generated public Response<BinaryData> getIntervalLegendWithResponse(String classmapName, RequestOptions requestOptions)
+        @Generated public AssetStatisticsResponse getItemAssetStatistics(String collectionId, String itemId)
+        @Generated public AssetStatisticsResponse getItemAssetStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, List<String> assetBandIndices, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assetExpression, Integer height, Integer width)
+        @Generated public Response<BinaryData> getItemAssetStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public List<String> getItemAvailableAssets(String collectionId, String itemId)
+        @Generated public List<String> getItemAvailableAssets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getItemAvailableAssetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public BinaryData getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format)
+        @Generated public BinaryData getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public BinaryData getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format)
+        @Generated public BinaryData getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getItemBboxCropWithDimensionsWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getItemBboxCropWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions)
+        @Generated public StacItemBounds getItemBounds(String collectionId, String itemId)
+        @Generated public StacItemBounds getItemBounds(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getItemBoundsWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public StacItemStatisticsGeoJson getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body)
+        @Generated public StacItemStatisticsGeoJson getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width)
+        @Generated public Response<BinaryData> getItemFeatureStatisticsWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions)
+        @Generated public TilerInfoMapResponse getItemInfo(String collectionId, String itemId)
+        @Generated public TilerInfoMapResponse getItemInfo(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets)
+        @Generated public TilerInfoGeoJsonFeature getItemInfoGeoJson(String collectionId, String itemId)
+        @Generated public TilerInfoGeoJsonFeature getItemInfoGeoJson(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets)
+        @Generated public Response<BinaryData> getItemInfoGeoJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getItemInfoWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public TilerCoreModelsResponsesPoint getItemPoint(String collectionId, String itemId, double longitude, double latitude)
+        @Generated public TilerCoreModelsResponsesPoint getItemPoint(String collectionId, String itemId, double longitude, double latitude, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem, Resampling resampling)
+        @Generated public Response<BinaryData> getItemPointWithResponse(String collectionId, String itemId, double longitude, double latitude, RequestOptions requestOptions)
+        @Generated public BinaryData getItemPreview(String collectionId, String itemId)
+        @Generated public BinaryData getItemPreview(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public BinaryData getItemPreviewWithFormat(String collectionId, String itemId, String format)
+        @Generated public BinaryData getItemPreviewWithFormat(String collectionId, String itemId, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getItemPreviewWithFormatWithResponse(String collectionId, String itemId, String format, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getItemPreviewWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public TilerStacItemStatistics getItemStatistics(String collectionId, String itemId)
+        @Generated public TilerStacItemStatistics getItemStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width)
+        @Generated public Response<BinaryData> getItemStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public TileJsonMetadata getItemTileJson(String collectionId, String itemId)
+        @Generated public TileJsonMetadata getItemTileJson(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getItemTileJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public TileJsonMetadata getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId)
+        @Generated public TileJsonMetadata getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getItemTileJsonWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public byte[] getItemWmtsCapabilities(String collectionId, String itemId)
+        @Generated public byte[] getItemWmtsCapabilities(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getItemWmtsCapabilitiesWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public byte[] getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId)
+        @Generated public byte[] getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getItemWmtsCapabilitiesWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public BinaryData getLegend(String colorMapName)
+        @Generated public BinaryData getLegend(String colorMapName, Double height, Double width, Integer trimStart, Integer trimEnd)
+        @Generated public Response<BinaryData> getLegendWithResponse(String colorMapName, RequestOptions requestOptions)
+        @Generated public TilerMosaicSearchRegistrationResponse registerMosaicsSearch(RegisterMosaicsSearchOptions options)
+        @Generated public Response<BinaryData> registerMosaicsSearchWithResponse(BinaryData registerMosaicsSearchRequest, RequestOptions requestOptions)
+        @Generated public List<BinaryData> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y)
+        @Generated public List<BinaryData> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId)
+        @Generated public Response<BinaryData> getSearchAssetsForTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public List<TilerAssetGeoJson> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y)
+        @Generated public List<TilerAssetGeoJson> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getSearchAssetsForTileWithTmsWithResponse(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public List<BinaryData> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy)
+        @Generated public List<BinaryData> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem)
+        @Generated public Response<BinaryData> getSearchBboxAssetsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions)
+        @Generated public BinaryData getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format)
+        @Generated public BinaryData getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask)
+        @Generated public BinaryData getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format)
+        @Generated public BinaryData getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask)
+        @Generated public Response<BinaryData> getSearchBboxCropWithDimensionsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getSearchBboxCropWithResponse(String searchId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions)
+        @Generated public TilerStacSearchRegistration getSearchInfo(String searchId)
+        @Generated public Response<BinaryData> getSearchInfoWithResponse(String searchId, RequestOptions requestOptions)
+        @Generated public TilerCoreModelsResponsesPoint getSearchPoint(String searchId, double longitude, double latitude)
+        @Generated public TilerCoreModelsResponsesPoint getSearchPoint(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling)
+        @Generated public List<StacItemPointAsset> getSearchPointWithAssets(String searchId, double longitude, double latitude)
+        @Generated public List<StacItemPointAsset> getSearchPointWithAssets(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem)
+        @Generated public Response<BinaryData> getSearchPointWithAssetsWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getSearchPointWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions)
+        @Generated public TileJsonMetadata getSearchTileJson(String searchId)
+        @Generated public TileJsonMetadata getSearchTileJson(String searchId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Integer padding, Double buffer, String colorFormula, String collectionId, Resampling resampling, PixelSelection pixelSelection, TerrainAlgorithm algorithm, String algorithmParams, List<String> rescale, ColorMapNames colormapName, String colormap, Boolean returnMask)
+        @Generated public Response<BinaryData> getSearchTileJsonWithResponse(String searchId, RequestOptions requestOptions)
+        @Generated public TileJsonMetadata getSearchTileJsonWithTms(String searchId, String tileMatrixSetId)
+        @Generated public TileJsonMetadata getSearchTileJsonWithTms(String searchId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer minZoom, Integer maxZoom, TilerImageFormat tileFormat, Integer tileScale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Response<BinaryData> getSearchTileJsonWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public BinaryData getSearchTileNoTms(String searchId, double z, double x, double y)
+        @Generated public BinaryData getSearchTileNoTms(String searchId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public BinaryData getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format)
+        @Generated public BinaryData getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Response<BinaryData> getSearchTileNoTmsByFormatWithResponse(String searchId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public BinaryData getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale)
+        @Generated public BinaryData getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public BinaryData getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format)
+        @Generated public BinaryData getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Response<BinaryData> getSearchTileNoTmsByScaleAndFormatWithResponse(String searchId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getSearchTileNoTmsByScaleWithResponse(String searchId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getSearchTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public TileSetMetadata getSearchTilesetMetadata(String searchId, String tileMatrixSetId)
+        @Generated public TileSetMetadata getSearchTilesetMetadata(String searchId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getSearchTilesetMetadataWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public TileSetList getSearchTilesets(String searchId)
+        @Generated public TileSetList getSearchTilesets(String searchId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getSearchTilesetsWithResponse(String searchId, RequestOptions requestOptions)
+        @Generated public BinaryData getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y)
+        @Generated public BinaryData getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public BinaryData getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format)
+        @Generated public BinaryData getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Response<BinaryData> getSearchTileWithTmsByFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public BinaryData getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale)
+        @Generated public BinaryData getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public BinaryData getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format)
+        @Generated public BinaryData getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding)
+        @Generated public Response<BinaryData> getSearchTileWithTmsByScaleAndFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getSearchTileWithTmsByScaleWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getSearchTileWithTmsWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public byte[] getSearchWmtsCapabilities(String searchId)
+        @Generated public byte[] getSearchWmtsCapabilities(String searchId, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject)
+        @Generated public Response<BinaryData> getSearchWmtsCapabilitiesWithResponse(String searchId, RequestOptions requestOptions)
+        @Generated public byte[] getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId)
+        @Generated public byte[] getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject)
+        @Generated public Response<BinaryData> getSearchWmtsCapabilitiesWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public List<String> getTileMatrices()
+        @Generated public Response<BinaryData> getTileMatricesWithResponse(RequestOptions requestOptions)
+        @Generated public TileMatrixSet getTileMatrixDefinitions(String tileMatrixSetId)
+        @Generated public Response<BinaryData> getTileMatrixDefinitionsWithResponse(String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public BinaryData getTileNoTms(String collectionId, String itemId, double z, double x, double y)
+        @Generated public BinaryData getTileNoTms(String collectionId, String itemId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public BinaryData getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format)
+        @Generated public BinaryData getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getTileNoTmsByFormatWithResponse(String collectionId, String itemId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public BinaryData getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale)
+        @Generated public BinaryData getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public BinaryData getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format)
+        @Generated public BinaryData getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getTileNoTmsByScaleAndFormatWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getTileNoTmsByScaleWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getTileNoTmsWithResponse(String collectionId, String itemId, double z, double x, double y, RequestOptions requestOptions)
+        @Generated public TileSetMetadata getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId)
+        @Generated public TileSetMetadata getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getTilesetMetadataWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions)
+        @Generated public TileSetList getTilesets(String collectionId, String itemId)
+        @Generated public TileSetList getTilesets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getTilesetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public BinaryData getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y)
+        @Generated public BinaryData getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public BinaryData getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format)
+        @Generated public BinaryData getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getTileWithTmsByFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions)
+        @Generated public BinaryData getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale)
+        @Generated public BinaryData getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public BinaryData getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format)
+        @Generated public BinaryData getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod)
+        @Generated public Response<BinaryData> getTileWithTmsByScaleAndFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getTileWithTmsByScaleWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getTileWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions)
+    }
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
+    public final class IngestionAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        @Generated public Mono<IngestionDefinition> get(String collectionId, String ingestionId)
+        @Generated public PollerFlux<Operation, Void> beginDelete(String collectionId, String ingestionId)
+        @Generated public PollerFlux<BinaryData, Void> beginDelete(String collectionId, String ingestionId, RequestOptions requestOptions)
+        @Generated public Mono<Void> cancelAllOperations()
+        @Generated public Mono<Response<Void>> cancelAllOperationsWithResponse(RequestOptions requestOptions)
+        @Generated public Mono<Void> cancelOperation(String operationId)
+        @Generated public Mono<Response<Void>> cancelOperationWithResponse(String operationId, RequestOptions requestOptions)
+        @Generated public Mono<IngestionDefinition> create(String collectionId, IngestionDefinition body)
+        @Generated public Mono<IngestionRun> createRun(String collectionId, String ingestionId)
+        @Generated public Mono<Response<BinaryData>> createRunWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions)
+        @Generated public Mono<IngestionSource> createSource(IngestionSource body)
+        @Generated public Mono<Response<BinaryData>> createSourceWithResponse(BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> createWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<Void> deleteSource(String id)
+        @Generated public Mono<Response<Void>> deleteSourceWithResponse(String id, RequestOptions requestOptions)
+        @Generated public PagedFlux<IngestionDefinition> list(String collectionId)
+        @Generated public PagedFlux<BinaryData> list(String collectionId, RequestOptions requestOptions)
+        @Generated public PagedFlux<IngestionDefinition> list(String collectionId, Integer top, Integer skip)
+        @Generated public PagedFlux<ManagedIdentityMetadata> listManagedIdentities()
+        @Generated public PagedFlux<BinaryData> listManagedIdentities(RequestOptions requestOptions)
+        @Generated public PagedFlux<Operation> listOperations()
+        @Generated public PagedFlux<BinaryData> listOperations(RequestOptions requestOptions)
+        @Generated public PagedFlux<Operation> listOperations(Integer top, Integer skip, String collectionId, OperationStatus status)
+        @Generated public PagedFlux<IngestionRun> listRuns(String collectionId, String ingestionId)
+        @Generated public PagedFlux<BinaryData> listRuns(String collectionId, String ingestionId, RequestOptions requestOptions)
+        @Generated public PagedFlux<IngestionRun> listRuns(String collectionId, String ingestionId, Integer top, Integer skip)
+        @Generated public PagedFlux<IngestionSourceSummary> listSources()
+        @Generated public PagedFlux<BinaryData> listSources(RequestOptions requestOptions)
+        @Generated public PagedFlux<IngestionSourceSummary> listSources(Integer top, Integer skip)
+        @Generated public Mono<Operation> getOperation(String operationId)
+        @Generated public Mono<Response<BinaryData>> getOperationWithResponse(String operationId, RequestOptions requestOptions)
+        @Generated public Mono<IngestionSource> replaceSource(String id, IngestionSource body)
+        @Generated public Mono<Response<BinaryData>> replaceSourceWithResponse(String id, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<IngestionRun> getRun(String collectionId, String ingestionId, String runId)
+        @Generated public Mono<Response<BinaryData>> getRunWithResponse(String collectionId, String ingestionId, String runId, RequestOptions requestOptions)
+        @Generated public Mono<IngestionSource> getSource(String id)
+        @Generated public Mono<Response<BinaryData>> getSourceWithResponse(String id, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> updateWithResponse(String collectionId, String ingestionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions)
+    }
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
+    public final class IngestionClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        @Generated public IngestionDefinition get(String collectionId, String ingestionId)
+        @Generated public SyncPoller<Operation, Void> beginDelete(String collectionId, String ingestionId)
+        @Generated public SyncPoller<BinaryData, Void> beginDelete(String collectionId, String ingestionId, RequestOptions requestOptions)
+        @Generated public void cancelAllOperations()
+        @Generated public Response<Void> cancelAllOperationsWithResponse(RequestOptions requestOptions)
+        @Generated public void cancelOperation(String operationId)
+        @Generated public Response<Void> cancelOperationWithResponse(String operationId, RequestOptions requestOptions)
+        @Generated public IngestionDefinition create(String collectionId, IngestionDefinition body)
+        @Generated public IngestionRun createRun(String collectionId, String ingestionId)
+        @Generated public Response<BinaryData> createRunWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions)
+        @Generated public IngestionSource createSource(IngestionSource body)
+        @Generated public Response<BinaryData> createSourceWithResponse(BinaryData body, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> createWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public void deleteSource(String id)
+        @Generated public Response<Void> deleteSourceWithResponse(String id, RequestOptions requestOptions)
+        @Generated public PagedIterable<IngestionDefinition> list(String collectionId)
+        @Generated public PagedIterable<BinaryData> list(String collectionId, RequestOptions requestOptions)
+        @Generated public PagedIterable<IngestionDefinition> list(String collectionId, Integer top, Integer skip)
+        @Generated public PagedIterable<ManagedIdentityMetadata> listManagedIdentities()
+        @Generated public PagedIterable<BinaryData> listManagedIdentities(RequestOptions requestOptions)
+        @Generated public PagedIterable<Operation> listOperations()
+        @Generated public PagedIterable<BinaryData> listOperations(RequestOptions requestOptions)
+        @Generated public PagedIterable<Operation> listOperations(Integer top, Integer skip, String collectionId, OperationStatus status)
+        @Generated public PagedIterable<IngestionRun> listRuns(String collectionId, String ingestionId)
+        @Generated public PagedIterable<BinaryData> listRuns(String collectionId, String ingestionId, RequestOptions requestOptions)
+        @Generated public PagedIterable<IngestionRun> listRuns(String collectionId, String ingestionId, Integer top, Integer skip)
+        @Generated public PagedIterable<IngestionSourceSummary> listSources()
+        @Generated public PagedIterable<BinaryData> listSources(RequestOptions requestOptions)
+        @Generated public PagedIterable<IngestionSourceSummary> listSources(Integer top, Integer skip)
+        @Generated public Operation getOperation(String operationId)
+        @Generated public Response<BinaryData> getOperationWithResponse(String operationId, RequestOptions requestOptions)
+        @Generated public IngestionSource replaceSource(String id, IngestionSource body)
+        @Generated public Response<BinaryData> replaceSourceWithResponse(String id, BinaryData body, RequestOptions requestOptions)
+        @Generated public IngestionRun getRun(String collectionId, String ingestionId, String runId)
+        @Generated public Response<BinaryData> getRunWithResponse(String collectionId, String ingestionId, String runId, RequestOptions requestOptions)
+        @Generated public IngestionSource getSource(String id)
+        @Generated public Response<BinaryData> getSourceWithResponse(String id, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> updateWithResponse(String collectionId, String ingestionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions)
+    }
+    @ServiceClientBuilder(serviceClients  =  { IngestionClient, StacClient, DataClient, SharedAccessSignatureClient, IngestionAsyncClient, StacAsyncClient, DataAsyncClient, SharedAccessSignatureAsyncClient })
+    public final class PlanetaryComputerProClientBuilder implements HttpTrait<PlanetaryComputerProClientBuilder> , ConfigurationTrait<PlanetaryComputerProClientBuilder> , TokenCredentialTrait<PlanetaryComputerProClientBuilder> , EndpointTrait<PlanetaryComputerProClientBuilder> {
+        @Generated public PlanetaryComputerProClientBuilder()
+        @Generated @Override public PlanetaryComputerProClientBuilder addPolicy(HttpPipelinePolicy customPolicy)
+        @Generated @Override public PlanetaryComputerProClientBuilder clientOptions(ClientOptions clientOptions)
+        @Generated @Override public PlanetaryComputerProClientBuilder configuration(Configuration configuration)
+        @Generated @Override public PlanetaryComputerProClientBuilder credential(TokenCredential tokenCredential)
+        @Generated @Override public PlanetaryComputerProClientBuilder endpoint(String endpoint)
+        @Generated @Override public PlanetaryComputerProClientBuilder httpClient(HttpClient httpClient)
+        @Generated @Override public PlanetaryComputerProClientBuilder httpLogOptions(HttpLogOptions httpLogOptions)
+        @Generated @Override public PlanetaryComputerProClientBuilder pipeline(HttpPipeline pipeline)
+        @Generated @Override public PlanetaryComputerProClientBuilder retryOptions(RetryOptions retryOptions)
+        @Generated public PlanetaryComputerProClientBuilder retryPolicy(RetryPolicy retryPolicy)
+        @Generated public PlanetaryComputerProClientBuilder serviceVersion(PlanetaryComputerServiceVersion serviceVersion)
+        @Generated public DataAsyncClient buildDataAsyncClient()
+        @Generated public DataClient buildDataClient()
+        @Generated public IngestionAsyncClient buildIngestionAsyncClient()
+        @Generated public IngestionClient buildIngestionClient()
+        @Generated public SharedAccessSignatureAsyncClient buildSharedAccessSignatureAsyncClient()
+        @Generated public SharedAccessSignatureClient buildSharedAccessSignatureClient()
+        @Generated public StacAsyncClient buildStacAsyncClient()
+        @Generated public StacClient buildStacClient()
+    }
+    public enum PlanetaryComputerServiceVersion implements ServiceVersion {
+        V2026_04_15("2026-04-15");
+        public static PlanetaryComputerServiceVersion getLatest(// returns V2026_04_15 )
+        @Override public String getVersion()
+    }
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
+    public final class SharedAccessSignatureAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        @Generated public Mono<Void> revokeToken()
+        @Generated public Mono<Void> revokeToken(Integer durationInMinutes)
+        @Generated public Mono<Response<Void>> revokeTokenWithResponse(RequestOptions requestOptions)
+        @Generated public Mono<SharedAccessSignatureToken> getToken(String collectionId)
+        @Generated public Mono<SharedAccessSignatureToken> getToken(String collectionId, Integer durationInMinutes)
+        @Generated public Mono<Response<BinaryData>> getTokenWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<SharedAccessSignatureSignedLink> getUrl(String href)
+        @Generated public Mono<SharedAccessSignatureSignedLink> getUrl(String href, Integer durationInMinutes)
+        @Generated public Mono<Response<BinaryData>> getUrlWithResponse(String href, RequestOptions requestOptions)
+    }
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
+    public final class SharedAccessSignatureClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        @Generated public void revokeToken()
+        @Generated public void revokeToken(Integer durationInMinutes)
+        @Generated public Response<Void> revokeTokenWithResponse(RequestOptions requestOptions)
+        @Generated public SharedAccessSignatureToken getToken(String collectionId)
+        @Generated public SharedAccessSignatureToken getToken(String collectionId, Integer durationInMinutes)
+        @Generated public Response<BinaryData> getTokenWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public SharedAccessSignatureSignedLink getUrl(String href)
+        @Generated public SharedAccessSignatureSignedLink getUrl(String href, Integer durationInMinutes)
+        @Generated public Response<BinaryData> getUrlWithResponse(String href, RequestOptions requestOptions)
+    }
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
+    public final class StacAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        @Generated public Mono<StacMosaic> addMosaic(String collectionId, StacMosaic body)
+        @Generated public Mono<Response<BinaryData>> addMosaicWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public PollerFlux<Operation, Void> beginCreateCollection(StacCollection body)
+        @Generated public PollerFlux<BinaryData, BinaryData> beginCreateCollection(BinaryData body, RequestOptions requestOptions)
+        @Generated public PollerFlux<Operation, Void> beginCreateItem(String collectionId, StacItemOrStacItemCollection body)
+        @Generated public PollerFlux<BinaryData, BinaryData> beginCreateItem(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public PollerFlux<Operation, Void> beginDeleteCollection(String collectionId)
+        @Generated public PollerFlux<BinaryData, Void> beginDeleteCollection(String collectionId, RequestOptions requestOptions)
+        @Generated public PollerFlux<Operation, Void> beginDeleteItem(String collectionId, String itemId)
+        @Generated public PollerFlux<BinaryData, Void> beginDeleteItem(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public PollerFlux<Operation, Void> beginReplaceItem(String collectionId, String itemId, StacItem body)
+        @Generated public PollerFlux<BinaryData, BinaryData> beginReplaceItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions)
+        @Generated public PollerFlux<BinaryData, BinaryData> beginUpdateItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<StacCollection> getCollection(String collectionId)
+        @Generated public Mono<StacCollection> getCollection(String collectionId, StacAssetUrlSigningMode sign, Integer durationInMinutes)
+        @Generated public Mono<UserCollectionSettings> getCollectionConfiguration(String collectionId)
+        @Generated public Mono<Response<BinaryData>> getCollectionConfigurationWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<QueryableDefinitionsResponse> getCollectionQueryables(String collectionId)
+        @Generated public Mono<Response<BinaryData>> getCollectionQueryablesWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<StacCatalogCollections> getCollections()
+        @Generated public Mono<StacCatalogCollections> getCollections(StacAssetUrlSigningMode sign, Integer durationInMinutes)
+        @Generated public Mono<Response<BinaryData>> getCollectionsWithResponse(RequestOptions requestOptions)
+        @Generated public Mono<BinaryData> getCollectionThumbnail(String collectionId)
+        @Generated public Mono<Response<BinaryData>> getCollectionThumbnailWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getCollectionWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<StacConformanceClasses> getConformanceClasses()
+        @Generated public Mono<Response<BinaryData>> getConformanceClassesWithResponse(RequestOptions requestOptions)
+        @Generated public Mono<StacCollection> createCollectionAsset(String collectionId, StacAssetData body)
+        @Generated public Mono<List<StacQueryable>> createQueryables(String collectionId, List<StacQueryable> body)
+        @Generated public Mono<Response<BinaryData>> createQueryablesWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<RenderOption> createRenderOption(String collectionId, RenderOption body)
+        @Generated public Mono<Response<BinaryData>> createRenderOptionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<StacCollection> deleteCollectionAsset(String collectionId, String assetId)
+        @Generated public Mono<Response<BinaryData>> deleteCollectionAssetWithResponse(String collectionId, String assetId, RequestOptions requestOptions)
+        @Generated public Mono<Void> deleteMosaic(String collectionId, String mosaicId)
+        @Generated public Mono<Response<Void>> deleteMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions)
+        @Generated public Mono<Void> deleteQueryable(String collectionId, String queryableName)
+        @Generated public Mono<Response<Void>> deleteQueryableWithResponse(String collectionId, String queryableName, RequestOptions requestOptions)
+        @Generated public Mono<Void> deleteRenderOption(String collectionId, String renderOptionId)
+        @Generated public Mono<Response<Void>> deleteRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions)
+        @Generated public Mono<StacItem> getItem(String collectionId, String itemId)
+        @Generated public Mono<StacItem> getItem(String collectionId, String itemId, StacAssetUrlSigningMode sign, Integer durationInMinutes)
+        @Generated public Mono<StacItemCollection> getItemCollection(String collectionId)
+        @Generated public Mono<StacItemCollection> getItemCollection(String collectionId, Integer limit, List<String> boundingBox, String datetime, StacAssetUrlSigningMode sign, Integer durationInMinutes, String token)
+        @Generated public Mono<Response<BinaryData>> getItemCollectionWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getItemWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public Mono<StacLandingPage> getLandingPage()
+        @Generated public Mono<Response<BinaryData>> getLandingPageWithResponse(RequestOptions requestOptions)
+        @Generated public Mono<StacMosaic> getMosaic(String collectionId, String mosaicId)
+        @Generated public Mono<List<StacMosaic>> getMosaics(String collectionId)
+        @Generated public Mono<Response<BinaryData>> getMosaicsWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions)
+        @Generated public Mono<PartitionType> getPartitionType(String collectionId)
+        @Generated public Mono<Response<BinaryData>> getPartitionTypeWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<QueryableDefinitionsResponse> getQueryables()
+        @Generated public Mono<Response<BinaryData>> getQueryablesWithResponse(RequestOptions requestOptions)
+        @Generated public Mono<RenderOption> getRenderOption(String collectionId, String renderOptionId)
+        @Generated public Mono<List<RenderOption>> getRenderOptions(String collectionId)
+        @Generated public Mono<Response<BinaryData>> getRenderOptionsWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Mono<Response<BinaryData>> getRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions)
+        @Generated public Mono<StacCollection> replaceCollection(String collectionId, StacCollection body)
+        @Generated public Mono<StacCollection> replaceCollectionAsset(String collectionId, String assetId, StacAssetData body)
+        @Generated public Mono<Response<BinaryData>> replaceCollectionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<StacMosaic> replaceMosaic(String collectionId, String mosaicId, StacMosaic body)
+        @Generated public Mono<Response<BinaryData>> replaceMosaicWithResponse(String collectionId, String mosaicId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<Void> replacePartitionType(String collectionId, PartitionType body)
+        @Generated public Mono<Response<Void>> replacePartitionTypeWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<StacQueryable> replaceQueryable(String collectionId, String queryableName, StacQueryable body)
+        @Generated public Mono<Response<BinaryData>> replaceQueryableWithResponse(String collectionId, String queryableName, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<RenderOption> replaceRenderOption(String collectionId, String renderOptionId, RenderOption body)
+        @Generated public Mono<Response<BinaryData>> replaceRenderOptionWithResponse(String collectionId, String renderOptionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<TileSettings> replaceTileSettings(String collectionId, TileSettings body)
+        @Generated public Mono<Response<BinaryData>> replaceTileSettingsWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<StacItemCollection> search(StacSearchParameters body)
+        @Generated public Mono<StacItemCollection> search(StacSearchParameters body, StacAssetUrlSigningMode sign, Integer durationInMinutes)
+        @Generated public Mono<Response<BinaryData>> searchWithResponse(BinaryData body, RequestOptions requestOptions)
+        @Generated public Mono<TileSettings> getTileSettings(String collectionId)
+        @Generated public Mono<Response<BinaryData>> getTileSettingsWithResponse(String collectionId, RequestOptions requestOptions)
+    }
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
+    public final class StacClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        @Generated public StacMosaic addMosaic(String collectionId, StacMosaic body)
+        @Generated public Response<BinaryData> addMosaicWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public SyncPoller<Operation, Void> beginCreateCollection(StacCollection body)
+        @Generated public SyncPoller<BinaryData, BinaryData> beginCreateCollection(BinaryData body, RequestOptions requestOptions)
+        @Generated public SyncPoller<Operation, Void> beginCreateItem(String collectionId, StacItemOrStacItemCollection body)
+        @Generated public SyncPoller<BinaryData, BinaryData> beginCreateItem(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public SyncPoller<Operation, Void> beginDeleteCollection(String collectionId)
+        @Generated public SyncPoller<BinaryData, Void> beginDeleteCollection(String collectionId, RequestOptions requestOptions)
+        @Generated public SyncPoller<Operation, Void> beginDeleteItem(String collectionId, String itemId)
+        @Generated public SyncPoller<BinaryData, Void> beginDeleteItem(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public SyncPoller<Operation, Void> beginReplaceItem(String collectionId, String itemId, StacItem body)
+        @Generated public SyncPoller<BinaryData, BinaryData> beginReplaceItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions)
+        @Generated public SyncPoller<BinaryData, BinaryData> beginUpdateItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions)
+        @Generated public StacCollection getCollection(String collectionId)
+        @Generated public StacCollection getCollection(String collectionId, StacAssetUrlSigningMode sign, Integer durationInMinutes)
+        @Generated public UserCollectionSettings getCollectionConfiguration(String collectionId)
+        @Generated public Response<BinaryData> getCollectionConfigurationWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public QueryableDefinitionsResponse getCollectionQueryables(String collectionId)
+        @Generated public Response<BinaryData> getCollectionQueryablesWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public StacCatalogCollections getCollections()
+        @Generated public StacCatalogCollections getCollections(StacAssetUrlSigningMode sign, Integer durationInMinutes)
+        @Generated public Response<BinaryData> getCollectionsWithResponse(RequestOptions requestOptions)
+        @Generated public BinaryData getCollectionThumbnail(String collectionId)
+        @Generated public Response<BinaryData> getCollectionThumbnailWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getCollectionWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public StacConformanceClasses getConformanceClasses()
+        @Generated public Response<BinaryData> getConformanceClassesWithResponse(RequestOptions requestOptions)
+        @Generated public StacCollection createCollectionAsset(String collectionId, StacAssetData body)
+        @Generated public List<StacQueryable> createQueryables(String collectionId, List<StacQueryable> body)
+        @Generated public Response<BinaryData> createQueryablesWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public RenderOption createRenderOption(String collectionId, RenderOption body)
+        @Generated public Response<BinaryData> createRenderOptionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public StacCollection deleteCollectionAsset(String collectionId, String assetId)
+        @Generated public Response<BinaryData> deleteCollectionAssetWithResponse(String collectionId, String assetId, RequestOptions requestOptions)
+        @Generated public void deleteMosaic(String collectionId, String mosaicId)
+        @Generated public Response<Void> deleteMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions)
+        @Generated public void deleteQueryable(String collectionId, String queryableName)
+        @Generated public Response<Void> deleteQueryableWithResponse(String collectionId, String queryableName, RequestOptions requestOptions)
+        @Generated public void deleteRenderOption(String collectionId, String renderOptionId)
+        @Generated public Response<Void> deleteRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions)
+        @Generated public StacItem getItem(String collectionId, String itemId)
+        @Generated public StacItem getItem(String collectionId, String itemId, StacAssetUrlSigningMode sign, Integer durationInMinutes)
+        @Generated public StacItemCollection getItemCollection(String collectionId)
+        @Generated public StacItemCollection getItemCollection(String collectionId, Integer limit, List<String> boundingBox, String datetime, StacAssetUrlSigningMode sign, Integer durationInMinutes, String token)
+        @Generated public Response<BinaryData> getItemCollectionWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getItemWithResponse(String collectionId, String itemId, RequestOptions requestOptions)
+        @Generated public StacLandingPage getLandingPage()
+        @Generated public Response<BinaryData> getLandingPageWithResponse(RequestOptions requestOptions)
+        @Generated public StacMosaic getMosaic(String collectionId, String mosaicId)
+        @Generated public List<StacMosaic> getMosaics(String collectionId)
+        @Generated public Response<BinaryData> getMosaicsWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions)
+        @Generated public PartitionType getPartitionType(String collectionId)
+        @Generated public Response<BinaryData> getPartitionTypeWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public QueryableDefinitionsResponse getQueryables()
+        @Generated public Response<BinaryData> getQueryablesWithResponse(RequestOptions requestOptions)
+        @Generated public RenderOption getRenderOption(String collectionId, String renderOptionId)
+        @Generated public List<RenderOption> getRenderOptions(String collectionId)
+        @Generated public Response<BinaryData> getRenderOptionsWithResponse(String collectionId, RequestOptions requestOptions)
+        @Generated public Response<BinaryData> getRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions)
+        @Generated public StacCollection replaceCollection(String collectionId, StacCollection body)
+        @Generated public StacCollection replaceCollectionAsset(String collectionId, String assetId, StacAssetData body)
+        @Generated public Response<BinaryData> replaceCollectionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public StacMosaic replaceMosaic(String collectionId, String mosaicId, StacMosaic body)
+        @Generated public Response<BinaryData> replaceMosaicWithResponse(String collectionId, String mosaicId, BinaryData body, RequestOptions requestOptions)
+        @Generated public void replacePartitionType(String collectionId, PartitionType body)
+        @Generated public Response<Void> replacePartitionTypeWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public StacQueryable replaceQueryable(String collectionId, String queryableName, StacQueryable body)
+        @Generated public Response<BinaryData> replaceQueryableWithResponse(String collectionId, String queryableName, BinaryData body, RequestOptions requestOptions)
+        @Generated public RenderOption replaceRenderOption(String collectionId, String renderOptionId, RenderOption body)
+        @Generated public Response<BinaryData> replaceRenderOptionWithResponse(String collectionId, String renderOptionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public TileSettings replaceTileSettings(String collectionId, TileSettings body)
+        @Generated public Response<BinaryData> replaceTileSettingsWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
+        @Generated public StacItemCollection search(StacSearchParameters body)
+        @Generated public StacItemCollection search(StacSearchParameters body, StacAssetUrlSigningMode sign, Integer durationInMinutes)
+        @Generated public Response<BinaryData> searchWithResponse(BinaryData body, RequestOptions requestOptions)
+        @Generated public TileSettings getTileSettings(String collectionId)
+        @Generated public Response<BinaryData> getTileSettingsWithResponse(String collectionId, RequestOptions requestOptions)
+    }
+}
+package com.azure.analytics.planetarycomputer.models {
     @Immutable
-    public final class AssetMetadata implements JsonSerializable<AssetMetadata> { 
-        @Generated public AssetMetadata(String key, String type, List<String> roles, String title, String description) 
-        @Generated public String getDescription() 
-        @Generated public String getKey() 
-        @Generated public List<String> getRoles() 
-        @Generated public String getTitle() 
-        @Generated public String getType() 
-    } 
+    public final class AssetMetadata implements JsonSerializable<AssetMetadata> {
+        @Generated public AssetMetadata(String key, String type, List<String> roles, String title, String description)
+        @Generated public String getDescription()
+        @Generated public String getKey()
+        @Generated public List<String> getRoles()
+        @Generated public String getTitle()
+        @Generated public String getType()
+    }
     @Immutable
-    public final class AssetStatisticsResponse implements JsonSerializable<AssetStatisticsResponse> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public Map<String, BandStatisticsMap> getAdditionalProperties() 
-    } 
+    public final class AssetStatisticsResponse implements JsonSerializable<AssetStatisticsResponse> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public Map<String, BandStatisticsMap> getAdditionalProperties()
+    }
     @Immutable
-    public final class BandStatistics implements JsonSerializable<BandStatistics> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public double getCount() 
-        @Generated public List<List<Double>> getHistogram() 
-        @Generated public double getMajority() 
-        @Generated public double getMaskedPixels() 
-        @Generated public double getMaximum() 
-        @Generated public double getMean() 
-        @Generated public double getMedian() 
-        @Generated public double getMinimum() 
-        @Generated public double getMinority() 
-        @Generated public double getPercentile2() 
-        @Generated public double getPercentile98() 
-        @Generated public double getStd() 
-        @Generated public double getSum() 
-        @Generated public double getUnique() 
-        @Generated public double getValidPercent() 
-        @Generated public double getValidPixels() 
-    } 
+    public final class BandStatistics implements JsonSerializable<BandStatistics> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public double getCount()
+        @Generated public List<List<Double>> getHistogram()
+        @Generated public double getMajority()
+        @Generated public double getMaskedPixels()
+        @Generated public double getMaximum()
+        @Generated public double getMean()
+        @Generated public double getMedian()
+        @Generated public double getMinimum()
+        @Generated public double getMinority()
+        @Generated public double getPercentile2()
+        @Generated public double getPercentile98()
+        @Generated public double getStd()
+        @Generated public double getSum()
+        @Generated public double getUnique()
+        @Generated public double getValidPercent()
+        @Generated public double getValidPixels()
+    }
     @Immutable
-    public final class BandStatisticsMap implements JsonSerializable<BandStatisticsMap> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public Map<String, BandStatistics> getAdditionalProperties() 
-    } 
+    public final class BandStatisticsMap implements JsonSerializable<BandStatisticsMap> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public Map<String, BandStatistics> getAdditionalProperties()
+    }
     @Immutable
-    public final class ClassMapLegendResponse implements JsonSerializable<ClassMapLegendResponse> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public Map<String, BinaryData> getAdditionalProperties() 
-    } 
-    public final class ColorMapNames extends ExpandableStringEnum<ColorMapNames> { 
-        @Generated public static final ColorMapNames ACCENT = fromString("accent"); 
-        @Generated public static final ColorMapNames ACCENT_R = fromString("accent_r"); 
-        @Generated public static final ColorMapNames AFMHOT = fromString("afmhot"); 
-        @Generated public static final ColorMapNames AFMHOT_R = fromString("afmhot_r"); 
-        @Generated public static final ColorMapNames AI4G_LULC = fromString("ai4g-lulc"); 
-        @Generated public static final ColorMapNames ALOS_FNF = fromString("alos-fnf"); 
-        @Generated public static final ColorMapNames ALOS_PALSAR_MASK = fromString("alos-palsar-mask"); 
-        @Generated public static final ColorMapNames AUTUMN = fromString("autumn"); 
-        @Generated public static final ColorMapNames AUTUMN_R = fromString("autumn_r"); 
-        @Generated public static final ColorMapNames BINARY = fromString("binary"); 
-        @Generated public static final ColorMapNames BINARY_R = fromString("binary_r"); 
-        @Generated public static final ColorMapNames BLUES = fromString("blues"); 
-        @Generated public static final ColorMapNames BLUES_R = fromString("blues_r"); 
-        @Generated public static final ColorMapNames BONE = fromString("bone"); 
-        @Generated public static final ColorMapNames BONE_R = fromString("bone_r"); 
-        @Generated public static final ColorMapNames BRBG = fromString("brbg"); 
-        @Generated public static final ColorMapNames BRBG_R = fromString("brbg_r"); 
-        @Generated public static final ColorMapNames BRG = fromString("brg"); 
-        @Generated public static final ColorMapNames BRG_R = fromString("brg_r"); 
-        @Generated public static final ColorMapNames BUGN = fromString("bugn"); 
-        @Generated public static final ColorMapNames BUGN_R = fromString("bugn_r"); 
-        @Generated public static final ColorMapNames BUPU = fromString("bupu"); 
-        @Generated public static final ColorMapNames BUPU_R = fromString("bupu_r"); 
-        @Generated public static final ColorMapNames BWR = fromString("bwr"); 
-        @Generated public static final ColorMapNames BWR_R = fromString("bwr_r"); 
-        @Generated public static final ColorMapNames C_CAP = fromString("c-cap"); 
-        @Generated public static final ColorMapNames CFASTIE = fromString("cfastie"); 
-        @Generated public static final ColorMapNames CHESAPEAKE_LC_13 = fromString("chesapeake-lc-13"); 
-        @Generated public static final ColorMapNames CHESAPEAKE_LC_7 = fromString("chesapeake-lc-7"); 
-        @Generated public static final ColorMapNames CHESAPEAKE_LU = fromString("chesapeake-lu"); 
-        @Generated public static final ColorMapNames CHLORIS_BIOMASS = fromString("chloris-biomass"); 
-        @Generated public static final ColorMapNames CIVIDIS = fromString("cividis"); 
-        @Generated public static final ColorMapNames CIVIDIS_R = fromString("cividis_r"); 
-        @Generated public static final ColorMapNames CMRMAP = fromString("cmrmap"); 
-        @Generated public static final ColorMapNames CMRMAP_R = fromString("cmrmap_r"); 
-        @Generated public static final ColorMapNames COOL = fromString("cool"); 
-        @Generated public static final ColorMapNames COOL_R = fromString("cool_r"); 
-        @Generated public static final ColorMapNames COOLWARM = fromString("coolwarm"); 
-        @Generated public static final ColorMapNames COOLWARM_R = fromString("coolwarm_r"); 
-        @Generated public static final ColorMapNames COPPER = fromString("copper"); 
-        @Generated public static final ColorMapNames COPPER_R = fromString("copper_r"); 
-        @Generated public static final ColorMapNames CUBEHELIX = fromString("cubehelix"); 
-        @Generated public static final ColorMapNames CUBEHELIX_R = fromString("cubehelix_r"); 
-        @Generated public static final ColorMapNames DARK2 = fromString("dark2"); 
-        @Generated public static final ColorMapNames DARK2_R = fromString("dark2_r"); 
-        @Generated public static final ColorMapNames DRCOG_LULC = fromString("drcog-lulc"); 
-        @Generated public static final ColorMapNames ESA_CCI_LC = fromString("esa-cci-lc"); 
-        @Generated public static final ColorMapNames ESA_WORLDCOVER = fromString("esa-worldcover"); 
-        @Generated public static final ColorMapNames FLAG = fromString("flag"); 
-        @Generated public static final ColorMapNames FLAG_R = fromString("flag_r"); 
-        @Generated public static final ColorMapNames GAP_LULC = fromString("gap-lulc"); 
-        @Generated public static final ColorMapNames GIST_EARTH = fromString("gist_earth"); 
-        @Generated public static final ColorMapNames GIST_EARTH_R = fromString("gist_earth_r"); 
-        @Generated public static final ColorMapNames GIST_GRAY = fromString("gist_gray"); 
-        @Generated public static final ColorMapNames GIST_GRAY_R = fromString("gist_gray_r"); 
-        @Generated public static final ColorMapNames GIST_HEAT = fromString("gist_heat"); 
-        @Generated public static final ColorMapNames GIST_HEAT_R = fromString("gist_heat_r"); 
-        @Generated public static final ColorMapNames GIST_NCAR = fromString("gist_ncar"); 
-        @Generated public static final ColorMapNames GIST_NCAR_R = fromString("gist_ncar_r"); 
-        @Generated public static final ColorMapNames GIST_RAINBOW = fromString("gist_rainbow"); 
-        @Generated public static final ColorMapNames GIST_RAINBOW_R = fromString("gist_rainbow_r"); 
-        @Generated public static final ColorMapNames GIST_STERN = fromString("gist_stern"); 
-        @Generated public static final ColorMapNames GIST_STERN_R = fromString("gist_stern_r"); 
-        @Generated public static final ColorMapNames GIST_YARG = fromString("gist_yarg"); 
-        @Generated public static final ColorMapNames GIST_YARG_R = fromString("gist_yarg_r"); 
-        @Generated public static final ColorMapNames GNBU = fromString("gnbu"); 
-        @Generated public static final ColorMapNames GNBU_R = fromString("gnbu_r"); 
-        @Generated public static final ColorMapNames GNUPLOT = fromString("gnuplot"); 
-        @Generated public static final ColorMapNames GNUPLOT2 = fromString("gnuplot2"); 
-        @Generated public static final ColorMapNames GNUPLOT2_R = fromString("gnuplot2_r"); 
-        @Generated public static final ColorMapNames GNUPLOT_R = fromString("gnuplot_r"); 
-        @Generated public static final ColorMapNames GRAY = fromString("gray"); 
-        @Generated public static final ColorMapNames GRAY_R = fromString("gray_r"); 
-        @Generated public static final ColorMapNames GREENS = fromString("greens"); 
-        @Generated public static final ColorMapNames GREENS_R = fromString("greens_r"); 
-        @Generated public static final ColorMapNames GREYS = fromString("greys"); 
-        @Generated public static final ColorMapNames GREYS_R = fromString("greys_r"); 
-        @Generated public static final ColorMapNames HOT = fromString("hot"); 
-        @Generated public static final ColorMapNames HOT_R = fromString("hot_r"); 
-        @Generated public static final ColorMapNames HSV = fromString("hsv"); 
-        @Generated public static final ColorMapNames HSV_R = fromString("hsv_r"); 
-        @Generated public static final ColorMapNames INFERNO = fromString("inferno"); 
-        @Generated public static final ColorMapNames INFERNO_R = fromString("inferno_r"); 
-        @Generated public static final ColorMapNames IO_BII = fromString("io-bii"); 
-        @Generated public static final ColorMapNames IO_LULC = fromString("io-lulc"); 
-        @Generated public static final ColorMapNames IO_LULC_9_CLASS = fromString("io-lulc-9-class"); 
-        @Generated public static final ColorMapNames JET = fromString("jet"); 
-        @Generated public static final ColorMapNames JET_R = fromString("jet_r"); 
-        @Generated public static final ColorMapNames JRC_CHANGE = fromString("jrc-change"); 
-        @Generated public static final ColorMapNames JRC_EXTENT = fromString("jrc-extent"); 
-        @Generated public static final ColorMapNames JRC_OCCURRENCE = fromString("jrc-occurrence"); 
-        @Generated public static final ColorMapNames JRC_RECURRENCE = fromString("jrc-recurrence"); 
-        @Generated public static final ColorMapNames JRC_SEASONALITY = fromString("jrc-seasonality"); 
-        @Generated public static final ColorMapNames JRC_TRANSITIONS = fromString("jrc-transitions"); 
-        @Generated public static final ColorMapNames LIDAR_CLASSIFICATION = fromString("lidar-classification"); 
-        @Generated public static final ColorMapNames LIDAR_HAG = fromString("lidar-hag"); 
-        @Generated public static final ColorMapNames LIDAR_HAG_ALTERNATIVE = fromString("lidar-hag-alternative"); 
-        @Generated public static final ColorMapNames LIDAR_INTENSITY = fromString("lidar-intensity"); 
-        @Generated public static final ColorMapNames LIDAR_RETURNS = fromString("lidar-returns"); 
-        @Generated public static final ColorMapNames MAGMA = fromString("magma"); 
-        @Generated public static final ColorMapNames MAGMA_R = fromString("magma_r"); 
-        @Generated public static final ColorMapNames MODIS_10A1 = fromString("modis-10A1"); 
-        @Generated public static final ColorMapNames MODIS_10A2 = fromString("modis-10A2"); 
-        @Generated public static final ColorMapNames MODIS_13A1_Q1 = fromString("modis-13A1|Q1"); 
-        @Generated public static final ColorMapNames MODIS_14A1_A2 = fromString("modis-14A1|A2"); 
-        @Generated public static final ColorMapNames MODIS_15A2H_A3H = fromString("modis-15A2H|A3H"); 
-        @Generated public static final ColorMapNames MODIS_16A3GF_ET = fromString("modis-16A3GF-ET"); 
-        @Generated public static final ColorMapNames MODIS_16A3GF_PET = fromString("modis-16A3GF-PET"); 
-        @Generated public static final ColorMapNames MODIS_17A2H_A2HGF = fromString("modis-17A2H|A2HGF"); 
-        @Generated public static final ColorMapNames MODIS_17A3HGF = fromString("modis-17A3HGF"); 
-        @Generated public static final ColorMapNames MODIS_64A1 = fromString("modis-64A1"); 
-        @Generated public static final ColorMapNames MTBS_SEVERITY = fromString("mtbs-severity"); 
-        @Generated public static final ColorMapNames NIPY_SPECTRAL = fromString("nipy_spectral"); 
-        @Generated public static final ColorMapNames NIPY_SPECTRAL_R = fromString("nipy_spectral_r"); 
-        @Generated public static final ColorMapNames NRCAN_LULC = fromString("nrcan-lulc"); 
-        @Generated public static final ColorMapNames OCEAN = fromString("ocean"); 
-        @Generated public static final ColorMapNames OCEAN_R = fromString("ocean_r"); 
-        @Generated public static final ColorMapNames ORANGES = fromString("oranges"); 
-        @Generated public static final ColorMapNames ORANGES_R = fromString("oranges_r"); 
-        @Generated public static final ColorMapNames ORRD = fromString("orrd"); 
-        @Generated public static final ColorMapNames ORRD_R = fromString("orrd_r"); 
-        @Generated public static final ColorMapNames PAIRED = fromString("paired"); 
-        @Generated public static final ColorMapNames PAIRED_R = fromString("paired_r"); 
-        @Generated public static final ColorMapNames PASTEL1 = fromString("pastel1"); 
-        @Generated public static final ColorMapNames PASTEL1_R = fromString("pastel1_r"); 
-        @Generated public static final ColorMapNames PASTEL2 = fromString("pastel2"); 
-        @Generated public static final ColorMapNames PASTEL2_R = fromString("pastel2_r"); 
-        @Generated public static final ColorMapNames PINK = fromString("pink"); 
-        @Generated public static final ColorMapNames PINK_R = fromString("pink_r"); 
-        @Generated public static final ColorMapNames PIYG = fromString("piyg"); 
-        @Generated public static final ColorMapNames PIYG_R = fromString("piyg_r"); 
-        @Generated public static final ColorMapNames PLASMA = fromString("plasma"); 
-        @Generated public static final ColorMapNames PLASMA_R = fromString("plasma_r"); 
-        @Generated public static final ColorMapNames PRGN = fromString("prgn"); 
-        @Generated public static final ColorMapNames PRGN_R = fromString("prgn_r"); 
-        @Generated public static final ColorMapNames PRISM = fromString("prism"); 
-        @Generated public static final ColorMapNames PRISM_R = fromString("prism_r"); 
-        @Generated public static final ColorMapNames PUBU = fromString("pubu"); 
-        @Generated public static final ColorMapNames PUBU_R = fromString("pubu_r"); 
-        @Generated public static final ColorMapNames PUBUGN = fromString("pubugn"); 
-        @Generated public static final ColorMapNames PUBUGN_R = fromString("pubugn_r"); 
-        @Generated public static final ColorMapNames PUOR = fromString("puor"); 
-        @Generated public static final ColorMapNames PUOR_R = fromString("puor_r"); 
-        @Generated public static final ColorMapNames PURD = fromString("purd"); 
-        @Generated public static final ColorMapNames PURD_R = fromString("purd_r"); 
-        @Generated public static final ColorMapNames PURPLES = fromString("purples"); 
-        @Generated public static final ColorMapNames PURPLES_R = fromString("purples_r"); 
-        @Generated public static final ColorMapNames QPE = fromString("qpe"); 
-        @Generated public static final ColorMapNames RAINBOW = fromString("rainbow"); 
-        @Generated public static final ColorMapNames RAINBOW_R = fromString("rainbow_r"); 
-        @Generated public static final ColorMapNames RDBU = fromString("rdbu"); 
-        @Generated public static final ColorMapNames RDBU_R = fromString("rdbu_r"); 
-        @Generated public static final ColorMapNames RDGY = fromString("rdgy"); 
-        @Generated public static final ColorMapNames RDGY_R = fromString("rdgy_r"); 
-        @Generated public static final ColorMapNames RDPU = fromString("rdpu"); 
-        @Generated public static final ColorMapNames RDPU_R = fromString("rdpu_r"); 
-        @Generated public static final ColorMapNames RDYLBU = fromString("rdylbu"); 
-        @Generated public static final ColorMapNames RDYLBU_R = fromString("rdylbu_r"); 
-        @Generated public static final ColorMapNames RDYLGN = fromString("rdylgn"); 
-        @Generated public static final ColorMapNames RDYLGN_R = fromString("rdylgn_r"); 
-        @Generated public static final ColorMapNames REDS = fromString("reds"); 
-        @Generated public static final ColorMapNames REDS_R = fromString("reds_r"); 
-        @Generated public static final ColorMapNames RPLUMBO = fromString("rplumbo"); 
-        @Generated public static final ColorMapNames SCHWARZWALD = fromString("schwarzwald"); 
-        @Generated public static final ColorMapNames SEISMIC = fromString("seismic"); 
-        @Generated public static final ColorMapNames SEISMIC_R = fromString("seismic_r"); 
-        @Generated public static final ColorMapNames SET1 = fromString("set1"); 
-        @Generated public static final ColorMapNames SET1_R = fromString("set1_r"); 
-        @Generated public static final ColorMapNames SET2 = fromString("set2"); 
-        @Generated public static final ColorMapNames SET2_R = fromString("set2_r"); 
-        @Generated public static final ColorMapNames SET3 = fromString("set3"); 
-        @Generated public static final ColorMapNames SET3_R = fromString("set3_r"); 
-        @Generated public static final ColorMapNames SPECTRAL = fromString("spectral"); 
-        @Generated public static final ColorMapNames SPECTRAL_R = fromString("spectral_r"); 
-        @Generated public static final ColorMapNames SPRING = fromString("spring"); 
-        @Generated public static final ColorMapNames SPRING_R = fromString("spring_r"); 
-        @Generated public static final ColorMapNames SUMMER = fromString("summer"); 
-        @Generated public static final ColorMapNames SUMMER_R = fromString("summer_r"); 
-        @Generated public static final ColorMapNames TAB10 = fromString("tab10"); 
-        @Generated public static final ColorMapNames TAB10_R = fromString("tab10_r"); 
-        @Generated public static final ColorMapNames TAB20 = fromString("tab20"); 
-        @Generated public static final ColorMapNames TAB20_R = fromString("tab20_r"); 
-        @Generated public static final ColorMapNames TAB20B = fromString("tab20b"); 
-        @Generated public static final ColorMapNames TAB20B_R = fromString("tab20b_r"); 
-        @Generated public static final ColorMapNames TAB20C = fromString("tab20c"); 
-        @Generated public static final ColorMapNames TAB20C_R = fromString("tab20c_r"); 
-        @Generated public static final ColorMapNames TERRAIN = fromString("terrain"); 
-        @Generated public static final ColorMapNames TERRAIN_R = fromString("terrain_r"); 
-        @Generated public static final ColorMapNames TWILIGHT = fromString("twilight"); 
-        @Generated public static final ColorMapNames TWILIGHT_R = fromString("twilight_r"); 
-        @Generated public static final ColorMapNames TWILIGHT_SHIFTED = fromString("twilight_shifted"); 
-        @Generated public static final ColorMapNames TWILIGHT_SHIFTED_R = fromString("twilight_shifted_r"); 
-        @Generated public static final ColorMapNames USDA_CDL = fromString("usda-cdl"); 
-        @Generated public static final ColorMapNames USDA_CDL_CORN = fromString("usda-cdl-corn"); 
-        @Generated public static final ColorMapNames USDA_CDL_COTTON = fromString("usda-cdl-cotton"); 
-        @Generated public static final ColorMapNames USDA_CDL_SOYBEANS = fromString("usda-cdl-soybeans"); 
-        @Generated public static final ColorMapNames USDA_CDL_WHEAT = fromString("usda-cdl-wheat"); 
-        @Generated public static final ColorMapNames USGS_LCMAP = fromString("usgs-lcmap"); 
-        @Generated public static final ColorMapNames VIIRS_10A1 = fromString("viirs-10a1"); 
-        @Generated public static final ColorMapNames VIIRS_13A1 = fromString("viirs-13a1"); 
-        @Generated public static final ColorMapNames VIIRS_14A1 = fromString("viirs-14a1"); 
-        @Generated public static final ColorMapNames VIIRS_15A2H = fromString("viirs-15a2H"); 
-        @Generated public static final ColorMapNames VIRIDIS = fromString("viridis"); 
-        @Generated public static final ColorMapNames VIRIDIS_R = fromString("viridis_r"); 
-        @Generated public static final ColorMapNames WINTER = fromString("winter"); 
-        @Generated public static final ColorMapNames WINTER_R = fromString("winter_r"); 
-        @Generated public static final ColorMapNames WISTIA = fromString("wistia"); 
-        @Generated public static final ColorMapNames WISTIA_R = fromString("wistia_r"); 
-        @Generated public static final ColorMapNames YLGN = fromString("ylgn"); 
-        @Generated public static final ColorMapNames YLGN_R = fromString("ylgn_r"); 
-        @Generated public static final ColorMapNames YLGNBU = fromString("ylgnbu"); 
-        @Generated public static final ColorMapNames YLGNBU_R = fromString("ylgnbu_r"); 
-        @Generated public static final ColorMapNames YLORBR = fromString("ylorbr"); 
-        @Generated public static final ColorMapNames YLORBR_R = fromString("ylorbr_r"); 
-        @Generated public static final ColorMapNames YLORRD = fromString("ylorrd"); 
-        @Generated public static final ColorMapNames YLORRD_R = fromString("ylorrd_r"); 
-        @Generated public static final ColorMapNames ALGAE = fromString("algae"); 
-        @Generated public static final ColorMapNames ALGAE_R = fromString("algae_r"); 
-        @Generated public static final ColorMapNames AMP = fromString("amp"); 
-        @Generated public static final ColorMapNames AMP_R = fromString("amp_r"); 
-        @Generated public static final ColorMapNames BALANCE = fromString("balance"); 
-        @Generated public static final ColorMapNames BALANCE_R = fromString("balance_r"); 
-        @Generated public static final ColorMapNames CURL = fromString("curl"); 
-        @Generated public static final ColorMapNames CURL_R = fromString("curl_r"); 
-        @Generated public static final ColorMapNames DEEP = fromString("deep"); 
-        @Generated public static final ColorMapNames DEEP_R = fromString("deep_r"); 
-        @Generated public static final ColorMapNames DELTA = fromString("delta"); 
-        @Generated public static final ColorMapNames DELTA_R = fromString("delta_r"); 
-        @Generated public static final ColorMapNames DENSE = fromString("dense"); 
-        @Generated public static final ColorMapNames DENSE_R = fromString("dense_r"); 
-        @Generated public static final ColorMapNames DIFF = fromString("diff"); 
-        @Generated public static final ColorMapNames DIFF_R = fromString("diff_r"); 
-        @Generated public static final ColorMapNames HALINE = fromString("haline"); 
-        @Generated public static final ColorMapNames HALINE_R = fromString("haline_r"); 
-        @Generated public static final ColorMapNames ICE = fromString("ice"); 
-        @Generated public static final ColorMapNames ICE_R = fromString("ice_r"); 
-        @Generated public static final ColorMapNames MATTER = fromString("matter"); 
-        @Generated public static final ColorMapNames MATTER_R = fromString("matter_r"); 
-        @Generated public static final ColorMapNames OXY = fromString("oxy"); 
-        @Generated public static final ColorMapNames OXY_R = fromString("oxy_r"); 
-        @Generated public static final ColorMapNames PHASE = fromString("phase"); 
-        @Generated public static final ColorMapNames PHASE_R = fromString("phase_r"); 
-        @Generated public static final ColorMapNames RAIN = fromString("rain"); 
-        @Generated public static final ColorMapNames RAIN_R = fromString("rain_r"); 
-        @Generated public static final ColorMapNames SOLAR = fromString("solar"); 
-        @Generated public static final ColorMapNames SOLAR_R = fromString("solar_r"); 
-        @Generated public static final ColorMapNames SPEED = fromString("speed"); 
-        @Generated public static final ColorMapNames SPEED_R = fromString("speed_r"); 
-        @Generated public static final ColorMapNames TARN = fromString("tarn"); 
-        @Generated public static final ColorMapNames TARN_R = fromString("tarn_r"); 
-        @Generated public static final ColorMapNames TEMPO = fromString("tempo"); 
-        @Generated public static final ColorMapNames TEMPO_R = fromString("tempo_r"); 
-        @Generated public static final ColorMapNames THERMAL = fromString("thermal"); 
-        @Generated public static final ColorMapNames THERMAL_R = fromString("thermal_r"); 
-        @Generated public static final ColorMapNames TOPO = fromString("topo"); 
-        @Generated public static final ColorMapNames TOPO_R = fromString("topo_r"); 
-        @Generated public static final ColorMapNames TURBID = fromString("turbid"); 
-        @Generated public static final ColorMapNames TURBID_R = fromString("turbid_r"); 
-        @Generated public static final ColorMapNames TURBO = fromString("turbo"); 
-        @Generated public static final ColorMapNames TURBO_R = fromString("turbo_r"); 
-        @Deprecated @Generated public ColorMapNames() 
-        @Generated public static ColorMapNames fromString(String name) 
-        @Generated public static Collection<ColorMapNames> values() 
-    } 
+    public final class ClassMapLegendResponse implements JsonSerializable<ClassMapLegendResponse> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public Map<String, BinaryData> getAdditionalProperties()
+    }
+    public final class ColorMapNames extends ExpandableStringEnum<ColorMapNames> {
+        @Generated public static final ColorMapNames ACCENT = fromString("accent");
+        @Generated public static final ColorMapNames ACCENT_R = fromString("accent_r");
+        @Generated public static final ColorMapNames AFMHOT = fromString("afmhot");
+        @Generated public static final ColorMapNames AFMHOT_R = fromString("afmhot_r");
+        @Generated public static final ColorMapNames AI4G_LULC = fromString("ai4g-lulc");
+        @Generated public static final ColorMapNames ALOS_FNF = fromString("alos-fnf");
+        @Generated public static final ColorMapNames ALOS_PALSAR_MASK = fromString("alos-palsar-mask");
+        @Generated public static final ColorMapNames AUTUMN = fromString("autumn");
+        @Generated public static final ColorMapNames AUTUMN_R = fromString("autumn_r");
+        @Generated public static final ColorMapNames BINARY = fromString("binary");
+        @Generated public static final ColorMapNames BINARY_R = fromString("binary_r");
+        @Generated public static final ColorMapNames BLUES = fromString("blues");
+        @Generated public static final ColorMapNames BLUES_R = fromString("blues_r");
+        @Generated public static final ColorMapNames BONE = fromString("bone");
+        @Generated public static final ColorMapNames BONE_R = fromString("bone_r");
+        @Generated public static final ColorMapNames BRBG = fromString("brbg");
+        @Generated public static final ColorMapNames BRBG_R = fromString("brbg_r");
+        @Generated public static final ColorMapNames BRG = fromString("brg");
+        @Generated public static final ColorMapNames BRG_R = fromString("brg_r");
+        @Generated public static final ColorMapNames BUGN = fromString("bugn");
+        @Generated public static final ColorMapNames BUGN_R = fromString("bugn_r");
+        @Generated public static final ColorMapNames BUPU = fromString("bupu");
+        @Generated public static final ColorMapNames BUPU_R = fromString("bupu_r");
+        @Generated public static final ColorMapNames BWR = fromString("bwr");
+        @Generated public static final ColorMapNames BWR_R = fromString("bwr_r");
+        @Generated public static final ColorMapNames C_CAP = fromString("c-cap");
+        @Generated public static final ColorMapNames CFASTIE = fromString("cfastie");
+        @Generated public static final ColorMapNames CHESAPEAKE_LC_13 = fromString("chesapeake-lc-13");
+        @Generated public static final ColorMapNames CHESAPEAKE_LC_7 = fromString("chesapeake-lc-7");
+        @Generated public static final ColorMapNames CHESAPEAKE_LU = fromString("chesapeake-lu");
+        @Generated public static final ColorMapNames CHLORIS_BIOMASS = fromString("chloris-biomass");
+        @Generated public static final ColorMapNames CIVIDIS = fromString("cividis");
+        @Generated public static final ColorMapNames CIVIDIS_R = fromString("cividis_r");
+        @Generated public static final ColorMapNames CMRMAP = fromString("cmrmap");
+        @Generated public static final ColorMapNames CMRMAP_R = fromString("cmrmap_r");
+        @Generated public static final ColorMapNames COOL = fromString("cool");
+        @Generated public static final ColorMapNames COOL_R = fromString("cool_r");
+        @Generated public static final ColorMapNames COOLWARM = fromString("coolwarm");
+        @Generated public static final ColorMapNames COOLWARM_R = fromString("coolwarm_r");
+        @Generated public static final ColorMapNames COPPER = fromString("copper");
+        @Generated public static final ColorMapNames COPPER_R = fromString("copper_r");
+        @Generated public static final ColorMapNames CUBEHELIX = fromString("cubehelix");
+        @Generated public static final ColorMapNames CUBEHELIX_R = fromString("cubehelix_r");
+        @Generated public static final ColorMapNames DARK2 = fromString("dark2");
+        @Generated public static final ColorMapNames DARK2_R = fromString("dark2_r");
+        @Generated public static final ColorMapNames DRCOG_LULC = fromString("drcog-lulc");
+        @Generated public static final ColorMapNames ESA_CCI_LC = fromString("esa-cci-lc");
+        @Generated public static final ColorMapNames ESA_WORLDCOVER = fromString("esa-worldcover");
+        @Generated public static final ColorMapNames FLAG = fromString("flag");
+        @Generated public static final ColorMapNames FLAG_R = fromString("flag_r");
+        @Generated public static final ColorMapNames GAP_LULC = fromString("gap-lulc");
+        @Generated public static final ColorMapNames GIST_EARTH = fromString("gist_earth");
+        @Generated public static final ColorMapNames GIST_EARTH_R = fromString("gist_earth_r");
+        @Generated public static final ColorMapNames GIST_GRAY = fromString("gist_gray");
+        @Generated public static final ColorMapNames GIST_GRAY_R = fromString("gist_gray_r");
+        @Generated public static final ColorMapNames GIST_HEAT = fromString("gist_heat");
+        @Generated public static final ColorMapNames GIST_HEAT_R = fromString("gist_heat_r");
+        @Generated public static final ColorMapNames GIST_NCAR = fromString("gist_ncar");
+        @Generated public static final ColorMapNames GIST_NCAR_R = fromString("gist_ncar_r");
+        @Generated public static final ColorMapNames GIST_RAINBOW = fromString("gist_rainbow");
+        @Generated public static final ColorMapNames GIST_RAINBOW_R = fromString("gist_rainbow_r");
+        @Generated public static final ColorMapNames GIST_STERN = fromString("gist_stern");
+        @Generated public static final ColorMapNames GIST_STERN_R = fromString("gist_stern_r");
+        @Generated public static final ColorMapNames GIST_YARG = fromString("gist_yarg");
+        @Generated public static final ColorMapNames GIST_YARG_R = fromString("gist_yarg_r");
+        @Generated public static final ColorMapNames GNBU = fromString("gnbu");
+        @Generated public static final ColorMapNames GNBU_R = fromString("gnbu_r");
+        @Generated public static final ColorMapNames GNUPLOT = fromString("gnuplot");
+        @Generated public static final ColorMapNames GNUPLOT2 = fromString("gnuplot2");
+        @Generated public static final ColorMapNames GNUPLOT2_R = fromString("gnuplot2_r");
+        @Generated public static final ColorMapNames GNUPLOT_R = fromString("gnuplot_r");
+        @Generated public static final ColorMapNames GRAY = fromString("gray");
+        @Generated public static final ColorMapNames GRAY_R = fromString("gray_r");
+        @Generated public static final ColorMapNames GREENS = fromString("greens");
+        @Generated public static final ColorMapNames GREENS_R = fromString("greens_r");
+        @Generated public static final ColorMapNames GREYS = fromString("greys");
+        @Generated public static final ColorMapNames GREYS_R = fromString("greys_r");
+        @Generated public static final ColorMapNames HOT = fromString("hot");
+        @Generated public static final ColorMapNames HOT_R = fromString("hot_r");
+        @Generated public static final ColorMapNames HSV = fromString("hsv");
+        @Generated public static final ColorMapNames HSV_R = fromString("hsv_r");
+        @Generated public static final ColorMapNames INFERNO = fromString("inferno");
+        @Generated public static final ColorMapNames INFERNO_R = fromString("inferno_r");
+        @Generated public static final ColorMapNames IO_BII = fromString("io-bii");
+        @Generated public static final ColorMapNames IO_LULC = fromString("io-lulc");
+        @Generated public static final ColorMapNames IO_LULC_9_CLASS = fromString("io-lulc-9-class");
+        @Generated public static final ColorMapNames JET = fromString("jet");
+        @Generated public static final ColorMapNames JET_R = fromString("jet_r");
+        @Generated public static final ColorMapNames JRC_CHANGE = fromString("jrc-change");
+        @Generated public static final ColorMapNames JRC_EXTENT = fromString("jrc-extent");
+        @Generated public static final ColorMapNames JRC_OCCURRENCE = fromString("jrc-occurrence");
+        @Generated public static final ColorMapNames JRC_RECURRENCE = fromString("jrc-recurrence");
+        @Generated public static final ColorMapNames JRC_SEASONALITY = fromString("jrc-seasonality");
+        @Generated public static final ColorMapNames JRC_TRANSITIONS = fromString("jrc-transitions");
+        @Generated public static final ColorMapNames LIDAR_CLASSIFICATION = fromString("lidar-classification");
+        @Generated public static final ColorMapNames LIDAR_HAG = fromString("lidar-hag");
+        @Generated public static final ColorMapNames LIDAR_HAG_ALTERNATIVE = fromString("lidar-hag-alternative");
+        @Generated public static final ColorMapNames LIDAR_INTENSITY = fromString("lidar-intensity");
+        @Generated public static final ColorMapNames LIDAR_RETURNS = fromString("lidar-returns");
+        @Generated public static final ColorMapNames MAGMA = fromString("magma");
+        @Generated public static final ColorMapNames MAGMA_R = fromString("magma_r");
+        @Generated public static final ColorMapNames MODIS_10A1 = fromString("modis-10A1");
+        @Generated public static final ColorMapNames MODIS_10A2 = fromString("modis-10A2");
+        @Generated public static final ColorMapNames MODIS_13A1_Q1 = fromString("modis-13A1|Q1");
+        @Generated public static final ColorMapNames MODIS_14A1_A2 = fromString("modis-14A1|A2");
+        @Generated public static final ColorMapNames MODIS_15A2H_A3H = fromString("modis-15A2H|A3H");
+        @Generated public static final ColorMapNames MODIS_16A3GF_ET = fromString("modis-16A3GF-ET");
+        @Generated public static final ColorMapNames MODIS_16A3GF_PET = fromString("modis-16A3GF-PET");
+        @Generated public static final ColorMapNames MODIS_17A2H_A2HGF = fromString("modis-17A2H|A2HGF");
+        @Generated public static final ColorMapNames MODIS_17A3HGF = fromString("modis-17A3HGF");
+        @Generated public static final ColorMapNames MODIS_64A1 = fromString("modis-64A1");
+        @Generated public static final ColorMapNames MTBS_SEVERITY = fromString("mtbs-severity");
+        @Generated public static final ColorMapNames NIPY_SPECTRAL = fromString("nipy_spectral");
+        @Generated public static final ColorMapNames NIPY_SPECTRAL_R = fromString("nipy_spectral_r");
+        @Generated public static final ColorMapNames NRCAN_LULC = fromString("nrcan-lulc");
+        @Generated public static final ColorMapNames OCEAN = fromString("ocean");
+        @Generated public static final ColorMapNames OCEAN_R = fromString("ocean_r");
+        @Generated public static final ColorMapNames ORANGES = fromString("oranges");
+        @Generated public static final ColorMapNames ORANGES_R = fromString("oranges_r");
+        @Generated public static final ColorMapNames ORRD = fromString("orrd");
+        @Generated public static final ColorMapNames ORRD_R = fromString("orrd_r");
+        @Generated public static final ColorMapNames PAIRED = fromString("paired");
+        @Generated public static final ColorMapNames PAIRED_R = fromString("paired_r");
+        @Generated public static final ColorMapNames PASTEL1 = fromString("pastel1");
+        @Generated public static final ColorMapNames PASTEL1_R = fromString("pastel1_r");
+        @Generated public static final ColorMapNames PASTEL2 = fromString("pastel2");
+        @Generated public static final ColorMapNames PASTEL2_R = fromString("pastel2_r");
+        @Generated public static final ColorMapNames PINK = fromString("pink");
+        @Generated public static final ColorMapNames PINK_R = fromString("pink_r");
+        @Generated public static final ColorMapNames PIYG = fromString("piyg");
+        @Generated public static final ColorMapNames PIYG_R = fromString("piyg_r");
+        @Generated public static final ColorMapNames PLASMA = fromString("plasma");
+        @Generated public static final ColorMapNames PLASMA_R = fromString("plasma_r");
+        @Generated public static final ColorMapNames PRGN = fromString("prgn");
+        @Generated public static final ColorMapNames PRGN_R = fromString("prgn_r");
+        @Generated public static final ColorMapNames PRISM = fromString("prism");
+        @Generated public static final ColorMapNames PRISM_R = fromString("prism_r");
+        @Generated public static final ColorMapNames PUBU = fromString("pubu");
+        @Generated public static final ColorMapNames PUBU_R = fromString("pubu_r");
+        @Generated public static final ColorMapNames PUBUGN = fromString("pubugn");
+        @Generated public static final ColorMapNames PUBUGN_R = fromString("pubugn_r");
+        @Generated public static final ColorMapNames PUOR = fromString("puor");
+        @Generated public static final ColorMapNames PUOR_R = fromString("puor_r");
+        @Generated public static final ColorMapNames PURD = fromString("purd");
+        @Generated public static final ColorMapNames PURD_R = fromString("purd_r");
+        @Generated public static final ColorMapNames PURPLES = fromString("purples");
+        @Generated public static final ColorMapNames PURPLES_R = fromString("purples_r");
+        @Generated public static final ColorMapNames QPE = fromString("qpe");
+        @Generated public static final ColorMapNames RAINBOW = fromString("rainbow");
+        @Generated public static final ColorMapNames RAINBOW_R = fromString("rainbow_r");
+        @Generated public static final ColorMapNames RDBU = fromString("rdbu");
+        @Generated public static final ColorMapNames RDBU_R = fromString("rdbu_r");
+        @Generated public static final ColorMapNames RDGY = fromString("rdgy");
+        @Generated public static final ColorMapNames RDGY_R = fromString("rdgy_r");
+        @Generated public static final ColorMapNames RDPU = fromString("rdpu");
+        @Generated public static final ColorMapNames RDPU_R = fromString("rdpu_r");
+        @Generated public static final ColorMapNames RDYLBU = fromString("rdylbu");
+        @Generated public static final ColorMapNames RDYLBU_R = fromString("rdylbu_r");
+        @Generated public static final ColorMapNames RDYLGN = fromString("rdylgn");
+        @Generated public static final ColorMapNames RDYLGN_R = fromString("rdylgn_r");
+        @Generated public static final ColorMapNames REDS = fromString("reds");
+        @Generated public static final ColorMapNames REDS_R = fromString("reds_r");
+        @Generated public static final ColorMapNames RPLUMBO = fromString("rplumbo");
+        @Generated public static final ColorMapNames SCHWARZWALD = fromString("schwarzwald");
+        @Generated public static final ColorMapNames SEISMIC = fromString("seismic");
+        @Generated public static final ColorMapNames SEISMIC_R = fromString("seismic_r");
+        @Generated public static final ColorMapNames SET1 = fromString("set1");
+        @Generated public static final ColorMapNames SET1_R = fromString("set1_r");
+        @Generated public static final ColorMapNames SET2 = fromString("set2");
+        @Generated public static final ColorMapNames SET2_R = fromString("set2_r");
+        @Generated public static final ColorMapNames SET3 = fromString("set3");
+        @Generated public static final ColorMapNames SET3_R = fromString("set3_r");
+        @Generated public static final ColorMapNames SPECTRAL = fromString("spectral");
+        @Generated public static final ColorMapNames SPECTRAL_R = fromString("spectral_r");
+        @Generated public static final ColorMapNames SPRING = fromString("spring");
+        @Generated public static final ColorMapNames SPRING_R = fromString("spring_r");
+        @Generated public static final ColorMapNames SUMMER = fromString("summer");
+        @Generated public static final ColorMapNames SUMMER_R = fromString("summer_r");
+        @Generated public static final ColorMapNames TAB10 = fromString("tab10");
+        @Generated public static final ColorMapNames TAB10_R = fromString("tab10_r");
+        @Generated public static final ColorMapNames TAB20 = fromString("tab20");
+        @Generated public static final ColorMapNames TAB20_R = fromString("tab20_r");
+        @Generated public static final ColorMapNames TAB20B = fromString("tab20b");
+        @Generated public static final ColorMapNames TAB20B_R = fromString("tab20b_r");
+        @Generated public static final ColorMapNames TAB20C = fromString("tab20c");
+        @Generated public static final ColorMapNames TAB20C_R = fromString("tab20c_r");
+        @Generated public static final ColorMapNames TERRAIN = fromString("terrain");
+        @Generated public static final ColorMapNames TERRAIN_R = fromString("terrain_r");
+        @Generated public static final ColorMapNames TWILIGHT = fromString("twilight");
+        @Generated public static final ColorMapNames TWILIGHT_R = fromString("twilight_r");
+        @Generated public static final ColorMapNames TWILIGHT_SHIFTED = fromString("twilight_shifted");
+        @Generated public static final ColorMapNames TWILIGHT_SHIFTED_R = fromString("twilight_shifted_r");
+        @Generated public static final ColorMapNames USDA_CDL = fromString("usda-cdl");
+        @Generated public static final ColorMapNames USDA_CDL_CORN = fromString("usda-cdl-corn");
+        @Generated public static final ColorMapNames USDA_CDL_COTTON = fromString("usda-cdl-cotton");
+        @Generated public static final ColorMapNames USDA_CDL_SOYBEANS = fromString("usda-cdl-soybeans");
+        @Generated public static final ColorMapNames USDA_CDL_WHEAT = fromString("usda-cdl-wheat");
+        @Generated public static final ColorMapNames USGS_LCMAP = fromString("usgs-lcmap");
+        @Generated public static final ColorMapNames VIIRS_10A1 = fromString("viirs-10a1");
+        @Generated public static final ColorMapNames VIIRS_13A1 = fromString("viirs-13a1");
+        @Generated public static final ColorMapNames VIIRS_14A1 = fromString("viirs-14a1");
+        @Generated public static final ColorMapNames VIIRS_15A2H = fromString("viirs-15a2H");
+        @Generated public static final ColorMapNames VIRIDIS = fromString("viridis");
+        @Generated public static final ColorMapNames VIRIDIS_R = fromString("viridis_r");
+        @Generated public static final ColorMapNames WINTER = fromString("winter");
+        @Generated public static final ColorMapNames WINTER_R = fromString("winter_r");
+        @Generated public static final ColorMapNames WISTIA = fromString("wistia");
+        @Generated public static final ColorMapNames WISTIA_R = fromString("wistia_r");
+        @Generated public static final ColorMapNames YLGN = fromString("ylgn");
+        @Generated public static final ColorMapNames YLGN_R = fromString("ylgn_r");
+        @Generated public static final ColorMapNames YLGNBU = fromString("ylgnbu");
+        @Generated public static final ColorMapNames YLGNBU_R = fromString("ylgnbu_r");
+        @Generated public static final ColorMapNames YLORBR = fromString("ylorbr");
+        @Generated public static final ColorMapNames YLORBR_R = fromString("ylorbr_r");
+        @Generated public static final ColorMapNames YLORRD = fromString("ylorrd");
+        @Generated public static final ColorMapNames YLORRD_R = fromString("ylorrd_r");
+        @Generated public static final ColorMapNames ALGAE = fromString("algae");
+        @Generated public static final ColorMapNames ALGAE_R = fromString("algae_r");
+        @Generated public static final ColorMapNames AMP = fromString("amp");
+        @Generated public static final ColorMapNames AMP_R = fromString("amp_r");
+        @Generated public static final ColorMapNames BALANCE = fromString("balance");
+        @Generated public static final ColorMapNames BALANCE_R = fromString("balance_r");
+        @Generated public static final ColorMapNames CURL = fromString("curl");
+        @Generated public static final ColorMapNames CURL_R = fromString("curl_r");
+        @Generated public static final ColorMapNames DEEP = fromString("deep");
+        @Generated public static final ColorMapNames DEEP_R = fromString("deep_r");
+        @Generated public static final ColorMapNames DELTA = fromString("delta");
+        @Generated public static final ColorMapNames DELTA_R = fromString("delta_r");
+        @Generated public static final ColorMapNames DENSE = fromString("dense");
+        @Generated public static final ColorMapNames DENSE_R = fromString("dense_r");
+        @Generated public static final ColorMapNames DIFF = fromString("diff");
+        @Generated public static final ColorMapNames DIFF_R = fromString("diff_r");
+        @Generated public static final ColorMapNames HALINE = fromString("haline");
+        @Generated public static final ColorMapNames HALINE_R = fromString("haline_r");
+        @Generated public static final ColorMapNames ICE = fromString("ice");
+        @Generated public static final ColorMapNames ICE_R = fromString("ice_r");
+        @Generated public static final ColorMapNames MATTER = fromString("matter");
+        @Generated public static final ColorMapNames MATTER_R = fromString("matter_r");
+        @Generated public static final ColorMapNames OXY = fromString("oxy");
+        @Generated public static final ColorMapNames OXY_R = fromString("oxy_r");
+        @Generated public static final ColorMapNames PHASE = fromString("phase");
+        @Generated public static final ColorMapNames PHASE_R = fromString("phase_r");
+        @Generated public static final ColorMapNames RAIN = fromString("rain");
+        @Generated public static final ColorMapNames RAIN_R = fromString("rain_r");
+        @Generated public static final ColorMapNames SOLAR = fromString("solar");
+        @Generated public static final ColorMapNames SOLAR_R = fromString("solar_r");
+        @Generated public static final ColorMapNames SPEED = fromString("speed");
+        @Generated public static final ColorMapNames SPEED_R = fromString("speed_r");
+        @Generated public static final ColorMapNames TARN = fromString("tarn");
+        @Generated public static final ColorMapNames TARN_R = fromString("tarn_r");
+        @Generated public static final ColorMapNames TEMPO = fromString("tempo");
+        @Generated public static final ColorMapNames TEMPO_R = fromString("tempo_r");
+        @Generated public static final ColorMapNames THERMAL = fromString("thermal");
+        @Generated public static final ColorMapNames THERMAL_R = fromString("thermal_r");
+        @Generated public static final ColorMapNames TOPO = fromString("topo");
+        @Generated public static final ColorMapNames TOPO_R = fromString("topo_r");
+        @Generated public static final ColorMapNames TURBID = fromString("turbid");
+        @Generated public static final ColorMapNames TURBID_R = fromString("turbid_r");
+        @Generated public static final ColorMapNames TURBO = fromString("turbo");
+        @Generated public static final ColorMapNames TURBO_R = fromString("turbo_r");
+        @Deprecated @Generated public ColorMapNames()
+        @Generated public static ColorMapNames fromString(String name)
+        @Generated public static Collection<ColorMapNames> values()
+    }
     @Immutable
-    public final class DefaultLocation implements JsonSerializable<DefaultLocation> { 
-        @Generated public DefaultLocation(int zoom, List<Double> coordinates) 
-        @Generated public List<Double> getCoordinates() 
-        @Generated public int getZoom() 
-    } 
+    public final class DefaultLocation implements JsonSerializable<DefaultLocation> {
+        @Generated public DefaultLocation(int zoom, List<Double> coordinates)
+        @Generated public List<Double> getCoordinates()
+        @Generated public int getZoom()
+    }
     @Immutable
-    public final class ErrorInfo implements JsonSerializable<ErrorInfo> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public ResponseError getError() 
-    } 
-    public final class FeatureType extends ExpandableStringEnum<FeatureType> { 
-        @Generated public static final FeatureType FEATURE = fromString("Feature"); 
-        @Deprecated @Generated public FeatureType() 
-        @Generated public static FeatureType fromString(String name) 
-        @Generated public static Collection<FeatureType> values() 
-    } 
+    public final class ErrorInfo implements JsonSerializable<ErrorInfo> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public ResponseError getError()
+    }
+    public final class FeatureType extends ExpandableStringEnum<FeatureType> {
+        @Generated public static final FeatureType FEATURE = fromString("Feature");
+        @Deprecated @Generated public FeatureType()
+        @Generated public static FeatureType fromString(String name)
+        @Generated public static Collection<FeatureType> values()
+    }
     @Fluent
-    public final class FileDetails { 
-        @Generated public FileDetails(BinaryData content) 
-        @Generated public BinaryData getContent() 
-        @Generated public String getContentType() 
-        @Generated public FileDetails setContentType(String contentType) 
-        @Generated public String getFilename() 
-        @Generated public FileDetails setFilename(String filename) 
-    } 
-    public final class FilterLanguage extends ExpandableStringEnum<FilterLanguage> { 
-        @Generated public static final FilterLanguage CQL_JSON = fromString("cql-json"); 
-        @Generated public static final FilterLanguage CQL2_JSON = fromString("cql2-json"); 
-        @Generated public static final FilterLanguage CQL2_TEXT = fromString("cql2-text"); 
-        @Deprecated @Generated public FilterLanguage() 
-        @Generated public static FilterLanguage fromString(String name) 
-        @Generated public static Collection<FilterLanguage> values() 
-    } 
+    public final class FileDetails {
+        @Generated public FileDetails(BinaryData content)
+        @Generated public BinaryData getContent()
+        @Generated public String getContentType()
+        @Generated public FileDetails setContentType(String contentType)
+        @Generated public String getFilename()
+        @Generated public FileDetails setFilename(String filename)
+    }
+    public final class FilterLanguage extends ExpandableStringEnum<FilterLanguage> {
+        @Generated public static final FilterLanguage CQL_JSON = fromString("cql-json");
+        @Generated public static final FilterLanguage CQL2_JSON = fromString("cql2-json");
+        @Generated public static final FilterLanguage CQL2_TEXT = fromString("cql2-text");
+        @Deprecated @Generated public FilterLanguage()
+        @Generated public static FilterLanguage fromString(String name)
+        @Generated public static Collection<FilterLanguage> values()
+    }
     @Fluent
-    public final class GeoJsonFeature implements JsonSerializable<GeoJsonFeature> { 
-        @Generated public GeoJsonFeature(GeoJsonGeometry geometry, FeatureType type) 
-        @Generated public GeoJsonGeometry getGeometry() 
-        @Generated public Map<String, BinaryData> getProperties() 
-        @Generated public GeoJsonFeature setProperties(Map<String, BinaryData> properties) 
-        @Generated public FeatureType getType() 
-    } 
+    public final class GeoJsonFeature implements JsonSerializable<GeoJsonFeature> {
+        @Generated public GeoJsonFeature(GeoJsonGeometry geometry, FeatureType type)
+        @Generated public GeoJsonGeometry getGeometry()
+        @Generated public Map<String, BinaryData> getProperties()
+        @Generated public GeoJsonFeature setProperties(Map<String, BinaryData> properties)
+        @Generated public FeatureType getType()
+    }
     @Fluent
-    public class GeoJsonGeometry implements JsonSerializable<GeoJsonGeometry> { 
-        @Generated public GeoJsonGeometry() 
-        @Generated public List<Double> getBoundingBox() 
-        @Generated public GeoJsonGeometry setBoundingBox(List<Double> boundingBox) 
-        @Generated public GeometryType getType() 
-    } 
+    public class GeoJsonGeometry implements JsonSerializable<GeoJsonGeometry> {
+        @Generated public GeoJsonGeometry()
+        @Generated public List<Double> getBoundingBox()
+        @Generated public GeoJsonGeometry setBoundingBox(List<Double> boundingBox)
+        @Generated public GeometryType getType()
+    }
     @Fluent
-    public final class GeoJsonLineString extends GeoJsonGeometry { 
-        @Generated public GeoJsonLineString() 
-        @Generated @Override public GeoJsonLineString setBoundingBox(List<Double> boundingBox) 
-        @Generated public List<List<Double>> getCoordinates() 
-        @Generated public GeoJsonLineString setCoordinates(List<List<Double>> coordinates) 
+    public final class GeoJsonLineString extends GeoJsonGeometry {
+        @Generated public GeoJsonLineString()
+        @Generated @Override public GeoJsonLineString setBoundingBox(List<Double> boundingBox)
+        @Generated public List<List<Double>> getCoordinates()
+        @Generated public GeoJsonLineString setCoordinates(List<List<Double>> coordinates)
         @Generated public static GeoJsonLineString fromJson(JsonReader jsonReader) throws IOException
         @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
-        @Generated @Override public GeometryType getType() 
-    } 
+        @Generated @Override public GeometryType getType()
+    }
     @Fluent
-    public final class GeoJsonMultiLineString extends GeoJsonGeometry { 
-        @Generated public GeoJsonMultiLineString() 
-        @Generated @Override public GeoJsonMultiLineString setBoundingBox(List<Double> boundingBox) 
-        @Generated public List<List<List<Double>>> getCoordinates() 
-        @Generated public GeoJsonMultiLineString setCoordinates(List<List<List<Double>>> coordinates) 
+    public final class GeoJsonMultiLineString extends GeoJsonGeometry {
+        @Generated public GeoJsonMultiLineString()
+        @Generated @Override public GeoJsonMultiLineString setBoundingBox(List<Double> boundingBox)
+        @Generated public List<List<List<Double>>> getCoordinates()
+        @Generated public GeoJsonMultiLineString setCoordinates(List<List<List<Double>>> coordinates)
         @Generated public static GeoJsonMultiLineString fromJson(JsonReader jsonReader) throws IOException
         @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
-        @Generated @Override public GeometryType getType() 
-    } 
+        @Generated @Override public GeometryType getType()
+    }
     @Fluent
-    public final class GeoJsonMultiPoint extends GeoJsonGeometry { 
-        @Generated public GeoJsonMultiPoint() 
-        @Generated @Override public GeoJsonMultiPoint setBoundingBox(List<Double> boundingBox) 
-        @Generated public List<List<Double>> getCoordinates() 
-        @Generated public GeoJsonMultiPoint setCoordinates(List<List<Double>> coordinates) 
+    public final class GeoJsonMultiPoint extends GeoJsonGeometry {
+        @Generated public GeoJsonMultiPoint()
+        @Generated @Override public GeoJsonMultiPoint setBoundingBox(List<Double> boundingBox)
+        @Generated public List<List<Double>> getCoordinates()
+        @Generated public GeoJsonMultiPoint setCoordinates(List<List<Double>> coordinates)
         @Generated public static GeoJsonMultiPoint fromJson(JsonReader jsonReader) throws IOException
         @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
-        @Generated @Override public GeometryType getType() 
-    } 
+        @Generated @Override public GeometryType getType()
+    }
     @Fluent
-    public final class GeoJsonMultiPolygon extends GeoJsonGeometry { 
-        @Generated public GeoJsonMultiPolygon() 
-        @Generated @Override public GeoJsonMultiPolygon setBoundingBox(List<Double> boundingBox) 
-        @Generated public List<List<List<List<Double>>>> getCoordinates() 
-        @Generated public GeoJsonMultiPolygon setCoordinates(List<List<List<List<Double>>>> coordinates) 
+    public final class GeoJsonMultiPolygon extends GeoJsonGeometry {
+        @Generated public GeoJsonMultiPolygon()
+        @Generated @Override public GeoJsonMultiPolygon setBoundingBox(List<Double> boundingBox)
+        @Generated public List<List<List<List<Double>>>> getCoordinates()
+        @Generated public GeoJsonMultiPolygon setCoordinates(List<List<List<List<Double>>>> coordinates)
         @Generated public static GeoJsonMultiPolygon fromJson(JsonReader jsonReader) throws IOException
         @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
-        @Generated @Override public GeometryType getType() 
-    } 
+        @Generated @Override public GeometryType getType()
+    }
     @Fluent
-    public final class GeoJsonPoint extends GeoJsonGeometry { 
-        @Generated public GeoJsonPoint() 
-        @Generated @Override public GeoJsonPoint setBoundingBox(List<Double> boundingBox) 
-        @Generated public List<Double> getCoordinates() 
-        @Generated public GeoJsonPoint setCoordinates(List<Double> coordinates) 
+    public final class GeoJsonPoint extends GeoJsonGeometry {
+        @Generated public GeoJsonPoint()
+        @Generated @Override public GeoJsonPoint setBoundingBox(List<Double> boundingBox)
+        @Generated public List<Double> getCoordinates()
+        @Generated public GeoJsonPoint setCoordinates(List<Double> coordinates)
         @Generated public static GeoJsonPoint fromJson(JsonReader jsonReader) throws IOException
         @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
-        @Generated @Override public GeometryType getType() 
-    } 
+        @Generated @Override public GeometryType getType()
+    }
     @Fluent
-    public final class GeoJsonPolygon extends GeoJsonGeometry { 
-        @Generated public GeoJsonPolygon() 
-        @Generated @Override public GeoJsonPolygon setBoundingBox(List<Double> boundingBox) 
-        @Generated public List<List<List<Double>>> getCoordinates() 
-        @Generated public GeoJsonPolygon setCoordinates(List<List<List<Double>>> coordinates) 
+    public final class GeoJsonPolygon extends GeoJsonGeometry {
+        @Generated public GeoJsonPolygon()
+        @Generated @Override public GeoJsonPolygon setBoundingBox(List<Double> boundingBox)
+        @Generated public List<List<List<Double>>> getCoordinates()
+        @Generated public GeoJsonPolygon setCoordinates(List<List<List<Double>>> coordinates)
         @Generated public static GeoJsonPolygon fromJson(JsonReader jsonReader) throws IOException
         @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
-        @Generated @Override public GeometryType getType() 
-    } 
-    public final class GeometryType extends ExpandableStringEnum<GeometryType> { 
-        @Generated public static final GeometryType POINT = fromString("Point"); 
-        @Generated public static final GeometryType LINE_STRING = fromString("LineString"); 
-        @Generated public static final GeometryType POLYGON = fromString("Polygon"); 
-        @Generated public static final GeometryType MULTI_POINT = fromString("MultiPoint"); 
-        @Generated public static final GeometryType MULTI_LINE_STRING = fromString("MultiLineString"); 
-        @Generated public static final GeometryType MULTI_POLYGON = fromString("MultiPolygon"); 
-        @Deprecated @Generated public GeometryType() 
-        @Generated public static GeometryType fromString(String name) 
-        @Generated public static Collection<GeometryType> values() 
-    } 
+        @Generated @Override public GeometryType getType()
+    }
+    public final class GeometryType extends ExpandableStringEnum<GeometryType> {
+        @Generated public static final GeometryType POINT = fromString("Point");
+        @Generated public static final GeometryType LINE_STRING = fromString("LineString");
+        @Generated public static final GeometryType POLYGON = fromString("Polygon");
+        @Generated public static final GeometryType MULTI_POINT = fromString("MultiPoint");
+        @Generated public static final GeometryType MULTI_LINE_STRING = fromString("MultiLineString");
+        @Generated public static final GeometryType MULTI_POLYGON = fromString("MultiPolygon");
+        @Deprecated @Generated public GeometryType()
+        @Generated public static GeometryType fromString(String name)
+        @Generated public static Collection<GeometryType> values()
+    }
     @Fluent
-    public final class IngestionDefinition implements JsonSerializable<IngestionDefinition> { 
-        @Generated public IngestionDefinition() 
-        @Generated public OffsetDateTime getCreationTime() 
-        @Generated public String getDisplayName() 
-        @Generated public IngestionDefinition setDisplayName(String displayName) 
-        @Generated public String getId() 
-        @Generated public IngestionType getImportType() 
-        @Generated public IngestionDefinition setImportType(IngestionType importType) 
-        @Generated public Boolean isKeepOriginalAssets() 
-        @Generated public IngestionDefinition setKeepOriginalAssets(Boolean keepOriginalAssets) 
-        @Generated public Boolean isSkipExistingItems() 
-        @Generated public IngestionDefinition setSkipExistingItems(Boolean skipExistingItems) 
-        @Generated public String getSourceCatalogUrl() 
-        @Generated public IngestionDefinition setSourceCatalogUrl(String sourceCatalogUrl) 
-        @Generated public String getStacGeoparquetUrl() 
-        @Generated public IngestionDefinition setStacGeoparquetUrl(String stacGeoparquetUrl) 
-        @Generated public IngestionStatus getStatus() 
-    } 
+    public final class IngestionDefinition implements JsonSerializable<IngestionDefinition> {
+        @Generated public IngestionDefinition()
+        @Generated public OffsetDateTime getCreationTime()
+        @Generated public String getDisplayName()
+        @Generated public IngestionDefinition setDisplayName(String displayName)
+        @Generated public String getId()
+        @Generated public IngestionType getImportType()
+        @Generated public IngestionDefinition setImportType(IngestionType importType)
+        @Generated public Boolean isKeepOriginalAssets()
+        @Generated public IngestionDefinition setKeepOriginalAssets(Boolean keepOriginalAssets)
+        @Generated public Boolean isSkipExistingItems()
+        @Generated public IngestionDefinition setSkipExistingItems(Boolean skipExistingItems)
+        @Generated public String getSourceCatalogUrl()
+        @Generated public IngestionDefinition setSourceCatalogUrl(String sourceCatalogUrl)
+        @Generated public String getStacGeoparquetUrl()
+        @Generated public IngestionDefinition setStacGeoparquetUrl(String stacGeoparquetUrl)
+        @Generated public IngestionStatus getStatus()
+    }
     @Immutable
-    public final class IngestionRun implements JsonSerializable<IngestionRun> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public OffsetDateTime getCreationTime() 
-        @Generated public String getId() 
-        @Generated public Boolean isKeepOriginalAssets() 
-        @Generated public IngestionRunOperation getOperation() 
-        @Generated public String getParentRunId() 
-        @Generated public Boolean isSkipExistingItems() 
-        @Generated public String getSourceCatalogUrl() 
-    } 
+    public final class IngestionRun implements JsonSerializable<IngestionRun> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public OffsetDateTime getCreationTime()
+        @Generated public String getId()
+        @Generated public Boolean isKeepOriginalAssets()
+        @Generated public IngestionRunOperation getOperation()
+        @Generated public String getParentRunId()
+        @Generated public Boolean isSkipExistingItems()
+        @Generated public String getSourceCatalogUrl()
+    }
     @Immutable
-    public final class IngestionRunOperation implements JsonSerializable<IngestionRunOperation> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public OffsetDateTime getCreationTime() 
-        @Generated public OffsetDateTime getFinishTime() 
-        @Generated public String getId() 
-        @Generated public OffsetDateTime getStartTime() 
-        @Generated public OperationStatus getStatus() 
-        @Generated public List<OperationStatusHistoryItem> getStatusHistory() 
-        @Generated public int getTotalFailedItems() 
-        @Generated public int getTotalItems() 
-        @Generated public int getTotalPendingItems() 
-        @Generated public int getTotalSuccessfulItems() 
-    } 
+    public final class IngestionRunOperation implements JsonSerializable<IngestionRunOperation> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public OffsetDateTime getCreationTime()
+        @Generated public OffsetDateTime getFinishTime()
+        @Generated public String getId()
+        @Generated public OffsetDateTime getStartTime()
+        @Generated public OperationStatus getStatus()
+        @Generated public List<OperationStatusHistoryItem> getStatusHistory()
+        @Generated public int getTotalFailedItems()
+        @Generated public int getTotalItems()
+        @Generated public int getTotalPendingItems()
+        @Generated public int getTotalSuccessfulItems()
+    }
     @Immutable
-    public class IngestionSource implements JsonSerializable<IngestionSource> { 
-        @Generated public IngestionSource(String id) 
-        @Generated public OffsetDateTime getCreated() 
-        @Generated public String getId() 
-        @Generated public IngestionSourceType getKind() 
-    } 
+    public class IngestionSource implements JsonSerializable<IngestionSource> {
+        @Generated public IngestionSource(String id)
+        @Generated public OffsetDateTime getCreated()
+        @Generated public String getId()
+        @Generated public IngestionSourceType getKind()
+    }
     @Immutable
-    public final class IngestionSourceSummary implements JsonSerializable<IngestionSourceSummary> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public OffsetDateTime getCreated() 
-        @Generated public String getId() 
-        @Generated public IngestionSourceType getKind() 
-    } 
-    public final class IngestionSourceType extends ExpandableStringEnum<IngestionSourceType> { 
-        @Generated public static final IngestionSourceType SHARED_ACCESS_SIGNATURE_TOKEN = fromString("SasToken"); 
-        @Generated public static final IngestionSourceType BLOB_MANAGED_IDENTITY = fromString("BlobManagedIdentity"); 
-        @Deprecated @Generated public IngestionSourceType() 
-        @Generated public static IngestionSourceType fromString(String name) 
-        @Generated public static Collection<IngestionSourceType> values() 
-    } 
-    public final class IngestionStatus extends ExpandableStringEnum<IngestionStatus> { 
-        @Generated public static final IngestionStatus READY = fromString("Ready"); 
-        @Generated public static final IngestionStatus DELETING = fromString("Deleting"); 
-        @Deprecated @Generated public IngestionStatus() 
-        @Generated public static IngestionStatus fromString(String name) 
-        @Generated public static Collection<IngestionStatus> values() 
-    } 
-    public final class IngestionType extends ExpandableStringEnum<IngestionType> { 
-        @Generated public static final IngestionType STATIC_CATALOG = fromString("StaticCatalog"); 
-        @Generated public static final IngestionType STAC_GEOPARQUET = fromString("StacGeoparquet"); 
-        @Deprecated @Generated public IngestionType() 
-        @Generated public static IngestionType fromString(String name) 
-        @Generated public static Collection<IngestionType> values() 
-    } 
-    public final class LegendConfigType extends ExpandableStringEnum<LegendConfigType> { 
-        @Generated public static final LegendConfigType CONTINUOUS = fromString("continuous"); 
-        @Generated public static final LegendConfigType CLASSMAP = fromString("classmap"); 
-        @Generated public static final LegendConfigType INTERVAL = fromString("interval"); 
-        @Generated public static final LegendConfigType NONE = fromString("none"); 
-        @Deprecated @Generated public LegendConfigType() 
-        @Generated public static LegendConfigType fromString(String name) 
-        @Generated public static Collection<LegendConfigType> values() 
-    } 
+    public final class IngestionSourceSummary implements JsonSerializable<IngestionSourceSummary> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public OffsetDateTime getCreated()
+        @Generated public String getId()
+        @Generated public IngestionSourceType getKind()
+    }
+    public final class IngestionSourceType extends ExpandableStringEnum<IngestionSourceType> {
+        @Generated public static final IngestionSourceType SHARED_ACCESS_SIGNATURE_TOKEN = fromString("SasToken");
+        @Generated public static final IngestionSourceType BLOB_MANAGED_IDENTITY = fromString("BlobManagedIdentity");
+        @Deprecated @Generated public IngestionSourceType()
+        @Generated public static IngestionSourceType fromString(String name)
+        @Generated public static Collection<IngestionSourceType> values()
+    }
+    public final class IngestionStatus extends ExpandableStringEnum<IngestionStatus> {
+        @Generated public static final IngestionStatus READY = fromString("Ready");
+        @Generated public static final IngestionStatus DELETING = fromString("Deleting");
+        @Deprecated @Generated public IngestionStatus()
+        @Generated public static IngestionStatus fromString(String name)
+        @Generated public static Collection<IngestionStatus> values()
+    }
+    public final class IngestionType extends ExpandableStringEnum<IngestionType> {
+        @Generated public static final IngestionType STATIC_CATALOG = fromString("StaticCatalog");
+        @Generated public static final IngestionType STAC_GEOPARQUET = fromString("StacGeoparquet");
+        @Deprecated @Generated public IngestionType()
+        @Generated public static IngestionType fromString(String name)
+        @Generated public static Collection<IngestionType> values()
+    }
+    public final class LegendConfigType extends ExpandableStringEnum<LegendConfigType> {
+        @Generated public static final LegendConfigType CONTINUOUS = fromString("continuous");
+        @Generated public static final LegendConfigType CLASSMAP = fromString("classmap");
+        @Generated public static final LegendConfigType INTERVAL = fromString("interval");
+        @Generated public static final LegendConfigType NONE = fromString("none");
+        @Deprecated @Generated public LegendConfigType()
+        @Generated public static LegendConfigType fromString(String name)
+        @Generated public static Collection<LegendConfigType> values()
+    }
     @Immutable
-    public final class ManagedIdentityConnection implements JsonSerializable<ManagedIdentityConnection> { 
-        @Generated public ManagedIdentityConnection(String containerUri, String objectId) 
-        @Generated public String getContainerUri() 
-        @Generated public String getObjectId() 
-    } 
+    public final class ManagedIdentityConnection implements JsonSerializable<ManagedIdentityConnection> {
+        @Generated public ManagedIdentityConnection(String containerUri, String objectId)
+        @Generated public String getContainerUri()
+        @Generated public String getObjectId()
+    }
     @Immutable
-    public final class ManagedIdentityIngestionSource extends IngestionSource { 
-        @Generated public ManagedIdentityIngestionSource(String id, ManagedIdentityConnection connectionInfo) 
-        @Generated public ManagedIdentityConnection getConnectionInfo() 
+    public final class ManagedIdentityIngestionSource extends IngestionSource {
+        @Generated public ManagedIdentityIngestionSource(String id, ManagedIdentityConnection connectionInfo)
+        @Generated public ManagedIdentityConnection getConnectionInfo()
         @Generated public static ManagedIdentityIngestionSource fromJson(JsonReader jsonReader) throws IOException
-        @Generated @Override public IngestionSourceType getKind() 
+        @Generated @Override public IngestionSourceType getKind()
         @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
-    } 
+    }
     @Immutable
-    public final class ManagedIdentityMetadata implements JsonSerializable<ManagedIdentityMetadata> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public String getObjectId() 
-        @Generated public String getResourceId() 
-    } 
+    public final class ManagedIdentityMetadata implements JsonSerializable<ManagedIdentityMetadata> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public String getObjectId()
+        @Generated public String getResourceId()
+    }
     @Fluent
-    public final class MosaicMetadata implements JsonSerializable<MosaicMetadata> { 
-        @Generated public MosaicMetadata() 
-        @Generated public List<String> getAssets() 
-        @Generated public MosaicMetadata setAssets(List<String> assets) 
-        @Generated public String getBounds() 
-        @Generated public MosaicMetadata setBounds(String bounds) 
-        @Generated public Map<String, String> getDefaults() 
-        @Generated public MosaicMetadata setDefaults(Map<String, String> defaults) 
-        @Generated public Integer getMaxZoom() 
-        @Generated public MosaicMetadata setMaxZoom(Integer maxZoom) 
-        @Generated public Integer getMinZoom() 
-        @Generated public MosaicMetadata setMinZoom(Integer minZoom) 
-        @Generated public String getName() 
-        @Generated public MosaicMetadata setName(String name) 
-        @Generated public MosaicMetadataType getType() 
-        @Generated public MosaicMetadata setType(MosaicMetadataType type) 
-    } 
-    public final class MosaicMetadataType extends ExpandableStringEnum<MosaicMetadataType> { 
-        @Generated public static final MosaicMetadataType MOSAIC = fromString("mosaic"); 
-        @Generated public static final MosaicMetadataType SEARCH = fromString("search"); 
-        @Deprecated @Generated public MosaicMetadataType() 
-        @Generated public static MosaicMetadataType fromString(String name) 
-        @Generated public static Collection<MosaicMetadataType> values() 
-    } 
-    public final class NoDataType extends ExpandableStringEnum<NoDataType> { 
-        @Generated public static final NoDataType ALPHA = fromString("Alpha"); 
-        @Generated public static final NoDataType MASK = fromString("Mask"); 
-        @Generated public static final NoDataType INTERNAL = fromString("Internal"); 
-        @Generated public static final NoDataType NODATA = fromString("Nodata"); 
-        @Generated public static final NoDataType NONE = fromString("None"); 
-        @Deprecated @Generated public NoDataType() 
-        @Generated public static NoDataType fromString(String name) 
-        @Generated public static Collection<NoDataType> values() 
-    } 
+    public final class MosaicMetadata implements JsonSerializable<MosaicMetadata> {
+        @Generated public MosaicMetadata()
+        @Generated public List<String> getAssets()
+        @Generated public MosaicMetadata setAssets(List<String> assets)
+        @Generated public String getBounds()
+        @Generated public MosaicMetadata setBounds(String bounds)
+        @Generated public Map<String, String> getDefaults()
+        @Generated public MosaicMetadata setDefaults(Map<String, String> defaults)
+        @Generated public Integer getMaxZoom()
+        @Generated public MosaicMetadata setMaxZoom(Integer maxZoom)
+        @Generated public Integer getMinZoom()
+        @Generated public MosaicMetadata setMinZoom(Integer minZoom)
+        @Generated public String getName()
+        @Generated public MosaicMetadata setName(String name)
+        @Generated public MosaicMetadataType getType()
+        @Generated public MosaicMetadata setType(MosaicMetadataType type)
+    }
+    public final class MosaicMetadataType extends ExpandableStringEnum<MosaicMetadataType> {
+        @Generated public static final MosaicMetadataType MOSAIC = fromString("mosaic");
+        @Generated public static final MosaicMetadataType SEARCH = fromString("search");
+        @Deprecated @Generated public MosaicMetadataType()
+        @Generated public static MosaicMetadataType fromString(String name)
+        @Generated public static Collection<MosaicMetadataType> values()
+    }
+    public final class NoDataType extends ExpandableStringEnum<NoDataType> {
+        @Generated public static final NoDataType ALPHA = fromString("Alpha");
+        @Generated public static final NoDataType MASK = fromString("Mask");
+        @Generated public static final NoDataType INTERNAL = fromString("Internal");
+        @Generated public static final NoDataType NODATA = fromString("Nodata");
+        @Generated public static final NoDataType NONE = fromString("None");
+        @Deprecated @Generated public NoDataType()
+        @Generated public static NoDataType fromString(String name)
+        @Generated public static Collection<NoDataType> values()
+    }
     @Immutable
-    public final class Operation implements JsonSerializable<Operation> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public Map<String, String> getAdditionalInformation() 
-        @Generated public String getCollectionId() 
-        @Generated public OffsetDateTime getCreationTime() 
-        @Generated public ErrorInfo getError() 
-        @Generated public OffsetDateTime getFinishTime() 
-        @Generated public String getId() 
-        @Generated public OffsetDateTime getStartTime() 
-        @Generated public OperationStatus getStatus() 
-        @Generated public List<OperationStatusHistoryItem> getStatusHistory() 
-        @Generated public String getType() 
-    } 
-    public final class OperationStatus extends ExpandableStringEnum<OperationStatus> { 
-        @Generated public static final OperationStatus PENDING = fromString("Pending"); 
-        @Generated public static final OperationStatus RUNNING = fromString("Running"); 
-        @Generated public static final OperationStatus SUCCEEDED = fromString("Succeeded"); 
-        @Generated public static final OperationStatus CANCELED = fromString("Canceled"); 
-        @Generated public static final OperationStatus CANCELING = fromString("Canceling"); 
-        @Generated public static final OperationStatus FAILED = fromString("Failed"); 
-        @Deprecated @Generated public OperationStatus() 
-        @Generated public static OperationStatus fromString(String name) 
-        @Generated public static Collection<OperationStatus> values() 
-    } 
+    public final class Operation implements JsonSerializable<Operation> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public Map<String, String> getAdditionalInformation()
+        @Generated public String getCollectionId()
+        @Generated public OffsetDateTime getCreationTime()
+        @Generated public ErrorInfo getError()
+        @Generated public OffsetDateTime getFinishTime()
+        @Generated public String getId()
+        @Generated public OffsetDateTime getStartTime()
+        @Generated public OperationStatus getStatus()
+        @Generated public List<OperationStatusHistoryItem> getStatusHistory()
+        @Generated public String getType()
+    }
+    public final class OperationStatus extends ExpandableStringEnum<OperationStatus> {
+        @Generated public static final OperationStatus PENDING = fromString("Pending");
+        @Generated public static final OperationStatus RUNNING = fromString("Running");
+        @Generated public static final OperationStatus SUCCEEDED = fromString("Succeeded");
+        @Generated public static final OperationStatus CANCELED = fromString("Canceled");
+        @Generated public static final OperationStatus CANCELING = fromString("Canceling");
+        @Generated public static final OperationStatus FAILED = fromString("Failed");
+        @Deprecated @Generated public OperationStatus()
+        @Generated public static OperationStatus fromString(String name)
+        @Generated public static Collection<OperationStatus> values()
+    }
     @Immutable
-    public final class OperationStatusHistoryItem implements JsonSerializable<OperationStatusHistoryItem> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public String getErrorCode() 
-        @Generated public String getErrorMessage() 
-        @Generated public OperationStatus getStatus() 
-        @Generated public OffsetDateTime getTimestamp() 
-    } 
+    public final class OperationStatusHistoryItem implements JsonSerializable<OperationStatusHistoryItem> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public String getErrorCode()
+        @Generated public String getErrorMessage()
+        @Generated public OperationStatus getStatus()
+        @Generated public OffsetDateTime getTimestamp()
+    }
     @Fluent
-    public final class PartitionType implements JsonSerializable<PartitionType> { 
-        @Generated public PartitionType() 
-        @Generated public PartitionTypeScheme getScheme() 
-        @Generated public PartitionType setScheme(PartitionTypeScheme scheme) 
-    } 
-    public final class PartitionTypeScheme extends ExpandableStringEnum<PartitionTypeScheme> { 
-        @Generated public static final PartitionTypeScheme YEAR = fromString("year"); 
-        @Generated public static final PartitionTypeScheme MONTH = fromString("month"); 
-        @Generated public static final PartitionTypeScheme NONE = fromString("none"); 
-        @Deprecated @Generated public PartitionTypeScheme() 
-        @Generated public static PartitionTypeScheme fromString(String name) 
-        @Generated public static Collection<PartitionTypeScheme> values() 
-    } 
-    public final class PixelSelection extends ExpandableStringEnum<PixelSelection> { 
-        @Generated public static final PixelSelection FIRST = fromString("first"); 
-        @Generated public static final PixelSelection HIGHEST = fromString("highest"); 
-        @Generated public static final PixelSelection LOWEST = fromString("lowest"); 
-        @Generated public static final PixelSelection MEAN = fromString("mean"); 
-        @Generated public static final PixelSelection MEDIAN = fromString("median"); 
-        @Generated public static final PixelSelection STANDARD_DEVIATION = fromString("stdev"); 
-        @Generated public static final PixelSelection LAST_BAND_LOW = fromString("lastbandlow"); 
-        @Generated public static final PixelSelection LAST_BAND_HIGH = fromString("lastbandhigh"); 
-        @Generated public static final PixelSelection COUNT = fromString("count"); 
-        @Deprecated @Generated public PixelSelection() 
-        @Generated public static PixelSelection fromString(String name) 
-        @Generated public static Collection<PixelSelection> values() 
-    } 
+    public final class PartitionType implements JsonSerializable<PartitionType> {
+        @Generated public PartitionType()
+        @Generated public PartitionTypeScheme getScheme()
+        @Generated public PartitionType setScheme(PartitionTypeScheme scheme)
+    }
+    public final class PartitionTypeScheme extends ExpandableStringEnum<PartitionTypeScheme> {
+        @Generated public static final PartitionTypeScheme YEAR = fromString("year");
+        @Generated public static final PartitionTypeScheme MONTH = fromString("month");
+        @Generated public static final PartitionTypeScheme NONE = fromString("none");
+        @Deprecated @Generated public PartitionTypeScheme()
+        @Generated public static PartitionTypeScheme fromString(String name)
+        @Generated public static Collection<PartitionTypeScheme> values()
+    }
+    public final class PixelSelection extends ExpandableStringEnum<PixelSelection> {
+        @Generated public static final PixelSelection FIRST = fromString("first");
+        @Generated public static final PixelSelection HIGHEST = fromString("highest");
+        @Generated public static final PixelSelection LOWEST = fromString("lowest");
+        @Generated public static final PixelSelection MEAN = fromString("mean");
+        @Generated public static final PixelSelection MEDIAN = fromString("median");
+        @Generated public static final PixelSelection STANDARD_DEVIATION = fromString("stdev");
+        @Generated public static final PixelSelection LAST_BAND_LOW = fromString("lastbandlow");
+        @Generated public static final PixelSelection LAST_BAND_HIGH = fromString("lastbandhigh");
+        @Generated public static final PixelSelection COUNT = fromString("count");
+        @Deprecated @Generated public PixelSelection()
+        @Generated public static PixelSelection fromString(String name)
+        @Generated public static Collection<PixelSelection> values()
+    }
     @Immutable
-    public final class QueryableDefinitionsResponse implements JsonSerializable<QueryableDefinitionsResponse> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public Map<String, BinaryData> getAdditionalProperties() 
-    } 
+    public final class QueryableDefinitionsResponse implements JsonSerializable<QueryableDefinitionsResponse> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public Map<String, BinaryData> getAdditionalProperties()
+    }
     @Fluent
-    public final class RegisterMosaicsSearchOptions { 
-        @Generated public RegisterMosaicsSearchOptions() 
-        @Generated public List<Double> getBoundingBox() 
-        @Generated public RegisterMosaicsSearchOptions setBoundingBox(List<Double> boundingBox) 
-        @Generated public List<String> getCollections() 
-        @Generated public RegisterMosaicsSearchOptions setCollections(List<String> collections) 
-        @Generated public String getDatetime() 
-        @Generated public RegisterMosaicsSearchOptions setDatetime(String datetime) 
-        @Generated public Map<String, BinaryData> getFilter() 
-        @Generated public RegisterMosaicsSearchOptions setFilter(Map<String, BinaryData> filter) 
-        @Generated public FilterLanguage getFilterLanguage() 
-        @Generated public RegisterMosaicsSearchOptions setFilterLanguage(FilterLanguage filterLanguage) 
-        @Generated public List<String> getIds() 
-        @Generated public RegisterMosaicsSearchOptions setIds(List<String> ids) 
-        @Generated public GeoJsonGeometry getIntersects() 
-        @Generated public RegisterMosaicsSearchOptions setIntersects(GeoJsonGeometry intersects) 
-        @Generated public MosaicMetadata getMetadata() 
-        @Generated public RegisterMosaicsSearchOptions setMetadata(MosaicMetadata metadata) 
-        @Generated public Map<String, BinaryData> getQuery() 
-        @Generated public RegisterMosaicsSearchOptions setQuery(Map<String, BinaryData> query) 
-        @Generated public List<StacSortExtension> getSortBy() 
-        @Generated public RegisterMosaicsSearchOptions setSortBy(List<StacSortExtension> sortBy) 
-    } 
+    public final class RegisterMosaicsSearchOptions {
+        @Generated public RegisterMosaicsSearchOptions()
+        @Generated public List<Double> getBoundingBox()
+        @Generated public RegisterMosaicsSearchOptions setBoundingBox(List<Double> boundingBox)
+        @Generated public List<String> getCollections()
+        @Generated public RegisterMosaicsSearchOptions setCollections(List<String> collections)
+        @Generated public String getDatetime()
+        @Generated public RegisterMosaicsSearchOptions setDatetime(String datetime)
+        @Generated public Map<String, BinaryData> getFilter()
+        @Generated public RegisterMosaicsSearchOptions setFilter(Map<String, BinaryData> filter)
+        @Generated public FilterLanguage getFilterLanguage()
+        @Generated public RegisterMosaicsSearchOptions setFilterLanguage(FilterLanguage filterLanguage)
+        @Generated public List<String> getIds()
+        @Generated public RegisterMosaicsSearchOptions setIds(List<String> ids)
+        @Generated public GeoJsonGeometry getIntersects()
+        @Generated public RegisterMosaicsSearchOptions setIntersects(GeoJsonGeometry intersects)
+        @Generated public MosaicMetadata getMetadata()
+        @Generated public RegisterMosaicsSearchOptions setMetadata(MosaicMetadata metadata)
+        @Generated public Map<String, BinaryData> getQuery()
+        @Generated public RegisterMosaicsSearchOptions setQuery(Map<String, BinaryData> query)
+        @Generated public List<StacSortExtension> getSortBy()
+        @Generated public RegisterMosaicsSearchOptions setSortBy(List<StacSortExtension> sortBy)
+    }
     @Fluent
-    public final class RenderOption implements JsonSerializable<RenderOption> { 
-        @Generated public RenderOption(String id, String name) 
-        @Generated public List<RenderOptionCondition> getConditions() 
-        @Generated public RenderOption setConditions(List<RenderOptionCondition> conditions) 
-        @Generated public String getDescription() 
-        @Generated public RenderOption setDescription(String description) 
-        @Generated public String getId() 
-        @Generated public RenderOptionLegend getLegend() 
-        @Generated public RenderOption setLegend(RenderOptionLegend legend) 
-        @Generated public Integer getMinZoom() 
-        @Generated public RenderOption setMinZoom(Integer minZoom) 
-        @Generated public String getName() 
-        @Generated public String getOptions() 
-        @Generated public RenderOption setOptions(String options) 
-        @Generated public RenderOptionType getType() 
-        @Generated public RenderOption setType(RenderOptionType type) 
-        @Generated public RenderOptionVectorOptions getVectorOptions() 
-        @Generated public RenderOption setVectorOptions(RenderOptionVectorOptions vectorOptions) 
-    } 
+    public final class RenderOption implements JsonSerializable<RenderOption> {
+        @Generated public RenderOption(String id, String name)
+        @Generated public List<RenderOptionCondition> getConditions()
+        @Generated public RenderOption setConditions(List<RenderOptionCondition> conditions)
+        @Generated public String getDescription()
+        @Generated public RenderOption setDescription(String description)
+        @Generated public String getId()
+        @Generated public RenderOptionLegend getLegend()
+        @Generated public RenderOption setLegend(RenderOptionLegend legend)
+        @Generated public Integer getMinZoom()
+        @Generated public RenderOption setMinZoom(Integer minZoom)
+        @Generated public String getName()
+        @Generated public String getOptions()
+        @Generated public RenderOption setOptions(String options)
+        @Generated public RenderOptionType getType()
+        @Generated public RenderOption setType(RenderOptionType type)
+        @Generated public RenderOptionVectorOptions getVectorOptions()
+        @Generated public RenderOption setVectorOptions(RenderOptionVectorOptions vectorOptions)
+    }
     @Fluent
-    public final class RenderOptionCondition implements JsonSerializable<RenderOptionCondition> { 
-        @Generated public RenderOptionCondition(String property) 
-        @Generated public String getProperty() 
-        @Generated public String getValue() 
-        @Generated public RenderOptionCondition setValue(String value) 
-    } 
+    public final class RenderOptionCondition implements JsonSerializable<RenderOptionCondition> {
+        @Generated public RenderOptionCondition(String property)
+        @Generated public String getProperty()
+        @Generated public String getValue()
+        @Generated public RenderOptionCondition setValue(String value)
+    }
     @Fluent
-    public final class RenderOptionLegend implements JsonSerializable<RenderOptionLegend> { 
-        @Generated public RenderOptionLegend() 
-        @Generated public List<String> getLabels() 
-        @Generated public RenderOptionLegend setLabels(List<String> labels) 
-        @Generated public Double getScaleFactor() 
-        @Generated public RenderOptionLegend setScaleFactor(Double scaleFactor) 
-        @Generated public Integer getTrimEnd() 
-        @Generated public RenderOptionLegend setTrimEnd(Integer trimEnd) 
-        @Generated public Integer getTrimStart() 
-        @Generated public RenderOptionLegend setTrimStart(Integer trimStart) 
-        @Generated public LegendConfigType getType() 
-        @Generated public RenderOptionLegend setType(LegendConfigType type) 
-    } 
-    public final class RenderOptionType extends ExpandableStringEnum<RenderOptionType> { 
-        @Generated public static final RenderOptionType RASTER_TILE = fromString("raster-tile"); 
-        @Generated public static final RenderOptionType VT_POLYGON = fromString("vt-polygon"); 
-        @Generated public static final RenderOptionType VT_LINE = fromString("vt-line"); 
-        @Deprecated @Generated public RenderOptionType() 
-        @Generated public static RenderOptionType fromString(String name) 
-        @Generated public static Collection<RenderOptionType> values() 
-    } 
+    public final class RenderOptionLegend implements JsonSerializable<RenderOptionLegend> {
+        @Generated public RenderOptionLegend()
+        @Generated public List<String> getLabels()
+        @Generated public RenderOptionLegend setLabels(List<String> labels)
+        @Generated public Double getScaleFactor()
+        @Generated public RenderOptionLegend setScaleFactor(Double scaleFactor)
+        @Generated public Integer getTrimEnd()
+        @Generated public RenderOptionLegend setTrimEnd(Integer trimEnd)
+        @Generated public Integer getTrimStart()
+        @Generated public RenderOptionLegend setTrimStart(Integer trimStart)
+        @Generated public LegendConfigType getType()
+        @Generated public RenderOptionLegend setType(LegendConfigType type)
+    }
+    public final class RenderOptionType extends ExpandableStringEnum<RenderOptionType> {
+        @Generated public static final RenderOptionType RASTER_TILE = fromString("raster-tile");
+        @Generated public static final RenderOptionType VT_POLYGON = fromString("vt-polygon");
+        @Generated public static final RenderOptionType VT_LINE = fromString("vt-line");
+        @Deprecated @Generated public RenderOptionType()
+        @Generated public static RenderOptionType fromString(String name)
+        @Generated public static Collection<RenderOptionType> values()
+    }
     @Fluent
-    public final class RenderOptionVectorOptions implements JsonSerializable<RenderOptionVectorOptions> { 
-        @Generated public RenderOptionVectorOptions(String tilejsonKey, String sourceLayer) 
-        @Generated public String getFillColor() 
-        @Generated public RenderOptionVectorOptions setFillColor(String fillColor) 
-        @Generated public List<String> getFilter() 
-        @Generated public RenderOptionVectorOptions setFilter(List<String> filter) 
-        @Generated public String getSourceLayer() 
-        @Generated public String getStrokeColor() 
-        @Generated public RenderOptionVectorOptions setStrokeColor(String strokeColor) 
-        @Generated public Integer getStrokeWidth() 
-        @Generated public RenderOptionVectorOptions setStrokeWidth(Integer strokeWidth) 
-        @Generated public String getTilejsonKey() 
-    } 
-    public final class Resampling extends ExpandableStringEnum<Resampling> { 
-        @Generated public static final Resampling NEAREST = fromString("nearest"); 
-        @Generated public static final Resampling BILINEAR = fromString("bilinear"); 
-        @Generated public static final Resampling CUBIC = fromString("cubic"); 
-        @Generated public static final Resampling CUBIC_SPLINE = fromString("cubic_spline"); 
-        @Generated public static final Resampling LANCZOS = fromString("lanczos"); 
-        @Generated public static final Resampling AVERAGE = fromString("average"); 
-        @Generated public static final Resampling MODE = fromString("mode"); 
-        @Generated public static final Resampling GAUSS = fromString("gauss"); 
-        @Generated public static final Resampling RMS = fromString("rms"); 
-        @Deprecated @Generated public Resampling() 
-        @Generated public static Resampling fromString(String name) 
-        @Generated public static Collection<Resampling> values() 
-    } 
+    public final class RenderOptionVectorOptions implements JsonSerializable<RenderOptionVectorOptions> {
+        @Generated public RenderOptionVectorOptions(String tilejsonKey, String sourceLayer)
+        @Generated public String getFillColor()
+        @Generated public RenderOptionVectorOptions setFillColor(String fillColor)
+        @Generated public List<String> getFilter()
+        @Generated public RenderOptionVectorOptions setFilter(List<String> filter)
+        @Generated public String getSourceLayer()
+        @Generated public String getStrokeColor()
+        @Generated public RenderOptionVectorOptions setStrokeColor(String strokeColor)
+        @Generated public Integer getStrokeWidth()
+        @Generated public RenderOptionVectorOptions setStrokeWidth(Integer strokeWidth)
+        @Generated public String getTilejsonKey()
+    }
+    public final class Resampling extends ExpandableStringEnum<Resampling> {
+        @Generated public static final Resampling NEAREST = fromString("nearest");
+        @Generated public static final Resampling BILINEAR = fromString("bilinear");
+        @Generated public static final Resampling CUBIC = fromString("cubic");
+        @Generated public static final Resampling CUBIC_SPLINE = fromString("cubic_spline");
+        @Generated public static final Resampling LANCZOS = fromString("lanczos");
+        @Generated public static final Resampling AVERAGE = fromString("average");
+        @Generated public static final Resampling MODE = fromString("mode");
+        @Generated public static final Resampling GAUSS = fromString("gauss");
+        @Generated public static final Resampling RMS = fromString("rms");
+        @Deprecated @Generated public Resampling()
+        @Generated public static Resampling fromString(String name)
+        @Generated public static Collection<Resampling> values()
+    }
     @Fluent
-    public final class SearchOptionsFields implements JsonSerializable<SearchOptionsFields> { 
-        @Generated public SearchOptionsFields() 
-        @Generated public List<String> getExclude() 
-        @Generated public SearchOptionsFields setExclude(List<String> exclude) 
-        @Generated public List<String> getInclude() 
-        @Generated public SearchOptionsFields setInclude(List<String> include) 
-    } 
-    public final class SelMethod extends ExpandableStringEnum<SelMethod> { 
-        @Generated public static final SelMethod NEAREST = fromString("nearest"); 
-        @Generated public static final SelMethod LINEAR = fromString("linear"); 
-        @Generated public static final SelMethod BILINEAR = fromString("bilinear"); 
-        @Generated public static final SelMethod CUBIC = fromString("cubic"); 
-        @Generated public static final SelMethod CUBIC_SPLINE = fromString("cubic_spline"); 
-        @Generated public static final SelMethod LANCZOS = fromString("lanczos"); 
-        @Generated public static final SelMethod AREA = fromString("area"); 
-        @Generated public static final SelMethod MODE = fromString("mode"); 
-        @Deprecated @Generated public SelMethod() 
-        @Generated public static SelMethod fromString(String name) 
-        @Generated public static Collection<SelMethod> values() 
-    } 
+    public final class SearchOptionsFields implements JsonSerializable<SearchOptionsFields> {
+        @Generated public SearchOptionsFields()
+        @Generated public List<String> getExclude()
+        @Generated public SearchOptionsFields setExclude(List<String> exclude)
+        @Generated public List<String> getInclude()
+        @Generated public SearchOptionsFields setInclude(List<String> include)
+    }
+    public final class SelMethod extends ExpandableStringEnum<SelMethod> {
+        @Generated public static final SelMethod NEAREST = fromString("nearest");
+        @Generated public static final SelMethod LINEAR = fromString("linear");
+        @Generated public static final SelMethod BILINEAR = fromString("bilinear");
+        @Generated public static final SelMethod CUBIC = fromString("cubic");
+        @Generated public static final SelMethod CUBIC_SPLINE = fromString("cubic_spline");
+        @Generated public static final SelMethod LANCZOS = fromString("lanczos");
+        @Generated public static final SelMethod AREA = fromString("area");
+        @Generated public static final SelMethod MODE = fromString("mode");
+        @Deprecated @Generated public SelMethod()
+        @Generated public static SelMethod fromString(String name)
+        @Generated public static Collection<SelMethod> values()
+    }
     @Immutable
-    public final class SharedAccessSignatureSignedLink implements JsonSerializable<SharedAccessSignatureSignedLink> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public OffsetDateTime getExpiresOn() 
-        @Generated public String getHref() 
-    } 
+    public final class SharedAccessSignatureSignedLink implements JsonSerializable<SharedAccessSignatureSignedLink> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public OffsetDateTime getExpiresOn()
+        @Generated public String getHref()
+    }
     @Immutable
-    public final class SharedAccessSignatureToken implements JsonSerializable<SharedAccessSignatureToken> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public OffsetDateTime getExpiresOn() 
-        @Generated public String getToken() 
-    } 
+    public final class SharedAccessSignatureToken implements JsonSerializable<SharedAccessSignatureToken> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public OffsetDateTime getExpiresOn()
+        @Generated public String getToken()
+    }
     @Fluent
-    public final class SharedAccessSignatureTokenConnection implements JsonSerializable<SharedAccessSignatureTokenConnection> { 
-        @Generated public SharedAccessSignatureTokenConnection(String containerUri) 
-        @Generated public String getContainerUri() 
-        @Generated public OffsetDateTime getExpiration() 
-        @Generated public String getSharedAccessSignatureToken() 
-        @Generated public SharedAccessSignatureTokenConnection setSharedAccessSignatureToken(String sharedAccessSignatureToken) 
-    } 
+    public final class SharedAccessSignatureTokenConnection implements JsonSerializable<SharedAccessSignatureTokenConnection> {
+        @Generated public SharedAccessSignatureTokenConnection(String containerUri)
+        @Generated public String getContainerUri()
+        @Generated public OffsetDateTime getExpiration()
+        @Generated public String getSharedAccessSignatureToken()
+        @Generated public SharedAccessSignatureTokenConnection setSharedAccessSignatureToken(String sharedAccessSignatureToken)
+    }
     @Immutable
-    public final class SharedAccessSignatureTokenIngestionSource extends IngestionSource { 
-        @Generated public SharedAccessSignatureTokenIngestionSource(String id, SharedAccessSignatureTokenConnection connectionInfo) 
-        @Generated public SharedAccessSignatureTokenConnection getConnectionInfo() 
+    public final class SharedAccessSignatureTokenIngestionSource extends IngestionSource {
+        @Generated public SharedAccessSignatureTokenIngestionSource(String id, SharedAccessSignatureTokenConnection connectionInfo)
+        @Generated public SharedAccessSignatureTokenConnection getConnectionInfo()
         @Generated public static SharedAccessSignatureTokenIngestionSource fromJson(JsonReader jsonReader) throws IOException
-        @Generated @Override public IngestionSourceType getKind() 
+        @Generated @Override public IngestionSourceType getKind()
         @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
-    } 
+    }
     @Fluent
-    public final class StacAsset implements JsonSerializable<StacAsset> { 
-        @Generated public StacAsset() 
-        @Generated public Map<String, BinaryData> getAdditionalProperties() 
-        @Generated public StacAsset setAdditionalProperties(Map<String, BinaryData> additionalProperties) 
-        @Generated public String getConstellation() 
-        @Generated public StacAsset setConstellation(String constellation) 
-        @Generated public OffsetDateTime getCreated() 
-        @Generated public StacAsset setCreated(OffsetDateTime created) 
-        @Generated public String getDescription() 
-        @Generated public StacAsset setDescription(String description) 
-        @Generated public Double getGsd() 
-        @Generated public StacAsset setGsd(Double gsd) 
-        @Generated public String getHref() 
-        @Generated public StacAsset setHref(String href) 
-        @Generated public List<String> getInstruments() 
-        @Generated public StacAsset setInstruments(List<String> instruments) 
-        @Generated public String getMission() 
-        @Generated public StacAsset setMission(String mission) 
-        @Generated public String getPlatform() 
-        @Generated public StacAsset setPlatform(String platform) 
-        @Generated public List<StacProvider> getProviders() 
-        @Generated public StacAsset setProviders(List<StacProvider> providers) 
-        @Generated public List<String> getRoles() 
-        @Generated public StacAsset setRoles(List<String> roles) 
-        @Generated public String getTitle() 
-        @Generated public StacAsset setTitle(String title) 
-        @Generated public String getType() 
-        @Generated public StacAsset setType(String type) 
-        @Generated public OffsetDateTime getUpdated() 
-        @Generated public StacAsset setUpdated(OffsetDateTime updated) 
-    } 
+    public final class StacAsset implements JsonSerializable<StacAsset> {
+        @Generated public StacAsset()
+        @Generated public Map<String, BinaryData> getAdditionalProperties()
+        @Generated public StacAsset setAdditionalProperties(Map<String, BinaryData> additionalProperties)
+        @Generated public String getConstellation()
+        @Generated public StacAsset setConstellation(String constellation)
+        @Generated public OffsetDateTime getCreated()
+        @Generated public StacAsset setCreated(OffsetDateTime created)
+        @Generated public String getDescription()
+        @Generated public StacAsset setDescription(String description)
+        @Generated public Double getGsd()
+        @Generated public StacAsset setGsd(Double gsd)
+        @Generated public String getHref()
+        @Generated public StacAsset setHref(String href)
+        @Generated public List<String> getInstruments()
+        @Generated public StacAsset setInstruments(List<String> instruments)
+        @Generated public String getMission()
+        @Generated public StacAsset setMission(String mission)
+        @Generated public String getPlatform()
+        @Generated public StacAsset setPlatform(String platform)
+        @Generated public List<StacProvider> getProviders()
+        @Generated public StacAsset setProviders(List<StacProvider> providers)
+        @Generated public List<String> getRoles()
+        @Generated public StacAsset setRoles(List<String> roles)
+        @Generated public String getTitle()
+        @Generated public StacAsset setTitle(String title)
+        @Generated public String getType()
+        @Generated public StacAsset setType(String type)
+        @Generated public OffsetDateTime getUpdated()
+        @Generated public StacAsset setUpdated(OffsetDateTime updated)
+    }
     @Immutable
-    public final class StacAssetData { 
-        @Generated public StacAssetData(AssetMetadata data, FileDetails file) 
-        @Generated public AssetMetadata getData() 
-        @Generated public FileDetails getFile() 
-    } 
-    public final class StacAssetUrlSigningMode extends ExpandableStringEnum<StacAssetUrlSigningMode> { 
-        @Generated public static final StacAssetUrlSigningMode TRUE = fromString("true"); 
-        @Generated public static final StacAssetUrlSigningMode FALSE = fromString("false"); 
-        @Deprecated @Generated public StacAssetUrlSigningMode() 
-        @Generated public static StacAssetUrlSigningMode fromString(String name) 
-        @Generated public static Collection<StacAssetUrlSigningMode> values() 
-    } 
+    public final class StacAssetData {
+        @Generated public StacAssetData(AssetMetadata data, FileDetails file)
+        @Generated public AssetMetadata getData()
+        @Generated public FileDetails getFile()
+    }
+    public final class StacAssetUrlSigningMode extends ExpandableStringEnum<StacAssetUrlSigningMode> {
+        @Generated public static final StacAssetUrlSigningMode TRUE = fromString("true");
+        @Generated public static final StacAssetUrlSigningMode FALSE = fromString("false");
+        @Deprecated @Generated public StacAssetUrlSigningMode()
+        @Generated public static StacAssetUrlSigningMode fromString(String name)
+        @Generated public static Collection<StacAssetUrlSigningMode> values()
+    }
     @Immutable
-    public final class StacCatalogCollections implements JsonSerializable<StacCatalogCollections> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public List<StacCollection> getCollections() 
-        @Generated public List<StacLink> getLinks() 
-    } 
+    public final class StacCatalogCollections implements JsonSerializable<StacCatalogCollections> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public List<StacCollection> getCollections()
+        @Generated public List<StacLink> getLinks()
+    }
     @Fluent
-    public final class StacCollection implements JsonSerializable<StacCollection> { 
-        @Generated public StacCollection(String description, List<StacLink> links, String license, StacExtensionExtent extent) 
-        @Generated public Map<String, BinaryData> getAdditionalProperties() 
-        @Generated public StacCollection setAdditionalProperties(Map<String, BinaryData> additionalProperties) 
-        @Generated public Map<String, StacAsset> getAssets() 
-        @Generated public StacCollection setAssets(Map<String, StacAsset> assets) 
-        @Generated public OffsetDateTime getCreatedOn() 
-        @Generated public StacCollection setCreatedOn(OffsetDateTime createdOn) 
-        @Generated public String getDescription() 
-        @Generated public StacExtensionExtent getExtent() 
-        @Generated public String getId() 
-        @Generated public Map<String, StacItemAsset> getItemAssets() 
-        @Generated public StacCollection setItemAssets(Map<String, StacItemAsset> itemAssets) 
-        @Generated public List<String> getKeywords() 
-        @Generated public StacCollection setKeywords(List<String> keywords) 
-        @Generated public String getLicense() 
-        @Generated public List<StacLink> getLinks() 
-        @Generated public List<StacProvider> getProviders() 
-        @Generated public StacCollection setProviders(List<StacProvider> providers) 
-        @Generated public String getShortDescription() 
-        @Generated public StacCollection setShortDescription(String shortDescription) 
-        @Generated public List<String> getStacExtensions() 
-        @Generated public StacCollection setStacExtensions(List<String> stacExtensions) 
-        @Generated public String getStacVersion() 
-        @Generated public StacCollection setStacVersion(String stacVersion) 
-        @Generated public Map<String, BinaryData> getSummaries() 
-        @Generated public StacCollection setSummaries(Map<String, BinaryData> summaries) 
-        @Generated public String getTitle() 
-        @Generated public StacCollection setTitle(String title) 
-        @Generated public String getType() 
-        @Generated public StacCollection setType(String type) 
-        @Generated public OffsetDateTime getUpdatedOn() 
-        @Generated public StacCollection setUpdatedOn(OffsetDateTime updatedOn) 
-    } 
+    public final class StacCollection implements JsonSerializable<StacCollection> {
+        @Generated public StacCollection(String description, List<StacLink> links, String license, StacExtensionExtent extent)
+        @Generated public Map<String, BinaryData> getAdditionalProperties()
+        @Generated public StacCollection setAdditionalProperties(Map<String, BinaryData> additionalProperties)
+        @Generated public Map<String, StacAsset> getAssets()
+        @Generated public StacCollection setAssets(Map<String, StacAsset> assets)
+        @Generated public OffsetDateTime getCreatedOn()
+        @Generated public StacCollection setCreatedOn(OffsetDateTime createdOn)
+        @Generated public String getDescription()
+        @Generated public StacExtensionExtent getExtent()
+        @Generated public String getId()
+        @Generated public Map<String, StacItemAsset> getItemAssets()
+        @Generated public StacCollection setItemAssets(Map<String, StacItemAsset> itemAssets)
+        @Generated public List<String> getKeywords()
+        @Generated public StacCollection setKeywords(List<String> keywords)
+        @Generated public String getLicense()
+        @Generated public List<StacLink> getLinks()
+        @Generated public List<StacProvider> getProviders()
+        @Generated public StacCollection setProviders(List<StacProvider> providers)
+        @Generated public String getShortDescription()
+        @Generated public StacCollection setShortDescription(String shortDescription)
+        @Generated public List<String> getStacExtensions()
+        @Generated public StacCollection setStacExtensions(List<String> stacExtensions)
+        @Generated public String getStacVersion()
+        @Generated public StacCollection setStacVersion(String stacVersion)
+        @Generated public Map<String, BinaryData> getSummaries()
+        @Generated public StacCollection setSummaries(Map<String, BinaryData> summaries)
+        @Generated public String getTitle()
+        @Generated public StacCollection setTitle(String title)
+        @Generated public String getType()
+        @Generated public StacCollection setType(String type)
+        @Generated public OffsetDateTime getUpdatedOn()
+        @Generated public StacCollection setUpdatedOn(OffsetDateTime updatedOn)
+    }
     @Immutable
-    public final class StacCollectionTemporalExtent implements JsonSerializable<StacCollectionTemporalExtent> { 
-        @Generated public StacCollectionTemporalExtent(List<List<OffsetDateTime>> interval) 
-        @Generated public List<List<OffsetDateTime>> getInterval() 
-    } 
+    public final class StacCollectionTemporalExtent implements JsonSerializable<StacCollectionTemporalExtent> {
+        @Generated public StacCollectionTemporalExtent(List<List<OffsetDateTime>> interval)
+        @Generated public List<List<OffsetDateTime>> getInterval()
+    }
     @Immutable
-    public final class StacConformanceClasses implements JsonSerializable<StacConformanceClasses> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public List<String> getConformsTo() 
-    } 
+    public final class StacConformanceClasses implements JsonSerializable<StacConformanceClasses> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public List<String> getConformsTo()
+    }
     @Fluent
-    public final class StacContextExtension implements JsonSerializable<StacContextExtension> { 
-        @Generated public StacContextExtension() 
-        @Generated public Integer getLimit() 
-        @Generated public StacContextExtension setLimit(Integer limit) 
-        @Generated public Integer getMatched() 
-        @Generated public StacContextExtension setMatched(Integer matched) 
-        @Generated public int getReturned() 
-        @Generated public StacContextExtension setReturned(int returned) 
-    } 
+    public final class StacContextExtension implements JsonSerializable<StacContextExtension> {
+        @Generated public StacContextExtension()
+        @Generated public Integer getLimit()
+        @Generated public StacContextExtension setLimit(Integer limit)
+        @Generated public Integer getMatched()
+        @Generated public StacContextExtension setMatched(Integer matched)
+        @Generated public int getReturned()
+        @Generated public StacContextExtension setReturned(int returned)
+    }
     @Immutable
-    public final class StacExtensionExtent implements JsonSerializable<StacExtensionExtent> { 
-        @Generated public StacExtensionExtent(StacExtensionSpatialExtent spatial, StacCollectionTemporalExtent temporal) 
-        @Generated public StacExtensionSpatialExtent getSpatial() 
-        @Generated public StacCollectionTemporalExtent getTemporal() 
-    } 
+    public final class StacExtensionExtent implements JsonSerializable<StacExtensionExtent> {
+        @Generated public StacExtensionExtent(StacExtensionSpatialExtent spatial, StacCollectionTemporalExtent temporal)
+        @Generated public StacExtensionSpatialExtent getSpatial()
+        @Generated public StacCollectionTemporalExtent getTemporal()
+    }
     @Fluent
-    public final class StacExtensionSpatialExtent implements JsonSerializable<StacExtensionSpatialExtent> { 
-        @Generated public StacExtensionSpatialExtent() 
-        @Generated public List<List<Double>> getBoundingBox() 
-        @Generated public StacExtensionSpatialExtent setBoundingBox(List<List<Double>> boundingBox) 
-    } 
+    public final class StacExtensionSpatialExtent implements JsonSerializable<StacExtensionSpatialExtent> {
+        @Generated public StacExtensionSpatialExtent()
+        @Generated public List<List<Double>> getBoundingBox()
+        @Generated public StacExtensionSpatialExtent setBoundingBox(List<List<Double>> boundingBox)
+    }
     @Fluent
-    public final class StacItem extends StacItemOrStacItemCollection { 
-        @Generated public StacItem() 
-        @Generated public Map<String, StacAsset> getAssets() 
-        @Generated public StacItem setAssets(Map<String, StacAsset> assets) 
-        @Generated public List<Double> getBoundingBox() 
-        @Generated public StacItem setBoundingBox(List<Double> boundingBox) 
-        @Generated public String getCollection() 
-        @Generated public StacItem setCollection(String collection) 
-        @Generated @Override public StacItem setCreatedOn(OffsetDateTime createdOn) 
-        @Generated public String getETag() 
-        @Generated public StacItem setETag(String eTag) 
+    public final class StacItem extends StacItemOrStacItemCollection {
+        @Generated public StacItem()
+        @Generated public Map<String, StacAsset> getAssets()
+        @Generated public StacItem setAssets(Map<String, StacAsset> assets)
+        @Generated public List<Double> getBoundingBox()
+        @Generated public StacItem setBoundingBox(List<Double> boundingBox)
+        @Generated public String getCollection()
+        @Generated public StacItem setCollection(String collection)
+        @Generated @Override public StacItem setCreatedOn(OffsetDateTime createdOn)
+        @Generated public String getETag()
+        @Generated public StacItem setETag(String eTag)
         @Generated public static StacItem fromJson(JsonReader jsonReader) throws IOException
-        @Generated public GeoJsonGeometry getGeometry() 
-        @Generated public StacItem setGeometry(GeoJsonGeometry geometry) 
-        @Generated public String getId() 
-        @Generated @Override public StacItem setLinks(List<StacLink> links) 
-        @Generated public StacItemProperties getProperties() 
-        @Generated public StacItem setProperties(StacItemProperties properties) 
-        @Generated @Override public StacItem setShortDescription(String shortDescription) 
-        @Generated @Override public StacItem setStacExtensions(List<String> stacExtensions) 
-        @Generated @Override public StacItem setStacVersion(String stacVersion) 
-        @Generated public OffsetDateTime getTimestamp() 
-        @Generated public StacItem setTimestamp(OffsetDateTime timestamp) 
+        @Generated public GeoJsonGeometry getGeometry()
+        @Generated public StacItem setGeometry(GeoJsonGeometry geometry)
+        @Generated public String getId()
+        @Generated @Override public StacItem setLinks(List<StacLink> links)
+        @Generated public StacItemProperties getProperties()
+        @Generated public StacItem setProperties(StacItemProperties properties)
+        @Generated @Override public StacItem setShortDescription(String shortDescription)
+        @Generated @Override public StacItem setStacExtensions(List<String> stacExtensions)
+        @Generated @Override public StacItem setStacVersion(String stacVersion)
+        @Generated public OffsetDateTime getTimestamp()
+        @Generated public StacItem setTimestamp(OffsetDateTime timestamp)
         @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
-        @Generated @Override public StacModelType getType() 
-        @Generated @Override public StacItem setUpdatedOn(OffsetDateTime updatedOn) 
-    } 
+        @Generated @Override public StacModelType getType()
+        @Generated @Override public StacItem setUpdatedOn(OffsetDateTime updatedOn)
+    }
     @Fluent
-    public final class StacItemAsset implements JsonSerializable<StacItemAsset> { 
-        @Generated public StacItemAsset(String title, String type) 
-        @Generated public Map<String, BinaryData> getAdditionalProperties() 
-        @Generated public StacItemAsset setAdditionalProperties(Map<String, BinaryData> additionalProperties) 
-        @Generated public String getConstellation() 
-        @Generated public StacItemAsset setConstellation(String constellation) 
-        @Generated public OffsetDateTime getCreated() 
-        @Generated public StacItemAsset setCreated(OffsetDateTime created) 
-        @Generated public String getDescription() 
-        @Generated public StacItemAsset setDescription(String description) 
-        @Generated public Double getGsd() 
-        @Generated public StacItemAsset setGsd(Double gsd) 
-        @Generated public String getHref() 
-        @Generated public StacItemAsset setHref(String href) 
-        @Generated public List<String> getInstruments() 
-        @Generated public StacItemAsset setInstruments(List<String> instruments) 
-        @Generated public String getMission() 
-        @Generated public StacItemAsset setMission(String mission) 
-        @Generated public String getPlatform() 
-        @Generated public StacItemAsset setPlatform(String platform) 
-        @Generated public List<StacProvider> getProviders() 
-        @Generated public StacItemAsset setProviders(List<StacProvider> providers) 
-        @Generated public List<String> getRoles() 
-        @Generated public StacItemAsset setRoles(List<String> roles) 
-        @Generated public String getTitle() 
-        @Generated public String getType() 
-        @Generated public OffsetDateTime getUpdated() 
-        @Generated public StacItemAsset setUpdated(OffsetDateTime updated) 
-    } 
+    public final class StacItemAsset implements JsonSerializable<StacItemAsset> {
+        @Generated public StacItemAsset(String title, String type)
+        @Generated public Map<String, BinaryData> getAdditionalProperties()
+        @Generated public StacItemAsset setAdditionalProperties(Map<String, BinaryData> additionalProperties)
+        @Generated public String getConstellation()
+        @Generated public StacItemAsset setConstellation(String constellation)
+        @Generated public OffsetDateTime getCreated()
+        @Generated public StacItemAsset setCreated(OffsetDateTime created)
+        @Generated public String getDescription()
+        @Generated public StacItemAsset setDescription(String description)
+        @Generated public Double getGsd()
+        @Generated public StacItemAsset setGsd(Double gsd)
+        @Generated public String getHref()
+        @Generated public StacItemAsset setHref(String href)
+        @Generated public List<String> getInstruments()
+        @Generated public StacItemAsset setInstruments(List<String> instruments)
+        @Generated public String getMission()
+        @Generated public StacItemAsset setMission(String mission)
+        @Generated public String getPlatform()
+        @Generated public StacItemAsset setPlatform(String platform)
+        @Generated public List<StacProvider> getProviders()
+        @Generated public StacItemAsset setProviders(List<StacProvider> providers)
+        @Generated public List<String> getRoles()
+        @Generated public StacItemAsset setRoles(List<String> roles)
+        @Generated public String getTitle()
+        @Generated public String getType()
+        @Generated public OffsetDateTime getUpdated()
+        @Generated public StacItemAsset setUpdated(OffsetDateTime updated)
+    }
     @Immutable
-    public final class StacItemBounds implements JsonSerializable<StacItemBounds> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public List<Double> getBounds() 
-    } 
+    public final class StacItemBounds implements JsonSerializable<StacItemBounds> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public List<Double> getBounds()
+    }
     @Fluent
-    public final class StacItemCollection extends StacItemOrStacItemCollection { 
-        @Generated public StacItemCollection() 
-        @Generated public List<Double> getBoundingBox() 
-        @Generated public StacItemCollection setBoundingBox(List<Double> boundingBox) 
-        @Generated public StacContextExtension getContext() 
-        @Generated public StacItemCollection setContext(StacContextExtension context) 
-        @Generated @Override public StacItemCollection setCreatedOn(OffsetDateTime createdOn) 
-        @Generated public List<StacItem> getFeatures() 
-        @Generated public StacItemCollection setFeatures(List<StacItem> features) 
+    public final class StacItemCollection extends StacItemOrStacItemCollection {
+        @Generated public StacItemCollection()
+        @Generated public List<Double> getBoundingBox()
+        @Generated public StacItemCollection setBoundingBox(List<Double> boundingBox)
+        @Generated public StacContextExtension getContext()
+        @Generated public StacItemCollection setContext(StacContextExtension context)
+        @Generated @Override public StacItemCollection setCreatedOn(OffsetDateTime createdOn)
+        @Generated public List<StacItem> getFeatures()
+        @Generated public StacItemCollection setFeatures(List<StacItem> features)
         @Generated public static StacItemCollection fromJson(JsonReader jsonReader) throws IOException
-        @Generated @Override public StacItemCollection setLinks(List<StacLink> links) 
-        @Generated @Override public StacItemCollection setShortDescription(String shortDescription) 
-        @Generated @Override public StacItemCollection setStacExtensions(List<String> stacExtensions) 
-        @Generated @Override public StacItemCollection setStacVersion(String stacVersion) 
+        @Generated @Override public StacItemCollection setLinks(List<StacLink> links)
+        @Generated @Override public StacItemCollection setShortDescription(String shortDescription)
+        @Generated @Override public StacItemCollection setStacExtensions(List<String> stacExtensions)
+        @Generated @Override public StacItemCollection setStacVersion(String stacVersion)
         @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
-        @Generated @Override public StacModelType getType() 
-        @Generated @Override public StacItemCollection setUpdatedOn(OffsetDateTime updatedOn) 
-    } 
+        @Generated @Override public StacModelType getType()
+        @Generated @Override public StacItemCollection setUpdatedOn(OffsetDateTime updatedOn)
+    }
     @Fluent
-    public class StacItemOrStacItemCollection implements JsonSerializable<StacItemOrStacItemCollection> { 
-        @Generated public StacItemOrStacItemCollection() 
-        @Generated public OffsetDateTime getCreatedOn() 
-        @Generated public StacItemOrStacItemCollection setCreatedOn(OffsetDateTime createdOn) 
-        @Generated public List<StacLink> getLinks() 
-        @Generated public StacItemOrStacItemCollection setLinks(List<StacLink> links) 
-        @Generated public String getShortDescription() 
-        @Generated public StacItemOrStacItemCollection setShortDescription(String shortDescription) 
-        @Generated public List<String> getStacExtensions() 
-        @Generated public StacItemOrStacItemCollection setStacExtensions(List<String> stacExtensions) 
-        @Generated public String getStacVersion() 
-        @Generated public StacItemOrStacItemCollection setStacVersion(String stacVersion) 
-        @Generated public StacModelType getType() 
-        @Generated public OffsetDateTime getUpdatedOn() 
-        @Generated public StacItemOrStacItemCollection setUpdatedOn(OffsetDateTime updatedOn) 
-    } 
+    public class StacItemOrStacItemCollection implements JsonSerializable<StacItemOrStacItemCollection> {
+        @Generated public StacItemOrStacItemCollection()
+        @Generated public OffsetDateTime getCreatedOn()
+        @Generated public StacItemOrStacItemCollection setCreatedOn(OffsetDateTime createdOn)
+        @Generated public List<StacLink> getLinks()
+        @Generated public StacItemOrStacItemCollection setLinks(List<StacLink> links)
+        @Generated public String getShortDescription()
+        @Generated public StacItemOrStacItemCollection setShortDescription(String shortDescription)
+        @Generated public List<String> getStacExtensions()
+        @Generated public StacItemOrStacItemCollection setStacExtensions(List<String> stacExtensions)
+        @Generated public String getStacVersion()
+        @Generated public StacItemOrStacItemCollection setStacVersion(String stacVersion)
+        @Generated public StacModelType getType()
+        @Generated public OffsetDateTime getUpdatedOn()
+        @Generated public StacItemOrStacItemCollection setUpdatedOn(OffsetDateTime updatedOn)
+    }
     @Immutable
-    public final class StacItemPointAsset implements JsonSerializable<StacItemPointAsset> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public Map<String, StacAsset> getAssets() 
-        @Generated public List<Double> getBoundingBox() 
-        @Generated public String getCollectionId() 
-        @Generated public String getId() 
-    } 
+    public final class StacItemPointAsset implements JsonSerializable<StacItemPointAsset> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public Map<String, StacAsset> getAssets()
+        @Generated public List<Double> getBoundingBox()
+        @Generated public String getCollectionId()
+        @Generated public String getId()
+    }
     @Fluent
-    public final class StacItemProperties implements JsonSerializable<StacItemProperties> { 
-        @Generated public StacItemProperties() 
-        @Generated public Map<String, BinaryData> getAdditionalProperties() 
-        @Generated public StacItemProperties setAdditionalProperties(Map<String, BinaryData> additionalProperties) 
-        @Generated public String getConstellation() 
-        @Generated public StacItemProperties setConstellation(String constellation) 
-        @Generated public OffsetDateTime getCreated() 
-        @Generated public StacItemProperties setCreated(OffsetDateTime created) 
-        @Generated public String getDatetime() 
-        @Generated public StacItemProperties setDatetime(String datetime) 
-        @Generated public String getDescription() 
-        @Generated public StacItemProperties setDescription(String description) 
-        @Generated public OffsetDateTime getEndDatetime() 
-        @Generated public StacItemProperties setEndDatetime(OffsetDateTime endDatetime) 
-        @Generated public Double getGsd() 
-        @Generated public StacItemProperties setGsd(Double gsd) 
-        @Generated public List<String> getInstruments() 
-        @Generated public StacItemProperties setInstruments(List<String> instruments) 
-        @Generated public String getMission() 
-        @Generated public StacItemProperties setMission(String mission) 
-        @Generated public String getPlatform() 
-        @Generated public StacItemProperties setPlatform(String platform) 
-        @Generated public List<StacProvider> getProviders() 
-        @Generated public StacItemProperties setProviders(List<StacProvider> providers) 
-        @Generated public OffsetDateTime getStartDatetime() 
-        @Generated public StacItemProperties setStartDatetime(OffsetDateTime startDatetime) 
-        @Generated public String getTitle() 
-        @Generated public StacItemProperties setTitle(String title) 
-        @Generated public OffsetDateTime getUpdated() 
-        @Generated public StacItemProperties setUpdated(OffsetDateTime updated) 
-    } 
+    public final class StacItemProperties implements JsonSerializable<StacItemProperties> {
+        @Generated public StacItemProperties()
+        @Generated public Map<String, BinaryData> getAdditionalProperties()
+        @Generated public StacItemProperties setAdditionalProperties(Map<String, BinaryData> additionalProperties)
+        @Generated public String getConstellation()
+        @Generated public StacItemProperties setConstellation(String constellation)
+        @Generated public OffsetDateTime getCreated()
+        @Generated public StacItemProperties setCreated(OffsetDateTime created)
+        @Generated public String getDatetime()
+        @Generated public StacItemProperties setDatetime(String datetime)
+        @Generated public String getDescription()
+        @Generated public StacItemProperties setDescription(String description)
+        @Generated public OffsetDateTime getEndDatetime()
+        @Generated public StacItemProperties setEndDatetime(OffsetDateTime endDatetime)
+        @Generated public Double getGsd()
+        @Generated public StacItemProperties setGsd(Double gsd)
+        @Generated public List<String> getInstruments()
+        @Generated public StacItemProperties setInstruments(List<String> instruments)
+        @Generated public String getMission()
+        @Generated public StacItemProperties setMission(String mission)
+        @Generated public String getPlatform()
+        @Generated public StacItemProperties setPlatform(String platform)
+        @Generated public List<StacProvider> getProviders()
+        @Generated public StacItemProperties setProviders(List<StacProvider> providers)
+        @Generated public OffsetDateTime getStartDatetime()
+        @Generated public StacItemProperties setStartDatetime(OffsetDateTime startDatetime)
+        @Generated public String getTitle()
+        @Generated public StacItemProperties setTitle(String title)
+        @Generated public OffsetDateTime getUpdated()
+        @Generated public StacItemProperties setUpdated(OffsetDateTime updated)
+    }
     @Immutable
-    public final class StacItemStatisticsGeoJson implements JsonSerializable<StacItemStatisticsGeoJson> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public GeoJsonGeometry getGeometry() 
-        @Generated public StacItemStatisticsGeoJsonProperties getProperties() 
-        @Generated public FeatureType getType() 
-    } 
+    public final class StacItemStatisticsGeoJson implements JsonSerializable<StacItemStatisticsGeoJson> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public GeoJsonGeometry getGeometry()
+        @Generated public StacItemStatisticsGeoJsonProperties getProperties()
+        @Generated public FeatureType getType()
+    }
     @Immutable
-    public final class StacItemStatisticsGeoJsonProperties implements JsonSerializable<StacItemStatisticsGeoJsonProperties> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public Map<String, BinaryData> getAdditionalProperties() 
-        @Generated public Map<String, BandStatistics> getStatistics() 
-    } 
+    public final class StacItemStatisticsGeoJsonProperties implements JsonSerializable<StacItemStatisticsGeoJsonProperties> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public Map<String, BinaryData> getAdditionalProperties()
+        @Generated public Map<String, BandStatistics> getStatistics()
+    }
     @Immutable
-    public final class StacLandingPage implements JsonSerializable<StacLandingPage> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public List<String> getConformsTo() 
-        @Generated public OffsetDateTime getCreatedOn() 
-        @Generated public String getDescription() 
-        @Generated public String getId() 
-        @Generated public List<StacLink> getLinks() 
-        @Generated public String getShortDescription() 
-        @Generated public List<String> getStacExtensions() 
-        @Generated public String getStacVersion() 
-        @Generated public String getTitle() 
-        @Generated public String getType() 
-        @Generated public OffsetDateTime getUpdatedOn() 
-    } 
+    public final class StacLandingPage implements JsonSerializable<StacLandingPage> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public List<String> getConformsTo()
+        @Generated public OffsetDateTime getCreatedOn()
+        @Generated public String getDescription()
+        @Generated public String getId()
+        @Generated public List<StacLink> getLinks()
+        @Generated public String getShortDescription()
+        @Generated public List<String> getStacExtensions()
+        @Generated public String getStacVersion()
+        @Generated public String getTitle()
+        @Generated public String getType()
+        @Generated public OffsetDateTime getUpdatedOn()
+    }
     @Fluent
-    public final class StacLink implements JsonSerializable<StacLink> { 
-        @Generated public StacLink() 
-        @Generated public Map<String, BinaryData> getBody() 
-        @Generated public StacLink setBody(Map<String, BinaryData> body) 
-        @Generated public Map<String, String> getHeaders() 
-        @Generated public StacLink setHeaders(Map<String, String> headers) 
-        @Generated public String getHref() 
-        @Generated public StacLink setHref(String href) 
-        @Generated public String getHreflang() 
-        @Generated public StacLink setHreflang(String hreflang) 
-        @Generated public Integer getLength() 
-        @Generated public StacLink setLength(Integer length) 
-        @Generated public Boolean isMerge() 
-        @Generated public StacLink setMerge(Boolean merge) 
-        @Generated public StacLinkMethod getMethod() 
-        @Generated public StacLink setMethod(StacLinkMethod method) 
-        @Generated public String getRel() 
-        @Generated public StacLink setRel(String rel) 
-        @Generated public String getTitle() 
-        @Generated public StacLink setTitle(String title) 
-        @Generated public StacLinkType getType() 
-        @Generated public StacLink setType(StacLinkType type) 
-    } 
-    public final class StacLinkMethod extends ExpandableStringEnum<StacLinkMethod> { 
-        @Generated public static final StacLinkMethod GET = fromString("GET"); 
-        @Generated public static final StacLinkMethod POST = fromString("POST"); 
-        @Deprecated @Generated public StacLinkMethod() 
-        @Generated public static StacLinkMethod fromString(String name) 
-        @Generated public static Collection<StacLinkMethod> values() 
-    } 
-    public final class StacLinkType extends ExpandableStringEnum<StacLinkType> { 
-        @Generated public static final StacLinkType IMAGE_TIFF_APPLICATION_GEOTIFF = fromString("image/tiff; application=geotiff"); 
-        @Generated public static final StacLinkType IMAGE_JP2 = fromString("image/jp2"); 
-        @Generated public static final StacLinkType IMAGE_PNG = fromString("image/png"); 
-        @Generated public static final StacLinkType IMAGE_JPEG = fromString("image/jpeg"); 
-        @Generated public static final StacLinkType IMAGE_JPG = fromString("image/jpg"); 
-        @Generated public static final StacLinkType IMAGE_WEBP = fromString("image/webp"); 
-        @Generated public static final StacLinkType APPLICATION_X_BINARY = fromString("application/x-binary"); 
-        @Generated public static final StacLinkType APPLICATION_XML = fromString("application/xml"); 
-        @Generated public static final StacLinkType APPLICATION_JSON = fromString("application/json"); 
-        @Generated public static final StacLinkType APPLICATION_GEO_JSON = fromString("application/geo+json"); 
-        @Generated public static final StacLinkType TEXT_HTML = fromString("text/html"); 
-        @Generated public static final StacLinkType TEXT_PLAIN = fromString("text/plain"); 
-        @Generated public static final StacLinkType APPLICATION_X_PROTOBUF = fromString("application/x-protobuf"); 
-        @Deprecated @Generated public StacLinkType() 
-        @Generated public static StacLinkType fromString(String name) 
-        @Generated public static Collection<StacLinkType> values() 
-    } 
-    public final class StacModelType extends ExpandableStringEnum<StacModelType> { 
-        @Generated public static final StacModelType FEATURE = fromString("Feature"); 
-        @Generated public static final StacModelType FEATURE_COLLECTION = fromString("FeatureCollection"); 
-        @Deprecated @Generated public StacModelType() 
-        @Generated public static StacModelType fromString(String name) 
-        @Generated public static Collection<StacModelType> values() 
-    } 
+    public final class StacLink implements JsonSerializable<StacLink> {
+        @Generated public StacLink()
+        @Generated public Map<String, BinaryData> getBody()
+        @Generated public StacLink setBody(Map<String, BinaryData> body)
+        @Generated public Map<String, String> getHeaders()
+        @Generated public StacLink setHeaders(Map<String, String> headers)
+        @Generated public String getHref()
+        @Generated public StacLink setHref(String href)
+        @Generated public String getHreflang()
+        @Generated public StacLink setHreflang(String hreflang)
+        @Generated public Integer getLength()
+        @Generated public StacLink setLength(Integer length)
+        @Generated public Boolean isMerge()
+        @Generated public StacLink setMerge(Boolean merge)
+        @Generated public StacLinkMethod getMethod()
+        @Generated public StacLink setMethod(StacLinkMethod method)
+        @Generated public String getRel()
+        @Generated public StacLink setRel(String rel)
+        @Generated public String getTitle()
+        @Generated public StacLink setTitle(String title)
+        @Generated public StacLinkType getType()
+        @Generated public StacLink setType(StacLinkType type)
+    }
+    public final class StacLinkMethod extends ExpandableStringEnum<StacLinkMethod> {
+        @Generated public static final StacLinkMethod GET = fromString("GET");
+        @Generated public static final StacLinkMethod POST = fromString("POST");
+        @Deprecated @Generated public StacLinkMethod()
+        @Generated public static StacLinkMethod fromString(String name)
+        @Generated public static Collection<StacLinkMethod> values()
+    }
+    public final class StacLinkType extends ExpandableStringEnum<StacLinkType> {
+        @Generated public static final StacLinkType IMAGE_TIFF_APPLICATION_GEOTIFF = fromString("image/tiff; application=geotiff");
+        @Generated public static final StacLinkType IMAGE_JP2 = fromString("image/jp2");
+        @Generated public static final StacLinkType IMAGE_PNG = fromString("image/png");
+        @Generated public static final StacLinkType IMAGE_JPEG = fromString("image/jpeg");
+        @Generated public static final StacLinkType IMAGE_JPG = fromString("image/jpg");
+        @Generated public static final StacLinkType IMAGE_WEBP = fromString("image/webp");
+        @Generated public static final StacLinkType APPLICATION_X_BINARY = fromString("application/x-binary");
+        @Generated public static final StacLinkType APPLICATION_XML = fromString("application/xml");
+        @Generated public static final StacLinkType APPLICATION_JSON = fromString("application/json");
+        @Generated public static final StacLinkType APPLICATION_GEO_JSON = fromString("application/geo+json");
+        @Generated public static final StacLinkType TEXT_HTML = fromString("text/html");
+        @Generated public static final StacLinkType TEXT_PLAIN = fromString("text/plain");
+        @Generated public static final StacLinkType APPLICATION_X_PROTOBUF = fromString("application/x-protobuf");
+        @Deprecated @Generated public StacLinkType()
+        @Generated public static StacLinkType fromString(String name)
+        @Generated public static Collection<StacLinkType> values()
+    }
+    public final class StacModelType extends ExpandableStringEnum<StacModelType> {
+        @Generated public static final StacModelType FEATURE = fromString("Feature");
+        @Generated public static final StacModelType FEATURE_COLLECTION = fromString("FeatureCollection");
+        @Deprecated @Generated public StacModelType()
+        @Generated public static StacModelType fromString(String name)
+        @Generated public static Collection<StacModelType> values()
+    }
     @Fluent
-    public final class StacMosaic implements JsonSerializable<StacMosaic> { 
-        @Generated public StacMosaic(String id, String name, List<Map<String, BinaryData>> cql) 
-        @Generated public List<Map<String, BinaryData>> getCql() 
-        @Generated public String getDescription() 
-        @Generated public StacMosaic setDescription(String description) 
-        @Generated public String getId() 
-        @Generated public String getName() 
-    } 
+    public final class StacMosaic implements JsonSerializable<StacMosaic> {
+        @Generated public StacMosaic(String id, String name, List<Map<String, BinaryData>> cql)
+        @Generated public List<Map<String, BinaryData>> getCql()
+        @Generated public String getDescription()
+        @Generated public StacMosaic setDescription(String description)
+        @Generated public String getId()
+        @Generated public String getName()
+    }
     @Immutable
-    public final class StacMosaicConfiguration implements JsonSerializable<StacMosaicConfiguration> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public Map<String, BinaryData> getDefaultCustomQuery() 
-        @Generated public DefaultLocation getDefaultLocation() 
-        @Generated public List<StacMosaic> getMosaics() 
-        @Generated public List<RenderOption> getRenderOptions() 
-    } 
+    public final class StacMosaicConfiguration implements JsonSerializable<StacMosaicConfiguration> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public Map<String, BinaryData> getDefaultCustomQuery()
+        @Generated public DefaultLocation getDefaultLocation()
+        @Generated public List<StacMosaic> getMosaics()
+        @Generated public List<RenderOption> getRenderOptions()
+    }
     @Fluent
-    public final class StacProvider implements JsonSerializable<StacProvider> { 
-        @Generated public StacProvider() 
-        @Generated public String getDescription() 
-        @Generated public StacProvider setDescription(String description) 
-        @Generated public String getName() 
-        @Generated public StacProvider setName(String name) 
-        @Generated public List<String> getRoles() 
-        @Generated public StacProvider setRoles(List<String> roles) 
-        @Generated public String getUrl() 
-        @Generated public StacProvider setUrl(String url) 
-    } 
+    public final class StacProvider implements JsonSerializable<StacProvider> {
+        @Generated public StacProvider()
+        @Generated public String getDescription()
+        @Generated public StacProvider setDescription(String description)
+        @Generated public String getName()
+        @Generated public StacProvider setName(String name)
+        @Generated public List<String> getRoles()
+        @Generated public StacProvider setRoles(List<String> roles)
+        @Generated public String getUrl()
+        @Generated public StacProvider setUrl(String url)
+    }
     @Fluent
-    public final class StacQueryable implements JsonSerializable<StacQueryable> { 
-        @Generated public StacQueryable(String name, Map<String, BinaryData> definition) 
-        @Generated public Boolean isCreateIndex() 
-        @Generated public StacQueryable setCreateIndex(Boolean createIndex) 
-        @Generated public StacQueryableDefinitionDataType getDataType() 
-        @Generated public StacQueryable setDataType(StacQueryableDefinitionDataType dataType) 
-        @Generated public Map<String, BinaryData> getDefinition() 
-        @Generated public String getName() 
-    } 
-    public final class StacQueryableDefinitionDataType extends ExpandableStringEnum<StacQueryableDefinitionDataType> { 
-        @Generated public static final StacQueryableDefinitionDataType STRING = fromString("string"); 
-        @Generated public static final StacQueryableDefinitionDataType NUMBER = fromString("number"); 
-        @Generated public static final StacQueryableDefinitionDataType BOOLEAN = fromString("boolean"); 
-        @Generated public static final StacQueryableDefinitionDataType TIMESTAMP = fromString("timestamp"); 
-        @Generated public static final StacQueryableDefinitionDataType DATE = fromString("date"); 
-        @Deprecated @Generated public StacQueryableDefinitionDataType() 
-        @Generated public static StacQueryableDefinitionDataType fromString(String name) 
-        @Generated public static Collection<StacQueryableDefinitionDataType> values() 
-    } 
+    public final class StacQueryable implements JsonSerializable<StacQueryable> {
+        @Generated public StacQueryable(String name, Map<String, BinaryData> definition)
+        @Generated public Boolean isCreateIndex()
+        @Generated public StacQueryable setCreateIndex(Boolean createIndex)
+        @Generated public StacQueryableDefinitionDataType getDataType()
+        @Generated public StacQueryable setDataType(StacQueryableDefinitionDataType dataType)
+        @Generated public Map<String, BinaryData> getDefinition()
+        @Generated public String getName()
+    }
+    public final class StacQueryableDefinitionDataType extends ExpandableStringEnum<StacQueryableDefinitionDataType> {
+        @Generated public static final StacQueryableDefinitionDataType STRING = fromString("string");
+        @Generated public static final StacQueryableDefinitionDataType NUMBER = fromString("number");
+        @Generated public static final StacQueryableDefinitionDataType BOOLEAN = fromString("boolean");
+        @Generated public static final StacQueryableDefinitionDataType TIMESTAMP = fromString("timestamp");
+        @Generated public static final StacQueryableDefinitionDataType DATE = fromString("date");
+        @Deprecated @Generated public StacQueryableDefinitionDataType()
+        @Generated public static StacQueryableDefinitionDataType fromString(String name)
+        @Generated public static Collection<StacQueryableDefinitionDataType> values()
+    }
     @Fluent
-    public final class StacSearchParameters implements JsonSerializable<StacSearchParameters> { 
-        @Generated public StacSearchParameters() 
-        @Generated public List<Double> getBoundingBox() 
-        @Generated public StacSearchParameters setBoundingBox(List<Double> boundingBox) 
-        @Generated public List<String> getCollections() 
-        @Generated public StacSearchParameters setCollections(List<String> collections) 
-        @Generated public Map<String, BinaryData> getConformanceClass() 
-        @Generated public StacSearchParameters setConformanceClass(Map<String, BinaryData> conformanceClass) 
-        @Generated public String getDatetime() 
-        @Generated public StacSearchParameters setDatetime(String datetime) 
-        @Generated public List<SearchOptionsFields> getFields() 
-        @Generated public StacSearchParameters setFields(List<SearchOptionsFields> fields) 
-        @Generated public Map<String, BinaryData> getFilter() 
-        @Generated public StacSearchParameters setFilter(Map<String, BinaryData> filter) 
-        @Generated public String getFilterCoordinateReferenceSystem() 
-        @Generated public StacSearchParameters setFilterCoordinateReferenceSystem(String filterCoordinateReferenceSystem) 
-        @Generated public FilterLanguage getFilterLang() 
-        @Generated public StacSearchParameters setFilterLang(FilterLanguage filterLang) 
-        @Generated public List<String> getIds() 
-        @Generated public StacSearchParameters setIds(List<String> ids) 
-        @Generated public GeoJsonGeometry getIntersects() 
-        @Generated public StacSearchParameters setIntersects(GeoJsonGeometry intersects) 
-        @Generated public Integer getLimit() 
-        @Generated public StacSearchParameters setLimit(Integer limit) 
-        @Generated public Map<String, BinaryData> getQuery() 
-        @Generated public StacSearchParameters setQuery(Map<String, BinaryData> query) 
-        @Generated public List<StacSortExtension> getSortBy() 
-        @Generated public StacSearchParameters setSortBy(List<StacSortExtension> sortBy) 
-        @Generated public String getToken() 
-        @Generated public StacSearchParameters setToken(String token) 
-    } 
-    public final class StacSearchSortingDirection extends ExpandableStringEnum<StacSearchSortingDirection> { 
-        @Generated public static final StacSearchSortingDirection ASC = fromString("asc"); 
-        @Generated public static final StacSearchSortingDirection DESC = fromString("desc"); 
-        @Deprecated @Generated public StacSearchSortingDirection() 
-        @Generated public static StacSearchSortingDirection fromString(String name) 
-        @Generated public static Collection<StacSearchSortingDirection> values() 
-    } 
+    public final class StacSearchParameters implements JsonSerializable<StacSearchParameters> {
+        @Generated public StacSearchParameters()
+        @Generated public List<Double> getBoundingBox()
+        @Generated public StacSearchParameters setBoundingBox(List<Double> boundingBox)
+        @Generated public List<String> getCollections()
+        @Generated public StacSearchParameters setCollections(List<String> collections)
+        @Generated public Map<String, BinaryData> getConformanceClass()
+        @Generated public StacSearchParameters setConformanceClass(Map<String, BinaryData> conformanceClass)
+        @Generated public String getDatetime()
+        @Generated public StacSearchParameters setDatetime(String datetime)
+        @Generated public List<SearchOptionsFields> getFields()
+        @Generated public StacSearchParameters setFields(List<SearchOptionsFields> fields)
+        @Generated public Map<String, BinaryData> getFilter()
+        @Generated public StacSearchParameters setFilter(Map<String, BinaryData> filter)
+        @Generated public String getFilterCoordinateReferenceSystem()
+        @Generated public StacSearchParameters setFilterCoordinateReferenceSystem(String filterCoordinateReferenceSystem)
+        @Generated public FilterLanguage getFilterLang()
+        @Generated public StacSearchParameters setFilterLang(FilterLanguage filterLang)
+        @Generated public List<String> getIds()
+        @Generated public StacSearchParameters setIds(List<String> ids)
+        @Generated public GeoJsonGeometry getIntersects()
+        @Generated public StacSearchParameters setIntersects(GeoJsonGeometry intersects)
+        @Generated public Integer getLimit()
+        @Generated public StacSearchParameters setLimit(Integer limit)
+        @Generated public Map<String, BinaryData> getQuery()
+        @Generated public StacSearchParameters setQuery(Map<String, BinaryData> query)
+        @Generated public List<StacSortExtension> getSortBy()
+        @Generated public StacSearchParameters setSortBy(List<StacSortExtension> sortBy)
+        @Generated public String getToken()
+        @Generated public StacSearchParameters setToken(String token)
+    }
+    public final class StacSearchSortingDirection extends ExpandableStringEnum<StacSearchSortingDirection> {
+        @Generated public static final StacSearchSortingDirection ASC = fromString("asc");
+        @Generated public static final StacSearchSortingDirection DESC = fromString("desc");
+        @Deprecated @Generated public StacSearchSortingDirection()
+        @Generated public static StacSearchSortingDirection fromString(String name)
+        @Generated public static Collection<StacSearchSortingDirection> values()
+    }
     @Immutable
-    public final class StacSortExtension implements JsonSerializable<StacSortExtension> { 
-        @Generated public StacSortExtension(String field, StacSearchSortingDirection direction) 
-        @Generated public StacSearchSortingDirection getDirection() 
-        @Generated public String getField() 
-    } 
-    public final class TerrainAlgorithm extends ExpandableStringEnum<TerrainAlgorithm> { 
-        @Generated public static final TerrainAlgorithm HILLSHADE = fromString("hillshade"); 
-        @Generated public static final TerrainAlgorithm CONTOURS = fromString("contours"); 
-        @Generated public static final TerrainAlgorithm NORMALIZED_INDEX = fromString("normalizedIndex"); 
-        @Generated public static final TerrainAlgorithm TERRARIUM = fromString("terrarium"); 
-        @Generated public static final TerrainAlgorithm TERRAINRGB = fromString("terrainrgb"); 
-        @Generated public static final TerrainAlgorithm SLOPE = fromString("slope"); 
-        @Generated public static final TerrainAlgorithm CAST = fromString("cast"); 
-        @Generated public static final TerrainAlgorithm CEIL = fromString("ceil"); 
-        @Generated public static final TerrainAlgorithm FLOOR = fromString("floor"); 
-        @Generated public static final TerrainAlgorithm MIN = fromString("min"); 
-        @Generated public static final TerrainAlgorithm MAX = fromString("max"); 
-        @Generated public static final TerrainAlgorithm MEDIAN = fromString("median"); 
-        @Generated public static final TerrainAlgorithm MEAN = fromString("mean"); 
-        @Generated public static final TerrainAlgorithm STD = fromString("std"); 
-        @Generated public static final TerrainAlgorithm VAR = fromString("var"); 
-        @Deprecated @Generated public TerrainAlgorithm() 
-        @Generated public static TerrainAlgorithm fromString(String name) 
-        @Generated public static Collection<TerrainAlgorithm> values() 
-    } 
-    public final class TileAddressingScheme extends ExpandableStringEnum<TileAddressingScheme> { 
-        @Generated public static final TileAddressingScheme XYZ = fromString("xyz"); 
-        @Generated public static final TileAddressingScheme TMS = fromString("tms"); 
-        @Deprecated @Generated public TileAddressingScheme() 
-        @Generated public static TileAddressingScheme fromString(String name) 
-        @Generated public static Collection<TileAddressingScheme> values() 
-    } 
+    public final class StacSortExtension implements JsonSerializable<StacSortExtension> {
+        @Generated public StacSortExtension(String field, StacSearchSortingDirection direction)
+        @Generated public StacSearchSortingDirection getDirection()
+        @Generated public String getField()
+    }
+    public final class TerrainAlgorithm extends ExpandableStringEnum<TerrainAlgorithm> {
+        @Generated public static final TerrainAlgorithm HILLSHADE = fromString("hillshade");
+        @Generated public static final TerrainAlgorithm CONTOURS = fromString("contours");
+        @Generated public static final TerrainAlgorithm NORMALIZED_INDEX = fromString("normalizedIndex");
+        @Generated public static final TerrainAlgorithm TERRARIUM = fromString("terrarium");
+        @Generated public static final TerrainAlgorithm TERRAINRGB = fromString("terrainrgb");
+        @Generated public static final TerrainAlgorithm SLOPE = fromString("slope");
+        @Generated public static final TerrainAlgorithm CAST = fromString("cast");
+        @Generated public static final TerrainAlgorithm CEIL = fromString("ceil");
+        @Generated public static final TerrainAlgorithm FLOOR = fromString("floor");
+        @Generated public static final TerrainAlgorithm MIN = fromString("min");
+        @Generated public static final TerrainAlgorithm MAX = fromString("max");
+        @Generated public static final TerrainAlgorithm MEDIAN = fromString("median");
+        @Generated public static final TerrainAlgorithm MEAN = fromString("mean");
+        @Generated public static final TerrainAlgorithm STD = fromString("std");
+        @Generated public static final TerrainAlgorithm VAR = fromString("var");
+        @Deprecated @Generated public TerrainAlgorithm()
+        @Generated public static TerrainAlgorithm fromString(String name)
+        @Generated public static Collection<TerrainAlgorithm> values()
+    }
+    public final class TileAddressingScheme extends ExpandableStringEnum<TileAddressingScheme> {
+        @Generated public static final TileAddressingScheme XYZ = fromString("xyz");
+        @Generated public static final TileAddressingScheme TMS = fromString("tms");
+        @Deprecated @Generated public TileAddressingScheme()
+        @Generated public static TileAddressingScheme fromString(String name)
+        @Generated public static Collection<TileAddressingScheme> values()
+    }
     @Immutable
-    public final class TileJsonMetadata implements JsonSerializable<TileJsonMetadata> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public String getAttribution() 
-        @Generated public List<Double> getBounds() 
-        @Generated public List<Double> getCenter() 
-        @Generated public List<String> getData() 
-        @Generated public String getDescription() 
-        @Generated public List<String> getGrids() 
-        @Generated public String getLegend() 
-        @Generated public Integer getMaxZoom() 
-        @Generated public Integer getMinZoom() 
-        @Generated public String getName() 
-        @Generated public TileAddressingScheme getScheme() 
-        @Generated public String getTemplate() 
-        @Generated public String getTileJson() 
-        @Generated public List<String> getTiles() 
-        @Generated public String getVersion() 
-    } 
+    public final class TileJsonMetadata implements JsonSerializable<TileJsonMetadata> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public String getAttribution()
+        @Generated public List<Double> getBounds()
+        @Generated public List<Double> getCenter()
+        @Generated public List<String> getData()
+        @Generated public String getDescription()
+        @Generated public List<String> getGrids()
+        @Generated public String getLegend()
+        @Generated public Integer getMaxZoom()
+        @Generated public Integer getMinZoom()
+        @Generated public String getName()
+        @Generated public TileAddressingScheme getScheme()
+        @Generated public String getTemplate()
+        @Generated public String getTileJson()
+        @Generated public List<String> getTiles()
+        @Generated public String getVersion()
+    }
     @Immutable
-    public final class TileMatrix implements JsonSerializable<TileMatrix> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public double getCellSize() 
-        @Generated public TileMatrixCornerOfOrigin getCornerOfOrigin() 
-        @Generated public String getDescription() 
-        @Generated public String getId() 
-        @Generated public List<String> getKeywords() 
-        @Generated public int getMatrixHeight() 
-        @Generated public int getMatrixWidth() 
-        @Generated public List<Double> getPointOfOrigin() 
-        @Generated public double getScaleDenominator() 
-        @Generated public int getTileHeight() 
-        @Generated public int getTileWidth() 
-        @Generated public String getTitle() 
-        @Generated public List<VariableMatrixWidth> getVariableMatrixWidths() 
-    } 
-    public final class TileMatrixCornerOfOrigin extends ExpandableStringEnum<TileMatrixCornerOfOrigin> { 
-        @Generated public static final TileMatrixCornerOfOrigin TOP_LEFT = fromString("topLeft"); 
-        @Generated public static final TileMatrixCornerOfOrigin BOTTOM_LEFT = fromString("bottomLeft"); 
-        @Deprecated @Generated public TileMatrixCornerOfOrigin() 
-        @Generated public static TileMatrixCornerOfOrigin fromString(String name) 
-        @Generated public static Collection<TileMatrixCornerOfOrigin> values() 
-    } 
+    public final class TileMatrix implements JsonSerializable<TileMatrix> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public double getCellSize()
+        @Generated public TileMatrixCornerOfOrigin getCornerOfOrigin()
+        @Generated public String getDescription()
+        @Generated public String getId()
+        @Generated public List<String> getKeywords()
+        @Generated public int getMatrixHeight()
+        @Generated public int getMatrixWidth()
+        @Generated public List<Double> getPointOfOrigin()
+        @Generated public double getScaleDenominator()
+        @Generated public int getTileHeight()
+        @Generated public int getTileWidth()
+        @Generated public String getTitle()
+        @Generated public List<VariableMatrixWidth> getVariableMatrixWidths()
+    }
+    public final class TileMatrixCornerOfOrigin extends ExpandableStringEnum<TileMatrixCornerOfOrigin> {
+        @Generated public static final TileMatrixCornerOfOrigin TOP_LEFT = fromString("topLeft");
+        @Generated public static final TileMatrixCornerOfOrigin BOTTOM_LEFT = fromString("bottomLeft");
+        @Deprecated @Generated public TileMatrixCornerOfOrigin()
+        @Generated public static TileMatrixCornerOfOrigin fromString(String name)
+        @Generated public static Collection<TileMatrixCornerOfOrigin> values()
+    }
     @Immutable
-    public final class TileMatrixSet implements JsonSerializable<TileMatrixSet> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public TileMatrixSetBoundingBox getBoundingBox() 
-        @Generated public String getCrs() 
-        @Generated public String getDescription() 
-        @Generated public String getId() 
-        @Generated public List<String> getKeywords() 
-        @Generated public List<String> getOrderedAxes() 
-        @Generated public List<TileMatrix> getTileMatrices() 
-        @Generated public String getTitle() 
-        @Generated public String getUri() 
-        @Generated public String getWellKnownScaleSet() 
-    } 
+    public final class TileMatrixSet implements JsonSerializable<TileMatrixSet> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public TileMatrixSetBoundingBox getBoundingBox()
+        @Generated public String getCrs()
+        @Generated public String getDescription()
+        @Generated public String getId()
+        @Generated public List<String> getKeywords()
+        @Generated public List<String> getOrderedAxes()
+        @Generated public List<TileMatrix> getTileMatrices()
+        @Generated public String getTitle()
+        @Generated public String getUri()
+        @Generated public String getWellKnownScaleSet()
+    }
     @Immutable
-    public final class TileMatrixSetBoundingBox implements JsonSerializable<TileMatrixSetBoundingBox> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public String getCrs() 
-        @Generated public List<String> getLowerLeft() 
-        @Generated public List<String> getOrderedAxes() 
-        @Generated public List<String> getUpperRight() 
-    } 
-    public final class TileMatrixSetId extends ExpandableStringEnum<TileMatrixSetId> { 
-        @Generated public static final TileMatrixSetId CANADIAN_NAD83_LCC = fromString("CanadianNAD83_LCC"); 
-        @Generated public static final TileMatrixSetId EUROPEAN_ETRS89_LAEAQUAD = fromString("EuropeanETRS89_LAEAQuad"); 
-        @Generated public static final TileMatrixSetId LINZANTARTICA_MAP_TILEGRID = fromString("LINZAntarticaMapTilegrid"); 
-        @Generated public static final TileMatrixSetId NZTM2000QUAD = fromString("NZTM2000Quad"); 
-        @Generated public static final TileMatrixSetId UPSANTARCTIC_WGS84QUAD = fromString("UPSAntarcticWGS84Quad"); 
-        @Generated public static final TileMatrixSetId UPSARCTIC_WGS84QUAD = fromString("UPSArcticWGS84Quad"); 
-        @Generated public static final TileMatrixSetId UTM31WGS84QUAD = fromString("UTM31WGS84Quad"); 
-        @Generated public static final TileMatrixSetId WGS1984QUAD = fromString("WGS1984Quad"); 
-        @Generated public static final TileMatrixSetId WEB_MERCATOR_QUAD = fromString("WebMercatorQuad"); 
-        @Generated public static final TileMatrixSetId WORLD_CRS84QUAD = fromString("WorldCRS84Quad"); 
-        @Generated public static final TileMatrixSetId WORLD_MERCATOR_WGS84QUAD = fromString("WorldMercatorWGS84Quad"); 
-        @Deprecated @Generated public TileMatrixSetId() 
-        @Generated public static TileMatrixSetId fromString(String name) 
-        @Generated public static Collection<TileMatrixSetId> values() 
-    } 
+    public final class TileMatrixSetBoundingBox implements JsonSerializable<TileMatrixSetBoundingBox> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public String getCrs()
+        @Generated public List<String> getLowerLeft()
+        @Generated public List<String> getOrderedAxes()
+        @Generated public List<String> getUpperRight()
+    }
+    public final class TileMatrixSetId extends ExpandableStringEnum<TileMatrixSetId> {
+        @Generated public static final TileMatrixSetId CANADIAN_NAD83_LCC = fromString("CanadianNAD83_LCC");
+        @Generated public static final TileMatrixSetId EUROPEAN_ETRS89_LAEAQUAD = fromString("EuropeanETRS89_LAEAQuad");
+        @Generated public static final TileMatrixSetId LINZANTARTICA_MAP_TILEGRID = fromString("LINZAntarticaMapTilegrid");
+        @Generated public static final TileMatrixSetId NZTM2000QUAD = fromString("NZTM2000Quad");
+        @Generated public static final TileMatrixSetId UPSANTARCTIC_WGS84QUAD = fromString("UPSAntarcticWGS84Quad");
+        @Generated public static final TileMatrixSetId UPSARCTIC_WGS84QUAD = fromString("UPSArcticWGS84Quad");
+        @Generated public static final TileMatrixSetId UTM31WGS84QUAD = fromString("UTM31WGS84Quad");
+        @Generated public static final TileMatrixSetId WGS1984QUAD = fromString("WGS1984Quad");
+        @Generated public static final TileMatrixSetId WEB_MERCATOR_QUAD = fromString("WebMercatorQuad");
+        @Generated public static final TileMatrixSetId WORLD_CRS84QUAD = fromString("WorldCRS84Quad");
+        @Generated public static final TileMatrixSetId WORLD_MERCATOR_WGS84QUAD = fromString("WorldMercatorWGS84Quad");
+        @Deprecated @Generated public TileMatrixSetId()
+        @Generated public static TileMatrixSetId fromString(String name)
+        @Generated public static Collection<TileMatrixSetId> values()
+    }
     @Immutable
-    public final class TileMatrixSetLimitsEntry implements JsonSerializable<TileMatrixSetLimitsEntry> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public int getMaxTileCol() 
-        @Generated public int getMaxTileRow() 
-        @Generated public int getMinTileCol() 
-        @Generated public int getMinTileRow() 
-        @Generated public String getTileMatrix() 
-    } 
+    public final class TileMatrixSetLimitsEntry implements JsonSerializable<TileMatrixSetLimitsEntry> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public int getMaxTileCol()
+        @Generated public int getMaxTileRow()
+        @Generated public int getMinTileCol()
+        @Generated public int getMinTileRow()
+        @Generated public String getTileMatrix()
+    }
     @Immutable
-    public final class TileSetBoundingBox implements JsonSerializable<TileSetBoundingBox> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public String getCrs() 
-        @Generated public List<Double> getLowerLeft() 
-        @Generated public List<Double> getUpperRight() 
-    } 
+    public final class TileSetBoundingBox implements JsonSerializable<TileSetBoundingBox> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public String getCrs()
+        @Generated public List<Double> getLowerLeft()
+        @Generated public List<Double> getUpperRight()
+    }
     @Immutable
-    public final class TileSetEntry implements JsonSerializable<TileSetEntry> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public String getAccessConstraints() 
-        @Generated public TileSetBoundingBox getBoundingBox() 
-        @Generated public String getCrs() 
-        @Generated public String getDataType() 
-        @Generated public List<TileSetLink> getLinks() 
-        @Generated public String getTitle() 
-    } 
+    public final class TileSetEntry implements JsonSerializable<TileSetEntry> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public String getAccessConstraints()
+        @Generated public TileSetBoundingBox getBoundingBox()
+        @Generated public String getCrs()
+        @Generated public String getDataType()
+        @Generated public List<TileSetLink> getLinks()
+        @Generated public String getTitle()
+    }
     @Immutable
-    public final class TileSetLink implements JsonSerializable<TileSetLink> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public String getHref() 
-        @Generated public String getRel() 
-        @Generated public String getTitle() 
-        @Generated public String getType() 
-    } 
+    public final class TileSetLink implements JsonSerializable<TileSetLink> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public String getHref()
+        @Generated public String getRel()
+        @Generated public String getTitle()
+        @Generated public String getType()
+    }
     @Immutable
-    public final class TileSetList implements JsonSerializable<TileSetList> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public List<TileSetEntry> getTilesets() 
-    } 
+    public final class TileSetList implements JsonSerializable<TileSetList> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public List<TileSetEntry> getTilesets()
+    }
     @Immutable
-    public final class TileSetMetadata implements JsonSerializable<TileSetMetadata> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public String getAccessConstraints() 
-        @Generated public TileSetBoundingBox getBoundingBox() 
-        @Generated public String getCrs() 
-        @Generated public String getDataType() 
-        @Generated public List<TileSetLink> getLinks() 
-        @Generated public List<TileMatrixSetLimitsEntry> getTileMatrixSetLimits() 
-        @Generated public String getTitle() 
-    } 
+    public final class TileSetMetadata implements JsonSerializable<TileSetMetadata> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public String getAccessConstraints()
+        @Generated public TileSetBoundingBox getBoundingBox()
+        @Generated public String getCrs()
+        @Generated public String getDataType()
+        @Generated public List<TileSetLink> getLinks()
+        @Generated public List<TileMatrixSetLimitsEntry> getTileMatrixSetLimits()
+        @Generated public String getTitle()
+    }
     @Fluent
-    public final class TileSettings implements JsonSerializable<TileSettings> { 
-        @Generated public TileSettings(int minZoom, int maxItemsPerTile) 
-        @Generated public DefaultLocation getDefaultLocation() 
-        @Generated public TileSettings setDefaultLocation(DefaultLocation defaultLocation) 
-        @Generated public int getMaxItemsPerTile() 
-        @Generated public int getMinZoom() 
-    } 
+    public final class TileSettings implements JsonSerializable<TileSettings> {
+        @Generated public TileSettings(int minZoom, int maxItemsPerTile)
+        @Generated public DefaultLocation getDefaultLocation()
+        @Generated public TileSettings setDefaultLocation(DefaultLocation defaultLocation)
+        @Generated public int getMaxItemsPerTile()
+        @Generated public int getMinZoom()
+    }
     @Immutable
-    public final class TilerAssetGeoJson implements JsonSerializable<TilerAssetGeoJson> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public Map<String, StacAsset> getAssets() 
-        @Generated public List<Double> getBoundingBox() 
-        @Generated public String getCollection() 
-        @Generated public String getId() 
-    } 
+    public final class TilerAssetGeoJson implements JsonSerializable<TilerAssetGeoJson> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public Map<String, StacAsset> getAssets()
+        @Generated public List<Double> getBoundingBox()
+        @Generated public String getCollection()
+        @Generated public String getId()
+    }
     @Immutable
-    public final class TilerCoreModelsResponsesPoint implements JsonSerializable<TilerCoreModelsResponsesPoint> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public List<String> getBandNames() 
-        @Generated public List<Double> getCoordinates() 
-        @Generated public List<Double> getValues() 
-    } 
-    public final class TilerImageFormat extends ExpandableStringEnum<TilerImageFormat> { 
-        @Generated public static final TilerImageFormat PNG = fromString("png"); 
-        @Generated public static final TilerImageFormat NPY = fromString("npy"); 
-        @Generated public static final TilerImageFormat TIF = fromString("tif"); 
-        @Generated public static final TilerImageFormat JPEG = fromString("jpeg"); 
-        @Generated public static final TilerImageFormat JPG = fromString("jpg"); 
-        @Generated public static final TilerImageFormat JP2 = fromString("jp2"); 
-        @Generated public static final TilerImageFormat WEBP = fromString("webp"); 
-        @Generated public static final TilerImageFormat PNGRAW = fromString("pngraw"); 
-        @Deprecated @Generated public TilerImageFormat() 
-        @Generated public static TilerImageFormat fromString(String name) 
-        @Generated public static Collection<TilerImageFormat> values() 
-    } 
+    public final class TilerCoreModelsResponsesPoint implements JsonSerializable<TilerCoreModelsResponsesPoint> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public List<String> getBandNames()
+        @Generated public List<Double> getCoordinates()
+        @Generated public List<Double> getValues()
+    }
+    public final class TilerImageFormat extends ExpandableStringEnum<TilerImageFormat> {
+        @Generated public static final TilerImageFormat PNG = fromString("png");
+        @Generated public static final TilerImageFormat NPY = fromString("npy");
+        @Generated public static final TilerImageFormat TIF = fromString("tif");
+        @Generated public static final TilerImageFormat JPEG = fromString("jpeg");
+        @Generated public static final TilerImageFormat JPG = fromString("jpg");
+        @Generated public static final TilerImageFormat JP2 = fromString("jp2");
+        @Generated public static final TilerImageFormat WEBP = fromString("webp");
+        @Generated public static final TilerImageFormat PNGRAW = fromString("pngraw");
+        @Deprecated @Generated public TilerImageFormat()
+        @Generated public static TilerImageFormat fromString(String name)
+        @Generated public static Collection<TilerImageFormat> values()
+    }
     @Immutable
-    public final class TilerInfo implements JsonSerializable<TilerInfo> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public List<List<String>> getBandDescriptions() 
-        @Generated public List<List<BinaryData>> getBandMetadata() 
-        @Generated public List<Double> getBounds() 
-        @Generated public List<String> getColorInterpretation() 
-        @Generated public Map<String, List<String>> getColormap() 
-        @Generated public String getCoordinateReferenceSystem() 
-        @Generated public Integer getCount() 
-        @Generated public String getDriver() 
-        @Generated public String getDtype() 
-        @Generated public Integer getHeight() 
-        @Generated public Integer getMaxZoom() 
-        @Generated public Integer getMinZoom() 
-        @Generated public NoDataType getNoDataType() 
-        @Generated public List<Integer> getOffsets() 
-        @Generated public List<Integer> getOverviews() 
-        @Generated public List<Integer> getScales() 
-        @Generated public Integer getWidth() 
-    } 
+    public final class TilerInfo implements JsonSerializable<TilerInfo> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public List<List<String>> getBandDescriptions()
+        @Generated public List<List<BinaryData>> getBandMetadata()
+        @Generated public List<Double> getBounds()
+        @Generated public List<String> getColorInterpretation()
+        @Generated public Map<String, List<String>> getColormap()
+        @Generated public String getCoordinateReferenceSystem()
+        @Generated public Integer getCount()
+        @Generated public String getDriver()
+        @Generated public String getDtype()
+        @Generated public Integer getHeight()
+        @Generated public Integer getMaxZoom()
+        @Generated public Integer getMinZoom()
+        @Generated public NoDataType getNoDataType()
+        @Generated public List<Integer> getOffsets()
+        @Generated public List<Integer> getOverviews()
+        @Generated public List<Integer> getScales()
+        @Generated public Integer getWidth()
+    }
     @Immutable
-    public final class TilerInfoGeoJsonFeature implements JsonSerializable<TilerInfoGeoJsonFeature> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public List<Double> getBoundingBox() 
-        @Generated public GeoJsonGeometry getGeometry() 
-        @Generated public String getId() 
-        @Generated public Map<String, TilerInfo> getProperties() 
-        @Generated public FeatureType getType() 
-    } 
+    public final class TilerInfoGeoJsonFeature implements JsonSerializable<TilerInfoGeoJsonFeature> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public List<Double> getBoundingBox()
+        @Generated public GeoJsonGeometry getGeometry()
+        @Generated public String getId()
+        @Generated public Map<String, TilerInfo> getProperties()
+        @Generated public FeatureType getType()
+    }
     @Immutable
-    public final class TilerInfoMapResponse implements JsonSerializable<TilerInfoMapResponse> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public Map<String, TilerInfo> getAdditionalProperties() 
-    } 
+    public final class TilerInfoMapResponse implements JsonSerializable<TilerInfoMapResponse> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public Map<String, TilerInfo> getAdditionalProperties()
+    }
     @Immutable
-    public final class TilerMosaicSearchRegistrationResponse implements JsonSerializable<TilerMosaicSearchRegistrationResponse> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public List<StacLink> getLinks() 
-        @Generated public String getSearchId() 
-    } 
+    public final class TilerMosaicSearchRegistrationResponse implements JsonSerializable<TilerMosaicSearchRegistrationResponse> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public List<StacLink> getLinks()
+        @Generated public String getSearchId()
+    }
     @Immutable
-    public final class TilerStacItemStatistics implements JsonSerializable<TilerStacItemStatistics> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public Map<String, BandStatistics> getAdditionalProperties() 
-    } 
+    public final class TilerStacItemStatistics implements JsonSerializable<TilerStacItemStatistics> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public Map<String, BandStatistics> getAdditionalProperties()
+    }
     @Immutable
-    public final class TilerStacSearchDefinition implements JsonSerializable<TilerStacSearchDefinition> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public String getHash() 
-        @Generated public OffsetDateTime getLastUsed() 
-        @Generated public MosaicMetadata getMetadata() 
-        @Generated public Map<String, BinaryData> getSearch() 
-        @Generated public int getUseCount() 
-    } 
+    public final class TilerStacSearchDefinition implements JsonSerializable<TilerStacSearchDefinition> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public String getHash()
+        @Generated public OffsetDateTime getLastUsed()
+        @Generated public MosaicMetadata getMetadata()
+        @Generated public Map<String, BinaryData> getSearch()
+        @Generated public int getUseCount()
+    }
     @Immutable
-    public final class TilerStacSearchRegistration implements JsonSerializable<TilerStacSearchRegistration> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public List<StacLink> getLinks() 
-        @Generated public TilerStacSearchDefinition getSearch() 
-    } 
+    public final class TilerStacSearchRegistration implements JsonSerializable<TilerStacSearchRegistration> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public List<StacLink> getLinks()
+        @Generated public TilerStacSearchDefinition getSearch()
+    }
     @Immutable
-    public final class UserCollectionSettings implements JsonSerializable<UserCollectionSettings> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public StacMosaicConfiguration getMosaicConfiguration() 
-        @Generated public TileSettings getTileSettings() 
-    } 
+    public final class UserCollectionSettings implements JsonSerializable<UserCollectionSettings> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public StacMosaicConfiguration getMosaicConfiguration()
+        @Generated public TileSettings getTileSettings()
+    }
     @Immutable
-    public final class VariableMatrixWidth implements JsonSerializable<VariableMatrixWidth> { 
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
-        @Generated public int getCoalesce() 
-        @Generated public int getMaxTileRow() 
-        @Generated public int getMinTileRow() 
-    } 
-    public final class WarpKernelResampling extends ExpandableStringEnum<WarpKernelResampling> { 
-        @Generated public static final WarpKernelResampling NEAREST = fromString("nearest"); 
-        @Generated public static final WarpKernelResampling BILINEAR = fromString("bilinear"); 
-        @Generated public static final WarpKernelResampling CUBIC = fromString("cubic"); 
-        @Generated public static final WarpKernelResampling CUBIC_SPLINE = fromString("cubic_spline"); 
-        @Generated public static final WarpKernelResampling LANCZOS = fromString("lanczos"); 
-        @Generated public static final WarpKernelResampling AVERAGE = fromString("average"); 
-        @Generated public static final WarpKernelResampling MODE = fromString("mode"); 
-        @Generated public static final WarpKernelResampling MAX = fromString("max"); 
-        @Generated public static final WarpKernelResampling MIN = fromString("min"); 
-        @Generated public static final WarpKernelResampling MED = fromString("med"); 
-        @Generated public static final WarpKernelResampling Q1 = fromString("q1"); 
-        @Generated public static final WarpKernelResampling Q3 = fromString("q3"); 
-        @Generated public static final WarpKernelResampling SUM = fromString("sum"); 
-        @Generated public static final WarpKernelResampling RMS = fromString("rms"); 
-        @Deprecated @Generated public WarpKernelResampling() 
-        @Generated public static WarpKernelResampling fromString(String name) 
-        @Generated public static Collection<WarpKernelResampling> values() 
-    } 
-} 
+    public final class VariableMatrixWidth implements JsonSerializable<VariableMatrixWidth> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Generated public int getCoalesce()
+        @Generated public int getMaxTileRow()
+        @Generated public int getMinTileRow()
+    }
+    public final class WarpKernelResampling extends ExpandableStringEnum<WarpKernelResampling> {
+        @Generated public static final WarpKernelResampling NEAREST = fromString("nearest");
+        @Generated public static final WarpKernelResampling BILINEAR = fromString("bilinear");
+        @Generated public static final WarpKernelResampling CUBIC = fromString("cubic");
+        @Generated public static final WarpKernelResampling CUBIC_SPLINE = fromString("cubic_spline");
+        @Generated public static final WarpKernelResampling LANCZOS = fromString("lanczos");
+        @Generated public static final WarpKernelResampling AVERAGE = fromString("average");
+        @Generated public static final WarpKernelResampling MODE = fromString("mode");
+        @Generated public static final WarpKernelResampling MAX = fromString("max");
+        @Generated public static final WarpKernelResampling MIN = fromString("min");
+        @Generated public static final WarpKernelResampling MED = fromString("med");
+        @Generated public static final WarpKernelResampling Q1 = fromString("q1");
+        @Generated public static final WarpKernelResampling Q3 = fromString("q3");
+        @Generated public static final WarpKernelResampling SUM = fromString("sum");
+        @Generated public static final WarpKernelResampling RMS = fromString("rms");
+        @Deprecated @Generated public WarpKernelResampling()
+        @Generated public static WarpKernelResampling fromString(String name)
+        @Generated public static Collection<WarpKernelResampling> values()
+    }
+}
 ```

--- a/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
+++ b/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
@@ -11,6 +11,7 @@ maven {
     name : Microsoft Azure SDK for Planetary Computer
     description : This package contains Microsoft Azure Planetary Computer client library.
     dependencies {
+        // compile scope
         com.azure:azure-core 1.59.0
         com.azure:azure-core-http-netty 1.16.6
     }
@@ -25,6 +26,8 @@ module com.azure.analytics.planetarycomputer {
 package com.azure.analytics.planetarycomputer {
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
     public final class DataAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         @Generated public Mono<ClassMapLegendResponse> getClassMapLegend(String classmapName)
         @Generated public Mono<ClassMapLegendResponse> getClassMapLegend(String classmapName, Integer trimStart, Integer trimEnd)
         @Generated public Mono<Response<BinaryData>> getClassMapLegendWithResponse(String classmapName, RequestOptions requestOptions)
@@ -278,6 +281,8 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
     public final class DataClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         @Generated public ClassMapLegendResponse getClassMapLegend(String classmapName)
         @Generated public ClassMapLegendResponse getClassMapLegend(String classmapName, Integer trimStart, Integer trimEnd)
         @Generated public Response<BinaryData> getClassMapLegendWithResponse(String classmapName, RequestOptions requestOptions)
@@ -531,6 +536,8 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
     public final class IngestionAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         @Generated public Mono<IngestionDefinition> get(String collectionId, String ingestionId)
         @Generated public PollerFlux<Operation, Void> beginDelete(String collectionId, String ingestionId)
         @Generated public PollerFlux<BinaryData, Void> beginDelete(String collectionId, String ingestionId, RequestOptions requestOptions)
@@ -573,6 +580,8 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
     public final class IngestionClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         @Generated public IngestionDefinition get(String collectionId, String ingestionId)
         @Generated public SyncPoller<Operation, Void> beginDelete(String collectionId, String ingestionId)
         @Generated public SyncPoller<BinaryData, Void> beginDelete(String collectionId, String ingestionId, RequestOptions requestOptions)
@@ -643,6 +652,8 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
     public final class SharedAccessSignatureAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         @Generated public Mono<Void> revokeToken()
         @Generated public Mono<Void> revokeToken(Integer durationInMinutes)
         @Generated public Mono<Response<Void>> revokeTokenWithResponse(RequestOptions requestOptions)
@@ -655,6 +666,8 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
     public final class SharedAccessSignatureClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         @Generated public void revokeToken()
         @Generated public void revokeToken(Integer durationInMinutes)
         @Generated public Response<Void> revokeTokenWithResponse(RequestOptions requestOptions)
@@ -667,6 +680,8 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
     public final class StacAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         @Generated public Mono<StacMosaic> addMosaic(String collectionId, StacMosaic body)
         @Generated public Mono<Response<BinaryData>> addMosaicWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
         @Generated public PollerFlux<Operation, Void> beginCreateCollection(StacCollection body)
@@ -748,6 +763,8 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
     public final class StacClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         @Generated public StacMosaic addMosaic(String collectionId, StacMosaic body)
         @Generated public Response<BinaryData> addMosaicWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
         @Generated public SyncPoller<Operation, Void> beginCreateCollection(StacCollection body)
@@ -840,10 +857,12 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class AssetStatisticsResponse implements JsonSerializable<AssetStatisticsResponse> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BandStatisticsMap> getAdditionalProperties()
     }
     @Immutable
     public final class BandStatistics implements JsonSerializable<BandStatistics> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public double getCount()
         @Generated public List<List<Double>> getHistogram()
         @Generated public double getMajority()
@@ -863,10 +882,12 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class BandStatisticsMap implements JsonSerializable<BandStatisticsMap> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BandStatistics> getAdditionalProperties()
     }
     @Immutable
     public final class ClassMapLegendResponse implements JsonSerializable<ClassMapLegendResponse> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BinaryData> getAdditionalProperties()
     }
     public final class ColorMapNames extends ExpandableStringEnum<ColorMapNames> {
@@ -1142,6 +1163,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class ErrorInfo implements JsonSerializable<ErrorInfo> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public ResponseError getError()
     }
     public final class FeatureType extends ExpandableStringEnum<FeatureType> {
@@ -1274,6 +1296,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class IngestionRun implements JsonSerializable<IngestionRun> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public OffsetDateTime getCreationTime()
         @Generated public String getId()
         @Generated public Boolean isKeepOriginalAssets()
@@ -1284,6 +1307,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class IngestionRunOperation implements JsonSerializable<IngestionRunOperation> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public OffsetDateTime getCreationTime()
         @Generated public OffsetDateTime getFinishTime()
         @Generated public String getId()
@@ -1304,6 +1328,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class IngestionSourceSummary implements JsonSerializable<IngestionSourceSummary> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public OffsetDateTime getCreated()
         @Generated public String getId()
         @Generated public IngestionSourceType getKind()
@@ -1354,6 +1379,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class ManagedIdentityMetadata implements JsonSerializable<ManagedIdentityMetadata> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getObjectId()
         @Generated public String getResourceId()
     }
@@ -1394,6 +1420,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class Operation implements JsonSerializable<Operation> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, String> getAdditionalInformation()
         @Generated public String getCollectionId()
         @Generated public OffsetDateTime getCreationTime()
@@ -1418,6 +1445,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class OperationStatusHistoryItem implements JsonSerializable<OperationStatusHistoryItem> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getErrorCode()
         @Generated public String getErrorMessage()
         @Generated public OperationStatus getStatus()
@@ -1453,6 +1481,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class QueryableDefinitionsResponse implements JsonSerializable<QueryableDefinitionsResponse> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BinaryData> getAdditionalProperties()
     }
     @Fluent
@@ -1579,11 +1608,13 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class SharedAccessSignatureSignedLink implements JsonSerializable<SharedAccessSignatureSignedLink> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public OffsetDateTime getExpiresOn()
         @Generated public String getHref()
     }
     @Immutable
     public final class SharedAccessSignatureToken implements JsonSerializable<SharedAccessSignatureToken> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public OffsetDateTime getExpiresOn()
         @Generated public String getToken()
     }
@@ -1650,6 +1681,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacCatalogCollections implements JsonSerializable<StacCatalogCollections> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<StacCollection> getCollections()
         @Generated public List<StacLink> getLinks()
     }
@@ -1695,6 +1727,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacConformanceClasses implements JsonSerializable<StacConformanceClasses> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<String> getConformsTo()
     }
     @Fluent
@@ -1779,6 +1812,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacItemBounds implements JsonSerializable<StacItemBounds> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<Double> getBounds()
     }
     @Fluent
@@ -1819,6 +1853,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacItemPointAsset implements JsonSerializable<StacItemPointAsset> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, StacAsset> getAssets()
         @Generated public List<Double> getBoundingBox()
         @Generated public String getCollectionId()
@@ -1858,17 +1893,20 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacItemStatisticsGeoJson implements JsonSerializable<StacItemStatisticsGeoJson> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public GeoJsonGeometry getGeometry()
         @Generated public StacItemStatisticsGeoJsonProperties getProperties()
         @Generated public FeatureType getType()
     }
     @Immutable
     public final class StacItemStatisticsGeoJsonProperties implements JsonSerializable<StacItemStatisticsGeoJsonProperties> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BinaryData> getAdditionalProperties()
         @Generated public Map<String, BandStatistics> getStatistics()
     }
     @Immutable
     public final class StacLandingPage implements JsonSerializable<StacLandingPage> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<String> getConformsTo()
         @Generated public OffsetDateTime getCreatedOn()
         @Generated public String getDescription()
@@ -1948,6 +1986,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacMosaicConfiguration implements JsonSerializable<StacMosaicConfiguration> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BinaryData> getDefaultCustomQuery()
         @Generated public DefaultLocation getDefaultLocation()
         @Generated public List<StacMosaic> getMosaics()
@@ -2059,6 +2098,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileJsonMetadata implements JsonSerializable<TileJsonMetadata> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getAttribution()
         @Generated public List<Double> getBounds()
         @Generated public List<Double> getCenter()
@@ -2077,6 +2117,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileMatrix implements JsonSerializable<TileMatrix> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public double getCellSize()
         @Generated public TileMatrixCornerOfOrigin getCornerOfOrigin()
         @Generated public String getDescription()
@@ -2100,6 +2141,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileMatrixSet implements JsonSerializable<TileMatrixSet> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public TileMatrixSetBoundingBox getBoundingBox()
         @Generated public String getCrs()
         @Generated public String getDescription()
@@ -2113,6 +2155,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileMatrixSetBoundingBox implements JsonSerializable<TileMatrixSetBoundingBox> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getCrs()
         @Generated public List<String> getLowerLeft()
         @Generated public List<String> getOrderedAxes()
@@ -2136,6 +2179,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileMatrixSetLimitsEntry implements JsonSerializable<TileMatrixSetLimitsEntry> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public int getMaxTileCol()
         @Generated public int getMaxTileRow()
         @Generated public int getMinTileCol()
@@ -2144,12 +2188,14 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileSetBoundingBox implements JsonSerializable<TileSetBoundingBox> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getCrs()
         @Generated public List<Double> getLowerLeft()
         @Generated public List<Double> getUpperRight()
     }
     @Immutable
     public final class TileSetEntry implements JsonSerializable<TileSetEntry> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getAccessConstraints()
         @Generated public TileSetBoundingBox getBoundingBox()
         @Generated public String getCrs()
@@ -2159,6 +2205,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileSetLink implements JsonSerializable<TileSetLink> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getHref()
         @Generated public String getRel()
         @Generated public String getTitle()
@@ -2166,10 +2213,12 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileSetList implements JsonSerializable<TileSetList> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<TileSetEntry> getTilesets()
     }
     @Immutable
     public final class TileSetMetadata implements JsonSerializable<TileSetMetadata> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getAccessConstraints()
         @Generated public TileSetBoundingBox getBoundingBox()
         @Generated public String getCrs()
@@ -2188,6 +2237,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerAssetGeoJson implements JsonSerializable<TilerAssetGeoJson> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, StacAsset> getAssets()
         @Generated public List<Double> getBoundingBox()
         @Generated public String getCollection()
@@ -2195,6 +2245,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerCoreModelsResponsesPoint implements JsonSerializable<TilerCoreModelsResponsesPoint> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<String> getBandNames()
         @Generated public List<Double> getCoordinates()
         @Generated public List<Double> getValues()
@@ -2214,6 +2265,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerInfo implements JsonSerializable<TilerInfo> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<List<String>> getBandDescriptions()
         @Generated public List<List<BinaryData>> getBandMetadata()
         @Generated public List<Double> getBounds()
@@ -2234,6 +2286,7 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerInfoGeoJsonFeature implements JsonSerializable<TilerInfoGeoJsonFeature> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<Double> getBoundingBox()
         @Generated public GeoJsonGeometry getGeometry()
         @Generated public String getId()
@@ -2242,19 +2295,23 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerInfoMapResponse implements JsonSerializable<TilerInfoMapResponse> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, TilerInfo> getAdditionalProperties()
     }
     @Immutable
     public final class TilerMosaicSearchRegistrationResponse implements JsonSerializable<TilerMosaicSearchRegistrationResponse> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<StacLink> getLinks()
         @Generated public String getSearchId()
     }
     @Immutable
     public final class TilerStacItemStatistics implements JsonSerializable<TilerStacItemStatistics> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BandStatistics> getAdditionalProperties()
     }
     @Immutable
     public final class TilerStacSearchDefinition implements JsonSerializable<TilerStacSearchDefinition> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getHash()
         @Generated public OffsetDateTime getLastUsed()
         @Generated public MosaicMetadata getMetadata()
@@ -2263,16 +2320,19 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerStacSearchRegistration implements JsonSerializable<TilerStacSearchRegistration> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<StacLink> getLinks()
         @Generated public TilerStacSearchDefinition getSearch()
     }
     @Immutable
     public final class UserCollectionSettings implements JsonSerializable<UserCollectionSettings> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public StacMosaicConfiguration getMosaicConfiguration()
         @Generated public TileSettings getTileSettings()
     }
     @Immutable
     public final class VariableMatrixWidth implements JsonSerializable<VariableMatrixWidth> {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public int getCoalesce()
         @Generated public int getMaxTileRow()
         @Generated public int getMinTileRow()

--- a/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
+++ b/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
@@ -1,0 +1,2360 @@
+```java
+maven { 
+    parent : com.azure:azure-client-sdk-parent:1.7.0 
+    properties : com.azure:azure-analytics-planetarycomputer:1.1.0-beta.1 
+    configuration { 
+        jacoco { 
+            min-line-coverage : 0.2 
+            min-branch-coverage : 0.05 
+        } 
+    } 
+    name : Microsoft Azure SDK for Planetary Computer 
+    description : This package contains Microsoft Azure Planetary Computer client library. 
+    dependencies { 
+        // compile scope 
+        com.azure:azure-core 1.59.0 
+        com.azure:azure-core-http-netty 1.16.6 
+    } 
+} 
+module com.azure.analytics.planetarycomputer { 
+    requires transitive com.azure.core;
+    exports com.azure.analytics.planetarycomputer;
+    exports com.azure.analytics.planetarycomputer.models;
+    opens com.azure.analytics.planetarycomputer.models to com.azure.core;
+    opens com.azure.analytics.planetarycomputer.implementation.models to com.azure.core;
+} 
+package com.azure.analytics.planetarycomputer { 
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true) 
+    public final class DataAsyncClient { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        // Service Methods: 
+        @Generated public Mono<ClassMapLegendResponse> getClassMapLegend(String classmapName) 
+        @Generated public Mono<ClassMapLegendResponse> getClassMapLegend(String classmapName, Integer trimStart, Integer trimEnd) 
+        @Generated public Mono<Response<BinaryData>> getClassMapLegendWithResponse(String classmapName, RequestOptions requestOptions) 
+        @Generated public Mono<List<BinaryData>> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy) 
+        @Generated public Mono<List<BinaryData>> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
+        @Generated public Mono<Response<BinaryData>> getCollectionAssetsForBboxWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions) 
+        @Generated public Mono<List<BinaryData>> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y) 
+        @Generated public Mono<List<BinaryData>> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId) 
+        @Generated public Mono<Response<BinaryData>> getCollectionAssetsForTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public Mono<List<TilerAssetGeoJson>> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y) 
+        @Generated public Mono<List<TilerAssetGeoJson>> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getCollectionAssetsForTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format) 
+        @Generated public Mono<BinaryData> getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
+        @Generated public Mono<BinaryData> getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
+        @Generated public Mono<BinaryData> getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
+        @Generated public Mono<Response<BinaryData>> getCollectionBboxCropWithDimensionsWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getCollectionBboxCropWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
+        @Generated public Mono<TilerStacSearchRegistration> getCollectionInfo(String collectionId) 
+        @Generated public Mono<Response<BinaryData>> getCollectionInfoWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getCollectionPoint(String collectionId, double longitude, double latitude) 
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getCollectionPoint(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling) 
+        @Generated public Mono<List<StacItemPointAsset>> getCollectionPointAssets(String collectionId, double longitude, double latitude) 
+        @Generated public Mono<List<StacItemPointAsset>> getCollectionPointAssets(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
+        @Generated public Mono<Response<BinaryData>> getCollectionPointAssetsWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getCollectionPointWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions) 
+        @Generated public Mono<TileJsonMetadata> getCollectionTileJson(String collectionId) 
+        @Generated public Mono<TileJsonMetadata> getCollectionTileJson(String collectionId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTileJsonWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<TileJsonMetadata> getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId) 
+        @Generated public Mono<TileJsonMetadata> getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTileJsonWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getCollectionTileNoTms(String collectionId, double z, double x, double y) 
+        @Generated public Mono<BinaryData> getCollectionTileNoTms(String collectionId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format) 
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsByFormatWithResponse(String collectionId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale) 
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format) 
+        @Generated public Mono<BinaryData> getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsByScaleAndFormatWithResponse(String collectionId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsByScaleWithResponse(String collectionId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public Mono<TileSetMetadata> getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId) 
+        @Generated public Mono<TileSetMetadata> getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTilesetMetadataWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public Mono<TileSetList> getCollectionTilesets(String collectionId) 
+        @Generated public Mono<TileSetList> getCollectionTilesets(String collectionId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTilesetsWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y) 
+        @Generated public Mono<BinaryData> getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format) 
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsByFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale) 
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
+        @Generated public Mono<BinaryData> getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsByScaleAndFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsByScaleWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getCollectionTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public Mono<byte[]> getCollectionWmtsCapabilities(String collectionId) 
+        @Generated public Mono<byte[]> getCollectionWmtsCapabilities(String collectionId, String ids, String bbox, String query, String sortby, String datetime, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
+        @Generated public Mono<Response<BinaryData>> getCollectionWmtsCapabilitiesWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<byte[]> getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId) 
+        @Generated public Mono<byte[]> getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
+        @Generated public Mono<Response<BinaryData>> getCollectionWmtsCapabilitiesWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> cropCollectionFeature(String collectionId, GeoJsonFeature body) 
+        @Generated public Mono<BinaryData> cropCollectionFeature(String collectionId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format) 
+        @Generated public Mono<BinaryData> cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body) 
+        @Generated public Mono<BinaryData> cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
+        @Generated public Mono<Response<BinaryData>> cropCollectionFeatureByFormatWithResponse(String collectionId, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body) 
+        @Generated public Mono<BinaryData> cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
+        @Generated public Mono<Response<BinaryData>> cropCollectionFeatureWidthByHeightWithResponse(String collectionId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> cropCollectionFeatureWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> cropFeature(String collectionId, String itemId, GeoJsonFeature body) 
+        @Generated public Mono<BinaryData> cropFeature(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TilerImageFormat format) 
+        @Generated public Mono<BinaryData> cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body) 
+        @Generated public Mono<BinaryData> cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> cropFeatureByFormatWithResponse(String collectionId, String itemId, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body) 
+        @Generated public Mono<BinaryData> cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> cropFeatureWidthByHeightWithResponse(String collectionId, String itemId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> cropFeatureWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> cropSearchFeature(String searchId, GeoJsonFeature body) 
+        @Generated public Mono<BinaryData> cropSearchFeature(String searchId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format) 
+        @Generated public Mono<BinaryData> cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body) 
+        @Generated public Mono<BinaryData> cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
+        @Generated public Mono<Response<BinaryData>> cropSearchFeatureByFormatWithResponse(String searchId, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body) 
+        @Generated public Mono<BinaryData> cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
+        @Generated public Mono<Response<BinaryData>> cropSearchFeatureWidthByHeightWithResponse(String searchId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> cropSearchFeatureWithResponse(String searchId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<List<List<List<Long>>>> getIntervalLegend(String classmapName) 
+        @Generated public Mono<List<List<List<Long>>>> getIntervalLegend(String classmapName, Integer trimStart, Integer trimEnd) 
+        @Generated public Mono<Response<BinaryData>> getIntervalLegendWithResponse(String classmapName, RequestOptions requestOptions) 
+        @Generated public Mono<AssetStatisticsResponse> getItemAssetStatistics(String collectionId, String itemId) 
+        @Generated public Mono<AssetStatisticsResponse> getItemAssetStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, List<String> assetBandIndices, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assetExpression, Integer height, Integer width) 
+        @Generated public Mono<Response<BinaryData>> getItemAssetStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Mono<List<String>> getItemAvailableAssets(String collectionId, String itemId) 
+        @Generated public Mono<List<String>> getItemAvailableAssets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getItemAvailableAssetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format) 
+        @Generated public Mono<BinaryData> getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<BinaryData> getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
+        @Generated public Mono<BinaryData> getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getItemBboxCropWithDimensionsWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getItemBboxCropWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
+        @Generated public Mono<StacItemBounds> getItemBounds(String collectionId, String itemId) 
+        @Generated public Mono<StacItemBounds> getItemBounds(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getItemBoundsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Mono<StacItemStatisticsGeoJson> getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body) 
+        @Generated public Mono<StacItemStatisticsGeoJson> getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width) 
+        @Generated public Mono<Response<BinaryData>> getItemFeatureStatisticsWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<TilerInfoMapResponse> getItemInfo(String collectionId, String itemId) 
+        @Generated public Mono<TilerInfoMapResponse> getItemInfo(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets) 
+        @Generated public Mono<TilerInfoGeoJsonFeature> getItemInfoGeoJson(String collectionId, String itemId) 
+        @Generated public Mono<TilerInfoGeoJsonFeature> getItemInfoGeoJson(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets) 
+        @Generated public Mono<Response<BinaryData>> getItemInfoGeoJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getItemInfoWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getItemPoint(String collectionId, String itemId, double longitude, double latitude) 
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getItemPoint(String collectionId, String itemId, double longitude, double latitude, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem, Resampling resampling) 
+        @Generated public Mono<Response<BinaryData>> getItemPointWithResponse(String collectionId, String itemId, double longitude, double latitude, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getItemPreview(String collectionId, String itemId) 
+        @Generated public Mono<BinaryData> getItemPreview(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<BinaryData> getItemPreviewWithFormat(String collectionId, String itemId, String format) 
+        @Generated public Mono<BinaryData> getItemPreviewWithFormat(String collectionId, String itemId, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getItemPreviewWithFormatWithResponse(String collectionId, String itemId, String format, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getItemPreviewWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Mono<TilerStacItemStatistics> getItemStatistics(String collectionId, String itemId) 
+        @Generated public Mono<TilerStacItemStatistics> getItemStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width) 
+        @Generated public Mono<Response<BinaryData>> getItemStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Mono<TileJsonMetadata> getItemTileJson(String collectionId, String itemId) 
+        @Generated public Mono<TileJsonMetadata> getItemTileJson(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getItemTileJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Mono<TileJsonMetadata> getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId) 
+        @Generated public Mono<TileJsonMetadata> getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getItemTileJsonWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public Mono<byte[]> getItemWmtsCapabilities(String collectionId, String itemId) 
+        @Generated public Mono<byte[]> getItemWmtsCapabilities(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getItemWmtsCapabilitiesWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Mono<byte[]> getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId) 
+        @Generated public Mono<byte[]> getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getItemWmtsCapabilitiesWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getLegend(String colorMapName) 
+        @Generated public Mono<BinaryData> getLegend(String colorMapName, Double height, Double width, Integer trimStart, Integer trimEnd) 
+        @Generated public Mono<Response<BinaryData>> getLegendWithResponse(String colorMapName, RequestOptions requestOptions) 
+        @Generated public Mono<TilerMosaicSearchRegistrationResponse> registerMosaicsSearch(RegisterMosaicsSearchOptions options) 
+        @Generated public Mono<Response<BinaryData>> registerMosaicsSearchWithResponse(BinaryData registerMosaicsSearchRequest, RequestOptions requestOptions) 
+        @Generated public Mono<List<BinaryData>> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y) 
+        @Generated public Mono<List<BinaryData>> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId) 
+        @Generated public Mono<Response<BinaryData>> getSearchAssetsForTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public Mono<List<TilerAssetGeoJson>> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y) 
+        @Generated public Mono<List<TilerAssetGeoJson>> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getSearchAssetsForTileWithTmsWithResponse(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public Mono<List<BinaryData>> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy) 
+        @Generated public Mono<List<BinaryData>> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
+        @Generated public Mono<Response<BinaryData>> getSearchBboxAssetsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format) 
+        @Generated public Mono<BinaryData> getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
+        @Generated public Mono<BinaryData> getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
+        @Generated public Mono<BinaryData> getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
+        @Generated public Mono<Response<BinaryData>> getSearchBboxCropWithDimensionsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getSearchBboxCropWithResponse(String searchId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
+        @Generated public Mono<TilerStacSearchRegistration> getSearchInfo(String searchId) 
+        @Generated public Mono<Response<BinaryData>> getSearchInfoWithResponse(String searchId, RequestOptions requestOptions) 
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getSearchPoint(String searchId, double longitude, double latitude) 
+        @Generated public Mono<TilerCoreModelsResponsesPoint> getSearchPoint(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling) 
+        @Generated public Mono<List<StacItemPointAsset>> getSearchPointWithAssets(String searchId, double longitude, double latitude) 
+        @Generated public Mono<List<StacItemPointAsset>> getSearchPointWithAssets(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
+        @Generated public Mono<Response<BinaryData>> getSearchPointWithAssetsWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getSearchPointWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions) 
+        @Generated public Mono<TileJsonMetadata> getSearchTileJson(String searchId) 
+        @Generated public Mono<TileJsonMetadata> getSearchTileJson(String searchId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Integer padding, Double buffer, String colorFormula, String collectionId, Resampling resampling, PixelSelection pixelSelection, TerrainAlgorithm algorithm, String algorithmParams, List<String> rescale, ColorMapNames colormapName, String colormap, Boolean returnMask) 
+        @Generated public Mono<Response<BinaryData>> getSearchTileJsonWithResponse(String searchId, RequestOptions requestOptions) 
+        @Generated public Mono<TileJsonMetadata> getSearchTileJsonWithTms(String searchId, String tileMatrixSetId) 
+        @Generated public Mono<TileJsonMetadata> getSearchTileJsonWithTms(String searchId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer minZoom, Integer maxZoom, TilerImageFormat tileFormat, Integer tileScale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<Response<BinaryData>> getSearchTileJsonWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getSearchTileNoTms(String searchId, double z, double x, double y) 
+        @Generated public Mono<BinaryData> getSearchTileNoTms(String searchId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format) 
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsByFormatWithResponse(String searchId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale) 
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format) 
+        @Generated public Mono<BinaryData> getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsByScaleAndFormatWithResponse(String searchId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsByScaleWithResponse(String searchId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getSearchTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public Mono<TileSetMetadata> getSearchTilesetMetadata(String searchId, String tileMatrixSetId) 
+        @Generated public Mono<TileSetMetadata> getSearchTilesetMetadata(String searchId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getSearchTilesetMetadataWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public Mono<TileSetList> getSearchTilesets(String searchId) 
+        @Generated public Mono<TileSetList> getSearchTilesets(String searchId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getSearchTilesetsWithResponse(String searchId, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y) 
+        @Generated public Mono<BinaryData> getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format) 
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsByFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale) 
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
+        @Generated public Mono<BinaryData> getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsByScaleAndFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsByScaleWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getSearchTileWithTmsWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public Mono<byte[]> getSearchWmtsCapabilities(String searchId) 
+        @Generated public Mono<byte[]> getSearchWmtsCapabilities(String searchId, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
+        @Generated public Mono<Response<BinaryData>> getSearchWmtsCapabilitiesWithResponse(String searchId, RequestOptions requestOptions) 
+        @Generated public Mono<byte[]> getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId) 
+        @Generated public Mono<byte[]> getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
+        @Generated public Mono<Response<BinaryData>> getSearchWmtsCapabilitiesWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public Mono<List<String>> getTileMatrices() 
+        @Generated public Mono<Response<BinaryData>> getTileMatricesWithResponse(RequestOptions requestOptions) 
+        @Generated public Mono<TileMatrixSet> getTileMatrixDefinitions(String tileMatrixSetId) 
+        @Generated public Mono<Response<BinaryData>> getTileMatrixDefinitionsWithResponse(String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getTileNoTms(String collectionId, String itemId, double z, double x, double y) 
+        @Generated public Mono<BinaryData> getTileNoTms(String collectionId, String itemId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<BinaryData> getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format) 
+        @Generated public Mono<BinaryData> getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getTileNoTmsByFormatWithResponse(String collectionId, String itemId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale) 
+        @Generated public Mono<BinaryData> getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<BinaryData> getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format) 
+        @Generated public Mono<BinaryData> getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getTileNoTmsByScaleAndFormatWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getTileNoTmsByScaleWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getTileNoTmsWithResponse(String collectionId, String itemId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public Mono<TileSetMetadata> getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId) 
+        @Generated public Mono<TileSetMetadata> getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getTilesetMetadataWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public Mono<TileSetList> getTilesets(String collectionId, String itemId) 
+        @Generated public Mono<TileSetList> getTilesets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getTilesetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y) 
+        @Generated public Mono<BinaryData> getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<BinaryData> getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format) 
+        @Generated public Mono<BinaryData> getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getTileWithTmsByFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale) 
+        @Generated public Mono<BinaryData> getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<BinaryData> getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
+        @Generated public Mono<BinaryData> getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Mono<Response<BinaryData>> getTileWithTmsByScaleAndFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getTileWithTmsByScaleWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getTileWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
+    } 
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder) 
+    public final class DataClient { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        // Service Methods: 
+        @Generated public ClassMapLegendResponse getClassMapLegend(String classmapName) 
+        @Generated public ClassMapLegendResponse getClassMapLegend(String classmapName, Integer trimStart, Integer trimEnd) 
+        @Generated public Response<BinaryData> getClassMapLegendWithResponse(String classmapName, RequestOptions requestOptions) 
+        @Generated public List<BinaryData> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy) 
+        @Generated public List<BinaryData> getCollectionAssetsForBbox(String collectionId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
+        @Generated public Response<BinaryData> getCollectionAssetsForBboxWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions) 
+        @Generated public List<BinaryData> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y) 
+        @Generated public List<BinaryData> getCollectionAssetsForTileNoTms(String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId) 
+        @Generated public Response<BinaryData> getCollectionAssetsForTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public List<TilerAssetGeoJson> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y) 
+        @Generated public List<TilerAssetGeoJson> getCollectionAssetsForTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getCollectionAssetsForTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public BinaryData getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format) 
+        @Generated public BinaryData getCollectionBboxCrop(String collectionId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
+        @Generated public BinaryData getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
+        @Generated public BinaryData getCollectionBboxCropWithDimensions(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
+        @Generated public Response<BinaryData> getCollectionBboxCropWithDimensionsWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getCollectionBboxCropWithResponse(String collectionId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
+        @Generated public TilerStacSearchRegistration getCollectionInfo(String collectionId) 
+        @Generated public Response<BinaryData> getCollectionInfoWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public TilerCoreModelsResponsesPoint getCollectionPoint(String collectionId, double longitude, double latitude) 
+        @Generated public TilerCoreModelsResponsesPoint getCollectionPoint(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling) 
+        @Generated public List<StacItemPointAsset> getCollectionPointAssets(String collectionId, double longitude, double latitude) 
+        @Generated public List<StacItemPointAsset> getCollectionPointAssets(String collectionId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
+        @Generated public Response<BinaryData> getCollectionPointAssetsWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getCollectionPointWithResponse(String collectionId, double longitude, double latitude, RequestOptions requestOptions) 
+        @Generated public TileJsonMetadata getCollectionTileJson(String collectionId) 
+        @Generated public TileJsonMetadata getCollectionTileJson(String collectionId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Response<BinaryData> getCollectionTileJsonWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public TileJsonMetadata getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId) 
+        @Generated public TileJsonMetadata getCollectionTileJsonWithTms(String collectionId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Response<BinaryData> getCollectionTileJsonWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public BinaryData getCollectionTileNoTms(String collectionId, double z, double x, double y) 
+        @Generated public BinaryData getCollectionTileNoTms(String collectionId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public BinaryData getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format) 
+        @Generated public BinaryData getCollectionTileNoTmsByFormat(String collectionId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Response<BinaryData> getCollectionTileNoTmsByFormatWithResponse(String collectionId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public BinaryData getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale) 
+        @Generated public BinaryData getCollectionTileNoTmsByScale(String collectionId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public BinaryData getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format) 
+        @Generated public BinaryData getCollectionTileNoTmsByScaleAndFormat(String collectionId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Response<BinaryData> getCollectionTileNoTmsByScaleAndFormatWithResponse(String collectionId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getCollectionTileNoTmsByScaleWithResponse(String collectionId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getCollectionTileNoTmsWithResponse(String collectionId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public TileSetMetadata getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId) 
+        @Generated public TileSetMetadata getCollectionTilesetMetadata(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getCollectionTilesetMetadataWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public TileSetList getCollectionTilesets(String collectionId) 
+        @Generated public TileSetList getCollectionTilesets(String collectionId, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getCollectionTilesetsWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public BinaryData getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y) 
+        @Generated public BinaryData getCollectionTileWithTms(String collectionId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public BinaryData getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format) 
+        @Generated public BinaryData getCollectionTileWithTmsByFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Response<BinaryData> getCollectionTileWithTmsByFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public BinaryData getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale) 
+        @Generated public BinaryData getCollectionTileWithTmsByScale(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public BinaryData getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
+        @Generated public BinaryData getCollectionTileWithTmsByScaleAndFormat(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Response<BinaryData> getCollectionTileWithTmsByScaleAndFormatWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getCollectionTileWithTmsByScaleWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getCollectionTileWithTmsWithResponse(String collectionId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public byte[] getCollectionWmtsCapabilities(String collectionId) 
+        @Generated public byte[] getCollectionWmtsCapabilities(String collectionId, String ids, String bbox, String query, String sortby, String datetime, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
+        @Generated public Response<BinaryData> getCollectionWmtsCapabilitiesWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public byte[] getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId) 
+        @Generated public byte[] getCollectionWmtsCapabilitiesWithTms(String collectionId, String tileMatrixSetId, String ids, String bbox, String query, String sortby, String datetime, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
+        @Generated public Response<BinaryData> getCollectionWmtsCapabilitiesWithTmsWithResponse(String collectionId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public BinaryData cropCollectionFeature(String collectionId, GeoJsonFeature body) 
+        @Generated public BinaryData cropCollectionFeature(String collectionId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format) 
+        @Generated public BinaryData cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body) 
+        @Generated public BinaryData cropCollectionFeatureByFormat(String collectionId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
+        @Generated public Response<BinaryData> cropCollectionFeatureByFormatWithResponse(String collectionId, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public BinaryData cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body) 
+        @Generated public BinaryData cropCollectionFeatureWidthByHeight(String collectionId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String ids, String bbox, String query, String sortby, String datetime, String subdatasetName, List<Integer> subdatasetBands, String crs, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
+        @Generated public Response<BinaryData> cropCollectionFeatureWidthByHeightWithResponse(String collectionId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> cropCollectionFeatureWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public BinaryData cropFeature(String collectionId, String itemId, GeoJsonFeature body) 
+        @Generated public BinaryData cropFeature(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TilerImageFormat format) 
+        @Generated public BinaryData cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body) 
+        @Generated public BinaryData cropFeatureByFormat(String collectionId, String itemId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> cropFeatureByFormatWithResponse(String collectionId, String itemId, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public BinaryData cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body) 
+        @Generated public BinaryData cropFeatureWidthByHeight(String collectionId, String itemId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> cropFeatureWidthByHeightWithResponse(String collectionId, String itemId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> cropFeatureWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public BinaryData cropSearchFeature(String searchId, GeoJsonFeature body) 
+        @Generated public BinaryData cropSearchFeature(String searchId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs, TilerImageFormat format) 
+        @Generated public BinaryData cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body) 
+        @Generated public BinaryData cropSearchFeatureByFormat(String searchId, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
+        @Generated public Response<BinaryData> cropSearchFeatureByFormatWithResponse(String searchId, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public BinaryData cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body) 
+        @Generated public BinaryData cropSearchFeatureWidthByHeight(String searchId, int width, int height, String format, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String destinationCrs) 
+        @Generated public Response<BinaryData> cropSearchFeatureWidthByHeightWithResponse(String searchId, int width, int height, String format, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> cropSearchFeatureWithResponse(String searchId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public List<List<List<Long>>> getIntervalLegend(String classmapName) 
+        @Generated public List<List<List<Long>>> getIntervalLegend(String classmapName, Integer trimStart, Integer trimEnd) 
+        @Generated public Response<BinaryData> getIntervalLegendWithResponse(String classmapName, RequestOptions requestOptions) 
+        @Generated public AssetStatisticsResponse getItemAssetStatistics(String collectionId, String itemId) 
+        @Generated public AssetStatisticsResponse getItemAssetStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, List<String> assetBandIndices, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assetExpression, Integer height, Integer width) 
+        @Generated public Response<BinaryData> getItemAssetStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public List<String> getItemAvailableAssets(String collectionId, String itemId) 
+        @Generated public List<String> getItemAvailableAssets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getItemAvailableAssetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public BinaryData getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format) 
+        @Generated public BinaryData getItemBboxCrop(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public BinaryData getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
+        @Generated public BinaryData getItemBboxCropWithDimensions(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String coordinateReferenceSystem, String destinationCrs, Resampling resampling, Integer maxSize, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getItemBboxCropWithDimensionsWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getItemBboxCropWithResponse(String collectionId, String itemId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
+        @Generated public StacItemBounds getItemBounds(String collectionId, String itemId) 
+        @Generated public StacItemBounds getItemBounds(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getItemBoundsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public StacItemStatisticsGeoJson getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body) 
+        @Generated public StacItemStatisticsGeoJson getItemFeatureStatistics(String collectionId, String itemId, GeoJsonFeature body, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String destinationCrs, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width) 
+        @Generated public Response<BinaryData> getItemFeatureStatisticsWithResponse(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public TilerInfoMapResponse getItemInfo(String collectionId, String itemId) 
+        @Generated public TilerInfoMapResponse getItemInfo(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets) 
+        @Generated public TilerInfoGeoJsonFeature getItemInfoGeoJson(String collectionId, String itemId) 
+        @Generated public TilerInfoGeoJsonFeature getItemInfoGeoJson(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<String> assets) 
+        @Generated public Response<BinaryData> getItemInfoGeoJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getItemInfoWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public TilerCoreModelsResponsesPoint getItemPoint(String collectionId, String itemId, double longitude, double latitude) 
+        @Generated public TilerCoreModelsResponsesPoint getItemPoint(String collectionId, String itemId, double longitude, double latitude, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem, Resampling resampling) 
+        @Generated public Response<BinaryData> getItemPointWithResponse(String collectionId, String itemId, double longitude, double latitude, RequestOptions requestOptions) 
+        @Generated public BinaryData getItemPreview(String collectionId, String itemId) 
+        @Generated public BinaryData getItemPreview(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public BinaryData getItemPreviewWithFormat(String collectionId, String itemId, String format) 
+        @Generated public BinaryData getItemPreviewWithFormat(String collectionId, String itemId, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, String colorFormula, String dstCrs, Resampling resampling, Integer maxSize, Integer height, Integer width, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getItemPreviewWithFormatWithResponse(String collectionId, String itemId, String format, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getItemPreviewWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public TilerStacItemStatistics getItemStatistics(String collectionId, String itemId) 
+        @Generated public TilerStacItemStatistics getItemStatistics(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Resampling resampling, Integer maxSize, Boolean categorical, List<Integer> categoriesPixels, List<Integer> percentiles, String histogramBins, String histogramRange, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String algorithm, String algorithmParams, Integer height, Integer width) 
+        @Generated public Response<BinaryData> getItemStatisticsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public TileJsonMetadata getItemTileJson(String collectionId, String itemId) 
+        @Generated public TileJsonMetadata getItemTileJson(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getItemTileJsonWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public TileJsonMetadata getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId) 
+        @Generated public TileJsonMetadata getItemTileJsonWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getItemTileJsonWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public byte[] getItemWmtsCapabilities(String collectionId, String itemId) 
+        @Generated public byte[] getItemWmtsCapabilities(String collectionId, String itemId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getItemWmtsCapabilitiesWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public byte[] getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId) 
+        @Generated public byte[] getItemWmtsCapabilitiesWithTms(String collectionId, String itemId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getItemWmtsCapabilitiesWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public BinaryData getLegend(String colorMapName) 
+        @Generated public BinaryData getLegend(String colorMapName, Double height, Double width, Integer trimStart, Integer trimEnd) 
+        @Generated public Response<BinaryData> getLegendWithResponse(String colorMapName, RequestOptions requestOptions) 
+        @Generated public TilerMosaicSearchRegistrationResponse registerMosaicsSearch(RegisterMosaicsSearchOptions options) 
+        @Generated public Response<BinaryData> registerMosaicsSearchWithResponse(BinaryData registerMosaicsSearchRequest, RequestOptions requestOptions) 
+        @Generated public List<BinaryData> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y) 
+        @Generated public List<BinaryData> getSearchAssetsForTileNoTms(String searchId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId) 
+        @Generated public Response<BinaryData> getSearchAssetsForTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public List<TilerAssetGeoJson> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y) 
+        @Generated public List<TilerAssetGeoJson> getSearchAssetsForTileWithTms(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getSearchAssetsForTileWithTmsWithResponse(String searchId, String tileMatrixSetId, String collectionId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public List<BinaryData> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy) 
+        @Generated public List<BinaryData> getSearchBboxAssets(String searchId, double minx, double miny, double maxx, double maxy, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
+        @Generated public Response<BinaryData> getSearchBboxAssetsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, RequestOptions requestOptions) 
+        @Generated public BinaryData getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format) 
+        @Generated public BinaryData getSearchBboxCrop(String searchId, double minx, double miny, double maxx, double maxy, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, Integer height, Integer width, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
+        @Generated public BinaryData getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format) 
+        @Generated public BinaryData getSearchBboxCropWithDimensions(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, String coordinateReferenceSystem, String destinationCrs, Integer maxSize, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask) 
+        @Generated public Response<BinaryData> getSearchBboxCropWithDimensionsWithResponse(String searchId, double minx, double miny, double maxx, double maxy, int width, int height, String format, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getSearchBboxCropWithResponse(String searchId, double minx, double miny, double maxx, double maxy, String format, RequestOptions requestOptions) 
+        @Generated public TilerStacSearchRegistration getSearchInfo(String searchId) 
+        @Generated public Response<BinaryData> getSearchInfoWithResponse(String searchId, RequestOptions requestOptions) 
+        @Generated public TilerCoreModelsResponsesPoint getSearchPoint(String searchId, double longitude, double latitude) 
+        @Generated public TilerCoreModelsResponsesPoint getSearchPoint(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, String coordinateReferenceSystem, Resampling resampling) 
+        @Generated public List<StacItemPointAsset> getSearchPointWithAssets(String searchId, double longitude, double latitude) 
+        @Generated public List<StacItemPointAsset> getSearchPointWithAssets(String searchId, double longitude, double latitude, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, String coordinateReferenceSystem) 
+        @Generated public Response<BinaryData> getSearchPointWithAssetsWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getSearchPointWithResponse(String searchId, double longitude, double latitude, RequestOptions requestOptions) 
+        @Generated public TileJsonMetadata getSearchTileJson(String searchId) 
+        @Generated public TileJsonMetadata getSearchTileJson(String searchId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, Integer padding, Double buffer, String colorFormula, String collectionId, Resampling resampling, PixelSelection pixelSelection, TerrainAlgorithm algorithm, String algorithmParams, List<String> rescale, ColorMapNames colormapName, String colormap, Boolean returnMask) 
+        @Generated public Response<BinaryData> getSearchTileJsonWithResponse(String searchId, RequestOptions requestOptions) 
+        @Generated public TileJsonMetadata getSearchTileJsonWithTms(String searchId, String tileMatrixSetId) 
+        @Generated public TileJsonMetadata getSearchTileJsonWithTms(String searchId, String tileMatrixSetId, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer minZoom, Integer maxZoom, TilerImageFormat tileFormat, Integer tileScale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Response<BinaryData> getSearchTileJsonWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public BinaryData getSearchTileNoTms(String searchId, double z, double x, double y) 
+        @Generated public BinaryData getSearchTileNoTms(String searchId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public BinaryData getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format) 
+        @Generated public BinaryData getSearchTileNoTmsByFormat(String searchId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Response<BinaryData> getSearchTileNoTmsByFormatWithResponse(String searchId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public BinaryData getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale) 
+        @Generated public BinaryData getSearchTileNoTmsByScale(String searchId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public BinaryData getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format) 
+        @Generated public BinaryData getSearchTileNoTmsByScaleAndFormat(String searchId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Response<BinaryData> getSearchTileNoTmsByScaleAndFormatWithResponse(String searchId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getSearchTileNoTmsByScaleWithResponse(String searchId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getSearchTileNoTmsWithResponse(String searchId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public TileSetMetadata getSearchTilesetMetadata(String searchId, String tileMatrixSetId) 
+        @Generated public TileSetMetadata getSearchTilesetMetadata(String searchId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getSearchTilesetMetadataWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public TileSetList getSearchTilesets(String searchId) 
+        @Generated public TileSetList getSearchTilesets(String searchId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getSearchTilesetsWithResponse(String searchId, RequestOptions requestOptions) 
+        @Generated public BinaryData getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y) 
+        @Generated public BinaryData getSearchTileWithTms(String searchId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public BinaryData getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format) 
+        @Generated public BinaryData getSearchTileWithTmsByFormat(String searchId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Response<BinaryData> getSearchTileWithTmsByFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public BinaryData getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale) 
+        @Generated public BinaryData getSearchTileWithTmsByScale(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public BinaryData getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
+        @Generated public BinaryData getSearchTileWithTmsByScaleAndFormat(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, Integer scanLimit, Integer itemsLimit, Integer timeLimit, Boolean exitWhenFull, Boolean skipCovered, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, String collection, Resampling resampling, PixelSelection pixelSelection, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding) 
+        @Generated public Response<BinaryData> getSearchTileWithTmsByScaleAndFormatWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getSearchTileWithTmsByScaleWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getSearchTileWithTmsWithResponse(String searchId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public byte[] getSearchWmtsCapabilities(String searchId) 
+        @Generated public byte[] getSearchWmtsCapabilities(String searchId, TileMatrixSetId tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
+        @Generated public Response<BinaryData> getSearchWmtsCapabilitiesWithResponse(String searchId, RequestOptions requestOptions) 
+        @Generated public byte[] getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId) 
+        @Generated public byte[] getSearchWmtsCapabilitiesWithTms(String searchId, String tileMatrixSetId, TilerImageFormat tileFormat, Integer tileScale, Integer minZoom, Integer maxZoom, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject) 
+        @Generated public Response<BinaryData> getSearchWmtsCapabilitiesWithTmsWithResponse(String searchId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public List<String> getTileMatrices() 
+        @Generated public Response<BinaryData> getTileMatricesWithResponse(RequestOptions requestOptions) 
+        @Generated public TileMatrixSet getTileMatrixDefinitions(String tileMatrixSetId) 
+        @Generated public Response<BinaryData> getTileMatrixDefinitionsWithResponse(String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public BinaryData getTileNoTms(String collectionId, String itemId, double z, double x, double y) 
+        @Generated public BinaryData getTileNoTms(String collectionId, String itemId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public BinaryData getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format) 
+        @Generated public BinaryData getTileNoTmsByFormat(String collectionId, String itemId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getTileNoTmsByFormatWithResponse(String collectionId, String itemId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public BinaryData getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale) 
+        @Generated public BinaryData getTileNoTmsByScale(String collectionId, String itemId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public BinaryData getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format) 
+        @Generated public BinaryData getTileNoTmsByScaleAndFormat(String collectionId, String itemId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TileMatrixSetId tileMatrixSetId, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getTileNoTmsByScaleAndFormatWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getTileNoTmsByScaleWithResponse(String collectionId, String itemId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getTileNoTmsWithResponse(String collectionId, String itemId, double z, double x, double y, RequestOptions requestOptions) 
+        @Generated public TileSetMetadata getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId) 
+        @Generated public TileSetMetadata getTilesetMetadata(String collectionId, String itemId, String tileMatrixSetId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getTilesetMetadataWithResponse(String collectionId, String itemId, String tileMatrixSetId, RequestOptions requestOptions) 
+        @Generated public TileSetList getTilesets(String collectionId, String itemId) 
+        @Generated public TileSetList getTilesets(String collectionId, String itemId, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getTilesetsWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public BinaryData getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y) 
+        @Generated public BinaryData getTileWithTms(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public BinaryData getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format) 
+        @Generated public BinaryData getTileWithTmsByFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Integer scale, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getTileWithTmsByFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, String format, RequestOptions requestOptions) 
+        @Generated public BinaryData getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale) 
+        @Generated public BinaryData getTileWithTmsByScale(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, TilerImageFormat format, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public BinaryData getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format) 
+        @Generated public BinaryData getTileWithTmsByScaleAndFormat(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, List<Integer> bidx, List<String> assets, String expression, List<String> assetBandIndices, Boolean assetAsBand, String noData, Boolean unscale, WarpKernelResampling reproject, TerrainAlgorithm algorithm, String algorithmParams, Double buffer, String colorFormula, Resampling resampling, List<String> rescale, ColorMapNames colorMapName, String colorMap, Boolean returnMask, Integer padding, String subdatasetName, List<Integer> subdatasetBands, String crs, String datetime, List<String> sel, SelMethod selMethod) 
+        @Generated public Response<BinaryData> getTileWithTmsByScaleAndFormatWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, String format, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getTileWithTmsByScaleWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getTileWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions) 
+    } 
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true) 
+    public final class IngestionAsyncClient { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        // Service Methods: 
+        @Generated public Mono<IngestionDefinition> get(String collectionId, String ingestionId) 
+        @Generated public PollerFlux<Operation, Void> beginDelete(String collectionId, String ingestionId) 
+        @Generated public PollerFlux<BinaryData, Void> beginDelete(String collectionId, String ingestionId, RequestOptions requestOptions) 
+        @Generated public Mono<Void> cancelAllOperations() 
+        @Generated public Mono<Response<Void>> cancelAllOperationsWithResponse(RequestOptions requestOptions) 
+        @Generated public Mono<Void> cancelOperation(String operationId) 
+        @Generated public Mono<Response<Void>> cancelOperationWithResponse(String operationId, RequestOptions requestOptions) 
+        @Generated public Mono<IngestionDefinition> create(String collectionId, IngestionDefinition body) 
+        @Generated public Mono<IngestionRun> createRun(String collectionId, String ingestionId) 
+        @Generated public Mono<Response<BinaryData>> createRunWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions) 
+        @Generated public Mono<IngestionSource> createSource(IngestionSource body) 
+        @Generated public Mono<Response<BinaryData>> createSourceWithResponse(BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> createWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<Void> deleteSource(String id) 
+        @Generated public Mono<Response<Void>> deleteSourceWithResponse(String id, RequestOptions requestOptions) 
+        @Generated public PagedFlux<IngestionDefinition> list(String collectionId) 
+        @Generated public PagedFlux<BinaryData> list(String collectionId, RequestOptions requestOptions) 
+        @Generated public PagedFlux<IngestionDefinition> list(String collectionId, Integer top, Integer skip) 
+        @Generated public PagedFlux<ManagedIdentityMetadata> listManagedIdentities() 
+        @Generated public PagedFlux<BinaryData> listManagedIdentities(RequestOptions requestOptions) 
+        @Generated public PagedFlux<Operation> listOperations() 
+        @Generated public PagedFlux<BinaryData> listOperations(RequestOptions requestOptions) 
+        @Generated public PagedFlux<Operation> listOperations(Integer top, Integer skip, String collectionId, OperationStatus status) 
+        @Generated public PagedFlux<IngestionRun> listRuns(String collectionId, String ingestionId) 
+        @Generated public PagedFlux<BinaryData> listRuns(String collectionId, String ingestionId, RequestOptions requestOptions) 
+        @Generated public PagedFlux<IngestionRun> listRuns(String collectionId, String ingestionId, Integer top, Integer skip) 
+        @Generated public PagedFlux<IngestionSourceSummary> listSources() 
+        @Generated public PagedFlux<BinaryData> listSources(RequestOptions requestOptions) 
+        @Generated public PagedFlux<IngestionSourceSummary> listSources(Integer top, Integer skip) 
+        @Generated public Mono<Operation> getOperation(String operationId) 
+        @Generated public Mono<Response<BinaryData>> getOperationWithResponse(String operationId, RequestOptions requestOptions) 
+        @Generated public Mono<IngestionSource> replaceSource(String id, IngestionSource body) 
+        @Generated public Mono<Response<BinaryData>> replaceSourceWithResponse(String id, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<IngestionRun> getRun(String collectionId, String ingestionId, String runId) 
+        @Generated public Mono<Response<BinaryData>> getRunWithResponse(String collectionId, String ingestionId, String runId, RequestOptions requestOptions) 
+        @Generated public Mono<IngestionSource> getSource(String id) 
+        @Generated public Mono<Response<BinaryData>> getSourceWithResponse(String id, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> updateWithResponse(String collectionId, String ingestionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions) 
+    } 
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder) 
+    public final class IngestionClient { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        // Service Methods: 
+        @Generated public IngestionDefinition get(String collectionId, String ingestionId) 
+        @Generated public SyncPoller<Operation, Void> beginDelete(String collectionId, String ingestionId) 
+        @Generated public SyncPoller<BinaryData, Void> beginDelete(String collectionId, String ingestionId, RequestOptions requestOptions) 
+        @Generated public void cancelAllOperations() 
+        @Generated public Response<Void> cancelAllOperationsWithResponse(RequestOptions requestOptions) 
+        @Generated public void cancelOperation(String operationId) 
+        @Generated public Response<Void> cancelOperationWithResponse(String operationId, RequestOptions requestOptions) 
+        @Generated public IngestionDefinition create(String collectionId, IngestionDefinition body) 
+        @Generated public IngestionRun createRun(String collectionId, String ingestionId) 
+        @Generated public Response<BinaryData> createRunWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions) 
+        @Generated public IngestionSource createSource(IngestionSource body) 
+        @Generated public Response<BinaryData> createSourceWithResponse(BinaryData body, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> createWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public void deleteSource(String id) 
+        @Generated public Response<Void> deleteSourceWithResponse(String id, RequestOptions requestOptions) 
+        @Generated public PagedIterable<IngestionDefinition> list(String collectionId) 
+        @Generated public PagedIterable<BinaryData> list(String collectionId, RequestOptions requestOptions) 
+        @Generated public PagedIterable<IngestionDefinition> list(String collectionId, Integer top, Integer skip) 
+        @Generated public PagedIterable<ManagedIdentityMetadata> listManagedIdentities() 
+        @Generated public PagedIterable<BinaryData> listManagedIdentities(RequestOptions requestOptions) 
+        @Generated public PagedIterable<Operation> listOperations() 
+        @Generated public PagedIterable<BinaryData> listOperations(RequestOptions requestOptions) 
+        @Generated public PagedIterable<Operation> listOperations(Integer top, Integer skip, String collectionId, OperationStatus status) 
+        @Generated public PagedIterable<IngestionRun> listRuns(String collectionId, String ingestionId) 
+        @Generated public PagedIterable<BinaryData> listRuns(String collectionId, String ingestionId, RequestOptions requestOptions) 
+        @Generated public PagedIterable<IngestionRun> listRuns(String collectionId, String ingestionId, Integer top, Integer skip) 
+        @Generated public PagedIterable<IngestionSourceSummary> listSources() 
+        @Generated public PagedIterable<BinaryData> listSources(RequestOptions requestOptions) 
+        @Generated public PagedIterable<IngestionSourceSummary> listSources(Integer top, Integer skip) 
+        @Generated public Operation getOperation(String operationId) 
+        @Generated public Response<BinaryData> getOperationWithResponse(String operationId, RequestOptions requestOptions) 
+        @Generated public IngestionSource replaceSource(String id, IngestionSource body) 
+        @Generated public Response<BinaryData> replaceSourceWithResponse(String id, BinaryData body, RequestOptions requestOptions) 
+        @Generated public IngestionRun getRun(String collectionId, String ingestionId, String runId) 
+        @Generated public Response<BinaryData> getRunWithResponse(String collectionId, String ingestionId, String runId, RequestOptions requestOptions) 
+        @Generated public IngestionSource getSource(String id) 
+        @Generated public Response<BinaryData> getSourceWithResponse(String id, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> updateWithResponse(String collectionId, String ingestionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions) 
+    } 
+    @ServiceClientBuilder(serviceClients  =  { IngestionClient, StacClient, DataClient, SharedAccessSignatureClient, IngestionAsyncClient, StacAsyncClient, DataAsyncClient, SharedAccessSignatureAsyncClient }) 
+    public final class PlanetaryComputerProClientBuilder implements HttpTrait<PlanetaryComputerProClientBuilder> , ConfigurationTrait<PlanetaryComputerProClientBuilder> , TokenCredentialTrait<PlanetaryComputerProClientBuilder> , EndpointTrait<PlanetaryComputerProClientBuilder> { 
+        @Generated public PlanetaryComputerProClientBuilder() 
+        @Generated @Override public PlanetaryComputerProClientBuilder addPolicy(HttpPipelinePolicy customPolicy) 
+        @Generated @Override public PlanetaryComputerProClientBuilder clientOptions(ClientOptions clientOptions) 
+        @Generated @Override public PlanetaryComputerProClientBuilder configuration(Configuration configuration) 
+        @Generated @Override public PlanetaryComputerProClientBuilder credential(TokenCredential tokenCredential) 
+        @Generated @Override public PlanetaryComputerProClientBuilder endpoint(String endpoint) 
+        @Generated @Override public PlanetaryComputerProClientBuilder httpClient(HttpClient httpClient) 
+        @Generated @Override public PlanetaryComputerProClientBuilder httpLogOptions(HttpLogOptions httpLogOptions) 
+        @Generated @Override public PlanetaryComputerProClientBuilder pipeline(HttpPipeline pipeline) 
+        @Generated @Override public PlanetaryComputerProClientBuilder retryOptions(RetryOptions retryOptions) 
+        @Generated public PlanetaryComputerProClientBuilder retryPolicy(RetryPolicy retryPolicy) 
+        @Generated public PlanetaryComputerProClientBuilder serviceVersion(PlanetaryComputerServiceVersion serviceVersion) 
+        @Generated public DataAsyncClient buildDataAsyncClient() 
+        @Generated public DataClient buildDataClient() 
+        @Generated public IngestionAsyncClient buildIngestionAsyncClient() 
+        @Generated public IngestionClient buildIngestionClient() 
+        @Generated public SharedAccessSignatureAsyncClient buildSharedAccessSignatureAsyncClient() 
+        @Generated public SharedAccessSignatureClient buildSharedAccessSignatureClient() 
+        @Generated public StacAsyncClient buildStacAsyncClient() 
+        @Generated public StacClient buildStacClient() 
+    } 
+    public enum PlanetaryComputerServiceVersion implements ServiceVersion { 
+        V2026_04_15("2026-04-15"); 
+        public static PlanetaryComputerServiceVersion getLatest(// returns V2026_04_15 ) 
+        @Override public String getVersion() 
+    } 
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true) 
+    public final class SharedAccessSignatureAsyncClient { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        // Service Methods: 
+        @Generated public Mono<Void> revokeToken() 
+        @Generated public Mono<Void> revokeToken(Integer durationInMinutes) 
+        @Generated public Mono<Response<Void>> revokeTokenWithResponse(RequestOptions requestOptions) 
+        @Generated public Mono<SharedAccessSignatureToken> getToken(String collectionId) 
+        @Generated public Mono<SharedAccessSignatureToken> getToken(String collectionId, Integer durationInMinutes) 
+        @Generated public Mono<Response<BinaryData>> getTokenWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<SharedAccessSignatureSignedLink> getUrl(String href) 
+        @Generated public Mono<SharedAccessSignatureSignedLink> getUrl(String href, Integer durationInMinutes) 
+        @Generated public Mono<Response<BinaryData>> getUrlWithResponse(String href, RequestOptions requestOptions) 
+    } 
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder) 
+    public final class SharedAccessSignatureClient { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        // Service Methods: 
+        @Generated public void revokeToken() 
+        @Generated public void revokeToken(Integer durationInMinutes) 
+        @Generated public Response<Void> revokeTokenWithResponse(RequestOptions requestOptions) 
+        @Generated public SharedAccessSignatureToken getToken(String collectionId) 
+        @Generated public SharedAccessSignatureToken getToken(String collectionId, Integer durationInMinutes) 
+        @Generated public Response<BinaryData> getTokenWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public SharedAccessSignatureSignedLink getUrl(String href) 
+        @Generated public SharedAccessSignatureSignedLink getUrl(String href, Integer durationInMinutes) 
+        @Generated public Response<BinaryData> getUrlWithResponse(String href, RequestOptions requestOptions) 
+    } 
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true) 
+    public final class StacAsyncClient { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        // Service Methods: 
+        @Generated public Mono<StacMosaic> addMosaic(String collectionId, StacMosaic body) 
+        @Generated public Mono<Response<BinaryData>> addMosaicWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public PollerFlux<Operation, Void> beginCreateCollection(StacCollection body) 
+        @Generated public PollerFlux<BinaryData, BinaryData> beginCreateCollection(BinaryData body, RequestOptions requestOptions) 
+        @Generated public PollerFlux<Operation, Void> beginCreateItem(String collectionId, StacItemOrStacItemCollection body) 
+        @Generated public PollerFlux<BinaryData, BinaryData> beginCreateItem(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public PollerFlux<Operation, Void> beginDeleteCollection(String collectionId) 
+        @Generated public PollerFlux<BinaryData, Void> beginDeleteCollection(String collectionId, RequestOptions requestOptions) 
+        @Generated public PollerFlux<Operation, Void> beginDeleteItem(String collectionId, String itemId) 
+        @Generated public PollerFlux<BinaryData, Void> beginDeleteItem(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public PollerFlux<Operation, Void> beginReplaceItem(String collectionId, String itemId, StacItem body) 
+        @Generated public PollerFlux<BinaryData, BinaryData> beginReplaceItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public PollerFlux<BinaryData, BinaryData> beginUpdateItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<StacCollection> getCollection(String collectionId) 
+        @Generated public Mono<StacCollection> getCollection(String collectionId, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
+        @Generated public Mono<UserCollectionSettings> getCollectionConfiguration(String collectionId) 
+        @Generated public Mono<Response<BinaryData>> getCollectionConfigurationWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<QueryableDefinitionsResponse> getCollectionQueryables(String collectionId) 
+        @Generated public Mono<Response<BinaryData>> getCollectionQueryablesWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<StacCatalogCollections> getCollections() 
+        @Generated public Mono<StacCatalogCollections> getCollections(StacAssetUrlSigningMode sign, Integer durationInMinutes) 
+        @Generated public Mono<Response<BinaryData>> getCollectionsWithResponse(RequestOptions requestOptions) 
+        @Generated public Mono<BinaryData> getCollectionThumbnail(String collectionId) 
+        @Generated public Mono<Response<BinaryData>> getCollectionThumbnailWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getCollectionWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<StacConformanceClasses> getConformanceClasses() 
+        @Generated public Mono<Response<BinaryData>> getConformanceClassesWithResponse(RequestOptions requestOptions) 
+        @Generated public Mono<StacCollection> createCollectionAsset(String collectionId, StacAssetData body) 
+        @Generated public Mono<List<StacQueryable>> createQueryables(String collectionId, List<StacQueryable> body) 
+        @Generated public Mono<Response<BinaryData>> createQueryablesWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<RenderOption> createRenderOption(String collectionId, RenderOption body) 
+        @Generated public Mono<Response<BinaryData>> createRenderOptionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<StacCollection> deleteCollectionAsset(String collectionId, String assetId) 
+        @Generated public Mono<Response<BinaryData>> deleteCollectionAssetWithResponse(String collectionId, String assetId, RequestOptions requestOptions) 
+        @Generated public Mono<Void> deleteMosaic(String collectionId, String mosaicId) 
+        @Generated public Mono<Response<Void>> deleteMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions) 
+        @Generated public Mono<Void> deleteQueryable(String collectionId, String queryableName) 
+        @Generated public Mono<Response<Void>> deleteQueryableWithResponse(String collectionId, String queryableName, RequestOptions requestOptions) 
+        @Generated public Mono<Void> deleteRenderOption(String collectionId, String renderOptionId) 
+        @Generated public Mono<Response<Void>> deleteRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions) 
+        @Generated public Mono<StacItem> getItem(String collectionId, String itemId) 
+        @Generated public Mono<StacItem> getItem(String collectionId, String itemId, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
+        @Generated public Mono<StacItemCollection> getItemCollection(String collectionId) 
+        @Generated public Mono<StacItemCollection> getItemCollection(String collectionId, Integer limit, List<String> boundingBox, String datetime, StacAssetUrlSigningMode sign, Integer durationInMinutes, String token) 
+        @Generated public Mono<Response<BinaryData>> getItemCollectionWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getItemWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public Mono<StacLandingPage> getLandingPage() 
+        @Generated public Mono<Response<BinaryData>> getLandingPageWithResponse(RequestOptions requestOptions) 
+        @Generated public Mono<StacMosaic> getMosaic(String collectionId, String mosaicId) 
+        @Generated public Mono<List<StacMosaic>> getMosaics(String collectionId) 
+        @Generated public Mono<Response<BinaryData>> getMosaicsWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions) 
+        @Generated public Mono<PartitionType> getPartitionType(String collectionId) 
+        @Generated public Mono<Response<BinaryData>> getPartitionTypeWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<QueryableDefinitionsResponse> getQueryables() 
+        @Generated public Mono<Response<BinaryData>> getQueryablesWithResponse(RequestOptions requestOptions) 
+        @Generated public Mono<RenderOption> getRenderOption(String collectionId, String renderOptionId) 
+        @Generated public Mono<List<RenderOption>> getRenderOptions(String collectionId) 
+        @Generated public Mono<Response<BinaryData>> getRenderOptionsWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Mono<Response<BinaryData>> getRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions) 
+        @Generated public Mono<StacCollection> replaceCollection(String collectionId, StacCollection body) 
+        @Generated public Mono<StacCollection> replaceCollectionAsset(String collectionId, String assetId, StacAssetData body) 
+        @Generated public Mono<Response<BinaryData>> replaceCollectionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<StacMosaic> replaceMosaic(String collectionId, String mosaicId, StacMosaic body) 
+        @Generated public Mono<Response<BinaryData>> replaceMosaicWithResponse(String collectionId, String mosaicId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<Void> replacePartitionType(String collectionId, PartitionType body) 
+        @Generated public Mono<Response<Void>> replacePartitionTypeWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<StacQueryable> replaceQueryable(String collectionId, String queryableName, StacQueryable body) 
+        @Generated public Mono<Response<BinaryData>> replaceQueryableWithResponse(String collectionId, String queryableName, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<RenderOption> replaceRenderOption(String collectionId, String renderOptionId, RenderOption body) 
+        @Generated public Mono<Response<BinaryData>> replaceRenderOptionWithResponse(String collectionId, String renderOptionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<TileSettings> replaceTileSettings(String collectionId, TileSettings body) 
+        @Generated public Mono<Response<BinaryData>> replaceTileSettingsWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<StacItemCollection> search(StacSearchParameters body) 
+        @Generated public Mono<StacItemCollection> search(StacSearchParameters body, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
+        @Generated public Mono<Response<BinaryData>> searchWithResponse(BinaryData body, RequestOptions requestOptions) 
+        @Generated public Mono<TileSettings> getTileSettings(String collectionId) 
+        @Generated public Mono<Response<BinaryData>> getTileSettingsWithResponse(String collectionId, RequestOptions requestOptions) 
+    } 
+    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder) 
+    public final class StacClient { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        // Service Methods: 
+        @Generated public StacMosaic addMosaic(String collectionId, StacMosaic body) 
+        @Generated public Response<BinaryData> addMosaicWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public SyncPoller<Operation, Void> beginCreateCollection(StacCollection body) 
+        @Generated public SyncPoller<BinaryData, BinaryData> beginCreateCollection(BinaryData body, RequestOptions requestOptions) 
+        @Generated public SyncPoller<Operation, Void> beginCreateItem(String collectionId, StacItemOrStacItemCollection body) 
+        @Generated public SyncPoller<BinaryData, BinaryData> beginCreateItem(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public SyncPoller<Operation, Void> beginDeleteCollection(String collectionId) 
+        @Generated public SyncPoller<BinaryData, Void> beginDeleteCollection(String collectionId, RequestOptions requestOptions) 
+        @Generated public SyncPoller<Operation, Void> beginDeleteItem(String collectionId, String itemId) 
+        @Generated public SyncPoller<BinaryData, Void> beginDeleteItem(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public SyncPoller<Operation, Void> beginReplaceItem(String collectionId, String itemId, StacItem body) 
+        @Generated public SyncPoller<BinaryData, BinaryData> beginReplaceItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public SyncPoller<BinaryData, BinaryData> beginUpdateItem(String collectionId, String itemId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public StacCollection getCollection(String collectionId) 
+        @Generated public StacCollection getCollection(String collectionId, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
+        @Generated public UserCollectionSettings getCollectionConfiguration(String collectionId) 
+        @Generated public Response<BinaryData> getCollectionConfigurationWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public QueryableDefinitionsResponse getCollectionQueryables(String collectionId) 
+        @Generated public Response<BinaryData> getCollectionQueryablesWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public StacCatalogCollections getCollections() 
+        @Generated public StacCatalogCollections getCollections(StacAssetUrlSigningMode sign, Integer durationInMinutes) 
+        @Generated public Response<BinaryData> getCollectionsWithResponse(RequestOptions requestOptions) 
+        @Generated public BinaryData getCollectionThumbnail(String collectionId) 
+        @Generated public Response<BinaryData> getCollectionThumbnailWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getCollectionWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public StacConformanceClasses getConformanceClasses() 
+        @Generated public Response<BinaryData> getConformanceClassesWithResponse(RequestOptions requestOptions) 
+        @Generated public StacCollection createCollectionAsset(String collectionId, StacAssetData body) 
+        @Generated public List<StacQueryable> createQueryables(String collectionId, List<StacQueryable> body) 
+        @Generated public Response<BinaryData> createQueryablesWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public RenderOption createRenderOption(String collectionId, RenderOption body) 
+        @Generated public Response<BinaryData> createRenderOptionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public StacCollection deleteCollectionAsset(String collectionId, String assetId) 
+        @Generated public Response<BinaryData> deleteCollectionAssetWithResponse(String collectionId, String assetId, RequestOptions requestOptions) 
+        @Generated public void deleteMosaic(String collectionId, String mosaicId) 
+        @Generated public Response<Void> deleteMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions) 
+        @Generated public void deleteQueryable(String collectionId, String queryableName) 
+        @Generated public Response<Void> deleteQueryableWithResponse(String collectionId, String queryableName, RequestOptions requestOptions) 
+        @Generated public void deleteRenderOption(String collectionId, String renderOptionId) 
+        @Generated public Response<Void> deleteRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions) 
+        @Generated public StacItem getItem(String collectionId, String itemId) 
+        @Generated public StacItem getItem(String collectionId, String itemId, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
+        @Generated public StacItemCollection getItemCollection(String collectionId) 
+        @Generated public StacItemCollection getItemCollection(String collectionId, Integer limit, List<String> boundingBox, String datetime, StacAssetUrlSigningMode sign, Integer durationInMinutes, String token) 
+        @Generated public Response<BinaryData> getItemCollectionWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getItemWithResponse(String collectionId, String itemId, RequestOptions requestOptions) 
+        @Generated public StacLandingPage getLandingPage() 
+        @Generated public Response<BinaryData> getLandingPageWithResponse(RequestOptions requestOptions) 
+        @Generated public StacMosaic getMosaic(String collectionId, String mosaicId) 
+        @Generated public List<StacMosaic> getMosaics(String collectionId) 
+        @Generated public Response<BinaryData> getMosaicsWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getMosaicWithResponse(String collectionId, String mosaicId, RequestOptions requestOptions) 
+        @Generated public PartitionType getPartitionType(String collectionId) 
+        @Generated public Response<BinaryData> getPartitionTypeWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public QueryableDefinitionsResponse getQueryables() 
+        @Generated public Response<BinaryData> getQueryablesWithResponse(RequestOptions requestOptions) 
+        @Generated public RenderOption getRenderOption(String collectionId, String renderOptionId) 
+        @Generated public List<RenderOption> getRenderOptions(String collectionId) 
+        @Generated public Response<BinaryData> getRenderOptionsWithResponse(String collectionId, RequestOptions requestOptions) 
+        @Generated public Response<BinaryData> getRenderOptionWithResponse(String collectionId, String renderOptionId, RequestOptions requestOptions) 
+        @Generated public StacCollection replaceCollection(String collectionId, StacCollection body) 
+        @Generated public StacCollection replaceCollectionAsset(String collectionId, String assetId, StacAssetData body) 
+        @Generated public Response<BinaryData> replaceCollectionWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public StacMosaic replaceMosaic(String collectionId, String mosaicId, StacMosaic body) 
+        @Generated public Response<BinaryData> replaceMosaicWithResponse(String collectionId, String mosaicId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public void replacePartitionType(String collectionId, PartitionType body) 
+        @Generated public Response<Void> replacePartitionTypeWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public StacQueryable replaceQueryable(String collectionId, String queryableName, StacQueryable body) 
+        @Generated public Response<BinaryData> replaceQueryableWithResponse(String collectionId, String queryableName, BinaryData body, RequestOptions requestOptions) 
+        @Generated public RenderOption replaceRenderOption(String collectionId, String renderOptionId, RenderOption body) 
+        @Generated public Response<BinaryData> replaceRenderOptionWithResponse(String collectionId, String renderOptionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public TileSettings replaceTileSettings(String collectionId, TileSettings body) 
+        @Generated public Response<BinaryData> replaceTileSettingsWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions) 
+        @Generated public StacItemCollection search(StacSearchParameters body) 
+        @Generated public StacItemCollection search(StacSearchParameters body, StacAssetUrlSigningMode sign, Integer durationInMinutes) 
+        @Generated public Response<BinaryData> searchWithResponse(BinaryData body, RequestOptions requestOptions) 
+        @Generated public TileSettings getTileSettings(String collectionId) 
+        @Generated public Response<BinaryData> getTileSettingsWithResponse(String collectionId, RequestOptions requestOptions) 
+    } 
+} 
+package com.azure.analytics.planetarycomputer.models { 
+    @Immutable
+    public final class AssetMetadata implements JsonSerializable<AssetMetadata> { 
+        @Generated public AssetMetadata(String key, String type, List<String> roles, String title, String description) 
+        @Generated public String getDescription() 
+        @Generated public String getKey() 
+        @Generated public List<String> getRoles() 
+        @Generated public String getTitle() 
+        @Generated public String getType() 
+    } 
+    @Immutable
+    public final class AssetStatisticsResponse implements JsonSerializable<AssetStatisticsResponse> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public Map<String, BandStatisticsMap> getAdditionalProperties() 
+    } 
+    @Immutable
+    public final class BandStatistics implements JsonSerializable<BandStatistics> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public double getCount() 
+        @Generated public List<List<Double>> getHistogram() 
+        @Generated public double getMajority() 
+        @Generated public double getMaskedPixels() 
+        @Generated public double getMaximum() 
+        @Generated public double getMean() 
+        @Generated public double getMedian() 
+        @Generated public double getMinimum() 
+        @Generated public double getMinority() 
+        @Generated public double getPercentile2() 
+        @Generated public double getPercentile98() 
+        @Generated public double getStd() 
+        @Generated public double getSum() 
+        @Generated public double getUnique() 
+        @Generated public double getValidPercent() 
+        @Generated public double getValidPixels() 
+    } 
+    @Immutable
+    public final class BandStatisticsMap implements JsonSerializable<BandStatisticsMap> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public Map<String, BandStatistics> getAdditionalProperties() 
+    } 
+    @Immutable
+    public final class ClassMapLegendResponse implements JsonSerializable<ClassMapLegendResponse> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public Map<String, BinaryData> getAdditionalProperties() 
+    } 
+    public final class ColorMapNames extends ExpandableStringEnum<ColorMapNames> { 
+        @Generated public static final ColorMapNames ACCENT = fromString("accent"); 
+        @Generated public static final ColorMapNames ACCENT_R = fromString("accent_r"); 
+        @Generated public static final ColorMapNames AFMHOT = fromString("afmhot"); 
+        @Generated public static final ColorMapNames AFMHOT_R = fromString("afmhot_r"); 
+        @Generated public static final ColorMapNames AI4G_LULC = fromString("ai4g-lulc"); 
+        @Generated public static final ColorMapNames ALOS_FNF = fromString("alos-fnf"); 
+        @Generated public static final ColorMapNames ALOS_PALSAR_MASK = fromString("alos-palsar-mask"); 
+        @Generated public static final ColorMapNames AUTUMN = fromString("autumn"); 
+        @Generated public static final ColorMapNames AUTUMN_R = fromString("autumn_r"); 
+        @Generated public static final ColorMapNames BINARY = fromString("binary"); 
+        @Generated public static final ColorMapNames BINARY_R = fromString("binary_r"); 
+        @Generated public static final ColorMapNames BLUES = fromString("blues"); 
+        @Generated public static final ColorMapNames BLUES_R = fromString("blues_r"); 
+        @Generated public static final ColorMapNames BONE = fromString("bone"); 
+        @Generated public static final ColorMapNames BONE_R = fromString("bone_r"); 
+        @Generated public static final ColorMapNames BRBG = fromString("brbg"); 
+        @Generated public static final ColorMapNames BRBG_R = fromString("brbg_r"); 
+        @Generated public static final ColorMapNames BRG = fromString("brg"); 
+        @Generated public static final ColorMapNames BRG_R = fromString("brg_r"); 
+        @Generated public static final ColorMapNames BUGN = fromString("bugn"); 
+        @Generated public static final ColorMapNames BUGN_R = fromString("bugn_r"); 
+        @Generated public static final ColorMapNames BUPU = fromString("bupu"); 
+        @Generated public static final ColorMapNames BUPU_R = fromString("bupu_r"); 
+        @Generated public static final ColorMapNames BWR = fromString("bwr"); 
+        @Generated public static final ColorMapNames BWR_R = fromString("bwr_r"); 
+        @Generated public static final ColorMapNames C_CAP = fromString("c-cap"); 
+        @Generated public static final ColorMapNames CFASTIE = fromString("cfastie"); 
+        @Generated public static final ColorMapNames CHESAPEAKE_LC_13 = fromString("chesapeake-lc-13"); 
+        @Generated public static final ColorMapNames CHESAPEAKE_LC_7 = fromString("chesapeake-lc-7"); 
+        @Generated public static final ColorMapNames CHESAPEAKE_LU = fromString("chesapeake-lu"); 
+        @Generated public static final ColorMapNames CHLORIS_BIOMASS = fromString("chloris-biomass"); 
+        @Generated public static final ColorMapNames CIVIDIS = fromString("cividis"); 
+        @Generated public static final ColorMapNames CIVIDIS_R = fromString("cividis_r"); 
+        @Generated public static final ColorMapNames CMRMAP = fromString("cmrmap"); 
+        @Generated public static final ColorMapNames CMRMAP_R = fromString("cmrmap_r"); 
+        @Generated public static final ColorMapNames COOL = fromString("cool"); 
+        @Generated public static final ColorMapNames COOL_R = fromString("cool_r"); 
+        @Generated public static final ColorMapNames COOLWARM = fromString("coolwarm"); 
+        @Generated public static final ColorMapNames COOLWARM_R = fromString("coolwarm_r"); 
+        @Generated public static final ColorMapNames COPPER = fromString("copper"); 
+        @Generated public static final ColorMapNames COPPER_R = fromString("copper_r"); 
+        @Generated public static final ColorMapNames CUBEHELIX = fromString("cubehelix"); 
+        @Generated public static final ColorMapNames CUBEHELIX_R = fromString("cubehelix_r"); 
+        @Generated public static final ColorMapNames DARK2 = fromString("dark2"); 
+        @Generated public static final ColorMapNames DARK2_R = fromString("dark2_r"); 
+        @Generated public static final ColorMapNames DRCOG_LULC = fromString("drcog-lulc"); 
+        @Generated public static final ColorMapNames ESA_CCI_LC = fromString("esa-cci-lc"); 
+        @Generated public static final ColorMapNames ESA_WORLDCOVER = fromString("esa-worldcover"); 
+        @Generated public static final ColorMapNames FLAG = fromString("flag"); 
+        @Generated public static final ColorMapNames FLAG_R = fromString("flag_r"); 
+        @Generated public static final ColorMapNames GAP_LULC = fromString("gap-lulc"); 
+        @Generated public static final ColorMapNames GIST_EARTH = fromString("gist_earth"); 
+        @Generated public static final ColorMapNames GIST_EARTH_R = fromString("gist_earth_r"); 
+        @Generated public static final ColorMapNames GIST_GRAY = fromString("gist_gray"); 
+        @Generated public static final ColorMapNames GIST_GRAY_R = fromString("gist_gray_r"); 
+        @Generated public static final ColorMapNames GIST_HEAT = fromString("gist_heat"); 
+        @Generated public static final ColorMapNames GIST_HEAT_R = fromString("gist_heat_r"); 
+        @Generated public static final ColorMapNames GIST_NCAR = fromString("gist_ncar"); 
+        @Generated public static final ColorMapNames GIST_NCAR_R = fromString("gist_ncar_r"); 
+        @Generated public static final ColorMapNames GIST_RAINBOW = fromString("gist_rainbow"); 
+        @Generated public static final ColorMapNames GIST_RAINBOW_R = fromString("gist_rainbow_r"); 
+        @Generated public static final ColorMapNames GIST_STERN = fromString("gist_stern"); 
+        @Generated public static final ColorMapNames GIST_STERN_R = fromString("gist_stern_r"); 
+        @Generated public static final ColorMapNames GIST_YARG = fromString("gist_yarg"); 
+        @Generated public static final ColorMapNames GIST_YARG_R = fromString("gist_yarg_r"); 
+        @Generated public static final ColorMapNames GNBU = fromString("gnbu"); 
+        @Generated public static final ColorMapNames GNBU_R = fromString("gnbu_r"); 
+        @Generated public static final ColorMapNames GNUPLOT = fromString("gnuplot"); 
+        @Generated public static final ColorMapNames GNUPLOT2 = fromString("gnuplot2"); 
+        @Generated public static final ColorMapNames GNUPLOT2_R = fromString("gnuplot2_r"); 
+        @Generated public static final ColorMapNames GNUPLOT_R = fromString("gnuplot_r"); 
+        @Generated public static final ColorMapNames GRAY = fromString("gray"); 
+        @Generated public static final ColorMapNames GRAY_R = fromString("gray_r"); 
+        @Generated public static final ColorMapNames GREENS = fromString("greens"); 
+        @Generated public static final ColorMapNames GREENS_R = fromString("greens_r"); 
+        @Generated public static final ColorMapNames GREYS = fromString("greys"); 
+        @Generated public static final ColorMapNames GREYS_R = fromString("greys_r"); 
+        @Generated public static final ColorMapNames HOT = fromString("hot"); 
+        @Generated public static final ColorMapNames HOT_R = fromString("hot_r"); 
+        @Generated public static final ColorMapNames HSV = fromString("hsv"); 
+        @Generated public static final ColorMapNames HSV_R = fromString("hsv_r"); 
+        @Generated public static final ColorMapNames INFERNO = fromString("inferno"); 
+        @Generated public static final ColorMapNames INFERNO_R = fromString("inferno_r"); 
+        @Generated public static final ColorMapNames IO_BII = fromString("io-bii"); 
+        @Generated public static final ColorMapNames IO_LULC = fromString("io-lulc"); 
+        @Generated public static final ColorMapNames IO_LULC_9_CLASS = fromString("io-lulc-9-class"); 
+        @Generated public static final ColorMapNames JET = fromString("jet"); 
+        @Generated public static final ColorMapNames JET_R = fromString("jet_r"); 
+        @Generated public static final ColorMapNames JRC_CHANGE = fromString("jrc-change"); 
+        @Generated public static final ColorMapNames JRC_EXTENT = fromString("jrc-extent"); 
+        @Generated public static final ColorMapNames JRC_OCCURRENCE = fromString("jrc-occurrence"); 
+        @Generated public static final ColorMapNames JRC_RECURRENCE = fromString("jrc-recurrence"); 
+        @Generated public static final ColorMapNames JRC_SEASONALITY = fromString("jrc-seasonality"); 
+        @Generated public static final ColorMapNames JRC_TRANSITIONS = fromString("jrc-transitions"); 
+        @Generated public static final ColorMapNames LIDAR_CLASSIFICATION = fromString("lidar-classification"); 
+        @Generated public static final ColorMapNames LIDAR_HAG = fromString("lidar-hag"); 
+        @Generated public static final ColorMapNames LIDAR_HAG_ALTERNATIVE = fromString("lidar-hag-alternative"); 
+        @Generated public static final ColorMapNames LIDAR_INTENSITY = fromString("lidar-intensity"); 
+        @Generated public static final ColorMapNames LIDAR_RETURNS = fromString("lidar-returns"); 
+        @Generated public static final ColorMapNames MAGMA = fromString("magma"); 
+        @Generated public static final ColorMapNames MAGMA_R = fromString("magma_r"); 
+        @Generated public static final ColorMapNames MODIS_10A1 = fromString("modis-10A1"); 
+        @Generated public static final ColorMapNames MODIS_10A2 = fromString("modis-10A2"); 
+        @Generated public static final ColorMapNames MODIS_13A1_Q1 = fromString("modis-13A1|Q1"); 
+        @Generated public static final ColorMapNames MODIS_14A1_A2 = fromString("modis-14A1|A2"); 
+        @Generated public static final ColorMapNames MODIS_15A2H_A3H = fromString("modis-15A2H|A3H"); 
+        @Generated public static final ColorMapNames MODIS_16A3GF_ET = fromString("modis-16A3GF-ET"); 
+        @Generated public static final ColorMapNames MODIS_16A3GF_PET = fromString("modis-16A3GF-PET"); 
+        @Generated public static final ColorMapNames MODIS_17A2H_A2HGF = fromString("modis-17A2H|A2HGF"); 
+        @Generated public static final ColorMapNames MODIS_17A3HGF = fromString("modis-17A3HGF"); 
+        @Generated public static final ColorMapNames MODIS_64A1 = fromString("modis-64A1"); 
+        @Generated public static final ColorMapNames MTBS_SEVERITY = fromString("mtbs-severity"); 
+        @Generated public static final ColorMapNames NIPY_SPECTRAL = fromString("nipy_spectral"); 
+        @Generated public static final ColorMapNames NIPY_SPECTRAL_R = fromString("nipy_spectral_r"); 
+        @Generated public static final ColorMapNames NRCAN_LULC = fromString("nrcan-lulc"); 
+        @Generated public static final ColorMapNames OCEAN = fromString("ocean"); 
+        @Generated public static final ColorMapNames OCEAN_R = fromString("ocean_r"); 
+        @Generated public static final ColorMapNames ORANGES = fromString("oranges"); 
+        @Generated public static final ColorMapNames ORANGES_R = fromString("oranges_r"); 
+        @Generated public static final ColorMapNames ORRD = fromString("orrd"); 
+        @Generated public static final ColorMapNames ORRD_R = fromString("orrd_r"); 
+        @Generated public static final ColorMapNames PAIRED = fromString("paired"); 
+        @Generated public static final ColorMapNames PAIRED_R = fromString("paired_r"); 
+        @Generated public static final ColorMapNames PASTEL1 = fromString("pastel1"); 
+        @Generated public static final ColorMapNames PASTEL1_R = fromString("pastel1_r"); 
+        @Generated public static final ColorMapNames PASTEL2 = fromString("pastel2"); 
+        @Generated public static final ColorMapNames PASTEL2_R = fromString("pastel2_r"); 
+        @Generated public static final ColorMapNames PINK = fromString("pink"); 
+        @Generated public static final ColorMapNames PINK_R = fromString("pink_r"); 
+        @Generated public static final ColorMapNames PIYG = fromString("piyg"); 
+        @Generated public static final ColorMapNames PIYG_R = fromString("piyg_r"); 
+        @Generated public static final ColorMapNames PLASMA = fromString("plasma"); 
+        @Generated public static final ColorMapNames PLASMA_R = fromString("plasma_r"); 
+        @Generated public static final ColorMapNames PRGN = fromString("prgn"); 
+        @Generated public static final ColorMapNames PRGN_R = fromString("prgn_r"); 
+        @Generated public static final ColorMapNames PRISM = fromString("prism"); 
+        @Generated public static final ColorMapNames PRISM_R = fromString("prism_r"); 
+        @Generated public static final ColorMapNames PUBU = fromString("pubu"); 
+        @Generated public static final ColorMapNames PUBU_R = fromString("pubu_r"); 
+        @Generated public static final ColorMapNames PUBUGN = fromString("pubugn"); 
+        @Generated public static final ColorMapNames PUBUGN_R = fromString("pubugn_r"); 
+        @Generated public static final ColorMapNames PUOR = fromString("puor"); 
+        @Generated public static final ColorMapNames PUOR_R = fromString("puor_r"); 
+        @Generated public static final ColorMapNames PURD = fromString("purd"); 
+        @Generated public static final ColorMapNames PURD_R = fromString("purd_r"); 
+        @Generated public static final ColorMapNames PURPLES = fromString("purples"); 
+        @Generated public static final ColorMapNames PURPLES_R = fromString("purples_r"); 
+        @Generated public static final ColorMapNames QPE = fromString("qpe"); 
+        @Generated public static final ColorMapNames RAINBOW = fromString("rainbow"); 
+        @Generated public static final ColorMapNames RAINBOW_R = fromString("rainbow_r"); 
+        @Generated public static final ColorMapNames RDBU = fromString("rdbu"); 
+        @Generated public static final ColorMapNames RDBU_R = fromString("rdbu_r"); 
+        @Generated public static final ColorMapNames RDGY = fromString("rdgy"); 
+        @Generated public static final ColorMapNames RDGY_R = fromString("rdgy_r"); 
+        @Generated public static final ColorMapNames RDPU = fromString("rdpu"); 
+        @Generated public static final ColorMapNames RDPU_R = fromString("rdpu_r"); 
+        @Generated public static final ColorMapNames RDYLBU = fromString("rdylbu"); 
+        @Generated public static final ColorMapNames RDYLBU_R = fromString("rdylbu_r"); 
+        @Generated public static final ColorMapNames RDYLGN = fromString("rdylgn"); 
+        @Generated public static final ColorMapNames RDYLGN_R = fromString("rdylgn_r"); 
+        @Generated public static final ColorMapNames REDS = fromString("reds"); 
+        @Generated public static final ColorMapNames REDS_R = fromString("reds_r"); 
+        @Generated public static final ColorMapNames RPLUMBO = fromString("rplumbo"); 
+        @Generated public static final ColorMapNames SCHWARZWALD = fromString("schwarzwald"); 
+        @Generated public static final ColorMapNames SEISMIC = fromString("seismic"); 
+        @Generated public static final ColorMapNames SEISMIC_R = fromString("seismic_r"); 
+        @Generated public static final ColorMapNames SET1 = fromString("set1"); 
+        @Generated public static final ColorMapNames SET1_R = fromString("set1_r"); 
+        @Generated public static final ColorMapNames SET2 = fromString("set2"); 
+        @Generated public static final ColorMapNames SET2_R = fromString("set2_r"); 
+        @Generated public static final ColorMapNames SET3 = fromString("set3"); 
+        @Generated public static final ColorMapNames SET3_R = fromString("set3_r"); 
+        @Generated public static final ColorMapNames SPECTRAL = fromString("spectral"); 
+        @Generated public static final ColorMapNames SPECTRAL_R = fromString("spectral_r"); 
+        @Generated public static final ColorMapNames SPRING = fromString("spring"); 
+        @Generated public static final ColorMapNames SPRING_R = fromString("spring_r"); 
+        @Generated public static final ColorMapNames SUMMER = fromString("summer"); 
+        @Generated public static final ColorMapNames SUMMER_R = fromString("summer_r"); 
+        @Generated public static final ColorMapNames TAB10 = fromString("tab10"); 
+        @Generated public static final ColorMapNames TAB10_R = fromString("tab10_r"); 
+        @Generated public static final ColorMapNames TAB20 = fromString("tab20"); 
+        @Generated public static final ColorMapNames TAB20_R = fromString("tab20_r"); 
+        @Generated public static final ColorMapNames TAB20B = fromString("tab20b"); 
+        @Generated public static final ColorMapNames TAB20B_R = fromString("tab20b_r"); 
+        @Generated public static final ColorMapNames TAB20C = fromString("tab20c"); 
+        @Generated public static final ColorMapNames TAB20C_R = fromString("tab20c_r"); 
+        @Generated public static final ColorMapNames TERRAIN = fromString("terrain"); 
+        @Generated public static final ColorMapNames TERRAIN_R = fromString("terrain_r"); 
+        @Generated public static final ColorMapNames TWILIGHT = fromString("twilight"); 
+        @Generated public static final ColorMapNames TWILIGHT_R = fromString("twilight_r"); 
+        @Generated public static final ColorMapNames TWILIGHT_SHIFTED = fromString("twilight_shifted"); 
+        @Generated public static final ColorMapNames TWILIGHT_SHIFTED_R = fromString("twilight_shifted_r"); 
+        @Generated public static final ColorMapNames USDA_CDL = fromString("usda-cdl"); 
+        @Generated public static final ColorMapNames USDA_CDL_CORN = fromString("usda-cdl-corn"); 
+        @Generated public static final ColorMapNames USDA_CDL_COTTON = fromString("usda-cdl-cotton"); 
+        @Generated public static final ColorMapNames USDA_CDL_SOYBEANS = fromString("usda-cdl-soybeans"); 
+        @Generated public static final ColorMapNames USDA_CDL_WHEAT = fromString("usda-cdl-wheat"); 
+        @Generated public static final ColorMapNames USGS_LCMAP = fromString("usgs-lcmap"); 
+        @Generated public static final ColorMapNames VIIRS_10A1 = fromString("viirs-10a1"); 
+        @Generated public static final ColorMapNames VIIRS_13A1 = fromString("viirs-13a1"); 
+        @Generated public static final ColorMapNames VIIRS_14A1 = fromString("viirs-14a1"); 
+        @Generated public static final ColorMapNames VIIRS_15A2H = fromString("viirs-15a2H"); 
+        @Generated public static final ColorMapNames VIRIDIS = fromString("viridis"); 
+        @Generated public static final ColorMapNames VIRIDIS_R = fromString("viridis_r"); 
+        @Generated public static final ColorMapNames WINTER = fromString("winter"); 
+        @Generated public static final ColorMapNames WINTER_R = fromString("winter_r"); 
+        @Generated public static final ColorMapNames WISTIA = fromString("wistia"); 
+        @Generated public static final ColorMapNames WISTIA_R = fromString("wistia_r"); 
+        @Generated public static final ColorMapNames YLGN = fromString("ylgn"); 
+        @Generated public static final ColorMapNames YLGN_R = fromString("ylgn_r"); 
+        @Generated public static final ColorMapNames YLGNBU = fromString("ylgnbu"); 
+        @Generated public static final ColorMapNames YLGNBU_R = fromString("ylgnbu_r"); 
+        @Generated public static final ColorMapNames YLORBR = fromString("ylorbr"); 
+        @Generated public static final ColorMapNames YLORBR_R = fromString("ylorbr_r"); 
+        @Generated public static final ColorMapNames YLORRD = fromString("ylorrd"); 
+        @Generated public static final ColorMapNames YLORRD_R = fromString("ylorrd_r"); 
+        @Generated public static final ColorMapNames ALGAE = fromString("algae"); 
+        @Generated public static final ColorMapNames ALGAE_R = fromString("algae_r"); 
+        @Generated public static final ColorMapNames AMP = fromString("amp"); 
+        @Generated public static final ColorMapNames AMP_R = fromString("amp_r"); 
+        @Generated public static final ColorMapNames BALANCE = fromString("balance"); 
+        @Generated public static final ColorMapNames BALANCE_R = fromString("balance_r"); 
+        @Generated public static final ColorMapNames CURL = fromString("curl"); 
+        @Generated public static final ColorMapNames CURL_R = fromString("curl_r"); 
+        @Generated public static final ColorMapNames DEEP = fromString("deep"); 
+        @Generated public static final ColorMapNames DEEP_R = fromString("deep_r"); 
+        @Generated public static final ColorMapNames DELTA = fromString("delta"); 
+        @Generated public static final ColorMapNames DELTA_R = fromString("delta_r"); 
+        @Generated public static final ColorMapNames DENSE = fromString("dense"); 
+        @Generated public static final ColorMapNames DENSE_R = fromString("dense_r"); 
+        @Generated public static final ColorMapNames DIFF = fromString("diff"); 
+        @Generated public static final ColorMapNames DIFF_R = fromString("diff_r"); 
+        @Generated public static final ColorMapNames HALINE = fromString("haline"); 
+        @Generated public static final ColorMapNames HALINE_R = fromString("haline_r"); 
+        @Generated public static final ColorMapNames ICE = fromString("ice"); 
+        @Generated public static final ColorMapNames ICE_R = fromString("ice_r"); 
+        @Generated public static final ColorMapNames MATTER = fromString("matter"); 
+        @Generated public static final ColorMapNames MATTER_R = fromString("matter_r"); 
+        @Generated public static final ColorMapNames OXY = fromString("oxy"); 
+        @Generated public static final ColorMapNames OXY_R = fromString("oxy_r"); 
+        @Generated public static final ColorMapNames PHASE = fromString("phase"); 
+        @Generated public static final ColorMapNames PHASE_R = fromString("phase_r"); 
+        @Generated public static final ColorMapNames RAIN = fromString("rain"); 
+        @Generated public static final ColorMapNames RAIN_R = fromString("rain_r"); 
+        @Generated public static final ColorMapNames SOLAR = fromString("solar"); 
+        @Generated public static final ColorMapNames SOLAR_R = fromString("solar_r"); 
+        @Generated public static final ColorMapNames SPEED = fromString("speed"); 
+        @Generated public static final ColorMapNames SPEED_R = fromString("speed_r"); 
+        @Generated public static final ColorMapNames TARN = fromString("tarn"); 
+        @Generated public static final ColorMapNames TARN_R = fromString("tarn_r"); 
+        @Generated public static final ColorMapNames TEMPO = fromString("tempo"); 
+        @Generated public static final ColorMapNames TEMPO_R = fromString("tempo_r"); 
+        @Generated public static final ColorMapNames THERMAL = fromString("thermal"); 
+        @Generated public static final ColorMapNames THERMAL_R = fromString("thermal_r"); 
+        @Generated public static final ColorMapNames TOPO = fromString("topo"); 
+        @Generated public static final ColorMapNames TOPO_R = fromString("topo_r"); 
+        @Generated public static final ColorMapNames TURBID = fromString("turbid"); 
+        @Generated public static final ColorMapNames TURBID_R = fromString("turbid_r"); 
+        @Generated public static final ColorMapNames TURBO = fromString("turbo"); 
+        @Generated public static final ColorMapNames TURBO_R = fromString("turbo_r"); 
+        @Deprecated @Generated public ColorMapNames() 
+        @Generated public static ColorMapNames fromString(String name) 
+        @Generated public static Collection<ColorMapNames> values() 
+    } 
+    @Immutable
+    public final class DefaultLocation implements JsonSerializable<DefaultLocation> { 
+        @Generated public DefaultLocation(int zoom, List<Double> coordinates) 
+        @Generated public List<Double> getCoordinates() 
+        @Generated public int getZoom() 
+    } 
+    @Immutable
+    public final class ErrorInfo implements JsonSerializable<ErrorInfo> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public ResponseError getError() 
+    } 
+    public final class FeatureType extends ExpandableStringEnum<FeatureType> { 
+        @Generated public static final FeatureType FEATURE = fromString("Feature"); 
+        @Deprecated @Generated public FeatureType() 
+        @Generated public static FeatureType fromString(String name) 
+        @Generated public static Collection<FeatureType> values() 
+    } 
+    @Fluent
+    public final class FileDetails { 
+        @Generated public FileDetails(BinaryData content) 
+        @Generated public BinaryData getContent() 
+        @Generated public String getContentType() 
+        @Generated public FileDetails setContentType(String contentType) 
+        @Generated public String getFilename() 
+        @Generated public FileDetails setFilename(String filename) 
+    } 
+    public final class FilterLanguage extends ExpandableStringEnum<FilterLanguage> { 
+        @Generated public static final FilterLanguage CQL_JSON = fromString("cql-json"); 
+        @Generated public static final FilterLanguage CQL2_JSON = fromString("cql2-json"); 
+        @Generated public static final FilterLanguage CQL2_TEXT = fromString("cql2-text"); 
+        @Deprecated @Generated public FilterLanguage() 
+        @Generated public static FilterLanguage fromString(String name) 
+        @Generated public static Collection<FilterLanguage> values() 
+    } 
+    @Fluent
+    public final class GeoJsonFeature implements JsonSerializable<GeoJsonFeature> { 
+        @Generated public GeoJsonFeature(GeoJsonGeometry geometry, FeatureType type) 
+        @Generated public GeoJsonGeometry getGeometry() 
+        @Generated public Map<String, BinaryData> getProperties() 
+        @Generated public GeoJsonFeature setProperties(Map<String, BinaryData> properties) 
+        @Generated public FeatureType getType() 
+    } 
+    @Fluent
+    public class GeoJsonGeometry implements JsonSerializable<GeoJsonGeometry> { 
+        @Generated public GeoJsonGeometry() 
+        @Generated public List<Double> getBoundingBox() 
+        @Generated public GeoJsonGeometry setBoundingBox(List<Double> boundingBox) 
+        @Generated public GeometryType getType() 
+    } 
+    @Fluent
+    public final class GeoJsonLineString extends GeoJsonGeometry { 
+        @Generated public GeoJsonLineString() 
+        @Generated @Override public GeoJsonLineString setBoundingBox(List<Double> boundingBox) 
+        @Generated public List<List<Double>> getCoordinates() 
+        @Generated public GeoJsonLineString setCoordinates(List<List<Double>> coordinates) 
+        @Generated public static GeoJsonLineString fromJson(JsonReader jsonReader) throws IOException
+        @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Generated @Override public GeometryType getType() 
+    } 
+    @Fluent
+    public final class GeoJsonMultiLineString extends GeoJsonGeometry { 
+        @Generated public GeoJsonMultiLineString() 
+        @Generated @Override public GeoJsonMultiLineString setBoundingBox(List<Double> boundingBox) 
+        @Generated public List<List<List<Double>>> getCoordinates() 
+        @Generated public GeoJsonMultiLineString setCoordinates(List<List<List<Double>>> coordinates) 
+        @Generated public static GeoJsonMultiLineString fromJson(JsonReader jsonReader) throws IOException
+        @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Generated @Override public GeometryType getType() 
+    } 
+    @Fluent
+    public final class GeoJsonMultiPoint extends GeoJsonGeometry { 
+        @Generated public GeoJsonMultiPoint() 
+        @Generated @Override public GeoJsonMultiPoint setBoundingBox(List<Double> boundingBox) 
+        @Generated public List<List<Double>> getCoordinates() 
+        @Generated public GeoJsonMultiPoint setCoordinates(List<List<Double>> coordinates) 
+        @Generated public static GeoJsonMultiPoint fromJson(JsonReader jsonReader) throws IOException
+        @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Generated @Override public GeometryType getType() 
+    } 
+    @Fluent
+    public final class GeoJsonMultiPolygon extends GeoJsonGeometry { 
+        @Generated public GeoJsonMultiPolygon() 
+        @Generated @Override public GeoJsonMultiPolygon setBoundingBox(List<Double> boundingBox) 
+        @Generated public List<List<List<List<Double>>>> getCoordinates() 
+        @Generated public GeoJsonMultiPolygon setCoordinates(List<List<List<List<Double>>>> coordinates) 
+        @Generated public static GeoJsonMultiPolygon fromJson(JsonReader jsonReader) throws IOException
+        @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Generated @Override public GeometryType getType() 
+    } 
+    @Fluent
+    public final class GeoJsonPoint extends GeoJsonGeometry { 
+        @Generated public GeoJsonPoint() 
+        @Generated @Override public GeoJsonPoint setBoundingBox(List<Double> boundingBox) 
+        @Generated public List<Double> getCoordinates() 
+        @Generated public GeoJsonPoint setCoordinates(List<Double> coordinates) 
+        @Generated public static GeoJsonPoint fromJson(JsonReader jsonReader) throws IOException
+        @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Generated @Override public GeometryType getType() 
+    } 
+    @Fluent
+    public final class GeoJsonPolygon extends GeoJsonGeometry { 
+        @Generated public GeoJsonPolygon() 
+        @Generated @Override public GeoJsonPolygon setBoundingBox(List<Double> boundingBox) 
+        @Generated public List<List<List<Double>>> getCoordinates() 
+        @Generated public GeoJsonPolygon setCoordinates(List<List<List<Double>>> coordinates) 
+        @Generated public static GeoJsonPolygon fromJson(JsonReader jsonReader) throws IOException
+        @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Generated @Override public GeometryType getType() 
+    } 
+    public final class GeometryType extends ExpandableStringEnum<GeometryType> { 
+        @Generated public static final GeometryType POINT = fromString("Point"); 
+        @Generated public static final GeometryType LINE_STRING = fromString("LineString"); 
+        @Generated public static final GeometryType POLYGON = fromString("Polygon"); 
+        @Generated public static final GeometryType MULTI_POINT = fromString("MultiPoint"); 
+        @Generated public static final GeometryType MULTI_LINE_STRING = fromString("MultiLineString"); 
+        @Generated public static final GeometryType MULTI_POLYGON = fromString("MultiPolygon"); 
+        @Deprecated @Generated public GeometryType() 
+        @Generated public static GeometryType fromString(String name) 
+        @Generated public static Collection<GeometryType> values() 
+    } 
+    @Fluent
+    public final class IngestionDefinition implements JsonSerializable<IngestionDefinition> { 
+        @Generated public IngestionDefinition() 
+        @Generated public OffsetDateTime getCreationTime() 
+        @Generated public String getDisplayName() 
+        @Generated public IngestionDefinition setDisplayName(String displayName) 
+        @Generated public String getId() 
+        @Generated public IngestionType getImportType() 
+        @Generated public IngestionDefinition setImportType(IngestionType importType) 
+        @Generated public Boolean isKeepOriginalAssets() 
+        @Generated public IngestionDefinition setKeepOriginalAssets(Boolean keepOriginalAssets) 
+        @Generated public Boolean isSkipExistingItems() 
+        @Generated public IngestionDefinition setSkipExistingItems(Boolean skipExistingItems) 
+        @Generated public String getSourceCatalogUrl() 
+        @Generated public IngestionDefinition setSourceCatalogUrl(String sourceCatalogUrl) 
+        @Generated public String getStacGeoparquetUrl() 
+        @Generated public IngestionDefinition setStacGeoparquetUrl(String stacGeoparquetUrl) 
+        @Generated public IngestionStatus getStatus() 
+    } 
+    @Immutable
+    public final class IngestionRun implements JsonSerializable<IngestionRun> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public OffsetDateTime getCreationTime() 
+        @Generated public String getId() 
+        @Generated public Boolean isKeepOriginalAssets() 
+        @Generated public IngestionRunOperation getOperation() 
+        @Generated public String getParentRunId() 
+        @Generated public Boolean isSkipExistingItems() 
+        @Generated public String getSourceCatalogUrl() 
+    } 
+    @Immutable
+    public final class IngestionRunOperation implements JsonSerializable<IngestionRunOperation> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public OffsetDateTime getCreationTime() 
+        @Generated public OffsetDateTime getFinishTime() 
+        @Generated public String getId() 
+        @Generated public OffsetDateTime getStartTime() 
+        @Generated public OperationStatus getStatus() 
+        @Generated public List<OperationStatusHistoryItem> getStatusHistory() 
+        @Generated public int getTotalFailedItems() 
+        @Generated public int getTotalItems() 
+        @Generated public int getTotalPendingItems() 
+        @Generated public int getTotalSuccessfulItems() 
+    } 
+    @Immutable
+    public class IngestionSource implements JsonSerializable<IngestionSource> { 
+        @Generated public IngestionSource(String id) 
+        @Generated public OffsetDateTime getCreated() 
+        @Generated public String getId() 
+        @Generated public IngestionSourceType getKind() 
+    } 
+    @Immutable
+    public final class IngestionSourceSummary implements JsonSerializable<IngestionSourceSummary> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public OffsetDateTime getCreated() 
+        @Generated public String getId() 
+        @Generated public IngestionSourceType getKind() 
+    } 
+    public final class IngestionSourceType extends ExpandableStringEnum<IngestionSourceType> { 
+        @Generated public static final IngestionSourceType SHARED_ACCESS_SIGNATURE_TOKEN = fromString("SasToken"); 
+        @Generated public static final IngestionSourceType BLOB_MANAGED_IDENTITY = fromString("BlobManagedIdentity"); 
+        @Deprecated @Generated public IngestionSourceType() 
+        @Generated public static IngestionSourceType fromString(String name) 
+        @Generated public static Collection<IngestionSourceType> values() 
+    } 
+    public final class IngestionStatus extends ExpandableStringEnum<IngestionStatus> { 
+        @Generated public static final IngestionStatus READY = fromString("Ready"); 
+        @Generated public static final IngestionStatus DELETING = fromString("Deleting"); 
+        @Deprecated @Generated public IngestionStatus() 
+        @Generated public static IngestionStatus fromString(String name) 
+        @Generated public static Collection<IngestionStatus> values() 
+    } 
+    public final class IngestionType extends ExpandableStringEnum<IngestionType> { 
+        @Generated public static final IngestionType STATIC_CATALOG = fromString("StaticCatalog"); 
+        @Generated public static final IngestionType STAC_GEOPARQUET = fromString("StacGeoparquet"); 
+        @Deprecated @Generated public IngestionType() 
+        @Generated public static IngestionType fromString(String name) 
+        @Generated public static Collection<IngestionType> values() 
+    } 
+    public final class LegendConfigType extends ExpandableStringEnum<LegendConfigType> { 
+        @Generated public static final LegendConfigType CONTINUOUS = fromString("continuous"); 
+        @Generated public static final LegendConfigType CLASSMAP = fromString("classmap"); 
+        @Generated public static final LegendConfigType INTERVAL = fromString("interval"); 
+        @Generated public static final LegendConfigType NONE = fromString("none"); 
+        @Deprecated @Generated public LegendConfigType() 
+        @Generated public static LegendConfigType fromString(String name) 
+        @Generated public static Collection<LegendConfigType> values() 
+    } 
+    @Immutable
+    public final class ManagedIdentityConnection implements JsonSerializable<ManagedIdentityConnection> { 
+        @Generated public ManagedIdentityConnection(String containerUri, String objectId) 
+        @Generated public String getContainerUri() 
+        @Generated public String getObjectId() 
+    } 
+    @Immutable
+    public final class ManagedIdentityIngestionSource extends IngestionSource { 
+        @Generated public ManagedIdentityIngestionSource(String id, ManagedIdentityConnection connectionInfo) 
+        @Generated public ManagedIdentityConnection getConnectionInfo() 
+        @Generated public static ManagedIdentityIngestionSource fromJson(JsonReader jsonReader) throws IOException
+        @Generated @Override public IngestionSourceType getKind() 
+        @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+    } 
+    @Immutable
+    public final class ManagedIdentityMetadata implements JsonSerializable<ManagedIdentityMetadata> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public String getObjectId() 
+        @Generated public String getResourceId() 
+    } 
+    @Fluent
+    public final class MosaicMetadata implements JsonSerializable<MosaicMetadata> { 
+        @Generated public MosaicMetadata() 
+        @Generated public List<String> getAssets() 
+        @Generated public MosaicMetadata setAssets(List<String> assets) 
+        @Generated public String getBounds() 
+        @Generated public MosaicMetadata setBounds(String bounds) 
+        @Generated public Map<String, String> getDefaults() 
+        @Generated public MosaicMetadata setDefaults(Map<String, String> defaults) 
+        @Generated public Integer getMaxZoom() 
+        @Generated public MosaicMetadata setMaxZoom(Integer maxZoom) 
+        @Generated public Integer getMinZoom() 
+        @Generated public MosaicMetadata setMinZoom(Integer minZoom) 
+        @Generated public String getName() 
+        @Generated public MosaicMetadata setName(String name) 
+        @Generated public MosaicMetadataType getType() 
+        @Generated public MosaicMetadata setType(MosaicMetadataType type) 
+    } 
+    public final class MosaicMetadataType extends ExpandableStringEnum<MosaicMetadataType> { 
+        @Generated public static final MosaicMetadataType MOSAIC = fromString("mosaic"); 
+        @Generated public static final MosaicMetadataType SEARCH = fromString("search"); 
+        @Deprecated @Generated public MosaicMetadataType() 
+        @Generated public static MosaicMetadataType fromString(String name) 
+        @Generated public static Collection<MosaicMetadataType> values() 
+    } 
+    public final class NoDataType extends ExpandableStringEnum<NoDataType> { 
+        @Generated public static final NoDataType ALPHA = fromString("Alpha"); 
+        @Generated public static final NoDataType MASK = fromString("Mask"); 
+        @Generated public static final NoDataType INTERNAL = fromString("Internal"); 
+        @Generated public static final NoDataType NODATA = fromString("Nodata"); 
+        @Generated public static final NoDataType NONE = fromString("None"); 
+        @Deprecated @Generated public NoDataType() 
+        @Generated public static NoDataType fromString(String name) 
+        @Generated public static Collection<NoDataType> values() 
+    } 
+    @Immutable
+    public final class Operation implements JsonSerializable<Operation> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public Map<String, String> getAdditionalInformation() 
+        @Generated public String getCollectionId() 
+        @Generated public OffsetDateTime getCreationTime() 
+        @Generated public ErrorInfo getError() 
+        @Generated public OffsetDateTime getFinishTime() 
+        @Generated public String getId() 
+        @Generated public OffsetDateTime getStartTime() 
+        @Generated public OperationStatus getStatus() 
+        @Generated public List<OperationStatusHistoryItem> getStatusHistory() 
+        @Generated public String getType() 
+    } 
+    public final class OperationStatus extends ExpandableStringEnum<OperationStatus> { 
+        @Generated public static final OperationStatus PENDING = fromString("Pending"); 
+        @Generated public static final OperationStatus RUNNING = fromString("Running"); 
+        @Generated public static final OperationStatus SUCCEEDED = fromString("Succeeded"); 
+        @Generated public static final OperationStatus CANCELED = fromString("Canceled"); 
+        @Generated public static final OperationStatus CANCELING = fromString("Canceling"); 
+        @Generated public static final OperationStatus FAILED = fromString("Failed"); 
+        @Deprecated @Generated public OperationStatus() 
+        @Generated public static OperationStatus fromString(String name) 
+        @Generated public static Collection<OperationStatus> values() 
+    } 
+    @Immutable
+    public final class OperationStatusHistoryItem implements JsonSerializable<OperationStatusHistoryItem> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public String getErrorCode() 
+        @Generated public String getErrorMessage() 
+        @Generated public OperationStatus getStatus() 
+        @Generated public OffsetDateTime getTimestamp() 
+    } 
+    @Fluent
+    public final class PartitionType implements JsonSerializable<PartitionType> { 
+        @Generated public PartitionType() 
+        @Generated public PartitionTypeScheme getScheme() 
+        @Generated public PartitionType setScheme(PartitionTypeScheme scheme) 
+    } 
+    public final class PartitionTypeScheme extends ExpandableStringEnum<PartitionTypeScheme> { 
+        @Generated public static final PartitionTypeScheme YEAR = fromString("year"); 
+        @Generated public static final PartitionTypeScheme MONTH = fromString("month"); 
+        @Generated public static final PartitionTypeScheme NONE = fromString("none"); 
+        @Deprecated @Generated public PartitionTypeScheme() 
+        @Generated public static PartitionTypeScheme fromString(String name) 
+        @Generated public static Collection<PartitionTypeScheme> values() 
+    } 
+    public final class PixelSelection extends ExpandableStringEnum<PixelSelection> { 
+        @Generated public static final PixelSelection FIRST = fromString("first"); 
+        @Generated public static final PixelSelection HIGHEST = fromString("highest"); 
+        @Generated public static final PixelSelection LOWEST = fromString("lowest"); 
+        @Generated public static final PixelSelection MEAN = fromString("mean"); 
+        @Generated public static final PixelSelection MEDIAN = fromString("median"); 
+        @Generated public static final PixelSelection STANDARD_DEVIATION = fromString("stdev"); 
+        @Generated public static final PixelSelection LAST_BAND_LOW = fromString("lastbandlow"); 
+        @Generated public static final PixelSelection LAST_BAND_HIGH = fromString("lastbandhigh"); 
+        @Generated public static final PixelSelection COUNT = fromString("count"); 
+        @Deprecated @Generated public PixelSelection() 
+        @Generated public static PixelSelection fromString(String name) 
+        @Generated public static Collection<PixelSelection> values() 
+    } 
+    @Immutable
+    public final class QueryableDefinitionsResponse implements JsonSerializable<QueryableDefinitionsResponse> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public Map<String, BinaryData> getAdditionalProperties() 
+    } 
+    @Fluent
+    public final class RegisterMosaicsSearchOptions { 
+        @Generated public RegisterMosaicsSearchOptions() 
+        @Generated public List<Double> getBoundingBox() 
+        @Generated public RegisterMosaicsSearchOptions setBoundingBox(List<Double> boundingBox) 
+        @Generated public List<String> getCollections() 
+        @Generated public RegisterMosaicsSearchOptions setCollections(List<String> collections) 
+        @Generated public String getDatetime() 
+        @Generated public RegisterMosaicsSearchOptions setDatetime(String datetime) 
+        @Generated public Map<String, BinaryData> getFilter() 
+        @Generated public RegisterMosaicsSearchOptions setFilter(Map<String, BinaryData> filter) 
+        @Generated public FilterLanguage getFilterLanguage() 
+        @Generated public RegisterMosaicsSearchOptions setFilterLanguage(FilterLanguage filterLanguage) 
+        @Generated public List<String> getIds() 
+        @Generated public RegisterMosaicsSearchOptions setIds(List<String> ids) 
+        @Generated public GeoJsonGeometry getIntersects() 
+        @Generated public RegisterMosaicsSearchOptions setIntersects(GeoJsonGeometry intersects) 
+        @Generated public MosaicMetadata getMetadata() 
+        @Generated public RegisterMosaicsSearchOptions setMetadata(MosaicMetadata metadata) 
+        @Generated public Map<String, BinaryData> getQuery() 
+        @Generated public RegisterMosaicsSearchOptions setQuery(Map<String, BinaryData> query) 
+        @Generated public List<StacSortExtension> getSortBy() 
+        @Generated public RegisterMosaicsSearchOptions setSortBy(List<StacSortExtension> sortBy) 
+    } 
+    @Fluent
+    public final class RenderOption implements JsonSerializable<RenderOption> { 
+        @Generated public RenderOption(String id, String name) 
+        @Generated public List<RenderOptionCondition> getConditions() 
+        @Generated public RenderOption setConditions(List<RenderOptionCondition> conditions) 
+        @Generated public String getDescription() 
+        @Generated public RenderOption setDescription(String description) 
+        @Generated public String getId() 
+        @Generated public RenderOptionLegend getLegend() 
+        @Generated public RenderOption setLegend(RenderOptionLegend legend) 
+        @Generated public Integer getMinZoom() 
+        @Generated public RenderOption setMinZoom(Integer minZoom) 
+        @Generated public String getName() 
+        @Generated public String getOptions() 
+        @Generated public RenderOption setOptions(String options) 
+        @Generated public RenderOptionType getType() 
+        @Generated public RenderOption setType(RenderOptionType type) 
+        @Generated public RenderOptionVectorOptions getVectorOptions() 
+        @Generated public RenderOption setVectorOptions(RenderOptionVectorOptions vectorOptions) 
+    } 
+    @Fluent
+    public final class RenderOptionCondition implements JsonSerializable<RenderOptionCondition> { 
+        @Generated public RenderOptionCondition(String property) 
+        @Generated public String getProperty() 
+        @Generated public String getValue() 
+        @Generated public RenderOptionCondition setValue(String value) 
+    } 
+    @Fluent
+    public final class RenderOptionLegend implements JsonSerializable<RenderOptionLegend> { 
+        @Generated public RenderOptionLegend() 
+        @Generated public List<String> getLabels() 
+        @Generated public RenderOptionLegend setLabels(List<String> labels) 
+        @Generated public Double getScaleFactor() 
+        @Generated public RenderOptionLegend setScaleFactor(Double scaleFactor) 
+        @Generated public Integer getTrimEnd() 
+        @Generated public RenderOptionLegend setTrimEnd(Integer trimEnd) 
+        @Generated public Integer getTrimStart() 
+        @Generated public RenderOptionLegend setTrimStart(Integer trimStart) 
+        @Generated public LegendConfigType getType() 
+        @Generated public RenderOptionLegend setType(LegendConfigType type) 
+    } 
+    public final class RenderOptionType extends ExpandableStringEnum<RenderOptionType> { 
+        @Generated public static final RenderOptionType RASTER_TILE = fromString("raster-tile"); 
+        @Generated public static final RenderOptionType VT_POLYGON = fromString("vt-polygon"); 
+        @Generated public static final RenderOptionType VT_LINE = fromString("vt-line"); 
+        @Deprecated @Generated public RenderOptionType() 
+        @Generated public static RenderOptionType fromString(String name) 
+        @Generated public static Collection<RenderOptionType> values() 
+    } 
+    @Fluent
+    public final class RenderOptionVectorOptions implements JsonSerializable<RenderOptionVectorOptions> { 
+        @Generated public RenderOptionVectorOptions(String tilejsonKey, String sourceLayer) 
+        @Generated public String getFillColor() 
+        @Generated public RenderOptionVectorOptions setFillColor(String fillColor) 
+        @Generated public List<String> getFilter() 
+        @Generated public RenderOptionVectorOptions setFilter(List<String> filter) 
+        @Generated public String getSourceLayer() 
+        @Generated public String getStrokeColor() 
+        @Generated public RenderOptionVectorOptions setStrokeColor(String strokeColor) 
+        @Generated public Integer getStrokeWidth() 
+        @Generated public RenderOptionVectorOptions setStrokeWidth(Integer strokeWidth) 
+        @Generated public String getTilejsonKey() 
+    } 
+    public final class Resampling extends ExpandableStringEnum<Resampling> { 
+        @Generated public static final Resampling NEAREST = fromString("nearest"); 
+        @Generated public static final Resampling BILINEAR = fromString("bilinear"); 
+        @Generated public static final Resampling CUBIC = fromString("cubic"); 
+        @Generated public static final Resampling CUBIC_SPLINE = fromString("cubic_spline"); 
+        @Generated public static final Resampling LANCZOS = fromString("lanczos"); 
+        @Generated public static final Resampling AVERAGE = fromString("average"); 
+        @Generated public static final Resampling MODE = fromString("mode"); 
+        @Generated public static final Resampling GAUSS = fromString("gauss"); 
+        @Generated public static final Resampling RMS = fromString("rms"); 
+        @Deprecated @Generated public Resampling() 
+        @Generated public static Resampling fromString(String name) 
+        @Generated public static Collection<Resampling> values() 
+    } 
+    @Fluent
+    public final class SearchOptionsFields implements JsonSerializable<SearchOptionsFields> { 
+        @Generated public SearchOptionsFields() 
+        @Generated public List<String> getExclude() 
+        @Generated public SearchOptionsFields setExclude(List<String> exclude) 
+        @Generated public List<String> getInclude() 
+        @Generated public SearchOptionsFields setInclude(List<String> include) 
+    } 
+    public final class SelMethod extends ExpandableStringEnum<SelMethod> { 
+        @Generated public static final SelMethod NEAREST = fromString("nearest"); 
+        @Generated public static final SelMethod LINEAR = fromString("linear"); 
+        @Generated public static final SelMethod BILINEAR = fromString("bilinear"); 
+        @Generated public static final SelMethod CUBIC = fromString("cubic"); 
+        @Generated public static final SelMethod CUBIC_SPLINE = fromString("cubic_spline"); 
+        @Generated public static final SelMethod LANCZOS = fromString("lanczos"); 
+        @Generated public static final SelMethod AREA = fromString("area"); 
+        @Generated public static final SelMethod MODE = fromString("mode"); 
+        @Deprecated @Generated public SelMethod() 
+        @Generated public static SelMethod fromString(String name) 
+        @Generated public static Collection<SelMethod> values() 
+    } 
+    @Immutable
+    public final class SharedAccessSignatureSignedLink implements JsonSerializable<SharedAccessSignatureSignedLink> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public OffsetDateTime getExpiresOn() 
+        @Generated public String getHref() 
+    } 
+    @Immutable
+    public final class SharedAccessSignatureToken implements JsonSerializable<SharedAccessSignatureToken> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public OffsetDateTime getExpiresOn() 
+        @Generated public String getToken() 
+    } 
+    @Fluent
+    public final class SharedAccessSignatureTokenConnection implements JsonSerializable<SharedAccessSignatureTokenConnection> { 
+        @Generated public SharedAccessSignatureTokenConnection(String containerUri) 
+        @Generated public String getContainerUri() 
+        @Generated public OffsetDateTime getExpiration() 
+        @Generated public String getSharedAccessSignatureToken() 
+        @Generated public SharedAccessSignatureTokenConnection setSharedAccessSignatureToken(String sharedAccessSignatureToken) 
+    } 
+    @Immutable
+    public final class SharedAccessSignatureTokenIngestionSource extends IngestionSource { 
+        @Generated public SharedAccessSignatureTokenIngestionSource(String id, SharedAccessSignatureTokenConnection connectionInfo) 
+        @Generated public SharedAccessSignatureTokenConnection getConnectionInfo() 
+        @Generated public static SharedAccessSignatureTokenIngestionSource fromJson(JsonReader jsonReader) throws IOException
+        @Generated @Override public IngestionSourceType getKind() 
+        @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+    } 
+    @Fluent
+    public final class StacAsset implements JsonSerializable<StacAsset> { 
+        @Generated public StacAsset() 
+        @Generated public Map<String, BinaryData> getAdditionalProperties() 
+        @Generated public StacAsset setAdditionalProperties(Map<String, BinaryData> additionalProperties) 
+        @Generated public String getConstellation() 
+        @Generated public StacAsset setConstellation(String constellation) 
+        @Generated public OffsetDateTime getCreated() 
+        @Generated public StacAsset setCreated(OffsetDateTime created) 
+        @Generated public String getDescription() 
+        @Generated public StacAsset setDescription(String description) 
+        @Generated public Double getGsd() 
+        @Generated public StacAsset setGsd(Double gsd) 
+        @Generated public String getHref() 
+        @Generated public StacAsset setHref(String href) 
+        @Generated public List<String> getInstruments() 
+        @Generated public StacAsset setInstruments(List<String> instruments) 
+        @Generated public String getMission() 
+        @Generated public StacAsset setMission(String mission) 
+        @Generated public String getPlatform() 
+        @Generated public StacAsset setPlatform(String platform) 
+        @Generated public List<StacProvider> getProviders() 
+        @Generated public StacAsset setProviders(List<StacProvider> providers) 
+        @Generated public List<String> getRoles() 
+        @Generated public StacAsset setRoles(List<String> roles) 
+        @Generated public String getTitle() 
+        @Generated public StacAsset setTitle(String title) 
+        @Generated public String getType() 
+        @Generated public StacAsset setType(String type) 
+        @Generated public OffsetDateTime getUpdated() 
+        @Generated public StacAsset setUpdated(OffsetDateTime updated) 
+    } 
+    @Immutable
+    public final class StacAssetData { 
+        @Generated public StacAssetData(AssetMetadata data, FileDetails file) 
+        @Generated public AssetMetadata getData() 
+        @Generated public FileDetails getFile() 
+    } 
+    public final class StacAssetUrlSigningMode extends ExpandableStringEnum<StacAssetUrlSigningMode> { 
+        @Generated public static final StacAssetUrlSigningMode TRUE = fromString("true"); 
+        @Generated public static final StacAssetUrlSigningMode FALSE = fromString("false"); 
+        @Deprecated @Generated public StacAssetUrlSigningMode() 
+        @Generated public static StacAssetUrlSigningMode fromString(String name) 
+        @Generated public static Collection<StacAssetUrlSigningMode> values() 
+    } 
+    @Immutable
+    public final class StacCatalogCollections implements JsonSerializable<StacCatalogCollections> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public List<StacCollection> getCollections() 
+        @Generated public List<StacLink> getLinks() 
+    } 
+    @Fluent
+    public final class StacCollection implements JsonSerializable<StacCollection> { 
+        @Generated public StacCollection(String description, List<StacLink> links, String license, StacExtensionExtent extent) 
+        @Generated public Map<String, BinaryData> getAdditionalProperties() 
+        @Generated public StacCollection setAdditionalProperties(Map<String, BinaryData> additionalProperties) 
+        @Generated public Map<String, StacAsset> getAssets() 
+        @Generated public StacCollection setAssets(Map<String, StacAsset> assets) 
+        @Generated public OffsetDateTime getCreatedOn() 
+        @Generated public StacCollection setCreatedOn(OffsetDateTime createdOn) 
+        @Generated public String getDescription() 
+        @Generated public StacExtensionExtent getExtent() 
+        @Generated public String getId() 
+        @Generated public Map<String, StacItemAsset> getItemAssets() 
+        @Generated public StacCollection setItemAssets(Map<String, StacItemAsset> itemAssets) 
+        @Generated public List<String> getKeywords() 
+        @Generated public StacCollection setKeywords(List<String> keywords) 
+        @Generated public String getLicense() 
+        @Generated public List<StacLink> getLinks() 
+        @Generated public List<StacProvider> getProviders() 
+        @Generated public StacCollection setProviders(List<StacProvider> providers) 
+        @Generated public String getShortDescription() 
+        @Generated public StacCollection setShortDescription(String shortDescription) 
+        @Generated public List<String> getStacExtensions() 
+        @Generated public StacCollection setStacExtensions(List<String> stacExtensions) 
+        @Generated public String getStacVersion() 
+        @Generated public StacCollection setStacVersion(String stacVersion) 
+        @Generated public Map<String, BinaryData> getSummaries() 
+        @Generated public StacCollection setSummaries(Map<String, BinaryData> summaries) 
+        @Generated public String getTitle() 
+        @Generated public StacCollection setTitle(String title) 
+        @Generated public String getType() 
+        @Generated public StacCollection setType(String type) 
+        @Generated public OffsetDateTime getUpdatedOn() 
+        @Generated public StacCollection setUpdatedOn(OffsetDateTime updatedOn) 
+    } 
+    @Immutable
+    public final class StacCollectionTemporalExtent implements JsonSerializable<StacCollectionTemporalExtent> { 
+        @Generated public StacCollectionTemporalExtent(List<List<OffsetDateTime>> interval) 
+        @Generated public List<List<OffsetDateTime>> getInterval() 
+    } 
+    @Immutable
+    public final class StacConformanceClasses implements JsonSerializable<StacConformanceClasses> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public List<String> getConformsTo() 
+    } 
+    @Fluent
+    public final class StacContextExtension implements JsonSerializable<StacContextExtension> { 
+        @Generated public StacContextExtension() 
+        @Generated public Integer getLimit() 
+        @Generated public StacContextExtension setLimit(Integer limit) 
+        @Generated public Integer getMatched() 
+        @Generated public StacContextExtension setMatched(Integer matched) 
+        @Generated public int getReturned() 
+        @Generated public StacContextExtension setReturned(int returned) 
+    } 
+    @Immutable
+    public final class StacExtensionExtent implements JsonSerializable<StacExtensionExtent> { 
+        @Generated public StacExtensionExtent(StacExtensionSpatialExtent spatial, StacCollectionTemporalExtent temporal) 
+        @Generated public StacExtensionSpatialExtent getSpatial() 
+        @Generated public StacCollectionTemporalExtent getTemporal() 
+    } 
+    @Fluent
+    public final class StacExtensionSpatialExtent implements JsonSerializable<StacExtensionSpatialExtent> { 
+        @Generated public StacExtensionSpatialExtent() 
+        @Generated public List<List<Double>> getBoundingBox() 
+        @Generated public StacExtensionSpatialExtent setBoundingBox(List<List<Double>> boundingBox) 
+    } 
+    @Fluent
+    public final class StacItem extends StacItemOrStacItemCollection { 
+        @Generated public StacItem() 
+        @Generated public Map<String, StacAsset> getAssets() 
+        @Generated public StacItem setAssets(Map<String, StacAsset> assets) 
+        @Generated public List<Double> getBoundingBox() 
+        @Generated public StacItem setBoundingBox(List<Double> boundingBox) 
+        @Generated public String getCollection() 
+        @Generated public StacItem setCollection(String collection) 
+        @Generated @Override public StacItem setCreatedOn(OffsetDateTime createdOn) 
+        @Generated public String getETag() 
+        @Generated public StacItem setETag(String eTag) 
+        @Generated public static StacItem fromJson(JsonReader jsonReader) throws IOException
+        @Generated public GeoJsonGeometry getGeometry() 
+        @Generated public StacItem setGeometry(GeoJsonGeometry geometry) 
+        @Generated public String getId() 
+        @Generated @Override public StacItem setLinks(List<StacLink> links) 
+        @Generated public StacItemProperties getProperties() 
+        @Generated public StacItem setProperties(StacItemProperties properties) 
+        @Generated @Override public StacItem setShortDescription(String shortDescription) 
+        @Generated @Override public StacItem setStacExtensions(List<String> stacExtensions) 
+        @Generated @Override public StacItem setStacVersion(String stacVersion) 
+        @Generated public OffsetDateTime getTimestamp() 
+        @Generated public StacItem setTimestamp(OffsetDateTime timestamp) 
+        @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Generated @Override public StacModelType getType() 
+        @Generated @Override public StacItem setUpdatedOn(OffsetDateTime updatedOn) 
+    } 
+    @Fluent
+    public final class StacItemAsset implements JsonSerializable<StacItemAsset> { 
+        @Generated public StacItemAsset(String title, String type) 
+        @Generated public Map<String, BinaryData> getAdditionalProperties() 
+        @Generated public StacItemAsset setAdditionalProperties(Map<String, BinaryData> additionalProperties) 
+        @Generated public String getConstellation() 
+        @Generated public StacItemAsset setConstellation(String constellation) 
+        @Generated public OffsetDateTime getCreated() 
+        @Generated public StacItemAsset setCreated(OffsetDateTime created) 
+        @Generated public String getDescription() 
+        @Generated public StacItemAsset setDescription(String description) 
+        @Generated public Double getGsd() 
+        @Generated public StacItemAsset setGsd(Double gsd) 
+        @Generated public String getHref() 
+        @Generated public StacItemAsset setHref(String href) 
+        @Generated public List<String> getInstruments() 
+        @Generated public StacItemAsset setInstruments(List<String> instruments) 
+        @Generated public String getMission() 
+        @Generated public StacItemAsset setMission(String mission) 
+        @Generated public String getPlatform() 
+        @Generated public StacItemAsset setPlatform(String platform) 
+        @Generated public List<StacProvider> getProviders() 
+        @Generated public StacItemAsset setProviders(List<StacProvider> providers) 
+        @Generated public List<String> getRoles() 
+        @Generated public StacItemAsset setRoles(List<String> roles) 
+        @Generated public String getTitle() 
+        @Generated public String getType() 
+        @Generated public OffsetDateTime getUpdated() 
+        @Generated public StacItemAsset setUpdated(OffsetDateTime updated) 
+    } 
+    @Immutable
+    public final class StacItemBounds implements JsonSerializable<StacItemBounds> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public List<Double> getBounds() 
+    } 
+    @Fluent
+    public final class StacItemCollection extends StacItemOrStacItemCollection { 
+        @Generated public StacItemCollection() 
+        @Generated public List<Double> getBoundingBox() 
+        @Generated public StacItemCollection setBoundingBox(List<Double> boundingBox) 
+        @Generated public StacContextExtension getContext() 
+        @Generated public StacItemCollection setContext(StacContextExtension context) 
+        @Generated @Override public StacItemCollection setCreatedOn(OffsetDateTime createdOn) 
+        @Generated public List<StacItem> getFeatures() 
+        @Generated public StacItemCollection setFeatures(List<StacItem> features) 
+        @Generated public static StacItemCollection fromJson(JsonReader jsonReader) throws IOException
+        @Generated @Override public StacItemCollection setLinks(List<StacLink> links) 
+        @Generated @Override public StacItemCollection setShortDescription(String shortDescription) 
+        @Generated @Override public StacItemCollection setStacExtensions(List<String> stacExtensions) 
+        @Generated @Override public StacItemCollection setStacVersion(String stacVersion) 
+        @Generated @Override public JsonWriter toJson(JsonWriter jsonWriter) throws IOException
+        @Generated @Override public StacModelType getType() 
+        @Generated @Override public StacItemCollection setUpdatedOn(OffsetDateTime updatedOn) 
+    } 
+    @Fluent
+    public class StacItemOrStacItemCollection implements JsonSerializable<StacItemOrStacItemCollection> { 
+        @Generated public StacItemOrStacItemCollection() 
+        @Generated public OffsetDateTime getCreatedOn() 
+        @Generated public StacItemOrStacItemCollection setCreatedOn(OffsetDateTime createdOn) 
+        @Generated public List<StacLink> getLinks() 
+        @Generated public StacItemOrStacItemCollection setLinks(List<StacLink> links) 
+        @Generated public String getShortDescription() 
+        @Generated public StacItemOrStacItemCollection setShortDescription(String shortDescription) 
+        @Generated public List<String> getStacExtensions() 
+        @Generated public StacItemOrStacItemCollection setStacExtensions(List<String> stacExtensions) 
+        @Generated public String getStacVersion() 
+        @Generated public StacItemOrStacItemCollection setStacVersion(String stacVersion) 
+        @Generated public StacModelType getType() 
+        @Generated public OffsetDateTime getUpdatedOn() 
+        @Generated public StacItemOrStacItemCollection setUpdatedOn(OffsetDateTime updatedOn) 
+    } 
+    @Immutable
+    public final class StacItemPointAsset implements JsonSerializable<StacItemPointAsset> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public Map<String, StacAsset> getAssets() 
+        @Generated public List<Double> getBoundingBox() 
+        @Generated public String getCollectionId() 
+        @Generated public String getId() 
+    } 
+    @Fluent
+    public final class StacItemProperties implements JsonSerializable<StacItemProperties> { 
+        @Generated public StacItemProperties() 
+        @Generated public Map<String, BinaryData> getAdditionalProperties() 
+        @Generated public StacItemProperties setAdditionalProperties(Map<String, BinaryData> additionalProperties) 
+        @Generated public String getConstellation() 
+        @Generated public StacItemProperties setConstellation(String constellation) 
+        @Generated public OffsetDateTime getCreated() 
+        @Generated public StacItemProperties setCreated(OffsetDateTime created) 
+        @Generated public String getDatetime() 
+        @Generated public StacItemProperties setDatetime(String datetime) 
+        @Generated public String getDescription() 
+        @Generated public StacItemProperties setDescription(String description) 
+        @Generated public OffsetDateTime getEndDatetime() 
+        @Generated public StacItemProperties setEndDatetime(OffsetDateTime endDatetime) 
+        @Generated public Double getGsd() 
+        @Generated public StacItemProperties setGsd(Double gsd) 
+        @Generated public List<String> getInstruments() 
+        @Generated public StacItemProperties setInstruments(List<String> instruments) 
+        @Generated public String getMission() 
+        @Generated public StacItemProperties setMission(String mission) 
+        @Generated public String getPlatform() 
+        @Generated public StacItemProperties setPlatform(String platform) 
+        @Generated public List<StacProvider> getProviders() 
+        @Generated public StacItemProperties setProviders(List<StacProvider> providers) 
+        @Generated public OffsetDateTime getStartDatetime() 
+        @Generated public StacItemProperties setStartDatetime(OffsetDateTime startDatetime) 
+        @Generated public String getTitle() 
+        @Generated public StacItemProperties setTitle(String title) 
+        @Generated public OffsetDateTime getUpdated() 
+        @Generated public StacItemProperties setUpdated(OffsetDateTime updated) 
+    } 
+    @Immutable
+    public final class StacItemStatisticsGeoJson implements JsonSerializable<StacItemStatisticsGeoJson> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public GeoJsonGeometry getGeometry() 
+        @Generated public StacItemStatisticsGeoJsonProperties getProperties() 
+        @Generated public FeatureType getType() 
+    } 
+    @Immutable
+    public final class StacItemStatisticsGeoJsonProperties implements JsonSerializable<StacItemStatisticsGeoJsonProperties> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public Map<String, BinaryData> getAdditionalProperties() 
+        @Generated public Map<String, BandStatistics> getStatistics() 
+    } 
+    @Immutable
+    public final class StacLandingPage implements JsonSerializable<StacLandingPage> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public List<String> getConformsTo() 
+        @Generated public OffsetDateTime getCreatedOn() 
+        @Generated public String getDescription() 
+        @Generated public String getId() 
+        @Generated public List<StacLink> getLinks() 
+        @Generated public String getShortDescription() 
+        @Generated public List<String> getStacExtensions() 
+        @Generated public String getStacVersion() 
+        @Generated public String getTitle() 
+        @Generated public String getType() 
+        @Generated public OffsetDateTime getUpdatedOn() 
+    } 
+    @Fluent
+    public final class StacLink implements JsonSerializable<StacLink> { 
+        @Generated public StacLink() 
+        @Generated public Map<String, BinaryData> getBody() 
+        @Generated public StacLink setBody(Map<String, BinaryData> body) 
+        @Generated public Map<String, String> getHeaders() 
+        @Generated public StacLink setHeaders(Map<String, String> headers) 
+        @Generated public String getHref() 
+        @Generated public StacLink setHref(String href) 
+        @Generated public String getHreflang() 
+        @Generated public StacLink setHreflang(String hreflang) 
+        @Generated public Integer getLength() 
+        @Generated public StacLink setLength(Integer length) 
+        @Generated public Boolean isMerge() 
+        @Generated public StacLink setMerge(Boolean merge) 
+        @Generated public StacLinkMethod getMethod() 
+        @Generated public StacLink setMethod(StacLinkMethod method) 
+        @Generated public String getRel() 
+        @Generated public StacLink setRel(String rel) 
+        @Generated public String getTitle() 
+        @Generated public StacLink setTitle(String title) 
+        @Generated public StacLinkType getType() 
+        @Generated public StacLink setType(StacLinkType type) 
+    } 
+    public final class StacLinkMethod extends ExpandableStringEnum<StacLinkMethod> { 
+        @Generated public static final StacLinkMethod GET = fromString("GET"); 
+        @Generated public static final StacLinkMethod POST = fromString("POST"); 
+        @Deprecated @Generated public StacLinkMethod() 
+        @Generated public static StacLinkMethod fromString(String name) 
+        @Generated public static Collection<StacLinkMethod> values() 
+    } 
+    public final class StacLinkType extends ExpandableStringEnum<StacLinkType> { 
+        @Generated public static final StacLinkType IMAGE_TIFF_APPLICATION_GEOTIFF = fromString("image/tiff; application=geotiff"); 
+        @Generated public static final StacLinkType IMAGE_JP2 = fromString("image/jp2"); 
+        @Generated public static final StacLinkType IMAGE_PNG = fromString("image/png"); 
+        @Generated public static final StacLinkType IMAGE_JPEG = fromString("image/jpeg"); 
+        @Generated public static final StacLinkType IMAGE_JPG = fromString("image/jpg"); 
+        @Generated public static final StacLinkType IMAGE_WEBP = fromString("image/webp"); 
+        @Generated public static final StacLinkType APPLICATION_X_BINARY = fromString("application/x-binary"); 
+        @Generated public static final StacLinkType APPLICATION_XML = fromString("application/xml"); 
+        @Generated public static final StacLinkType APPLICATION_JSON = fromString("application/json"); 
+        @Generated public static final StacLinkType APPLICATION_GEO_JSON = fromString("application/geo+json"); 
+        @Generated public static final StacLinkType TEXT_HTML = fromString("text/html"); 
+        @Generated public static final StacLinkType TEXT_PLAIN = fromString("text/plain"); 
+        @Generated public static final StacLinkType APPLICATION_X_PROTOBUF = fromString("application/x-protobuf"); 
+        @Deprecated @Generated public StacLinkType() 
+        @Generated public static StacLinkType fromString(String name) 
+        @Generated public static Collection<StacLinkType> values() 
+    } 
+    public final class StacModelType extends ExpandableStringEnum<StacModelType> { 
+        @Generated public static final StacModelType FEATURE = fromString("Feature"); 
+        @Generated public static final StacModelType FEATURE_COLLECTION = fromString("FeatureCollection"); 
+        @Deprecated @Generated public StacModelType() 
+        @Generated public static StacModelType fromString(String name) 
+        @Generated public static Collection<StacModelType> values() 
+    } 
+    @Fluent
+    public final class StacMosaic implements JsonSerializable<StacMosaic> { 
+        @Generated public StacMosaic(String id, String name, List<Map<String, BinaryData>> cql) 
+        @Generated public List<Map<String, BinaryData>> getCql() 
+        @Generated public String getDescription() 
+        @Generated public StacMosaic setDescription(String description) 
+        @Generated public String getId() 
+        @Generated public String getName() 
+    } 
+    @Immutable
+    public final class StacMosaicConfiguration implements JsonSerializable<StacMosaicConfiguration> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public Map<String, BinaryData> getDefaultCustomQuery() 
+        @Generated public DefaultLocation getDefaultLocation() 
+        @Generated public List<StacMosaic> getMosaics() 
+        @Generated public List<RenderOption> getRenderOptions() 
+    } 
+    @Fluent
+    public final class StacProvider implements JsonSerializable<StacProvider> { 
+        @Generated public StacProvider() 
+        @Generated public String getDescription() 
+        @Generated public StacProvider setDescription(String description) 
+        @Generated public String getName() 
+        @Generated public StacProvider setName(String name) 
+        @Generated public List<String> getRoles() 
+        @Generated public StacProvider setRoles(List<String> roles) 
+        @Generated public String getUrl() 
+        @Generated public StacProvider setUrl(String url) 
+    } 
+    @Fluent
+    public final class StacQueryable implements JsonSerializable<StacQueryable> { 
+        @Generated public StacQueryable(String name, Map<String, BinaryData> definition) 
+        @Generated public Boolean isCreateIndex() 
+        @Generated public StacQueryable setCreateIndex(Boolean createIndex) 
+        @Generated public StacQueryableDefinitionDataType getDataType() 
+        @Generated public StacQueryable setDataType(StacQueryableDefinitionDataType dataType) 
+        @Generated public Map<String, BinaryData> getDefinition() 
+        @Generated public String getName() 
+    } 
+    public final class StacQueryableDefinitionDataType extends ExpandableStringEnum<StacQueryableDefinitionDataType> { 
+        @Generated public static final StacQueryableDefinitionDataType STRING = fromString("string"); 
+        @Generated public static final StacQueryableDefinitionDataType NUMBER = fromString("number"); 
+        @Generated public static final StacQueryableDefinitionDataType BOOLEAN = fromString("boolean"); 
+        @Generated public static final StacQueryableDefinitionDataType TIMESTAMP = fromString("timestamp"); 
+        @Generated public static final StacQueryableDefinitionDataType DATE = fromString("date"); 
+        @Deprecated @Generated public StacQueryableDefinitionDataType() 
+        @Generated public static StacQueryableDefinitionDataType fromString(String name) 
+        @Generated public static Collection<StacQueryableDefinitionDataType> values() 
+    } 
+    @Fluent
+    public final class StacSearchParameters implements JsonSerializable<StacSearchParameters> { 
+        @Generated public StacSearchParameters() 
+        @Generated public List<Double> getBoundingBox() 
+        @Generated public StacSearchParameters setBoundingBox(List<Double> boundingBox) 
+        @Generated public List<String> getCollections() 
+        @Generated public StacSearchParameters setCollections(List<String> collections) 
+        @Generated public Map<String, BinaryData> getConformanceClass() 
+        @Generated public StacSearchParameters setConformanceClass(Map<String, BinaryData> conformanceClass) 
+        @Generated public String getDatetime() 
+        @Generated public StacSearchParameters setDatetime(String datetime) 
+        @Generated public List<SearchOptionsFields> getFields() 
+        @Generated public StacSearchParameters setFields(List<SearchOptionsFields> fields) 
+        @Generated public Map<String, BinaryData> getFilter() 
+        @Generated public StacSearchParameters setFilter(Map<String, BinaryData> filter) 
+        @Generated public String getFilterCoordinateReferenceSystem() 
+        @Generated public StacSearchParameters setFilterCoordinateReferenceSystem(String filterCoordinateReferenceSystem) 
+        @Generated public FilterLanguage getFilterLang() 
+        @Generated public StacSearchParameters setFilterLang(FilterLanguage filterLang) 
+        @Generated public List<String> getIds() 
+        @Generated public StacSearchParameters setIds(List<String> ids) 
+        @Generated public GeoJsonGeometry getIntersects() 
+        @Generated public StacSearchParameters setIntersects(GeoJsonGeometry intersects) 
+        @Generated public Integer getLimit() 
+        @Generated public StacSearchParameters setLimit(Integer limit) 
+        @Generated public Map<String, BinaryData> getQuery() 
+        @Generated public StacSearchParameters setQuery(Map<String, BinaryData> query) 
+        @Generated public List<StacSortExtension> getSortBy() 
+        @Generated public StacSearchParameters setSortBy(List<StacSortExtension> sortBy) 
+        @Generated public String getToken() 
+        @Generated public StacSearchParameters setToken(String token) 
+    } 
+    public final class StacSearchSortingDirection extends ExpandableStringEnum<StacSearchSortingDirection> { 
+        @Generated public static final StacSearchSortingDirection ASC = fromString("asc"); 
+        @Generated public static final StacSearchSortingDirection DESC = fromString("desc"); 
+        @Deprecated @Generated public StacSearchSortingDirection() 
+        @Generated public static StacSearchSortingDirection fromString(String name) 
+        @Generated public static Collection<StacSearchSortingDirection> values() 
+    } 
+    @Immutable
+    public final class StacSortExtension implements JsonSerializable<StacSortExtension> { 
+        @Generated public StacSortExtension(String field, StacSearchSortingDirection direction) 
+        @Generated public StacSearchSortingDirection getDirection() 
+        @Generated public String getField() 
+    } 
+    public final class TerrainAlgorithm extends ExpandableStringEnum<TerrainAlgorithm> { 
+        @Generated public static final TerrainAlgorithm HILLSHADE = fromString("hillshade"); 
+        @Generated public static final TerrainAlgorithm CONTOURS = fromString("contours"); 
+        @Generated public static final TerrainAlgorithm NORMALIZED_INDEX = fromString("normalizedIndex"); 
+        @Generated public static final TerrainAlgorithm TERRARIUM = fromString("terrarium"); 
+        @Generated public static final TerrainAlgorithm TERRAINRGB = fromString("terrainrgb"); 
+        @Generated public static final TerrainAlgorithm SLOPE = fromString("slope"); 
+        @Generated public static final TerrainAlgorithm CAST = fromString("cast"); 
+        @Generated public static final TerrainAlgorithm CEIL = fromString("ceil"); 
+        @Generated public static final TerrainAlgorithm FLOOR = fromString("floor"); 
+        @Generated public static final TerrainAlgorithm MIN = fromString("min"); 
+        @Generated public static final TerrainAlgorithm MAX = fromString("max"); 
+        @Generated public static final TerrainAlgorithm MEDIAN = fromString("median"); 
+        @Generated public static final TerrainAlgorithm MEAN = fromString("mean"); 
+        @Generated public static final TerrainAlgorithm STD = fromString("std"); 
+        @Generated public static final TerrainAlgorithm VAR = fromString("var"); 
+        @Deprecated @Generated public TerrainAlgorithm() 
+        @Generated public static TerrainAlgorithm fromString(String name) 
+        @Generated public static Collection<TerrainAlgorithm> values() 
+    } 
+    public final class TileAddressingScheme extends ExpandableStringEnum<TileAddressingScheme> { 
+        @Generated public static final TileAddressingScheme XYZ = fromString("xyz"); 
+        @Generated public static final TileAddressingScheme TMS = fromString("tms"); 
+        @Deprecated @Generated public TileAddressingScheme() 
+        @Generated public static TileAddressingScheme fromString(String name) 
+        @Generated public static Collection<TileAddressingScheme> values() 
+    } 
+    @Immutable
+    public final class TileJsonMetadata implements JsonSerializable<TileJsonMetadata> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public String getAttribution() 
+        @Generated public List<Double> getBounds() 
+        @Generated public List<Double> getCenter() 
+        @Generated public List<String> getData() 
+        @Generated public String getDescription() 
+        @Generated public List<String> getGrids() 
+        @Generated public String getLegend() 
+        @Generated public Integer getMaxZoom() 
+        @Generated public Integer getMinZoom() 
+        @Generated public String getName() 
+        @Generated public TileAddressingScheme getScheme() 
+        @Generated public String getTemplate() 
+        @Generated public String getTileJson() 
+        @Generated public List<String> getTiles() 
+        @Generated public String getVersion() 
+    } 
+    @Immutable
+    public final class TileMatrix implements JsonSerializable<TileMatrix> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public double getCellSize() 
+        @Generated public TileMatrixCornerOfOrigin getCornerOfOrigin() 
+        @Generated public String getDescription() 
+        @Generated public String getId() 
+        @Generated public List<String> getKeywords() 
+        @Generated public int getMatrixHeight() 
+        @Generated public int getMatrixWidth() 
+        @Generated public List<Double> getPointOfOrigin() 
+        @Generated public double getScaleDenominator() 
+        @Generated public int getTileHeight() 
+        @Generated public int getTileWidth() 
+        @Generated public String getTitle() 
+        @Generated public List<VariableMatrixWidth> getVariableMatrixWidths() 
+    } 
+    public final class TileMatrixCornerOfOrigin extends ExpandableStringEnum<TileMatrixCornerOfOrigin> { 
+        @Generated public static final TileMatrixCornerOfOrigin TOP_LEFT = fromString("topLeft"); 
+        @Generated public static final TileMatrixCornerOfOrigin BOTTOM_LEFT = fromString("bottomLeft"); 
+        @Deprecated @Generated public TileMatrixCornerOfOrigin() 
+        @Generated public static TileMatrixCornerOfOrigin fromString(String name) 
+        @Generated public static Collection<TileMatrixCornerOfOrigin> values() 
+    } 
+    @Immutable
+    public final class TileMatrixSet implements JsonSerializable<TileMatrixSet> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public TileMatrixSetBoundingBox getBoundingBox() 
+        @Generated public String getCrs() 
+        @Generated public String getDescription() 
+        @Generated public String getId() 
+        @Generated public List<String> getKeywords() 
+        @Generated public List<String> getOrderedAxes() 
+        @Generated public List<TileMatrix> getTileMatrices() 
+        @Generated public String getTitle() 
+        @Generated public String getUri() 
+        @Generated public String getWellKnownScaleSet() 
+    } 
+    @Immutable
+    public final class TileMatrixSetBoundingBox implements JsonSerializable<TileMatrixSetBoundingBox> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public String getCrs() 
+        @Generated public List<String> getLowerLeft() 
+        @Generated public List<String> getOrderedAxes() 
+        @Generated public List<String> getUpperRight() 
+    } 
+    public final class TileMatrixSetId extends ExpandableStringEnum<TileMatrixSetId> { 
+        @Generated public static final TileMatrixSetId CANADIAN_NAD83_LCC = fromString("CanadianNAD83_LCC"); 
+        @Generated public static final TileMatrixSetId EUROPEAN_ETRS89_LAEAQUAD = fromString("EuropeanETRS89_LAEAQuad"); 
+        @Generated public static final TileMatrixSetId LINZANTARTICA_MAP_TILEGRID = fromString("LINZAntarticaMapTilegrid"); 
+        @Generated public static final TileMatrixSetId NZTM2000QUAD = fromString("NZTM2000Quad"); 
+        @Generated public static final TileMatrixSetId UPSANTARCTIC_WGS84QUAD = fromString("UPSAntarcticWGS84Quad"); 
+        @Generated public static final TileMatrixSetId UPSARCTIC_WGS84QUAD = fromString("UPSArcticWGS84Quad"); 
+        @Generated public static final TileMatrixSetId UTM31WGS84QUAD = fromString("UTM31WGS84Quad"); 
+        @Generated public static final TileMatrixSetId WGS1984QUAD = fromString("WGS1984Quad"); 
+        @Generated public static final TileMatrixSetId WEB_MERCATOR_QUAD = fromString("WebMercatorQuad"); 
+        @Generated public static final TileMatrixSetId WORLD_CRS84QUAD = fromString("WorldCRS84Quad"); 
+        @Generated public static final TileMatrixSetId WORLD_MERCATOR_WGS84QUAD = fromString("WorldMercatorWGS84Quad"); 
+        @Deprecated @Generated public TileMatrixSetId() 
+        @Generated public static TileMatrixSetId fromString(String name) 
+        @Generated public static Collection<TileMatrixSetId> values() 
+    } 
+    @Immutable
+    public final class TileMatrixSetLimitsEntry implements JsonSerializable<TileMatrixSetLimitsEntry> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public int getMaxTileCol() 
+        @Generated public int getMaxTileRow() 
+        @Generated public int getMinTileCol() 
+        @Generated public int getMinTileRow() 
+        @Generated public String getTileMatrix() 
+    } 
+    @Immutable
+    public final class TileSetBoundingBox implements JsonSerializable<TileSetBoundingBox> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public String getCrs() 
+        @Generated public List<Double> getLowerLeft() 
+        @Generated public List<Double> getUpperRight() 
+    } 
+    @Immutable
+    public final class TileSetEntry implements JsonSerializable<TileSetEntry> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public String getAccessConstraints() 
+        @Generated public TileSetBoundingBox getBoundingBox() 
+        @Generated public String getCrs() 
+        @Generated public String getDataType() 
+        @Generated public List<TileSetLink> getLinks() 
+        @Generated public String getTitle() 
+    } 
+    @Immutable
+    public final class TileSetLink implements JsonSerializable<TileSetLink> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public String getHref() 
+        @Generated public String getRel() 
+        @Generated public String getTitle() 
+        @Generated public String getType() 
+    } 
+    @Immutable
+    public final class TileSetList implements JsonSerializable<TileSetList> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public List<TileSetEntry> getTilesets() 
+    } 
+    @Immutable
+    public final class TileSetMetadata implements JsonSerializable<TileSetMetadata> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public String getAccessConstraints() 
+        @Generated public TileSetBoundingBox getBoundingBox() 
+        @Generated public String getCrs() 
+        @Generated public String getDataType() 
+        @Generated public List<TileSetLink> getLinks() 
+        @Generated public List<TileMatrixSetLimitsEntry> getTileMatrixSetLimits() 
+        @Generated public String getTitle() 
+    } 
+    @Fluent
+    public final class TileSettings implements JsonSerializable<TileSettings> { 
+        @Generated public TileSettings(int minZoom, int maxItemsPerTile) 
+        @Generated public DefaultLocation getDefaultLocation() 
+        @Generated public TileSettings setDefaultLocation(DefaultLocation defaultLocation) 
+        @Generated public int getMaxItemsPerTile() 
+        @Generated public int getMinZoom() 
+    } 
+    @Immutable
+    public final class TilerAssetGeoJson implements JsonSerializable<TilerAssetGeoJson> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public Map<String, StacAsset> getAssets() 
+        @Generated public List<Double> getBoundingBox() 
+        @Generated public String getCollection() 
+        @Generated public String getId() 
+    } 
+    @Immutable
+    public final class TilerCoreModelsResponsesPoint implements JsonSerializable<TilerCoreModelsResponsesPoint> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public List<String> getBandNames() 
+        @Generated public List<Double> getCoordinates() 
+        @Generated public List<Double> getValues() 
+    } 
+    public final class TilerImageFormat extends ExpandableStringEnum<TilerImageFormat> { 
+        @Generated public static final TilerImageFormat PNG = fromString("png"); 
+        @Generated public static final TilerImageFormat NPY = fromString("npy"); 
+        @Generated public static final TilerImageFormat TIF = fromString("tif"); 
+        @Generated public static final TilerImageFormat JPEG = fromString("jpeg"); 
+        @Generated public static final TilerImageFormat JPG = fromString("jpg"); 
+        @Generated public static final TilerImageFormat JP2 = fromString("jp2"); 
+        @Generated public static final TilerImageFormat WEBP = fromString("webp"); 
+        @Generated public static final TilerImageFormat PNGRAW = fromString("pngraw"); 
+        @Deprecated @Generated public TilerImageFormat() 
+        @Generated public static TilerImageFormat fromString(String name) 
+        @Generated public static Collection<TilerImageFormat> values() 
+    } 
+    @Immutable
+    public final class TilerInfo implements JsonSerializable<TilerInfo> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public List<List<String>> getBandDescriptions() 
+        @Generated public List<List<BinaryData>> getBandMetadata() 
+        @Generated public List<Double> getBounds() 
+        @Generated public List<String> getColorInterpretation() 
+        @Generated public Map<String, List<String>> getColormap() 
+        @Generated public String getCoordinateReferenceSystem() 
+        @Generated public Integer getCount() 
+        @Generated public String getDriver() 
+        @Generated public String getDtype() 
+        @Generated public Integer getHeight() 
+        @Generated public Integer getMaxZoom() 
+        @Generated public Integer getMinZoom() 
+        @Generated public NoDataType getNoDataType() 
+        @Generated public List<Integer> getOffsets() 
+        @Generated public List<Integer> getOverviews() 
+        @Generated public List<Integer> getScales() 
+        @Generated public Integer getWidth() 
+    } 
+    @Immutable
+    public final class TilerInfoGeoJsonFeature implements JsonSerializable<TilerInfoGeoJsonFeature> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public List<Double> getBoundingBox() 
+        @Generated public GeoJsonGeometry getGeometry() 
+        @Generated public String getId() 
+        @Generated public Map<String, TilerInfo> getProperties() 
+        @Generated public FeatureType getType() 
+    } 
+    @Immutable
+    public final class TilerInfoMapResponse implements JsonSerializable<TilerInfoMapResponse> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public Map<String, TilerInfo> getAdditionalProperties() 
+    } 
+    @Immutable
+    public final class TilerMosaicSearchRegistrationResponse implements JsonSerializable<TilerMosaicSearchRegistrationResponse> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public List<StacLink> getLinks() 
+        @Generated public String getSearchId() 
+    } 
+    @Immutable
+    public final class TilerStacItemStatistics implements JsonSerializable<TilerStacItemStatistics> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public Map<String, BandStatistics> getAdditionalProperties() 
+    } 
+    @Immutable
+    public final class TilerStacSearchDefinition implements JsonSerializable<TilerStacSearchDefinition> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public String getHash() 
+        @Generated public OffsetDateTime getLastUsed() 
+        @Generated public MosaicMetadata getMetadata() 
+        @Generated public Map<String, BinaryData> getSearch() 
+        @Generated public int getUseCount() 
+    } 
+    @Immutable
+    public final class TilerStacSearchRegistration implements JsonSerializable<TilerStacSearchRegistration> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public List<StacLink> getLinks() 
+        @Generated public TilerStacSearchDefinition getSearch() 
+    } 
+    @Immutable
+    public final class UserCollectionSettings implements JsonSerializable<UserCollectionSettings> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public StacMosaicConfiguration getMosaicConfiguration() 
+        @Generated public TileSettings getTileSettings() 
+    } 
+    @Immutable
+    public final class VariableMatrixWidth implements JsonSerializable<VariableMatrixWidth> { 
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'. 
+        @Generated public int getCoalesce() 
+        @Generated public int getMaxTileRow() 
+        @Generated public int getMinTileRow() 
+    } 
+    public final class WarpKernelResampling extends ExpandableStringEnum<WarpKernelResampling> { 
+        @Generated public static final WarpKernelResampling NEAREST = fromString("nearest"); 
+        @Generated public static final WarpKernelResampling BILINEAR = fromString("bilinear"); 
+        @Generated public static final WarpKernelResampling CUBIC = fromString("cubic"); 
+        @Generated public static final WarpKernelResampling CUBIC_SPLINE = fromString("cubic_spline"); 
+        @Generated public static final WarpKernelResampling LANCZOS = fromString("lanczos"); 
+        @Generated public static final WarpKernelResampling AVERAGE = fromString("average"); 
+        @Generated public static final WarpKernelResampling MODE = fromString("mode"); 
+        @Generated public static final WarpKernelResampling MAX = fromString("max"); 
+        @Generated public static final WarpKernelResampling MIN = fromString("min"); 
+        @Generated public static final WarpKernelResampling MED = fromString("med"); 
+        @Generated public static final WarpKernelResampling Q1 = fromString("q1"); 
+        @Generated public static final WarpKernelResampling Q3 = fromString("q3"); 
+        @Generated public static final WarpKernelResampling SUM = fromString("sum"); 
+        @Generated public static final WarpKernelResampling RMS = fromString("rms"); 
+        @Deprecated @Generated public WarpKernelResampling() 
+        @Generated public static WarpKernelResampling fromString(String name) 
+        @Generated public static Collection<WarpKernelResampling> values() 
+    } 
+} 
+```

--- a/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
+++ b/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
@@ -647,7 +647,7 @@ package com.azure.analytics.planetarycomputer {
     }
     public enum PlanetaryComputerServiceVersion implements ServiceVersion {
         V2026_04_15("2026-04-15");
-        public static PlanetaryComputerServiceVersion getLatest(// returns V2026_04_15 )
+        public static PlanetaryComputerServiceVersion getLatest() // returns V2026_04_15
         @Override public String getVersion()
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)

--- a/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
+++ b/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
@@ -24,7 +24,7 @@ module com.azure.analytics.planetarycomputer {
     opens com.azure.analytics.planetarycomputer.implementation.models to com.azure.core;
 }
 package com.azure.analytics.planetarycomputer {
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
+    @ServiceClient(builder = PlanetaryComputerProClientBuilder, isAsync = true)
     public final class DataAsyncClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -279,7 +279,7 @@ package com.azure.analytics.planetarycomputer {
         @Generated public Mono<Response<BinaryData>> getTileWithTmsByScaleWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions)
         @Generated public Mono<Response<BinaryData>> getTileWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions)
     }
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
+    @ServiceClient(builder = PlanetaryComputerProClientBuilder)
     public final class DataClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -534,7 +534,7 @@ package com.azure.analytics.planetarycomputer {
         @Generated public Response<BinaryData> getTileWithTmsByScaleWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, double scale, RequestOptions requestOptions)
         @Generated public Response<BinaryData> getTileWithTmsWithResponse(String collectionId, String itemId, String tileMatrixSetId, double z, double x, double y, RequestOptions requestOptions)
     }
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
+    @ServiceClient(builder = PlanetaryComputerProClientBuilder, isAsync = true)
     public final class IngestionAsyncClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -578,7 +578,7 @@ package com.azure.analytics.planetarycomputer {
         @Generated public Mono<Response<BinaryData>> updateWithResponse(String collectionId, String ingestionId, BinaryData body, RequestOptions requestOptions)
         @Generated public Mono<Response<BinaryData>> getWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions)
     }
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
+    @ServiceClient(builder = PlanetaryComputerProClientBuilder)
     public final class IngestionClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -622,7 +622,7 @@ package com.azure.analytics.planetarycomputer {
         @Generated public Response<BinaryData> updateWithResponse(String collectionId, String ingestionId, BinaryData body, RequestOptions requestOptions)
         @Generated public Response<BinaryData> getWithResponse(String collectionId, String ingestionId, RequestOptions requestOptions)
     }
-    @ServiceClientBuilder(serviceClients  =  { IngestionClient, StacClient, DataClient, SharedAccessSignatureClient, IngestionAsyncClient, StacAsyncClient, DataAsyncClient, SharedAccessSignatureAsyncClient })
+    @ServiceClientBuilder(serviceClients = { IngestionClient, StacClient, DataClient, SharedAccessSignatureClient, IngestionAsyncClient, StacAsyncClient, DataAsyncClient, SharedAccessSignatureAsyncClient })
     public final class PlanetaryComputerProClientBuilder implements HttpTrait<PlanetaryComputerProClientBuilder> , ConfigurationTrait<PlanetaryComputerProClientBuilder> , TokenCredentialTrait<PlanetaryComputerProClientBuilder> , EndpointTrait<PlanetaryComputerProClientBuilder> {
         @Generated public PlanetaryComputerProClientBuilder()
         @Generated @Override public PlanetaryComputerProClientBuilder addPolicy(HttpPipelinePolicy customPolicy)
@@ -650,7 +650,7 @@ package com.azure.analytics.planetarycomputer {
         public static PlanetaryComputerServiceVersion getLatest() // returns V2026_04_15
         @Override public String getVersion()
     }
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
+    @ServiceClient(builder = PlanetaryComputerProClientBuilder, isAsync = true)
     public final class SharedAccessSignatureAsyncClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -664,7 +664,7 @@ package com.azure.analytics.planetarycomputer {
         @Generated public Mono<SharedAccessSignatureSignedLink> getUrl(String href, Integer durationInMinutes)
         @Generated public Mono<Response<BinaryData>> getUrlWithResponse(String href, RequestOptions requestOptions)
     }
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
+    @ServiceClient(builder = PlanetaryComputerProClientBuilder)
     public final class SharedAccessSignatureClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -678,7 +678,7 @@ package com.azure.analytics.planetarycomputer {
         @Generated public SharedAccessSignatureSignedLink getUrl(String href, Integer durationInMinutes)
         @Generated public Response<BinaryData> getUrlWithResponse(String href, RequestOptions requestOptions)
     }
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
+    @ServiceClient(builder = PlanetaryComputerProClientBuilder, isAsync = true)
     public final class StacAsyncClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -761,7 +761,7 @@ package com.azure.analytics.planetarycomputer {
         @Generated public Mono<TileSettings> getTileSettings(String collectionId)
         @Generated public Mono<Response<BinaryData>> getTileSettingsWithResponse(String collectionId, RequestOptions requestOptions)
     }
-    @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
+    @ServiceClient(builder = PlanetaryComputerProClientBuilder)
     public final class StacClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:

--- a/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
+++ b/sdk/planetarycomputer/azure-analytics-planetarycomputer/api.md
@@ -11,7 +11,6 @@ maven {
     name : Microsoft Azure SDK for Planetary Computer
     description : This package contains Microsoft Azure Planetary Computer client library.
     dependencies {
-        // compile scope
         com.azure:azure-core 1.59.0
         com.azure:azure-core-http-netty 1.16.6
     }
@@ -26,8 +25,6 @@ module com.azure.analytics.planetarycomputer {
 package com.azure.analytics.planetarycomputer {
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
     public final class DataAsyncClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         @Generated public Mono<ClassMapLegendResponse> getClassMapLegend(String classmapName)
         @Generated public Mono<ClassMapLegendResponse> getClassMapLegend(String classmapName, Integer trimStart, Integer trimEnd)
         @Generated public Mono<Response<BinaryData>> getClassMapLegendWithResponse(String classmapName, RequestOptions requestOptions)
@@ -281,8 +278,6 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
     public final class DataClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         @Generated public ClassMapLegendResponse getClassMapLegend(String classmapName)
         @Generated public ClassMapLegendResponse getClassMapLegend(String classmapName, Integer trimStart, Integer trimEnd)
         @Generated public Response<BinaryData> getClassMapLegendWithResponse(String classmapName, RequestOptions requestOptions)
@@ -536,8 +531,6 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
     public final class IngestionAsyncClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         @Generated public Mono<IngestionDefinition> get(String collectionId, String ingestionId)
         @Generated public PollerFlux<Operation, Void> beginDelete(String collectionId, String ingestionId)
         @Generated public PollerFlux<BinaryData, Void> beginDelete(String collectionId, String ingestionId, RequestOptions requestOptions)
@@ -580,8 +573,6 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
     public final class IngestionClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         @Generated public IngestionDefinition get(String collectionId, String ingestionId)
         @Generated public SyncPoller<Operation, Void> beginDelete(String collectionId, String ingestionId)
         @Generated public SyncPoller<BinaryData, Void> beginDelete(String collectionId, String ingestionId, RequestOptions requestOptions)
@@ -652,8 +643,6 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
     public final class SharedAccessSignatureAsyncClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         @Generated public Mono<Void> revokeToken()
         @Generated public Mono<Void> revokeToken(Integer durationInMinutes)
         @Generated public Mono<Response<Void>> revokeTokenWithResponse(RequestOptions requestOptions)
@@ -666,8 +655,6 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
     public final class SharedAccessSignatureClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         @Generated public void revokeToken()
         @Generated public void revokeToken(Integer durationInMinutes)
         @Generated public Response<Void> revokeTokenWithResponse(RequestOptions requestOptions)
@@ -680,8 +667,6 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder, isAsync  =  true)
     public final class StacAsyncClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         @Generated public Mono<StacMosaic> addMosaic(String collectionId, StacMosaic body)
         @Generated public Mono<Response<BinaryData>> addMosaicWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
         @Generated public PollerFlux<Operation, Void> beginCreateCollection(StacCollection body)
@@ -763,8 +748,6 @@ package com.azure.analytics.planetarycomputer {
     }
     @ServiceClient(builder  =  PlanetaryComputerProClientBuilder)
     public final class StacClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         @Generated public StacMosaic addMosaic(String collectionId, StacMosaic body)
         @Generated public Response<BinaryData> addMosaicWithResponse(String collectionId, BinaryData body, RequestOptions requestOptions)
         @Generated public SyncPoller<Operation, Void> beginCreateCollection(StacCollection body)
@@ -857,12 +840,10 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class AssetStatisticsResponse implements JsonSerializable<AssetStatisticsResponse> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BandStatisticsMap> getAdditionalProperties()
     }
     @Immutable
     public final class BandStatistics implements JsonSerializable<BandStatistics> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public double getCount()
         @Generated public List<List<Double>> getHistogram()
         @Generated public double getMajority()
@@ -882,12 +863,10 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class BandStatisticsMap implements JsonSerializable<BandStatisticsMap> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BandStatistics> getAdditionalProperties()
     }
     @Immutable
     public final class ClassMapLegendResponse implements JsonSerializable<ClassMapLegendResponse> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BinaryData> getAdditionalProperties()
     }
     public final class ColorMapNames extends ExpandableStringEnum<ColorMapNames> {
@@ -1163,7 +1142,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class ErrorInfo implements JsonSerializable<ErrorInfo> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public ResponseError getError()
     }
     public final class FeatureType extends ExpandableStringEnum<FeatureType> {
@@ -1296,7 +1274,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class IngestionRun implements JsonSerializable<IngestionRun> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public OffsetDateTime getCreationTime()
         @Generated public String getId()
         @Generated public Boolean isKeepOriginalAssets()
@@ -1307,7 +1284,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class IngestionRunOperation implements JsonSerializable<IngestionRunOperation> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public OffsetDateTime getCreationTime()
         @Generated public OffsetDateTime getFinishTime()
         @Generated public String getId()
@@ -1328,7 +1304,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class IngestionSourceSummary implements JsonSerializable<IngestionSourceSummary> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public OffsetDateTime getCreated()
         @Generated public String getId()
         @Generated public IngestionSourceType getKind()
@@ -1379,7 +1354,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class ManagedIdentityMetadata implements JsonSerializable<ManagedIdentityMetadata> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getObjectId()
         @Generated public String getResourceId()
     }
@@ -1420,7 +1394,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class Operation implements JsonSerializable<Operation> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, String> getAdditionalInformation()
         @Generated public String getCollectionId()
         @Generated public OffsetDateTime getCreationTime()
@@ -1445,7 +1418,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class OperationStatusHistoryItem implements JsonSerializable<OperationStatusHistoryItem> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getErrorCode()
         @Generated public String getErrorMessage()
         @Generated public OperationStatus getStatus()
@@ -1481,7 +1453,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class QueryableDefinitionsResponse implements JsonSerializable<QueryableDefinitionsResponse> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BinaryData> getAdditionalProperties()
     }
     @Fluent
@@ -1608,13 +1579,11 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class SharedAccessSignatureSignedLink implements JsonSerializable<SharedAccessSignatureSignedLink> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public OffsetDateTime getExpiresOn()
         @Generated public String getHref()
     }
     @Immutable
     public final class SharedAccessSignatureToken implements JsonSerializable<SharedAccessSignatureToken> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public OffsetDateTime getExpiresOn()
         @Generated public String getToken()
     }
@@ -1681,7 +1650,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacCatalogCollections implements JsonSerializable<StacCatalogCollections> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<StacCollection> getCollections()
         @Generated public List<StacLink> getLinks()
     }
@@ -1727,7 +1695,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacConformanceClasses implements JsonSerializable<StacConformanceClasses> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<String> getConformsTo()
     }
     @Fluent
@@ -1812,7 +1779,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacItemBounds implements JsonSerializable<StacItemBounds> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<Double> getBounds()
     }
     @Fluent
@@ -1853,7 +1819,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacItemPointAsset implements JsonSerializable<StacItemPointAsset> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, StacAsset> getAssets()
         @Generated public List<Double> getBoundingBox()
         @Generated public String getCollectionId()
@@ -1893,20 +1858,17 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacItemStatisticsGeoJson implements JsonSerializable<StacItemStatisticsGeoJson> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public GeoJsonGeometry getGeometry()
         @Generated public StacItemStatisticsGeoJsonProperties getProperties()
         @Generated public FeatureType getType()
     }
     @Immutable
     public final class StacItemStatisticsGeoJsonProperties implements JsonSerializable<StacItemStatisticsGeoJsonProperties> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BinaryData> getAdditionalProperties()
         @Generated public Map<String, BandStatistics> getStatistics()
     }
     @Immutable
     public final class StacLandingPage implements JsonSerializable<StacLandingPage> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<String> getConformsTo()
         @Generated public OffsetDateTime getCreatedOn()
         @Generated public String getDescription()
@@ -1986,7 +1948,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class StacMosaicConfiguration implements JsonSerializable<StacMosaicConfiguration> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BinaryData> getDefaultCustomQuery()
         @Generated public DefaultLocation getDefaultLocation()
         @Generated public List<StacMosaic> getMosaics()
@@ -2098,7 +2059,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileJsonMetadata implements JsonSerializable<TileJsonMetadata> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getAttribution()
         @Generated public List<Double> getBounds()
         @Generated public List<Double> getCenter()
@@ -2117,7 +2077,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileMatrix implements JsonSerializable<TileMatrix> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public double getCellSize()
         @Generated public TileMatrixCornerOfOrigin getCornerOfOrigin()
         @Generated public String getDescription()
@@ -2141,7 +2100,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileMatrixSet implements JsonSerializable<TileMatrixSet> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public TileMatrixSetBoundingBox getBoundingBox()
         @Generated public String getCrs()
         @Generated public String getDescription()
@@ -2155,7 +2113,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileMatrixSetBoundingBox implements JsonSerializable<TileMatrixSetBoundingBox> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getCrs()
         @Generated public List<String> getLowerLeft()
         @Generated public List<String> getOrderedAxes()
@@ -2179,7 +2136,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileMatrixSetLimitsEntry implements JsonSerializable<TileMatrixSetLimitsEntry> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public int getMaxTileCol()
         @Generated public int getMaxTileRow()
         @Generated public int getMinTileCol()
@@ -2188,14 +2144,12 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileSetBoundingBox implements JsonSerializable<TileSetBoundingBox> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getCrs()
         @Generated public List<Double> getLowerLeft()
         @Generated public List<Double> getUpperRight()
     }
     @Immutable
     public final class TileSetEntry implements JsonSerializable<TileSetEntry> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getAccessConstraints()
         @Generated public TileSetBoundingBox getBoundingBox()
         @Generated public String getCrs()
@@ -2205,7 +2159,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileSetLink implements JsonSerializable<TileSetLink> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getHref()
         @Generated public String getRel()
         @Generated public String getTitle()
@@ -2213,12 +2166,10 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TileSetList implements JsonSerializable<TileSetList> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<TileSetEntry> getTilesets()
     }
     @Immutable
     public final class TileSetMetadata implements JsonSerializable<TileSetMetadata> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getAccessConstraints()
         @Generated public TileSetBoundingBox getBoundingBox()
         @Generated public String getCrs()
@@ -2237,7 +2188,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerAssetGeoJson implements JsonSerializable<TilerAssetGeoJson> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, StacAsset> getAssets()
         @Generated public List<Double> getBoundingBox()
         @Generated public String getCollection()
@@ -2245,7 +2195,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerCoreModelsResponsesPoint implements JsonSerializable<TilerCoreModelsResponsesPoint> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<String> getBandNames()
         @Generated public List<Double> getCoordinates()
         @Generated public List<Double> getValues()
@@ -2265,7 +2214,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerInfo implements JsonSerializable<TilerInfo> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<List<String>> getBandDescriptions()
         @Generated public List<List<BinaryData>> getBandMetadata()
         @Generated public List<Double> getBounds()
@@ -2286,7 +2234,6 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerInfoGeoJsonFeature implements JsonSerializable<TilerInfoGeoJsonFeature> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<Double> getBoundingBox()
         @Generated public GeoJsonGeometry getGeometry()
         @Generated public String getId()
@@ -2295,23 +2242,19 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerInfoMapResponse implements JsonSerializable<TilerInfoMapResponse> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, TilerInfo> getAdditionalProperties()
     }
     @Immutable
     public final class TilerMosaicSearchRegistrationResponse implements JsonSerializable<TilerMosaicSearchRegistrationResponse> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<StacLink> getLinks()
         @Generated public String getSearchId()
     }
     @Immutable
     public final class TilerStacItemStatistics implements JsonSerializable<TilerStacItemStatistics> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public Map<String, BandStatistics> getAdditionalProperties()
     }
     @Immutable
     public final class TilerStacSearchDefinition implements JsonSerializable<TilerStacSearchDefinition> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public String getHash()
         @Generated public OffsetDateTime getLastUsed()
         @Generated public MosaicMetadata getMetadata()
@@ -2320,19 +2263,16 @@ package com.azure.analytics.planetarycomputer.models {
     }
     @Immutable
     public final class TilerStacSearchRegistration implements JsonSerializable<TilerStacSearchRegistration> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public List<StacLink> getLinks()
         @Generated public TilerStacSearchDefinition getSearch()
     }
     @Immutable
     public final class UserCollectionSettings implements JsonSerializable<UserCollectionSettings> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public StacMosaicConfiguration getMosaicConfiguration()
         @Generated public TileSettings getTileSettings()
     }
     @Immutable
     public final class VariableMatrixWidth implements JsonSerializable<VariableMatrixWidth> {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Generated public int getCoalesce()
         @Generated public int getMaxTileRow()
         @Generated public int getMinTileRow()

--- a/sdk/storage/azure-storage-blob/api.md
+++ b/sdk/storage/azure-storage-blob/api.md
@@ -5,13 +5,11 @@ maven {
     name : Microsoft Azure client library for Blob Storage
     description : This module contains client library for Microsoft Azure Blob Storage.
     dependencies {
-        // compile scope
         com.azure:azure-xml 1.2.1
         com.azure:azure-core 1.59.0
         com.azure:azure-core-http-netty 1.16.6
         com.azure:azure-storage-common 12.35.0-beta.2
         com.azure:azure-storage-internal-avro 12.21.0-beta.2
-        // provided scope
         com.google.code.findbugs:jsr305 3.0.2
     }
 }
@@ -64,7 +62,6 @@ package com.azure.storage.blob {
         public static final int BLOB_DEFAULT_HTBB_UPLOAD_BLOCK_SIZE = BlobConstants.BLOB_DEFAULT_HTBB_UPLOAD_BLOCK_SIZE;
         protected BlobClient(BlobAsyncClient client)
         protected BlobClient(BlobAsyncClient client, HttpPipeline pipeline, String url, BlobServiceVersion serviceVersion, String accountName, String containerName, String blobName, String snapshot, CpkInfo customerProvidedKey, EncryptionScope encryptionScope, String versionId)
-        // Service Methods:
         public void upload(InputStream data)
         public void upload(BinaryData data)
         public void upload(InputStream data, long length)
@@ -78,7 +75,6 @@ package com.azure.storage.blob {
         @Deprecated public Response<BlockBlobItem> uploadWithResponse(BlobParallelUploadOptions options, Context context)
         public Response<BlockBlobItem> uploadWithResponse(BlobParallelUploadOptions options, Duration timeout, Context context)
         @Deprecated public void uploadWithResponse(InputStream data, long length, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions, Duration timeout, Context context)
-        // Non-Service Methods:
         public AppendBlobClient getAppendBlobClient()
         public BlockBlobClient getBlockBlobClient()
         @Override public BlobClient getCustomerProvidedKeyClient(CustomerProvidedKey customerProvidedKey)
@@ -123,8 +119,6 @@ package com.azure.storage.blob {
         public static final String ROOT_CONTAINER_NAME = BlobConstants.ROOT_CONTAINER_NAME;
         public static final String STATIC_WEBSITE_CONTAINER_NAME = BlobConstants.STATIC_WEBSITE_CONTAINER_NAME;
         public static final String LOG_CONTAINER_NAME = BlobConstants.LOG_CONTAINER_NAME;
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public Mono<BlobContainerAccessPolicies> getAccessPolicy()
         public Mono<Void> setAccessPolicy(PublicAccessType accessType, List<BlobSignedIdentifier> identifiers)
         public Mono<Response<BlobContainerAccessPolicies>> getAccessPolicyWithResponse(String leaseId)
@@ -152,7 +146,6 @@ package com.azure.storage.blob {
         public Mono<Response<Void>> setMetadataWithResponse(Map<String, String> metadata, BlobRequestConditions requestConditions)
         public Mono<BlobContainerProperties> getProperties()
         public Mono<Response<BlobContainerProperties>> getPropertiesWithResponse(String leaseId)
-        // Non-Service Methods:
         public String getAccountName()
         public String getAccountUrl()
         public BlobAsyncClient getBlobAsyncClient(String blobName)
@@ -177,8 +170,6 @@ package com.azure.storage.blob {
         public static final String ROOT_CONTAINER_NAME = BlobConstants.ROOT_CONTAINER_NAME;
         public static final String STATIC_WEBSITE_CONTAINER_NAME = BlobConstants.STATIC_WEBSITE_CONTAINER_NAME;
         public static final String LOG_CONTAINER_NAME = BlobConstants.LOG_CONTAINER_NAME;
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public BlobContainerAccessPolicies getAccessPolicy()
         public void setAccessPolicy(PublicAccessType accessType, List<BlobSignedIdentifier> identifiers)
         public Response<BlobContainerAccessPolicies> getAccessPolicyWithResponse(String leaseId, Duration timeout, Context context)
@@ -206,7 +197,6 @@ package com.azure.storage.blob {
         public Response<Void> setMetadataWithResponse(Map<String, String> metadata, BlobRequestConditions requestConditions, Duration timeout, Context context)
         public BlobContainerProperties getProperties()
         public Response<BlobContainerProperties> getPropertiesWithResponse(String leaseId, Duration timeout, Context context)
-        // Non-Service Methods:
         public String getAccountName()
         public String getAccountUrl()
         public BlobClient getBlobClient(String blobName)
@@ -257,8 +247,6 @@ package com.azure.storage.blob {
     }
     @ServiceClient(builder  =  BlobServiceClientBuilder, isAsync  =  true)
     public final class BlobServiceAsyncClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public Mono<StorageAccountInfo> getAccountInfo()
         public Mono<Response<StorageAccountInfo>> getAccountInfoWithResponse()
         public Mono<BlobContainerAsyncClient> createBlobContainer(String containerName)
@@ -284,7 +272,6 @@ package com.azure.storage.blob {
         public Mono<UserDelegationKey> getUserDelegationKey(OffsetDateTime start, OffsetDateTime expiry)
         public Mono<Response<UserDelegationKey>> getUserDelegationKeyWithResponse(BlobGetUserDelegationKeyOptions options)
         public Mono<Response<UserDelegationKey>> getUserDelegationKeyWithResponse(OffsetDateTime start, OffsetDateTime expiry)
-        // Non-Service Methods:
         public String getAccountName()
         public String getAccountUrl()
         public BlobContainerAsyncClient getBlobContainerAsyncClient(String containerName)
@@ -296,8 +283,6 @@ package com.azure.storage.blob {
     }
     @ServiceClient(builder  =  BlobServiceClientBuilder)
     public final class BlobServiceClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public StorageAccountInfo getAccountInfo()
         public Response<StorageAccountInfo> getAccountInfoWithResponse(Duration timeout, Context context)
         public BlobContainerClient createBlobContainer(String containerName)
@@ -323,7 +308,6 @@ package com.azure.storage.blob {
         public UserDelegationKey getUserDelegationKey(OffsetDateTime start, OffsetDateTime expiry)
         public Response<UserDelegationKey> getUserDelegationKeyWithResponse(BlobGetUserDelegationKeyOptions options, Duration timeout, Context context)
         public Response<UserDelegationKey> getUserDelegationKeyWithResponse(OffsetDateTime start, OffsetDateTime expiry, Duration timeout, Context context)
-        // Non-Service Methods:
         public String getAccountName()
         public String getAccountUrl()
         public BlobContainerClient getBlobContainerClient(String containerName)
@@ -1293,7 +1277,6 @@ package com.azure.storage.blob.models {
         public BlobQueryResponse(BlobQueryAsyncResponse response)
     }
     public interface BlobQuerySerialization {
-        // This interface does not declare any API.
     }
     @Immutable
     public final class BlobRange {
@@ -2508,8 +2491,6 @@ package com.azure.storage.blob.specialized {
     public final class AppendBlobAsyncClient extends BlobAsyncClientBase {
         @Deprecated public static final int MAX_APPEND_BLOCK_BYTES = 4 *  Constants.MB;
         @Deprecated public static final int MAX_BLOCKS = 50000;
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public Mono<AppendBlobItem> appendBlock(Flux<ByteBuffer> data, long length)
         public Mono<AppendBlobItem> appendBlockFromUrl(String sourceUrl, BlobRange sourceRange)
         public Mono<Response<AppendBlobItem>> appendBlockFromUrlWithResponse(AppendBlobAppendBlockFromUrlOptions options)
@@ -2524,7 +2505,6 @@ package com.azure.storage.blob.specialized {
         public Mono<Response<AppendBlobItem>> createWithResponse(BlobHttpHeaders headers, Map<String, String> metadata, BlobRequestConditions requestConditions)
         public Mono<Void> seal()
         public Mono<Response<Void>> sealWithResponse(AppendBlobSealOptions options)
-        // Non-Service Methods:
         @Override public AppendBlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
         @Override public AppendBlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
         public int getMaxAppendBlockBytes()
@@ -2534,8 +2514,6 @@ package com.azure.storage.blob.specialized {
     public final class AppendBlobClient extends BlobClientBase {
         @Deprecated public static final int MAX_APPEND_BLOCK_BYTES = 4 *  Constants.MB;
         @Deprecated public static final int MAX_BLOCKS = 50000;
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public AppendBlobItem appendBlock(InputStream data, long length)
         public AppendBlobItem appendBlockFromUrl(String sourceUrl, BlobRange sourceRange)
         public Response<AppendBlobItem> appendBlockFromUrlWithResponse(AppendBlobAppendBlockFromUrlOptions options, Duration timeout, Context context)
@@ -2550,7 +2528,6 @@ package com.azure.storage.blob.specialized {
         public Response<AppendBlobItem> createWithResponse(BlobHttpHeaders headers, Map<String, String> metadata, BlobRequestConditions requestConditions, Duration timeout, Context context)
         public void seal()
         public Response<Void> sealWithResponse(AppendBlobSealOptions options, Duration timeout, Context context)
-        // Non-Service Methods:
         public BlobOutputStream getBlobOutputStream()
         public BlobOutputStream getBlobOutputStream(boolean overwrite)
         public BlobOutputStream getBlobOutputStream(AppendBlobRequestConditions requestConditions)
@@ -2742,14 +2719,11 @@ package com.azure.storage.blob.specialized {
         public String getVersionId()
     }
     public final class BlobInputStream extends StorageInputStream {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Override protected synchronized ByteBuffer dispatchRead(int readLength, long offset) throws IOException
         public BlobProperties getProperties()
     }
     @ServiceClient(builder  =  BlobLeaseClientBuilder, isAsync  =  true)
     public final class BlobLeaseAsyncClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public Mono<String> acquireLease(int durationInSeconds)
         public Mono<Response<String>> acquireLeaseWithResponse(BlobAcquireLeaseOptions options)
         public Mono<Response<String>> acquireLeaseWithResponse(int durationInSeconds, RequestConditions modifiedRequestConditions)
@@ -2765,15 +2739,12 @@ package com.azure.storage.blob.specialized {
         public Mono<String> renewLease()
         public Mono<Response<String>> renewLeaseWithResponse(RequestConditions modifiedRequestConditions)
         public Mono<Response<String>> renewLeaseWithResponse(BlobRenewLeaseOptions options)
-        // Non-Service Methods:
         public String getAccountName()
         public String getLeaseId()
         public String getResourceUrl()
     }
     @ServiceClient(builder  =  BlobLeaseClientBuilder)
     public final class BlobLeaseClient {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public String acquireLease(int durationInSeconds)
         public Response<String> acquireLeaseWithResponse(BlobAcquireLeaseOptions options, Duration timeout, Context context)
         public Response<String> acquireLeaseWithResponse(int durationInSeconds, RequestConditions modifiedRequestConditions, Duration timeout, Context context)
@@ -2789,7 +2760,6 @@ package com.azure.storage.blob.specialized {
         public String renewLease()
         public Response<String> renewLeaseWithResponse(RequestConditions modifiedRequestConditions, Duration timeout, Context context)
         public Response<String> renewLeaseWithResponse(BlobRenewLeaseOptions options, Duration timeout, Context context)
-        // Non-Service Methods:
         public String getAccountName()
         public String getLeaseId()
         public String getResourceUrl()
@@ -2806,7 +2776,6 @@ package com.azure.storage.blob.specialized {
         public BlobLeaseClient buildClient()
     }
     public abstract class BlobOutputStream extends StorageOutputStream {
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static BlobOutputStream blockBlobOutputStream(BlobAsyncClient client, BlockBlobOutputStreamOptions options, Context context)
         public static BlobOutputStream blockBlobOutputStream(BlobAsyncClient client, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions)
         public static BlobOutputStream blockBlobOutputStream(BlobAsyncClient client, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions, Context context)
@@ -2819,8 +2788,6 @@ package com.azure.storage.blob.specialized {
         @Deprecated public static final int MAX_STAGE_BLOCK_BYTES = 100 *  Constants.MB;
         public static final long MAX_STAGE_BLOCK_BYTES_LONG = BlobConstants.MAX_STAGE_BLOCK_BYTES_LONG;
         public static final int MAX_BLOCKS = BlobConstants.MAX_BLOCKS;
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public Mono<BlockBlobItem> commitBlockList(List<String> base64BlockIds)
         public Mono<BlockBlobItem> commitBlockList(List<String> base64BlockIds, boolean overwrite)
         public Mono<Response<BlockBlobItem>> commitBlockListWithResponse(BlockBlobCommitBlockListOptions options)
@@ -2844,7 +2811,6 @@ package com.azure.storage.blob.specialized {
         public Mono<Response<BlockBlobItem>> uploadFromUrlWithResponse(BlobUploadFromUrlOptions options)
         public Mono<Response<BlockBlobItem>> uploadWithResponse(BlockBlobSimpleUploadOptions options)
         public Mono<Response<BlockBlobItem>> uploadWithResponse(Flux<ByteBuffer> data, long length, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, byte[] contentMd5, BlobRequestConditions requestConditions)
-        // Non-Service Methods:
         @Override public BlockBlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
         @Override public BlockBlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
     }
@@ -2855,8 +2821,6 @@ package com.azure.storage.blob.specialized {
         @Deprecated public static final int MAX_STAGE_BLOCK_BYTES = 100 *  Constants.MB;
         public static final long MAX_STAGE_BLOCK_BYTES_LONG = BlobConstants.MAX_STAGE_BLOCK_BYTES_LONG;
         public static final int MAX_BLOCKS = BlobConstants.MAX_BLOCKS;
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public BlockBlobItem commitBlockList(List<String> base64BlockIds)
         public BlockBlobItem commitBlockList(List<String> base64BlockIds, boolean overwrite)
         public Response<BlockBlobItem> commitBlockListWithResponse(BlockBlobCommitBlockListOptions options, Duration timeout, Context context)
@@ -2880,7 +2844,6 @@ package com.azure.storage.blob.specialized {
         public Response<BlockBlobItem> uploadFromUrlWithResponse(BlobUploadFromUrlOptions options, Duration timeout, Context context)
         public Response<BlockBlobItem> uploadWithResponse(BlockBlobSimpleUploadOptions options, Duration timeout, Context context)
         public Response<BlockBlobItem> uploadWithResponse(InputStream data, long length, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, byte[] contentMd5, BlobRequestConditions requestConditions, Duration timeout, Context context)
-        // Non-Service Methods:
         public BlobOutputStream getBlobOutputStream()
         public BlobOutputStream getBlobOutputStream(boolean overwrite)
         public BlobOutputStream getBlobOutputStream(BlobRequestConditions requestConditions)
@@ -2895,8 +2858,6 @@ package com.azure.storage.blob.specialized {
     public final class PageBlobAsyncClient extends BlobAsyncClientBase {
         public static final int PAGE_BYTES = BlobConstants.PAGE_BYTES;
         public static final int MAX_PUT_PAGES_BYTES = BlobConstants.MAX_PUT_PAGES_BYTES;
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public Mono<PageBlobItem> clearPages(PageRange pageRange)
         public Mono<Response<PageBlobItem>> clearPagesWithResponse(PageRange pageRange, PageBlobRequestConditions pageBlobRequestConditions)
         public Mono<CopyStatusType> copyIncremental(String source, String snapshot)
@@ -2928,7 +2889,6 @@ package com.azure.storage.blob.specialized {
         public Mono<Response<PageBlobItem>> uploadPagesFromUrlWithResponse(PageRange range, String sourceUrl, Long sourceOffset, byte[] sourceContentMd5, PageBlobRequestConditions destRequestConditions, BlobRequestConditions sourceRequestConditions)
         public Mono<Response<PageBlobItem>> uploadPagesWithResponse(PageRange pageRange, Flux<ByteBuffer> body, PageBlobUploadPagesOptions options)
         @Deprecated public Mono<Response<PageBlobItem>> uploadPagesWithResponse(PageRange pageRange, Flux<ByteBuffer> body, byte[] contentMd5, PageBlobRequestConditions pageBlobRequestConditions)
-        // Non-Service Methods:
         @Override public PageBlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
         @Override public PageBlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
     }
@@ -2936,8 +2896,6 @@ package com.azure.storage.blob.specialized {
     public final class PageBlobClient extends BlobClientBase {
         public static final int PAGE_BYTES = BlobConstants.PAGE_BYTES;
         public static final int MAX_PUT_PAGES_BYTES = BlobConstants.MAX_PUT_PAGES_BYTES;
-        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
-        // Service Methods:
         public PageBlobItem clearPages(PageRange pageRange)
         public Response<PageBlobItem> clearPagesWithResponse(PageRange pageRange, PageBlobRequestConditions pageBlobRequestConditions, Duration timeout, Context context)
         public CopyStatusType copyIncremental(String source, String snapshot)
@@ -2969,7 +2927,6 @@ package com.azure.storage.blob.specialized {
         public Response<PageBlobItem> uploadPagesFromUrlWithResponse(PageRange range, String sourceUrl, Long sourceOffset, byte[] sourceContentMd5, PageBlobRequestConditions destRequestConditions, BlobRequestConditions sourceRequestConditions, Duration timeout, Context context)
         public Response<PageBlobItem> uploadPagesWithResponse(PageRange pageRange, InputStream body, PageBlobUploadPagesOptions options, Duration timeout, Context context)
         @Deprecated public Response<PageBlobItem> uploadPagesWithResponse(PageRange pageRange, InputStream body, byte[] contentMd5, PageBlobRequestConditions pageBlobRequestConditions, Duration timeout, Context context)
-        // Non-Service Methods:
         public BlobOutputStream getBlobOutputStream(PageRange pageRange)
         public BlobOutputStream getBlobOutputStream(PageBlobOutputStreamOptions options)
         public BlobOutputStream getBlobOutputStream(PageRange pageRange, BlobRequestConditions requestConditions)

--- a/sdk/storage/azure-storage-blob/api.md
+++ b/sdk/storage/azure-storage-blob/api.md
@@ -1,0 +1,3019 @@
+```java
+maven {
+    parent : com.azure:azure-client-sdk-parent:1.7.0
+    properties : com.azure:azure-storage-blob:12.36.0-beta.2
+    name : Microsoft Azure client library for Blob Storage
+    description : This module contains client library for Microsoft Azure Blob Storage.
+    dependencies {
+        // compile scope
+        com.azure:azure-xml 1.2.1
+        com.azure:azure-core 1.59.0
+        com.azure:azure-core-http-netty 1.16.6
+        com.azure:azure-storage-common 12.35.0-beta.2
+        com.azure:azure-storage-internal-avro 12.21.0-beta.2
+        // provided scope
+        com.google.code.findbugs:jsr305 3.0.2
+    }
+}
+module com.azure.storage.blob {
+    requires transitive com.azure.storage.common;
+    requires com.azure.storage.internal.avro;
+    exports com.azure.storage.blob;
+    exports com.azure.storage.blob.models;
+    exports com.azure.storage.blob.options;
+    exports com.azure.storage.blob.sas;
+    exports com.azure.storage.blob.specialized;
+    exports com.azure.storage.blob.implementation to com.azure.storage.blob.cryptography, com.azure.storage.blob.batch, com.azure.storage.file.datalake;
+    exports com.azure.storage.blob.implementation.models to com.azure.storage.blob.batch, com.azure.storage.blob.cryptography;
+    exports com.azure.storage.blob.implementation.util to com.azure.storage.blob.cryptography, com.azure.storage.file.datalake, com.azure.storage.blob.changefeed, com.azure.core, com.azure.storage.blob.batch, com.azure.storage.blob.nio;
+    opens com.azure.storage.blob.models to com.azure.core;
+    opens com.azure.storage.blob.implementation to com.azure.core;
+    opens com.azure.storage.blob.implementation.models to com.azure.core;
+}
+package com.azure.storage.blob {
+    public class BlobAsyncClient extends BlobAsyncClientBase {
+        public static final int BLOB_DEFAULT_UPLOAD_BLOCK_SIZE = BlobConstants.BLOB_DEFAULT_UPLOAD_BLOCK_SIZE;
+        public static final int BLOB_DEFAULT_NUMBER_OF_BUFFERS = BlobConstants.BLOB_DEFAULT_NUMBER_OF_BUFFERS;
+        public static final int BLOB_DEFAULT_HTBB_UPLOAD_BLOCK_SIZE = BlobConstants.BLOB_DEFAULT_HTBB_UPLOAD_BLOCK_SIZE;
+        protected BlobAsyncClient(HttpPipeline pipeline, String url, BlobServiceVersion serviceVersion, String accountName, String containerName, String blobName, String snapshot, CpkInfo customerProvidedKey)
+        protected BlobAsyncClient(HttpPipeline pipeline, String url, BlobServiceVersion serviceVersion, String accountName, String containerName, String blobName, String snapshot, CpkInfo customerProvidedKey, EncryptionScope encryptionScope)
+        protected BlobAsyncClient(HttpPipeline pipeline, String url, BlobServiceVersion serviceVersion, String accountName, String containerName, String blobName, String snapshot, CpkInfo customerProvidedKey, EncryptionScope encryptionScope, String versionId)
+        public AppendBlobAsyncClient getAppendBlobAsyncClient()
+        public BlockBlobAsyncClient getBlockBlobAsyncClient()
+        @Override public BlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
+        @Override public BlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
+        public PageBlobAsyncClient getPageBlobAsyncClient()
+        @Override public BlobAsyncClient getSnapshotClient(String snapshot)
+        public Mono<BlockBlobItem> upload(BinaryData data)
+        public Mono<BlockBlobItem> upload(Flux<ByteBuffer> data, ParallelTransferOptions parallelTransferOptions)
+        public Mono<BlockBlobItem> upload(BinaryData data, boolean overwrite)
+        public Mono<BlockBlobItem> upload(Flux<ByteBuffer> data, ParallelTransferOptions parallelTransferOptions, boolean overwrite)
+        @Deprecated protected AsynchronousFileChannel uploadFileResourceSupplier(String filePath)
+        public Mono<Void> uploadFromFile(String filePath)
+        public Mono<Void> uploadFromFile(String filePath, boolean overwrite)
+        public Mono<Void> uploadFromFile(String filePath, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions)
+        public Mono<Response<BlockBlobItem>> uploadFromFileWithResponse(BlobUploadFromFileOptions options)
+        public Mono<Response<BlockBlobItem>> uploadWithResponse(BlobParallelUploadOptions options)
+        public Mono<Response<BlockBlobItem>> uploadWithResponse(Flux<ByteBuffer> data, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions)
+        @Override public BlobAsyncClient getVersionClient(String versionId)
+    }
+    @ServiceClient(builder  =  BlobClientBuilder)
+    public class BlobClient extends BlobClientBase {
+        public static final int BLOB_DEFAULT_UPLOAD_BLOCK_SIZE = BlobConstants.BLOB_DEFAULT_UPLOAD_BLOCK_SIZE;
+        public static final int BLOB_DEFAULT_NUMBER_OF_BUFFERS = BlobConstants.BLOB_DEFAULT_NUMBER_OF_BUFFERS;
+        public static final int BLOB_DEFAULT_HTBB_UPLOAD_BLOCK_SIZE = BlobConstants.BLOB_DEFAULT_HTBB_UPLOAD_BLOCK_SIZE;
+        protected BlobClient(BlobAsyncClient client)
+        protected BlobClient(BlobAsyncClient client, HttpPipeline pipeline, String url, BlobServiceVersion serviceVersion, String accountName, String containerName, String blobName, String snapshot, CpkInfo customerProvidedKey, EncryptionScope encryptionScope, String versionId)
+        // Service Methods:
+        public void upload(InputStream data)
+        public void upload(BinaryData data)
+        public void upload(InputStream data, long length)
+        public void upload(InputStream data, boolean overwrite)
+        public void upload(BinaryData data, boolean overwrite)
+        public void upload(InputStream data, long length, boolean overwrite)
+        public void uploadFromFile(String filePath)
+        public void uploadFromFile(String filePath, boolean overwrite)
+        public void uploadFromFile(String filePath, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions, Duration timeout)
+        public Response<BlockBlobItem> uploadFromFileWithResponse(BlobUploadFromFileOptions options, Duration timeout, Context context)
+        @Deprecated public Response<BlockBlobItem> uploadWithResponse(BlobParallelUploadOptions options, Context context)
+        public Response<BlockBlobItem> uploadWithResponse(BlobParallelUploadOptions options, Duration timeout, Context context)
+        @Deprecated public void uploadWithResponse(InputStream data, long length, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        // Non-Service Methods:
+        public AppendBlobClient getAppendBlobClient()
+        public BlockBlobClient getBlockBlobClient()
+        @Override public BlobClient getCustomerProvidedKeyClient(CustomerProvidedKey customerProvidedKey)
+        @Override public BlobClient getEncryptionScopeClient(String encryptionScope)
+        public PageBlobClient getPageBlobClient()
+        @Override public BlobClient getSnapshotClient(String snapshot)
+        @Override public BlobClient getVersionClient(String versionId)
+    }
+    @ServiceClientBuilder(serviceClients  =  { BlobClient, BlobAsyncClient })
+    public final class BlobClientBuilder implements TokenCredentialTrait<BlobClientBuilder> , ConnectionStringTrait<BlobClientBuilder> , AzureNamedKeyCredentialTrait<BlobClientBuilder> , AzureSasCredentialTrait<BlobClientBuilder> , HttpTrait<BlobClientBuilder> , ConfigurationTrait<BlobClientBuilder> , EndpointTrait<BlobClientBuilder> {
+        public BlobClientBuilder()
+        @Override public BlobClientBuilder addPolicy(HttpPipelinePolicy pipelinePolicy)
+        public BlobClientBuilder setAnonymousAccess()
+        public BlobClientBuilder audience(BlobAudience audience)
+        public BlobClientBuilder blobName(String blobName)
+        @Override public BlobClientBuilder clientOptions(ClientOptions clientOptions)
+        @Override public BlobClientBuilder configuration(Configuration configuration)
+        @Override public BlobClientBuilder connectionString(String connectionString)
+        public BlobClientBuilder containerName(String containerName)
+        public BlobClientBuilder credential(StorageSharedKeyCredential credential)
+        @Override public BlobClientBuilder credential(AzureNamedKeyCredential credential)
+        @Override public BlobClientBuilder credential(TokenCredential credential)
+        @Override public BlobClientBuilder credential(AzureSasCredential credential)
+        public BlobClientBuilder customerProvidedKey(CustomerProvidedKey customerProvidedKey)
+        public static HttpLogOptions getDefaultHttpLogOptions()
+        public BlobClientBuilder encryptionScope(String encryptionScope)
+        @Override public BlobClientBuilder endpoint(String endpoint)
+        @Override public BlobClientBuilder httpClient(HttpClient httpClient)
+        @Override public BlobClientBuilder httpLogOptions(HttpLogOptions logOptions)
+        @Override public BlobClientBuilder pipeline(HttpPipeline httpPipeline)
+        public BlobClientBuilder retryOptions(RequestRetryOptions retryOptions)
+        @Override public BlobClientBuilder retryOptions(RetryOptions retryOptions)
+        public BlobClientBuilder sasToken(String sasToken)
+        public BlobClientBuilder serviceVersion(BlobServiceVersion version)
+        public BlobClientBuilder snapshot(String snapshot)
+        public BlobClientBuilder versionId(String versionId)
+        public BlobAsyncClient buildAsyncClient()
+        public BlobClient buildClient()
+    }
+    @ServiceClient(builder  =  BlobContainerClientBuilder, isAsync  =  true)
+    public final class BlobContainerAsyncClient {
+        public static final String ROOT_CONTAINER_NAME = BlobConstants.ROOT_CONTAINER_NAME;
+        public static final String STATIC_WEBSITE_CONTAINER_NAME = BlobConstants.STATIC_WEBSITE_CONTAINER_NAME;
+        public static final String LOG_CONTAINER_NAME = BlobConstants.LOG_CONTAINER_NAME;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public Mono<BlobContainerAccessPolicies> getAccessPolicy()
+        public Mono<Void> setAccessPolicy(PublicAccessType accessType, List<BlobSignedIdentifier> identifiers)
+        public Mono<Response<BlobContainerAccessPolicies>> getAccessPolicyWithResponse(String leaseId)
+        public Mono<Response<Void>> setAccessPolicyWithResponse(PublicAccessType accessType, List<BlobSignedIdentifier> identifiers, BlobRequestConditions requestConditions)
+        public Mono<StorageAccountInfo> getAccountInfo()
+        public Mono<Response<StorageAccountInfo>> getAccountInfoWithResponse()
+        public Mono<Void> create()
+        public Mono<Boolean> createIfNotExists()
+        public Mono<Response<Boolean>> createIfNotExistsWithResponse(BlobContainerCreateOptions options)
+        public Mono<Response<Void>> createWithResponse(Map<String, String> metadata, PublicAccessType accessType)
+        public Mono<Void> delete()
+        public Mono<Boolean> deleteIfExists()
+        public Mono<Response<Boolean>> deleteIfExistsWithResponse(BlobRequestConditions requestConditions)
+        public Mono<Response<Void>> deleteWithResponse(BlobRequestConditions requestConditions)
+        public Mono<Boolean> exists()
+        public Mono<Response<Boolean>> existsWithResponse()
+        public PagedFlux<TaggedBlobItem> findBlobsByTags(String query)
+        public PagedFlux<TaggedBlobItem> findBlobsByTags(FindBlobsOptions options)
+        public PagedFlux<BlobItem> listBlobs()
+        public PagedFlux<BlobItem> listBlobs(ListBlobsOptions options)
+        public PagedFlux<BlobItem> listBlobs(ListBlobsOptions options, String continuationToken)
+        public PagedFlux<BlobItem> listBlobsByHierarchy(String directory)
+        public PagedFlux<BlobItem> listBlobsByHierarchy(String delimiter, ListBlobsOptions options)
+        public Mono<Void> setMetadata(Map<String, String> metadata)
+        public Mono<Response<Void>> setMetadataWithResponse(Map<String, String> metadata, BlobRequestConditions requestConditions)
+        public Mono<BlobContainerProperties> getProperties()
+        public Mono<Response<BlobContainerProperties>> getPropertiesWithResponse(String leaseId)
+        // Non-Service Methods:
+        public String getAccountName()
+        public String getAccountUrl()
+        public BlobAsyncClient getBlobAsyncClient(String blobName)
+        public BlobAsyncClient getBlobAsyncClient(String blobName, String snapshot)
+        public String getBlobContainerName()
+        public String getBlobContainerUrl()
+        public BlobAsyncClient getBlobVersionAsyncClient(String blobName, String versionId)
+        public CpkInfo getCustomerProvidedKey()
+        public String getEncryptionScope()
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues)
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, Context context)
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, Consumer<String> stringToSignHandler, Context context)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey, String accountName, Context context)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey, String accountName, Consumer<String> stringToSignHandler, Context context)
+        public HttpPipeline getHttpPipeline()
+        public BlobServiceAsyncClient getServiceAsyncClient()
+        public BlobServiceVersion getServiceVersion()
+    }
+    @ServiceClient(builder  =  BlobContainerClientBuilder)
+    public final class BlobContainerClient {
+        public static final String ROOT_CONTAINER_NAME = BlobConstants.ROOT_CONTAINER_NAME;
+        public static final String STATIC_WEBSITE_CONTAINER_NAME = BlobConstants.STATIC_WEBSITE_CONTAINER_NAME;
+        public static final String LOG_CONTAINER_NAME = BlobConstants.LOG_CONTAINER_NAME;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public BlobContainerAccessPolicies getAccessPolicy()
+        public void setAccessPolicy(PublicAccessType accessType, List<BlobSignedIdentifier> identifiers)
+        public Response<BlobContainerAccessPolicies> getAccessPolicyWithResponse(String leaseId, Duration timeout, Context context)
+        public Response<Void> setAccessPolicyWithResponse(PublicAccessType accessType, List<BlobSignedIdentifier> identifiers, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public StorageAccountInfo getAccountInfo(Duration timeout)
+        public Response<StorageAccountInfo> getAccountInfoWithResponse(Duration timeout, Context context)
+        public void create()
+        public boolean createIfNotExists()
+        public Response<Boolean> createIfNotExistsWithResponse(BlobContainerCreateOptions options, Duration timeout, Context context)
+        public Response<Void> createWithResponse(Map<String, String> metadata, PublicAccessType accessType, Duration timeout, Context context)
+        public void delete()
+        public boolean deleteIfExists()
+        public Response<Boolean> deleteIfExistsWithResponse(BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public Response<Void> deleteWithResponse(BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public boolean exists()
+        public Response<Boolean> existsWithResponse(Duration timeout, Context context)
+        public PagedIterable<TaggedBlobItem> findBlobsByTags(String query)
+        public PagedIterable<TaggedBlobItem> findBlobsByTags(FindBlobsOptions options, Duration timeout, Context context)
+        public PagedIterable<BlobItem> listBlobs()
+        public PagedIterable<BlobItem> listBlobs(ListBlobsOptions options, Duration timeout)
+        public PagedIterable<BlobItem> listBlobs(ListBlobsOptions options, String continuationToken, Duration timeout)
+        public PagedIterable<BlobItem> listBlobsByHierarchy(String directory)
+        public PagedIterable<BlobItem> listBlobsByHierarchy(String delimiter, ListBlobsOptions options, Duration timeout)
+        public void setMetadata(Map<String, String> metadata)
+        public Response<Void> setMetadataWithResponse(Map<String, String> metadata, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public BlobContainerProperties getProperties()
+        public Response<BlobContainerProperties> getPropertiesWithResponse(String leaseId, Duration timeout, Context context)
+        // Non-Service Methods:
+        public String getAccountName()
+        public String getAccountUrl()
+        public BlobClient getBlobClient(String blobName)
+        public BlobClient getBlobClient(String blobName, String snapshot)
+        public String getBlobContainerName()
+        public String getBlobContainerUrl()
+        public BlobClient getBlobVersionClient(String blobName, String versionId)
+        public CpkInfo getCustomerProvidedKey()
+        public String getEncryptionScope()
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues)
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, Context context)
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, Consumer<String> stringToSignHandler, Context context)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey, String accountName, Context context)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey, String accountName, Consumer<String> stringToSignHandler, Context context)
+        public HttpPipeline getHttpPipeline()
+        public BlobServiceClient getServiceClient()
+        public BlobServiceVersion getServiceVersion()
+    }
+    @ServiceClientBuilder(serviceClients  =  { BlobContainerClient, BlobContainerAsyncClient })
+    public final class BlobContainerClientBuilder implements TokenCredentialTrait<BlobContainerClientBuilder> , ConnectionStringTrait<BlobContainerClientBuilder> , AzureSasCredentialTrait<BlobContainerClientBuilder> , AzureNamedKeyCredentialTrait<BlobContainerClientBuilder> , HttpTrait<BlobContainerClientBuilder> , ConfigurationTrait<BlobContainerClientBuilder> , EndpointTrait<BlobContainerClientBuilder> {
+        public BlobContainerClientBuilder()
+        @Override public BlobContainerClientBuilder addPolicy(HttpPipelinePolicy pipelinePolicy)
+        public BlobContainerClientBuilder setAnonymousAccess()
+        public BlobContainerClientBuilder audience(BlobAudience audience)
+        public BlobContainerClientBuilder blobContainerEncryptionScope(BlobContainerEncryptionScope blobContainerEncryptionScope)
+        @Override public BlobContainerClientBuilder clientOptions(ClientOptions clientOptions)
+        @Override public BlobContainerClientBuilder configuration(Configuration configuration)
+        @Override public BlobContainerClientBuilder connectionString(String connectionString)
+        public BlobContainerClientBuilder containerName(String containerName)
+        public BlobContainerClientBuilder credential(StorageSharedKeyCredential credential)
+        @Override public BlobContainerClientBuilder credential(AzureNamedKeyCredential credential)
+        @Override public BlobContainerClientBuilder credential(TokenCredential credential)
+        @Override public BlobContainerClientBuilder credential(AzureSasCredential credential)
+        public BlobContainerClientBuilder customerProvidedKey(CustomerProvidedKey customerProvidedKey)
+        public static HttpLogOptions getDefaultHttpLogOptions()
+        public BlobContainerClientBuilder encryptionScope(String encryptionScope)
+        @Override public BlobContainerClientBuilder endpoint(String endpoint)
+        @Override public BlobContainerClientBuilder httpClient(HttpClient httpClient)
+        @Override public BlobContainerClientBuilder httpLogOptions(HttpLogOptions logOptions)
+        @Override public BlobContainerClientBuilder pipeline(HttpPipeline httpPipeline)
+        public BlobContainerClientBuilder retryOptions(RequestRetryOptions retryOptions)
+        @Override public BlobContainerClientBuilder retryOptions(RetryOptions retryOptions)
+        public BlobContainerClientBuilder sasToken(String sasToken)
+        public BlobContainerClientBuilder serviceVersion(BlobServiceVersion version)
+        public BlobContainerAsyncClient buildAsyncClient()
+        public BlobContainerClient buildClient()
+    }
+    @ServiceClient(builder  =  BlobServiceClientBuilder, isAsync  =  true)
+    public final class BlobServiceAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public Mono<StorageAccountInfo> getAccountInfo()
+        public Mono<Response<StorageAccountInfo>> getAccountInfoWithResponse()
+        public Mono<BlobContainerAsyncClient> createBlobContainer(String containerName)
+        public Mono<BlobContainerAsyncClient> createBlobContainerIfNotExists(String containerName)
+        public Mono<Response<BlobContainerAsyncClient>> createBlobContainerIfNotExistsWithResponse(String containerName, BlobContainerCreateOptions options)
+        public Mono<Response<BlobContainerAsyncClient>> createBlobContainerWithResponse(String containerName, Map<String, String> metadata, PublicAccessType accessType)
+        public Mono<Void> deleteBlobContainer(String containerName)
+        public Mono<Boolean> deleteBlobContainerIfExists(String containerName)
+        public Mono<Response<Boolean>> deleteBlobContainerIfExistsWithResponse(String containerName)
+        public Mono<Response<Void>> deleteBlobContainerWithResponse(String containerName)
+        public PagedFlux<TaggedBlobItem> findBlobsByTags(String query)
+        public PagedFlux<TaggedBlobItem> findBlobsByTags(FindBlobsOptions options)
+        public PagedFlux<BlobContainerItem> listBlobContainers()
+        public PagedFlux<BlobContainerItem> listBlobContainers(ListBlobContainersOptions options)
+        public Mono<BlobServiceProperties> getProperties()
+        public Mono<Void> setProperties(BlobServiceProperties properties)
+        public Mono<Response<BlobServiceProperties>> getPropertiesWithResponse()
+        public Mono<Response<Void>> setPropertiesWithResponse(BlobServiceProperties properties)
+        public Mono<BlobServiceStatistics> getStatistics()
+        public Mono<Response<BlobServiceStatistics>> getStatisticsWithResponse()
+        public Mono<BlobContainerAsyncClient> undeleteBlobContainer(String deletedContainerName, String deletedContainerVersion)
+        public Mono<Response<BlobContainerAsyncClient>> undeleteBlobContainerWithResponse(UndeleteBlobContainerOptions options)
+        public Mono<UserDelegationKey> getUserDelegationKey(OffsetDateTime start, OffsetDateTime expiry)
+        public Mono<Response<UserDelegationKey>> getUserDelegationKeyWithResponse(BlobGetUserDelegationKeyOptions options)
+        public Mono<Response<UserDelegationKey>> getUserDelegationKeyWithResponse(OffsetDateTime start, OffsetDateTime expiry)
+        // Non-Service Methods:
+        public String getAccountName()
+        public String getAccountUrl()
+        public BlobContainerAsyncClient getBlobContainerAsyncClient(String containerName)
+        public String generateAccountSas(AccountSasSignatureValues accountSasSignatureValues)
+        public String generateAccountSas(AccountSasSignatureValues accountSasSignatureValues, Context context)
+        public String generateAccountSas(AccountSasSignatureValues accountSasSignatureValues, Consumer<String> stringToSignHandler, Context context)
+        public HttpPipeline getHttpPipeline()
+        public BlobServiceVersion getServiceVersion()
+    }
+    @ServiceClient(builder  =  BlobServiceClientBuilder)
+    public final class BlobServiceClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public StorageAccountInfo getAccountInfo()
+        public Response<StorageAccountInfo> getAccountInfoWithResponse(Duration timeout, Context context)
+        public BlobContainerClient createBlobContainer(String containerName)
+        public BlobContainerClient createBlobContainerIfNotExists(String containerName)
+        public Response<BlobContainerClient> createBlobContainerIfNotExistsWithResponse(String containerName, BlobContainerCreateOptions options, Context context)
+        public Response<BlobContainerClient> createBlobContainerWithResponse(String containerName, Map<String, String> metadata, PublicAccessType accessType, Context context)
+        public void deleteBlobContainer(String containerName)
+        public boolean deleteBlobContainerIfExists(String containerName)
+        public Response<Boolean> deleteBlobContainerIfExistsWithResponse(String containerName, Context context)
+        public Response<Void> deleteBlobContainerWithResponse(String containerName, Context context)
+        public PagedIterable<TaggedBlobItem> findBlobsByTags(String query)
+        public PagedIterable<TaggedBlobItem> findBlobsByTags(FindBlobsOptions options, Duration timeout, Context context)
+        public PagedIterable<BlobContainerItem> listBlobContainers()
+        public PagedIterable<BlobContainerItem> listBlobContainers(ListBlobContainersOptions options, Duration timeout)
+        public BlobServiceProperties getProperties()
+        public void setProperties(BlobServiceProperties properties)
+        public Response<BlobServiceProperties> getPropertiesWithResponse(Duration timeout, Context context)
+        public Response<Void> setPropertiesWithResponse(BlobServiceProperties properties, Duration timeout, Context context)
+        public BlobServiceStatistics getStatistics()
+        public Response<BlobServiceStatistics> getStatisticsWithResponse(Duration timeout, Context context)
+        public BlobContainerClient undeleteBlobContainer(String deletedContainerName, String deletedContainerVersion)
+        public Response<BlobContainerClient> undeleteBlobContainerWithResponse(UndeleteBlobContainerOptions options, Duration timeout, Context context)
+        public UserDelegationKey getUserDelegationKey(OffsetDateTime start, OffsetDateTime expiry)
+        public Response<UserDelegationKey> getUserDelegationKeyWithResponse(BlobGetUserDelegationKeyOptions options, Duration timeout, Context context)
+        public Response<UserDelegationKey> getUserDelegationKeyWithResponse(OffsetDateTime start, OffsetDateTime expiry, Duration timeout, Context context)
+        // Non-Service Methods:
+        public String getAccountName()
+        public String getAccountUrl()
+        public BlobContainerClient getBlobContainerClient(String containerName)
+        public String generateAccountSas(AccountSasSignatureValues accountSasSignatureValues)
+        public String generateAccountSas(AccountSasSignatureValues accountSasSignatureValues, Context context)
+        public String generateAccountSas(AccountSasSignatureValues accountSasSignatureValues, Consumer<String> stringToSignHandler, Context context)
+        public HttpPipeline getHttpPipeline()
+        public BlobServiceVersion getServiceVersion()
+    }
+    @ServiceClientBuilder(serviceClients  =  { BlobServiceClient, BlobServiceAsyncClient })
+    public final class BlobServiceClientBuilder implements TokenCredentialTrait<BlobServiceClientBuilder> , ConnectionStringTrait<BlobServiceClientBuilder> , AzureNamedKeyCredentialTrait<BlobServiceClientBuilder> , AzureSasCredentialTrait<BlobServiceClientBuilder> , HttpTrait<BlobServiceClientBuilder> , ConfigurationTrait<BlobServiceClientBuilder> , EndpointTrait<BlobServiceClientBuilder> {
+        public BlobServiceClientBuilder()
+        @Override public BlobServiceClientBuilder addPolicy(HttpPipelinePolicy pipelinePolicy)
+        public BlobServiceClientBuilder audience(BlobAudience audience)
+        public BlobServiceClientBuilder blobContainerEncryptionScope(BlobContainerEncryptionScope blobContainerEncryptionScope)
+        @Override public BlobServiceClientBuilder clientOptions(ClientOptions clientOptions)
+        @Override public BlobServiceClientBuilder configuration(Configuration configuration)
+        @Override public BlobServiceClientBuilder connectionString(String connectionString)
+        public BlobServiceClientBuilder credential(StorageSharedKeyCredential credential)
+        @Override public BlobServiceClientBuilder credential(AzureNamedKeyCredential credential)
+        @Override public BlobServiceClientBuilder credential(TokenCredential credential)
+        @Override public BlobServiceClientBuilder credential(AzureSasCredential credential)
+        public BlobServiceClientBuilder customerProvidedKey(CustomerProvidedKey customerProvidedKey)
+        public static HttpLogOptions getDefaultHttpLogOptions()
+        public BlobServiceClientBuilder encryptionScope(String encryptionScope)
+        @Override public BlobServiceClientBuilder endpoint(String endpoint)
+        @Override public BlobServiceClientBuilder httpClient(HttpClient httpClient)
+        @Override public BlobServiceClientBuilder httpLogOptions(HttpLogOptions logOptions)
+        @Override public BlobServiceClientBuilder pipeline(HttpPipeline httpPipeline)
+        public BlobServiceClientBuilder retryOptions(RequestRetryOptions retryOptions)
+        @Override public BlobServiceClientBuilder retryOptions(RetryOptions retryOptions)
+        public BlobServiceClientBuilder sasToken(String sasToken)
+        public BlobServiceClientBuilder serviceVersion(BlobServiceVersion version)
+        public BlobServiceAsyncClient buildAsyncClient()
+        public BlobServiceClient buildClient()
+    }
+    public enum BlobServiceVersion implements ServiceVersion {
+        V2019_02_02("2019-02-02"),
+        V2019_07_07("2019-07-07"),
+        V2019_12_12("2019-12-12"),
+        V2020_02_10("2020-02-10"),
+        V2020_04_08("2020-04-08"),
+        V2020_06_12("2020-06-12"),
+        V2020_08_04("2020-08-04"),
+        V2020_10_02("2020-10-02"),
+        V2020_12_06("2020-12-06"),
+        V2021_02_12("2021-02-12"),
+        V2021_04_10("2021-04-10"),
+        V2021_06_08("2021-06-08"),
+        V2021_08_06("2021-08-06"),
+        V2021_10_04("2021-10-04"),
+        V2021_12_02("2021-12-02"),
+        V2022_11_02("2022-11-02"),
+        V2023_01_03("2023-01-03"),
+        V2023_05_03("2023-05-03"),
+        V2023_08_03("2023-08-03"),
+        V2023_11_03("2023-11-03"),
+        V2024_02_04("2024-02-04"),
+        V2024_05_04("2024-05-04"),
+        V2024_08_04("2024-08-04"),
+        V2024_11_04("2024-11-04"),
+        V2025_01_05("2025-01-05"),
+        V2025_05_05("2025-05-05"),
+        V2025_07_05("2025-07-05"),
+        V2025_11_05("2025-11-05"),
+        V2026_02_06("2026-02-06"),
+        V2026_04_06("2026-04-06"),
+        V2026_06_06("2026-06-06"),
+        V2026_10_06("2026-10-06");
+        public static BlobServiceVersion getLatest(// returns V2026_10_06 )
+        @Override public String getVersion()
+    }
+    public final class BlobUrlParts {
+        public BlobUrlParts()
+        public String getAccountName()
+        public BlobUrlParts setAccountName(String accountName)
+        public String getBlobContainerName()
+        public String getBlobName()
+        public BlobUrlParts setBlobName(String blobName)
+        public CommonSasQueryParameters getCommonSasQueryParameters()
+        public BlobUrlParts setCommonSasQueryParameters(CommonSasQueryParameters commonSasQueryParameters)
+        public BlobUrlParts setContainerName(String containerName)
+        public String getHost()
+        public BlobUrlParts setHost(String host)
+        public static BlobUrlParts parse(String url)
+        public static BlobUrlParts parse(URL url)
+        public BlobUrlParts parseSasQueryParameters(String queryParams)
+        @Deprecated public BlobServiceSasQueryParameters getSasQueryParameters()
+        @Deprecated public BlobUrlParts setSasQueryParameters(BlobServiceSasQueryParameters blobServiceSasQueryParameters)
+        public String getScheme()
+        public BlobUrlParts setScheme(String scheme)
+        public String getSnapshot()
+        public BlobUrlParts setSnapshot(String snapshot)
+        public URL toUrl()
+        public Map<String, String[]> getUnparsedParameters()
+        public BlobUrlParts setUnparsedParameters(Map<String, String[]> unparsedParameters)
+        public String getVersionId()
+        public BlobUrlParts setVersionId(String versionId)
+    }
+    public final class HttpGetterInfo {
+        public HttpGetterInfo()
+        public Long getCount()
+        public HttpGetterInfo setCount(Long count)
+        public String getETag()
+        public HttpGetterInfo setETag(String eTag)
+        public long getOffset()
+        public HttpGetterInfo setOffset(long offset)
+    }
+    @Deprecated
+    public interface ProgressReceiver extends ProgressListener {
+        @Override default void handleProgress(long bytesTransferred)
+        void reportProgress(long bytesTransferred)
+    }
+    @Deprecated
+    public final class ProgressReporter {
+        public ProgressReporter()
+        @Deprecated public static Flux<ByteBuffer> addParallelProgressReporting(Flux<ByteBuffer> data, ProgressReceiver progressReceiver, Lock lock, AtomicLong totalProgress)
+        @Deprecated public static Flux<ByteBuffer> addProgressReporting(Flux<ByteBuffer> data, ProgressReceiver progressReceiver)
+    }
+}
+package com.azure.storage.blob.models {
+    public final class AccessTier extends ExpandableStringEnum<AccessTier> {
+        @Generated public static final AccessTier P4 = fromString("P4");
+        @Generated public static final AccessTier P6 = fromString("P6");
+        @Generated public static final AccessTier P10 = fromString("P10");
+        @Generated public static final AccessTier P15 = fromString("P15");
+        @Generated public static final AccessTier P20 = fromString("P20");
+        @Generated public static final AccessTier P30 = fromString("P30");
+        @Generated public static final AccessTier P40 = fromString("P40");
+        @Generated public static final AccessTier P50 = fromString("P50");
+        @Generated public static final AccessTier P60 = fromString("P60");
+        @Generated public static final AccessTier P70 = fromString("P70");
+        @Generated public static final AccessTier P80 = fromString("P80");
+        @Generated public static final AccessTier HOT = fromString("Hot");
+        @Generated public static final AccessTier COOL = fromString("Cool");
+        @Generated public static final AccessTier ARCHIVE = fromString("Archive");
+        @Generated public static final AccessTier PREMIUM = fromString("Premium");
+        @Generated public static final AccessTier COLD = fromString("Cold");
+        @Generated public static final AccessTier SMART = fromString("Smart");
+        @Deprecated @Generated public AccessTier()
+        @Generated public static AccessTier fromString(String name)
+        @Generated public static Collection<AccessTier> values()
+    }
+    public enum AccountKind {
+        STORAGE("Storage"),
+        BLOB_STORAGE("BlobStorage"),
+        STORAGE_V2("StorageV2"),
+        FILE_STORAGE("FileStorage"),
+        BLOCK_BLOB_STORAGE("BlockBlobStorage");
+        public static AccountKind fromString(String value)
+        @Override public String toString()
+    }
+    @Immutable
+    public class AppendBlobItem {
+        public AppendBlobItem(String eTag, OffsetDateTime lastModified, byte[] contentMd5, boolean isServerEncrypted, String encryptionKeySha256, String blobAppendOffset, Integer blobCommittedBlockCount)
+        public AppendBlobItem(String eTag, OffsetDateTime lastModified, byte[] contentMd5, boolean isServerEncrypted, String encryptionKeySha256, String encryptionScope, String blobAppendOffset, Integer blobCommittedBlockCount)
+        public AppendBlobItem(String eTag, OffsetDateTime lastModified, byte[] contentMd5, boolean isServerEncrypted, String encryptionKeySha256, String encryptionScope, String blobAppendOffset, Integer blobCommittedBlockCount, String versionId)
+        public String getBlobAppendOffset()
+        public Integer getBlobCommittedBlockCount()
+        public byte[] getContentCrc64()
+        public byte[] getContentMd5()
+        public String getEncryptionKeySha256()
+        public String getEncryptionScope()
+        public String getETag()
+        public OffsetDateTime getLastModified()
+        public boolean isServerEncrypted()
+        public String getVersionId()
+    }
+    @Fluent
+    public final class AppendBlobRequestConditions extends BlobRequestConditions {
+        public AppendBlobRequestConditions()
+        public Long getAppendPosition()
+        public AppendBlobRequestConditions setAppendPosition(Long appendPosition)
+        @Override public AppendBlobRequestConditions setIfMatch(String ifMatch)
+        @Override public AppendBlobRequestConditions setIfModifiedSince(OffsetDateTime ifModifiedSince)
+        @Override public AppendBlobRequestConditions setIfNoneMatch(String ifNoneMatch)
+        @Override public AppendBlobRequestConditions setIfUnmodifiedSince(OffsetDateTime ifUnmodifiedSince)
+        @Override public AppendBlobRequestConditions setLeaseId(String leaseId)
+        public Long getMaxSize()
+        public AppendBlobRequestConditions setMaxSize(Long maxSize)
+        @Override public AppendBlobRequestConditions setTagsConditions(String tagsConditions)
+    }
+    public final class ArchiveStatus extends ExpandableStringEnum<ArchiveStatus> {
+        @Generated public static final ArchiveStatus REHYDRATE_PENDING_TO_HOT = fromString("rehydrate-pending-to-hot");
+        @Generated public static final ArchiveStatus REHYDRATE_PENDING_TO_COOL = fromString("rehydrate-pending-to-cool");
+        @Generated public static final ArchiveStatus REHYDRATE_PENDING_TO_COLD = fromString("rehydrate-pending-to-cold");
+        @Generated public static final ArchiveStatus REHYDRATE_PENDING_TO_SMART = fromString("rehydrate-pending-to-smart");
+        @Deprecated @Generated public ArchiveStatus()
+        @Generated public static ArchiveStatus fromString(String name)
+        @Generated public static Collection<ArchiveStatus> values()
+    }
+    @Fluent
+    public final class BlobAccessPolicy implements XmlSerializable<BlobAccessPolicy> {
+        @Generated public BlobAccessPolicy()
+        @Generated public OffsetDateTime getExpiresOn()
+        @Generated public BlobAccessPolicy setExpiresOn(OffsetDateTime expiresOn)
+        @Generated public String getPermissions()
+        @Generated public BlobAccessPolicy setPermissions(String permissions)
+        @Generated public OffsetDateTime getStartsOn()
+        @Generated public BlobAccessPolicy setStartsOn(OffsetDateTime startsOn)
+    }
+    @Fluent
+    public final class BlobAnalyticsLogging implements XmlSerializable<BlobAnalyticsLogging> {
+        @Generated public BlobAnalyticsLogging()
+        @Generated public boolean isDelete()
+        @Generated public BlobAnalyticsLogging setDelete(boolean delete)
+        @Generated public boolean isRead()
+        @Generated public BlobAnalyticsLogging setRead(boolean read)
+        @Generated public BlobRetentionPolicy getRetentionPolicy()
+        @Generated public BlobAnalyticsLogging setRetentionPolicy(BlobRetentionPolicy retentionPolicy)
+        @Generated public String getVersion()
+        @Generated public BlobAnalyticsLogging setVersion(String version)
+        @Generated public boolean isWrite()
+        @Generated public BlobAnalyticsLogging setWrite(boolean write)
+    }
+    public class BlobAudience extends ExpandableStringEnum<BlobAudience> {
+        public static final BlobAudience AZURE_PUBLIC_CLOUD = fromString("https://storage.azure.com/");
+        @Deprecated public BlobAudience()
+        public static BlobAudience createBlobServiceAccountAudience(String storageAccountName)
+        public static BlobAudience fromString(String audience)
+        public static Collection<BlobAudience> values()
+    }
+    public class BlobBeginCopySourceRequestConditions extends RequestConditions {
+        public BlobBeginCopySourceRequestConditions()
+        @Override public BlobBeginCopySourceRequestConditions setIfMatch(String ifMatch)
+        @Override public BlobBeginCopySourceRequestConditions setIfModifiedSince(OffsetDateTime ifModifiedSince)
+        @Override public BlobBeginCopySourceRequestConditions setIfNoneMatch(String ifNoneMatch)
+        @Override public BlobBeginCopySourceRequestConditions setIfUnmodifiedSince(OffsetDateTime ifUnmodifiedSince)
+        public String getTagsConditions()
+        public BlobBeginCopySourceRequestConditions setTagsConditions(String tagsConditions)
+    }
+    @Immutable
+    public class BlobContainerAccessPolicies {
+        public BlobContainerAccessPolicies(PublicAccessType blobAccessType, List<BlobSignedIdentifier> identifiers)
+        public PublicAccessType getBlobAccessType()
+        public List<BlobSignedIdentifier> getIdentifiers()
+    }
+    @Fluent
+    public final class BlobContainerEncryptionScope {
+        @Generated public BlobContainerEncryptionScope()
+        @Generated public String getDefaultEncryptionScope()
+        @Generated public BlobContainerEncryptionScope setDefaultEncryptionScope(String defaultEncryptionScope)
+        @Generated public boolean isEncryptionScopeOverridePrevented()
+        @Generated public BlobContainerEncryptionScope setEncryptionScopeOverridePrevented(Boolean encryptionScopeOverridePrevented)
+    }
+    @Fluent
+    public final class BlobContainerItem implements XmlSerializable<BlobContainerItem> {
+        @Generated public BlobContainerItem()
+        @Generated public Boolean isDeleted()
+        @Generated public BlobContainerItem setDeleted(Boolean deleted)
+        @Generated public Map<String, String> getMetadata()
+        @Generated public BlobContainerItem setMetadata(Map<String, String> metadata)
+        @Generated public String getName()
+        @Generated public BlobContainerItem setName(String name)
+        @Generated public BlobContainerItemProperties getProperties()
+        @Generated public BlobContainerItem setProperties(BlobContainerItemProperties properties)
+        @Generated public String getVersion()
+        @Generated public BlobContainerItem setVersion(String version)
+    }
+    @Fluent
+    public final class BlobContainerItemProperties implements XmlSerializable<BlobContainerItemProperties> {
+        @Generated public BlobContainerItemProperties()
+        @Generated public String getDefaultEncryptionScope()
+        @Generated public BlobContainerItemProperties setDefaultEncryptionScope(String defaultEncryptionScope)
+        @Generated public OffsetDateTime getDeletedTime()
+        @Generated public BlobContainerItemProperties setDeletedTime(OffsetDateTime deletedTime)
+        @Generated public boolean isEncryptionScopeOverridePrevented()
+        @Generated public BlobContainerItemProperties setEncryptionScopeOverridePrevented(boolean encryptionScopeOverridePrevented)
+        @Generated public String getETag()
+        @Generated public BlobContainerItemProperties setETag(String eTag)
+        @Generated public Boolean isHasImmutabilityPolicy()
+        @Generated public BlobContainerItemProperties setHasImmutabilityPolicy(Boolean hasImmutabilityPolicy)
+        @Generated public Boolean isHasLegalHold()
+        @Generated public BlobContainerItemProperties setHasLegalHold(Boolean hasLegalHold)
+        @Generated public Boolean isImmutableStorageWithVersioningEnabled()
+        @Generated public BlobContainerItemProperties setImmutableStorageWithVersioningEnabled(Boolean isImmutableStorageWithVersioningEnabled)
+        @Generated public OffsetDateTime getLastModified()
+        @Generated public BlobContainerItemProperties setLastModified(OffsetDateTime lastModified)
+        @Generated public LeaseDurationType getLeaseDuration()
+        @Generated public BlobContainerItemProperties setLeaseDuration(LeaseDurationType leaseDuration)
+        @Generated public LeaseStateType getLeaseState()
+        @Generated public BlobContainerItemProperties setLeaseState(LeaseStateType leaseState)
+        @Generated public LeaseStatusType getLeaseStatus()
+        @Generated public BlobContainerItemProperties setLeaseStatus(LeaseStatusType leaseStatus)
+        @Generated public PublicAccessType getPublicAccess()
+        @Generated public BlobContainerItemProperties setPublicAccess(PublicAccessType publicAccess)
+        @Generated public Integer getRemainingRetentionDays()
+        @Generated public BlobContainerItemProperties setRemainingRetentionDays(Integer remainingRetentionDays)
+    }
+    @Fluent
+    public final class BlobContainerListDetails {
+        public BlobContainerListDetails()
+        public boolean getRetrieveDeleted()
+        public BlobContainerListDetails setRetrieveDeleted(boolean retrieveDeleted)
+        public boolean getRetrieveMetadata()
+        public BlobContainerListDetails setRetrieveMetadata(boolean retrieveMetadata)
+        public boolean getRetrieveSystemContainers()
+        public BlobContainerListDetails setRetrieveSystemContainers(boolean retrieveSystemContainers)
+        @Deprecated public ListBlobContainersIncludeType toIncludeType()
+    }
+    @Immutable
+    public final class BlobContainerProperties {
+        public BlobContainerProperties(Map<String, String> metadata, String eTag, OffsetDateTime lastModified, LeaseDurationType leaseDuration, LeaseStateType leaseState, LeaseStatusType leaseStatus, PublicAccessType blobPublicAccess, boolean hasImmutabilityPolicy, boolean hasLegalHold)
+        public BlobContainerProperties(Map<String, String> metadata, String eTag, OffsetDateTime lastModified, LeaseDurationType leaseDuration, LeaseStateType leaseState, LeaseStatusType leaseStatus, PublicAccessType blobPublicAccess, boolean hasImmutabilityPolicy, boolean hasLegalHold, String defaultEncryptionScope, Boolean encryptionScopeOverridePrevented)
+        public BlobContainerProperties(Map<String, String> metadata, String eTag, OffsetDateTime lastModified, LeaseDurationType leaseDuration, LeaseStateType leaseState, LeaseStatusType leaseStatus, PublicAccessType blobPublicAccess, boolean hasImmutabilityPolicy, boolean hasLegalHold, String defaultEncryptionScope, Boolean encryptionScopeOverridePrevented, Boolean isImmutableStorageWithVersioningEnabled)
+        public PublicAccessType getBlobPublicAccess()
+        public String getDefaultEncryptionScope()
+        public Boolean isEncryptionScopeOverridePrevented()
+        public String getETag()
+        public boolean hasImmutabilityPolicy()
+        public boolean hasLegalHold()
+        public Boolean isImmutableStorageWithVersioningEnabled()
+        public OffsetDateTime getLastModified()
+        public LeaseDurationType getLeaseDuration()
+        public LeaseStateType getLeaseState()
+        public LeaseStatusType getLeaseStatus()
+        public Map<String, String> getMetadata()
+    }
+    @Immutable
+    public class BlobCopyInfo {
+        public BlobCopyInfo(String copySource, String copyId, CopyStatusType copyStatus, String eTag, OffsetDateTime lastModified, String error)
+        public BlobCopyInfo(String copySource, String copyId, CopyStatusType copyStatus, String eTag, OffsetDateTime lastModified, String error, String versionId)
+        public BlobCopyInfo(String copySource, String copyId, CopyStatusType copyStatus, String eTag, OffsetDateTime lastModified, String error, String versionId, String encryptionScope)
+        public String getCopyId()
+        public String getCopySourceUrl()
+        public CopyStatusType getCopyStatus()
+        public String getEncryptionScope()
+        public String getError()
+        public String getETag()
+        public OffsetDateTime getLastModified()
+        public String getVersionId()
+    }
+    public final class BlobCopySourceTagsMode extends ExpandableStringEnum<BlobCopySourceTagsMode> {
+        @Generated public static final BlobCopySourceTagsMode REPLACE = fromString("REPLACE");
+        @Generated public static final BlobCopySourceTagsMode COPY = fromString("COPY");
+        @Deprecated @Generated public BlobCopySourceTagsMode()
+        @Generated public static BlobCopySourceTagsMode fromString(String name)
+        @Generated public static Collection<BlobCopySourceTagsMode> values()
+    }
+    @Fluent
+    public final class BlobCorsRule implements XmlSerializable<BlobCorsRule> {
+        @Generated public BlobCorsRule()
+        @Generated public String getAllowedHeaders()
+        @Generated public BlobCorsRule setAllowedHeaders(String allowedHeaders)
+        @Generated public String getAllowedMethods()
+        @Generated public BlobCorsRule setAllowedMethods(String allowedMethods)
+        @Generated public String getAllowedOrigins()
+        @Generated public BlobCorsRule setAllowedOrigins(String allowedOrigins)
+        @Generated public String getExposedHeaders()
+        @Generated public BlobCorsRule setExposedHeaders(String exposedHeaders)
+        @Generated public int getMaxAgeInSeconds()
+        @Generated public BlobCorsRule setMaxAgeInSeconds(int maxAgeInSeconds)
+    }
+    public final class BlobDownloadAsyncResponse extends ResponseBase<BlobDownloadHeaders, Flux<ByteBuffer>> implements Closeable {
+        public BlobDownloadAsyncResponse(HttpRequest request, int statusCode, HttpHeaders headers, Flux<ByteBuffer> value, BlobDownloadHeaders deserializedHeaders)
+        @Override public void close() throws IOException
+        public Mono<Void> writeValueToAsync(AsynchronousByteChannel channel, ProgressReporter progressReporter)
+    }
+    public final class BlobDownloadContentAsyncResponse extends ResponseBase<BlobDownloadHeaders, BinaryData> {
+        public BlobDownloadContentAsyncResponse(HttpRequest request, int statusCode, HttpHeaders headers, BinaryData value, BlobDownloadHeaders deserializedHeaders)
+    }
+    public final class BlobDownloadContentResponse extends ResponseBase<BlobDownloadHeaders, BinaryData> {
+        public BlobDownloadContentResponse(BlobDownloadContentAsyncResponse response)
+    }
+    @Fluent
+    public final class BlobDownloadHeaders {
+        public BlobDownloadHeaders()
+        public String getAcceptRanges()
+        public BlobDownloadHeaders setAcceptRanges(String acceptRanges)
+        public Integer getBlobCommittedBlockCount()
+        public BlobDownloadHeaders setBlobCommittedBlockCount(Integer blobCommittedBlockCount)
+        public byte[] getBlobContentMD5()
+        public BlobDownloadHeaders setBlobContentMD5(byte[] blobContentMD5)
+        public Long getBlobSequenceNumber()
+        public BlobDownloadHeaders setBlobSequenceNumber(Long blobSequenceNumber)
+        public BlobType getBlobType()
+        public BlobDownloadHeaders setBlobType(BlobType blobType)
+        public String getCacheControl()
+        public BlobDownloadHeaders setCacheControl(String cacheControl)
+        public String getClientRequestId()
+        public BlobDownloadHeaders setClientRequestId(String clientRequestId)
+        public byte[] getContentCrc64()
+        public BlobDownloadHeaders setContentCrc64(byte[] contentCrc64)
+        public String getContentDisposition()
+        public BlobDownloadHeaders setContentDisposition(String contentDisposition)
+        public String getContentEncoding()
+        public BlobDownloadHeaders setContentEncoding(String contentEncoding)
+        public String getContentLanguage()
+        public BlobDownloadHeaders setContentLanguage(String contentLanguage)
+        public Long getContentLength()
+        public BlobDownloadHeaders setContentLength(Long contentLength)
+        public byte[] getContentMd5()
+        public BlobDownloadHeaders setContentMd5(byte[] contentMd5)
+        public String getContentRange()
+        public BlobDownloadHeaders setContentRange(String contentRange)
+        public String getContentType()
+        public BlobDownloadHeaders setContentType(String contentType)
+        public OffsetDateTime getCopyCompletionTime()
+        public BlobDownloadHeaders setCopyCompletionTime(OffsetDateTime copyCompletionTime)
+        public String getCopyId()
+        public BlobDownloadHeaders setCopyId(String copyId)
+        public String getCopyProgress()
+        public BlobDownloadHeaders setCopyProgress(String copyProgress)
+        public String getCopySource()
+        public BlobDownloadHeaders setCopySource(String copySource)
+        public CopyStatusType getCopyStatus()
+        public BlobDownloadHeaders setCopyStatus(CopyStatusType copyStatus)
+        public String getCopyStatusDescription()
+        public BlobDownloadHeaders setCopyStatusDescription(String copyStatusDescription)
+        public OffsetDateTime getCreationTime()
+        public BlobDownloadHeaders setCreationTime(OffsetDateTime creationTime)
+        public Boolean isCurrentVersion()
+        public BlobDownloadHeaders setCurrentVersion(Boolean currentVersion)
+        public OffsetDateTime getDateProperty()
+        public BlobDownloadHeaders setDateProperty(OffsetDateTime dateProperty)
+        public String getEncryptionKeySha256()
+        public BlobDownloadHeaders setEncryptionKeySha256(String encryptionKeySha256)
+        public String getEncryptionScope()
+        public BlobDownloadHeaders setEncryptionScope(String encryptionScope)
+        public String getErrorCode()
+        public BlobDownloadHeaders setErrorCode(String errorCode)
+        public String getETag()
+        public BlobDownloadHeaders setETag(String eTag)
+        public Boolean hasLegalHold()
+        public BlobDownloadHeaders setHasLegalHold(Boolean hasLegalHold)
+        public BlobImmutabilityPolicy getImmutabilityPolicy()
+        public BlobDownloadHeaders setImmutabilityPolicy(BlobImmutabilityPolicy immutabilityPolicy)
+        public BlobDownloadHeaders setIsServerEncrypted(Boolean isServerEncrypted)
+        public OffsetDateTime getLastAccessedTime()
+        public BlobDownloadHeaders setLastAccessedTime(OffsetDateTime lastAccessedTime)
+        public OffsetDateTime getLastModified()
+        public BlobDownloadHeaders setLastModified(OffsetDateTime lastModified)
+        public LeaseDurationType getLeaseDuration()
+        public BlobDownloadHeaders setLeaseDuration(LeaseDurationType leaseDuration)
+        public LeaseStateType getLeaseState()
+        public BlobDownloadHeaders setLeaseState(LeaseStateType leaseState)
+        public LeaseStatusType getLeaseStatus()
+        public BlobDownloadHeaders setLeaseStatus(LeaseStatusType leaseStatus)
+        public Map<String, String> getMetadata()
+        public BlobDownloadHeaders setMetadata(Map<String, String> metadata)
+        public String getObjectReplicationDestinationPolicyId()
+        public BlobDownloadHeaders setObjectReplicationDestinationPolicyId(String objectReplicationDestinationPolicyId)
+        public List<ObjectReplicationPolicy> getObjectReplicationSourcePolicies()
+        public BlobDownloadHeaders setObjectReplicationSourcePolicies(List<ObjectReplicationPolicy> objectReplicationSourcePolicies)
+        public String getRequestId()
+        public BlobDownloadHeaders setRequestId(String requestId)
+        public Boolean isSealed()
+        public BlobDownloadHeaders setSealed(Boolean sealed)
+        public Boolean isServerEncrypted()
+        public Long getTagCount()
+        public BlobDownloadHeaders setTagCount(Long tagCount)
+        public String getVersion()
+        public BlobDownloadHeaders setVersion(String version)
+        public String getVersionId()
+        public BlobDownloadHeaders setVersionId(String versionId)
+    }
+    public final class BlobDownloadResponse extends ResponseBase<BlobDownloadHeaders, Void> {
+        public BlobDownloadResponse(BlobDownloadAsyncResponse response)
+    }
+    public final class BlobErrorCode extends ExpandableStringEnum<BlobErrorCode> {
+        @Generated public static final BlobErrorCode ACCOUNT_ALREADY_EXISTS = fromString("AccountAlreadyExists");
+        @Generated public static final BlobErrorCode ACCOUNT_BEING_CREATED = fromString("AccountBeingCreated");
+        @Generated public static final BlobErrorCode ACCOUNT_IS_DISABLED = fromString("AccountIsDisabled");
+        @Generated public static final BlobErrorCode AUTHENTICATION_FAILED = fromString("AuthenticationFailed");
+        @Generated public static final BlobErrorCode AUTHORIZATION_FAILURE = fromString("AuthorizationFailure");
+        @Generated public static final BlobErrorCode CONDITION_HEADERS_NOT_SUPPORTED = fromString("ConditionHeadersNotSupported");
+        @Generated public static final BlobErrorCode CONDITION_NOT_MET = fromString("ConditionNotMet");
+        @Generated public static final BlobErrorCode EMPTY_METADATA_KEY = fromString("EmptyMetadataKey");
+        @Generated public static final BlobErrorCode INSUFFICIENT_ACCOUNT_PERMISSIONS = fromString("InsufficientAccountPermissions");
+        @Generated public static final BlobErrorCode INTERNAL_ERROR = fromString("InternalError");
+        @Generated public static final BlobErrorCode INVALID_AUTHENTICATION_INFO = fromString("InvalidAuthenticationInfo");
+        @Generated public static final BlobErrorCode INVALID_HEADER_VALUE = fromString("InvalidHeaderValue");
+        @Generated public static final BlobErrorCode INVALID_HTTP_VERB = fromString("InvalidHttpVerb");
+        @Generated public static final BlobErrorCode INVALID_INPUT = fromString("InvalidInput");
+        @Generated public static final BlobErrorCode INVALID_MD5 = fromString("InvalidMd5");
+        @Generated public static final BlobErrorCode INVALID_METADATA = fromString("InvalidMetadata");
+        @Generated public static final BlobErrorCode INVALID_QUERY_PARAMETER_VALUE = fromString("InvalidQueryParameterValue");
+        @Generated public static final BlobErrorCode INVALID_RANGE = fromString("InvalidRange");
+        @Generated public static final BlobErrorCode INVALID_RESOURCE_NAME = fromString("InvalidResourceName");
+        @Generated public static final BlobErrorCode INVALID_URI = fromString("InvalidUri");
+        @Generated public static final BlobErrorCode INVALID_XML_DOCUMENT = fromString("InvalidXmlDocument");
+        @Generated public static final BlobErrorCode INVALID_XML_NODE_VALUE = fromString("InvalidXmlNodeValue");
+        @Generated public static final BlobErrorCode MD5MISMATCH = fromString("Md5Mismatch");
+        @Generated public static final BlobErrorCode METADATA_TOO_LARGE = fromString("MetadataTooLarge");
+        @Generated public static final BlobErrorCode MISSING_CONTENT_LENGTH_HEADER = fromString("MissingContentLengthHeader");
+        @Generated public static final BlobErrorCode MISSING_REQUIRED_QUERY_PARAMETER = fromString("MissingRequiredQueryParameter");
+        @Generated public static final BlobErrorCode MISSING_REQUIRED_HEADER = fromString("MissingRequiredHeader");
+        @Generated public static final BlobErrorCode MISSING_REQUIRED_XML_NODE = fromString("MissingRequiredXmlNode");
+        @Generated public static final BlobErrorCode MULTIPLE_CONDITION_HEADERS_NOT_SUPPORTED = fromString("MultipleConditionHeadersNotSupported");
+        @Generated public static final BlobErrorCode OPERATION_TIMED_OUT = fromString("OperationTimedOut");
+        @Generated public static final BlobErrorCode OUT_OF_RANGE_INPUT = fromString("OutOfRangeInput");
+        @Generated public static final BlobErrorCode OUT_OF_RANGE_QUERY_PARAMETER_VALUE = fromString("OutOfRangeQueryParameterValue");
+        @Generated public static final BlobErrorCode REQUEST_BODY_TOO_LARGE = fromString("RequestBodyTooLarge");
+        @Generated public static final BlobErrorCode RESOURCE_TYPE_MISMATCH = fromString("ResourceTypeMismatch");
+        @Generated public static final BlobErrorCode REQUEST_URL_FAILED_TO_PARSE = fromString("RequestUrlFailedToParse");
+        @Generated public static final BlobErrorCode RESOURCE_ALREADY_EXISTS = fromString("ResourceAlreadyExists");
+        @Generated public static final BlobErrorCode RESOURCE_NOT_FOUND = fromString("ResourceNotFound");
+        @Generated public static final BlobErrorCode SERVER_BUSY = fromString("ServerBusy");
+        @Generated public static final BlobErrorCode UNSUPPORTED_HEADER = fromString("UnsupportedHeader");
+        @Generated public static final BlobErrorCode UNSUPPORTED_XML_NODE = fromString("UnsupportedXmlNode");
+        @Generated public static final BlobErrorCode UNSUPPORTED_QUERY_PARAMETER = fromString("UnsupportedQueryParameter");
+        @Generated public static final BlobErrorCode UNSUPPORTED_HTTP_VERB = fromString("UnsupportedHttpVerb");
+        @Generated public static final BlobErrorCode APPEND_POSITION_CONDITION_NOT_MET = fromString("AppendPositionConditionNotMet");
+        @Generated public static final BlobErrorCode BLOB_ALREADY_EXISTS = fromString("BlobAlreadyExists");
+        @Generated public static final BlobErrorCode BLOB_IMMUTABLE_DUE_TO_POLICY = fromString("BlobImmutableDueToPolicy");
+        @Generated public static final BlobErrorCode BLOB_NOT_FOUND = fromString("BlobNotFound");
+        @Generated public static final BlobErrorCode BLOB_OVERWRITTEN = fromString("BlobOverwritten");
+        @Generated public static final BlobErrorCode BLOB_TIER_INADEQUATE_FOR_CONTENT_LENGTH = fromString("BlobTierInadequateForContentLength");
+        @Generated public static final BlobErrorCode BLOB_USES_CUSTOMER_SPECIFIED_ENCRYPTION = fromString("BlobUsesCustomerSpecifiedEncryption");
+        @Generated public static final BlobErrorCode BLOCK_COUNT_EXCEEDS_LIMIT = fromString("BlockCountExceedsLimit");
+        @Generated public static final BlobErrorCode BLOCK_LIST_TOO_LONG = fromString("BlockListTooLong");
+        @Generated public static final BlobErrorCode CANNOT_CHANGE_TO_LOWER_TIER = fromString("CannotChangeToLowerTier");
+        @Generated public static final BlobErrorCode CANNOT_VERIFY_COPY_SOURCE = fromString("CannotVerifyCopySource");
+        @Generated public static final BlobErrorCode CONTAINER_ALREADY_EXISTS = fromString("ContainerAlreadyExists");
+        @Generated public static final BlobErrorCode CONTAINER_BEING_DELETED = fromString("ContainerBeingDeleted");
+        @Generated public static final BlobErrorCode CONTAINER_DISABLED = fromString("ContainerDisabled");
+        @Generated public static final BlobErrorCode CONTAINER_NOT_FOUND = fromString("ContainerNotFound");
+        @Generated public static final BlobErrorCode CONTENT_LENGTH_LARGER_THAN_TIER_LIMIT = fromString("ContentLengthLargerThanTierLimit");
+        @Generated public static final BlobErrorCode COPY_ACROSS_ACCOUNTS_NOT_SUPPORTED = fromString("CopyAcrossAccountsNotSupported");
+        @Generated public static final BlobErrorCode COPY_ID_MISMATCH = fromString("CopyIdMismatch");
+        @Generated public static final BlobErrorCode FEATURE_VERSION_MISMATCH = fromString("FeatureVersionMismatch");
+        @Generated public static final BlobErrorCode INCREMENTAL_COPY_BLOB_MISMATCH = fromString("IncrementalCopyBlobMismatch");
+        @Generated public static final BlobErrorCode INCREMENTAL_COPY_OF_EARLIER_SNAPSHOT_NOT_ALLOWED = fromString("IncrementalCopyOfEarlierSnapshotNotAllowed");
+        @Generated public static final BlobErrorCode INCREMENTAL_COPY_SOURCE_MUST_BE_SNAPSHOT = fromString("IncrementalCopySourceMustBeSnapshot");
+        @Generated public static final BlobErrorCode INFINITE_LEASE_DURATION_REQUIRED = fromString("InfiniteLeaseDurationRequired");
+        @Generated public static final BlobErrorCode INVALID_BLOB_OR_BLOCK = fromString("InvalidBlobOrBlock");
+        @Generated public static final BlobErrorCode INVALID_BLOB_TIER = fromString("InvalidBlobTier");
+        @Generated public static final BlobErrorCode INVALID_BLOB_TYPE = fromString("InvalidBlobType");
+        @Generated public static final BlobErrorCode INVALID_BLOCK_ID = fromString("InvalidBlockId");
+        @Generated public static final BlobErrorCode INVALID_BLOCK_LIST = fromString("InvalidBlockList");
+        @Generated public static final BlobErrorCode INVALID_OPERATION = fromString("InvalidOperation");
+        @Generated public static final BlobErrorCode INVALID_PAGE_RANGE = fromString("InvalidPageRange");
+        @Generated public static final BlobErrorCode INVALID_SOURCE_BLOB_TYPE = fromString("InvalidSourceBlobType");
+        @Generated public static final BlobErrorCode INVALID_SOURCE_BLOB_URL = fromString("InvalidSourceBlobUrl");
+        @Generated public static final BlobErrorCode INVALID_VERSION_FOR_PAGE_BLOB_OPERATION = fromString("InvalidVersionForPageBlobOperation");
+        @Generated public static final BlobErrorCode LEASE_ALREADY_PRESENT = fromString("LeaseAlreadyPresent");
+        @Generated public static final BlobErrorCode LEASE_ALREADY_BROKEN = fromString("LeaseAlreadyBroken");
+        @Generated public static final BlobErrorCode LEASE_ID_MISMATCH_WITH_BLOB_OPERATION = fromString("LeaseIdMismatchWithBlobOperation");
+        @Generated public static final BlobErrorCode LEASE_ID_MISMATCH_WITH_CONTAINER_OPERATION = fromString("LeaseIdMismatchWithContainerOperation");
+        @Generated public static final BlobErrorCode LEASE_ID_MISMATCH_WITH_LEASE_OPERATION = fromString("LeaseIdMismatchWithLeaseOperation");
+        @Generated public static final BlobErrorCode LEASE_ID_MISSING = fromString("LeaseIdMissing");
+        @Generated public static final BlobErrorCode LEASE_IS_BREAKING_AND_CANNOT_BE_ACQUIRED = fromString("LeaseIsBreakingAndCannotBeAcquired");
+        @Generated public static final BlobErrorCode LEASE_IS_BREAKING_AND_CANNOT_BE_CHANGED = fromString("LeaseIsBreakingAndCannotBeChanged");
+        @Generated public static final BlobErrorCode LEASE_IS_BROKEN_AND_CANNOT_BE_RENEWED = fromString("LeaseIsBrokenAndCannotBeRenewed");
+        @Generated public static final BlobErrorCode LEASE_LOST = fromString("LeaseLost");
+        @Generated public static final BlobErrorCode LEASE_NOT_PRESENT_WITH_BLOB_OPERATION = fromString("LeaseNotPresentWithBlobOperation");
+        @Generated public static final BlobErrorCode LEASE_NOT_PRESENT_WITH_CONTAINER_OPERATION = fromString("LeaseNotPresentWithContainerOperation");
+        @Generated public static final BlobErrorCode LEASE_NOT_PRESENT_WITH_LEASE_OPERATION = fromString("LeaseNotPresentWithLeaseOperation");
+        @Generated public static final BlobErrorCode MAX_BLOB_SIZE_CONDITION_NOT_MET = fromString("MaxBlobSizeConditionNotMet");
+        @Generated public static final BlobErrorCode NO_AUTHENTICATION_INFORMATION = fromString("NoAuthenticationInformation");
+        @Generated public static final BlobErrorCode NO_PENDING_COPY_OPERATION = fromString("NoPendingCopyOperation");
+        @Generated public static final BlobErrorCode OPERATION_NOT_ALLOWED_ON_INCREMENTAL_COPY_BLOB = fromString("OperationNotAllowedOnIncrementalCopyBlob");
+        @Generated public static final BlobErrorCode PENDING_COPY_OPERATION = fromString("PendingCopyOperation");
+        @Generated public static final BlobErrorCode PREVIOUS_SNAPSHOT_CANNOT_BE_NEWER = fromString("PreviousSnapshotCannotBeNewer");
+        @Generated public static final BlobErrorCode PREVIOUS_SNAPSHOT_NOT_FOUND = fromString("PreviousSnapshotNotFound");
+        @Generated public static final BlobErrorCode PREVIOUS_SNAPSHOT_OPERATION_NOT_SUPPORTED = fromString("PreviousSnapshotOperationNotSupported");
+        @Generated public static final BlobErrorCode SEQUENCE_NUMBER_CONDITION_NOT_MET = fromString("SequenceNumberConditionNotMet");
+        @Generated public static final BlobErrorCode SEQUENCE_NUMBER_INCREMENT_TOO_LARGE = fromString("SequenceNumberIncrementTooLarge");
+        @Generated public static final BlobErrorCode SNAPSHOT_COUNT_EXCEEDED = fromString("SnapshotCountExceeded");
+        @Generated public static final BlobErrorCode SNAPSHOT_OPERATION_RATE_EXCEEDED = fromString("SnapshotOperationRateExceeded");
+        @Generated public static final BlobErrorCode SNAPSHOTS_PRESENT = fromString("SnapshotsPresent");
+        @Generated public static final BlobErrorCode SOURCE_CONDITION_NOT_MET = fromString("SourceConditionNotMet");
+        @Generated public static final BlobErrorCode SYSTEM_IN_USE = fromString("SystemInUse");
+        @Generated public static final BlobErrorCode TARGET_CONDITION_NOT_MET = fromString("TargetConditionNotMet");
+        @Generated public static final BlobErrorCode UNAUTHORIZED_BLOB_OVERWRITE = fromString("UnauthorizedBlobOverwrite");
+        @Generated public static final BlobErrorCode BLOB_BEING_REHYDRATED = fromString("BlobBeingRehydrated");
+        @Generated public static final BlobErrorCode BLOB_ARCHIVED = fromString("BlobArchived");
+        @Generated public static final BlobErrorCode BLOB_NOT_ARCHIVED = fromString("BlobNotArchived");
+        @Generated public static final BlobErrorCode AUTHORIZATION_SOURCE_IPMISMATCH = fromString("AuthorizationSourceIPMismatch");
+        @Generated public static final BlobErrorCode AUTHORIZATION_PROTOCOL_MISMATCH = fromString("AuthorizationProtocolMismatch");
+        @Generated public static final BlobErrorCode AUTHORIZATION_PERMISSION_MISMATCH = fromString("AuthorizationPermissionMismatch");
+        @Generated public static final BlobErrorCode AUTHORIZATION_SERVICE_MISMATCH = fromString("AuthorizationServiceMismatch");
+        @Generated public static final BlobErrorCode AUTHORIZATION_RESOURCE_TYPE_MISMATCH = fromString("AuthorizationResourceTypeMismatch");
+        @Generated public static final BlobErrorCode BLOB_ACCESS_TIER_NOT_SUPPORTED_FOR_ACCOUNT_TYPE = fromString("BlobAccessTierNotSupportedForAccountType");
+        @Deprecated @Generated public static final BlobErrorCode SNAPHOT_OPERATION_RATE_EXCEEDED = fromString("SnapshotOperationRateExceeded");
+        @Deprecated @Generated public static final BlobErrorCode INCREMENTAL_COPY_OF_ERALIER_VERSION_SNAPSHOT_NOT_ALLOWED = fromString("IncrementalCopyOfEralierVersionSnapshotNotAllowed");
+        @Deprecated @Generated public static final BlobErrorCode INCREMENTAL_COPY_OF_EARLIER_VERSION_SNAPSHOT_NOT_ALLOWED = fromString("IncrementalCopyOfEarlierVersionSnapshotNotAllowed");
+        @Deprecated @Generated public BlobErrorCode()
+        @Generated public static BlobErrorCode fromString(String name)
+        @Generated public static Collection<BlobErrorCode> values()
+    }
+    @Fluent
+    public final class BlobHttpHeaders {
+        @Generated public BlobHttpHeaders()
+        @Generated public String getCacheControl()
+        @Generated public BlobHttpHeaders setCacheControl(String cacheControl)
+        @Generated public String getContentDisposition()
+        @Generated public BlobHttpHeaders setContentDisposition(String contentDisposition)
+        @Generated public String getContentEncoding()
+        @Generated public BlobHttpHeaders setContentEncoding(String contentEncoding)
+        @Generated public String getContentLanguage()
+        @Generated public BlobHttpHeaders setContentLanguage(String contentLanguage)
+        @Generated public byte[] getContentMd5()
+        @Generated public BlobHttpHeaders setContentMd5(byte[] contentMd5)
+        @Generated public String getContentType()
+        @Generated public BlobHttpHeaders setContentType(String contentType)
+    }
+    public final class BlobImmutabilityPolicy {
+        public BlobImmutabilityPolicy()
+        public OffsetDateTime getExpiryTime()
+        public BlobImmutabilityPolicy setExpiryTime(OffsetDateTime expiryTime)
+        public BlobImmutabilityPolicyMode getPolicyMode()
+        public BlobImmutabilityPolicy setPolicyMode(BlobImmutabilityPolicyMode policyMode)
+    }
+    public enum BlobImmutabilityPolicyMode {
+        MUTABLE("Mutable"),
+        UNLOCKED("Unlocked"),
+        LOCKED("Locked");
+        public static BlobImmutabilityPolicyMode fromString(String value)
+        @Override public String toString()
+    }
+    @Fluent
+    public final class BlobItem {
+        public BlobItem()
+        public Boolean isCurrentVersion()
+        public BlobItem setCurrentVersion(Boolean isCurrentVersion)
+        public boolean isDeleted()
+        public BlobItem setDeleted(boolean deleted)
+        public Boolean hasVersionsOnly()
+        public BlobItem setHasVersionsOnly(Boolean hasVersionsOnly)
+        public BlobItem setIsPrefix(Boolean isPrefix)
+        public Map<String, String> getMetadata()
+        public BlobItem setMetadata(Map<String, String> metadata)
+        public String getName()
+        public BlobItem setName(String name)
+        public List<ObjectReplicationPolicy> getObjectReplicationSourcePolicies()
+        public BlobItem setObjectReplicationSourcePolicies(List<ObjectReplicationPolicy> objectReplicationSourcePolicies)
+        public Boolean isPrefix()
+        public BlobItemProperties getProperties()
+        public BlobItem setProperties(BlobItemProperties properties)
+        public String getSnapshot()
+        public BlobItem setSnapshot(String snapshot)
+        public Map<String, String> getTags()
+        public BlobItem setTags(Map<String, String> tags)
+        public String getVersionId()
+        public BlobItem setVersionId(String versionId)
+    }
+    @Fluent
+    public final class BlobItemProperties {
+        public BlobItemProperties()
+        public AccessTier getAccessTier()
+        public BlobItemProperties setAccessTier(AccessTier accessTier)
+        public OffsetDateTime getAccessTierChangeTime()
+        public BlobItemProperties setAccessTierChangeTime(OffsetDateTime accessTierChangeTime)
+        public Boolean isAccessTierInferred()
+        public BlobItemProperties setAccessTierInferred(Boolean accessTierInferred)
+        public ArchiveStatus getArchiveStatus()
+        public BlobItemProperties setArchiveStatus(ArchiveStatus archiveStatus)
+        public Long getBlobSequenceNumber()
+        public BlobItemProperties setBlobSequenceNumber(Long blobSequenceNumber)
+        public BlobType getBlobType()
+        public BlobItemProperties setBlobType(BlobType blobType)
+        public String getCacheControl()
+        public BlobItemProperties setCacheControl(String cacheControl)
+        public String getContentDisposition()
+        public BlobItemProperties setContentDisposition(String contentDisposition)
+        public String getContentEncoding()
+        public BlobItemProperties setContentEncoding(String contentEncoding)
+        public String getContentLanguage()
+        public BlobItemProperties setContentLanguage(String contentLanguage)
+        public Long getContentLength()
+        public BlobItemProperties setContentLength(Long contentLength)
+        public byte[] getContentMd5()
+        public BlobItemProperties setContentMd5(byte[] contentMd5)
+        public String getContentType()
+        public BlobItemProperties setContentType(String contentType)
+        public OffsetDateTime getCopyCompletionTime()
+        public BlobItemProperties setCopyCompletionTime(OffsetDateTime copyCompletionTime)
+        public String getCopyId()
+        public BlobItemProperties setCopyId(String copyId)
+        public String getCopyProgress()
+        public BlobItemProperties setCopyProgress(String copyProgress)
+        public String getCopySource()
+        public BlobItemProperties setCopySource(String copySource)
+        public CopyStatusType getCopyStatus()
+        public BlobItemProperties setCopyStatus(CopyStatusType copyStatus)
+        public String getCopyStatusDescription()
+        public BlobItemProperties setCopyStatusDescription(String copyStatusDescription)
+        public OffsetDateTime getCreationTime()
+        public BlobItemProperties setCreationTime(OffsetDateTime creationTime)
+        public String getCustomerProvidedKeySha256()
+        public BlobItemProperties setCustomerProvidedKeySha256(String customerProvidedKeySha256)
+        public OffsetDateTime getDeletedTime()
+        public BlobItemProperties setDeletedTime(OffsetDateTime deletedTime)
+        public String getDestinationSnapshot()
+        public BlobItemProperties setDestinationSnapshot(String destinationSnapshot)
+        public String getEncryptionScope()
+        public BlobItemProperties setEncryptionScope(String encryptionScope)
+        public String getETag()
+        public BlobItemProperties setETag(String eTag)
+        public OffsetDateTime getExpiryTime()
+        public BlobItemProperties setExpiryTime(OffsetDateTime expiryTime)
+        public Boolean hasLegalHold()
+        public BlobItemProperties setHasLegalHold(Boolean hasLegalHold)
+        public BlobImmutabilityPolicy getImmutabilityPolicy()
+        public BlobItemProperties setImmutabilityPolicy(BlobImmutabilityPolicy immutabilityPolicy)
+        public Boolean isIncrementalCopy()
+        public BlobItemProperties setIncrementalCopy(Boolean incrementalCopy)
+        public OffsetDateTime getLastAccessedTime()
+        public BlobItemProperties setLastAccessedTime(OffsetDateTime lastAccessedTime)
+        public OffsetDateTime getLastModified()
+        public BlobItemProperties setLastModified(OffsetDateTime lastModified)
+        public LeaseDurationType getLeaseDuration()
+        public BlobItemProperties setLeaseDuration(LeaseDurationType leaseDuration)
+        public LeaseStateType getLeaseState()
+        public BlobItemProperties setLeaseState(LeaseStateType leaseState)
+        public LeaseStatusType getLeaseStatus()
+        public BlobItemProperties setLeaseStatus(LeaseStatusType leaseStatus)
+        public RehydratePriority getRehydratePriority()
+        public BlobItemProperties setRehydratePriority(RehydratePriority rehydratePriority)
+        public Integer getRemainingRetentionDays()
+        public BlobItemProperties setRemainingRetentionDays(Integer remainingRetentionDays)
+        public Boolean isSealed()
+        public BlobItemProperties setSealed(Boolean sealed)
+        public Boolean isServerEncrypted()
+        public BlobItemProperties setServerEncrypted(Boolean serverEncrypted)
+        public AccessTier getSmartAccessTier()
+        public BlobItemProperties setSmartAccessTier(AccessTier smartAccessTier)
+        public Integer getTagCount()
+        public BlobItemProperties setTagCount(Integer tagCount)
+    }
+    public class BlobLeaseRequestConditions extends RequestConditions {
+        public BlobLeaseRequestConditions()
+        @Override public BlobLeaseRequestConditions setIfMatch(String ifMatch)
+        @Override public BlobLeaseRequestConditions setIfModifiedSince(OffsetDateTime ifModifiedSince)
+        @Override public BlobLeaseRequestConditions setIfNoneMatch(String ifNoneMatch)
+        @Override public BlobLeaseRequestConditions setIfUnmodifiedSince(OffsetDateTime ifUnmodifiedSince)
+        public String getTagsConditions()
+        public BlobLeaseRequestConditions setTagsConditions(String tagsConditions)
+    }
+    public interface BlobLegalHoldResult {
+        boolean hasLegalHold()
+    }
+    @Fluent
+    public final class BlobListDetails {
+        public BlobListDetails()
+        public boolean getRetrieveCopy()
+        public BlobListDetails setRetrieveCopy(boolean retrieveCopy)
+        public boolean getRetrieveDeletedBlobs()
+        public BlobListDetails setRetrieveDeletedBlobs(boolean retrieveDeletedBlobs)
+        public boolean getRetrieveDeletedBlobsWithVersions()
+        public BlobListDetails setRetrieveDeletedBlobsWithVersions(boolean retrieveDeletedWithVersions)
+        public boolean getRetrieveImmutabilityPolicy()
+        public BlobListDetails setRetrieveImmutabilityPolicy(boolean retrieveImmutabilityPolicy)
+        public boolean getRetrieveLegalHold()
+        public BlobListDetails setRetrieveLegalHold(boolean retrieveLegalHold)
+        public boolean getRetrieveMetadata()
+        public BlobListDetails setRetrieveMetadata(boolean retrieveMetadata)
+        public boolean getRetrieveSnapshots()
+        public BlobListDetails setRetrieveSnapshots(boolean retrieveSnapshots)
+        public boolean getRetrieveTags()
+        public BlobListDetails setRetrieveTags(boolean retrieveTags)
+        public boolean getRetrieveUncommittedBlobs()
+        public BlobListDetails setRetrieveUncommittedBlobs(boolean retrieveUncommittedBlobs)
+        public boolean getRetrieveVersions()
+        public BlobListDetails setRetrieveVersions(boolean retrieveVersions)
+        public ArrayList<ListBlobsIncludeItem> toList()
+    }
+    @Fluent
+    public final class BlobMetrics implements XmlSerializable<BlobMetrics> {
+        @Generated public BlobMetrics()
+        @Generated public boolean isEnabled()
+        @Generated public BlobMetrics setEnabled(boolean enabled)
+        @Generated public Boolean isIncludeApis()
+        @Generated public BlobMetrics setIncludeApis(Boolean includeApis)
+        @Generated public BlobRetentionPolicy getRetentionPolicy()
+        @Generated public BlobMetrics setRetentionPolicy(BlobRetentionPolicy retentionPolicy)
+        @Generated public String getVersion()
+        @Generated public BlobMetrics setVersion(String version)
+    }
+    @Fluent
+    public final class BlobPrefix implements XmlSerializable<BlobPrefix> {
+        public BlobPrefix()
+        public String getName()
+        public BlobPrefix setName(String name)
+    }
+    @Immutable
+    public final class BlobProperties {
+        public BlobProperties(OffsetDateTime creationTime, OffsetDateTime lastModified, String eTag, long blobSize, String contentType, byte[] contentMd5, String contentEncoding, String contentDisposition, String contentLanguage, String cacheControl, Long blobSequenceNumber, BlobType blobType, LeaseStatusType leaseStatus, LeaseStateType leaseState, LeaseDurationType leaseDuration, String copyId, CopyStatusType copyStatus, String copySource, String copyProgress, OffsetDateTime copyCompletionTime, String copyStatusDescription, Boolean isServerEncrypted, Boolean isIncrementalCopy, String copyDestinationSnapshot, AccessTier accessTier, Boolean isAccessTierInferred, ArchiveStatus archiveStatus, String encryptionKeySha256, OffsetDateTime accessTierChangeTime, Map<String, String> metadata, Integer committedBlockCount)
+        public BlobProperties(OffsetDateTime creationTime, OffsetDateTime lastModified, String eTag, long blobSize, String contentType, byte[] contentMd5, String contentEncoding, String contentDisposition, String contentLanguage, String cacheControl, Long blobSequenceNumber, BlobType blobType, LeaseStatusType leaseStatus, LeaseStateType leaseState, LeaseDurationType leaseDuration, String copyId, CopyStatusType copyStatus, String copySource, String copyProgress, OffsetDateTime copyCompletionTime, String copyStatusDescription, Boolean isServerEncrypted, Boolean isIncrementalCopy, String copyDestinationSnapshot, AccessTier accessTier, Boolean isAccessTierInferred, ArchiveStatus archiveStatus, String encryptionKeySha256, String encryptionScope, OffsetDateTime accessTierChangeTime, Map<String, String> metadata, Integer committedBlockCount, Long tagCount, String versionId, Boolean isCurrentVersion, List<ObjectReplicationPolicy> objectReplicationSourcePolicies, String objectReplicationDestinationPolicyId)
+        public BlobProperties(OffsetDateTime creationTime, OffsetDateTime lastModified, String eTag, long blobSize, String contentType, byte[] contentMd5, String contentEncoding, String contentDisposition, String contentLanguage, String cacheControl, Long blobSequenceNumber, BlobType blobType, LeaseStatusType leaseStatus, LeaseStateType leaseState, LeaseDurationType leaseDuration, String copyId, CopyStatusType copyStatus, String copySource, String copyProgress, OffsetDateTime copyCompletionTime, String copyStatusDescription, Boolean isServerEncrypted, Boolean isIncrementalCopy, String copyDestinationSnapshot, AccessTier accessTier, Boolean isAccessTierInferred, ArchiveStatus archiveStatus, String encryptionKeySha256, String encryptionScope, OffsetDateTime accessTierChangeTime, Map<String, String> metadata, Integer committedBlockCount, String versionId, Boolean isCurrentVersion, Long tagCount, Map<String, String> objectReplicationStatus, String rehydratePriority, Boolean isSealed)
+        public BlobProperties(OffsetDateTime creationTime, OffsetDateTime lastModified, String eTag, long blobSize, String contentType, byte[] contentMd5, String contentEncoding, String contentDisposition, String contentLanguage, String cacheControl, Long blobSequenceNumber, BlobType blobType, LeaseStatusType leaseStatus, LeaseStateType leaseState, LeaseDurationType leaseDuration, String copyId, CopyStatusType copyStatus, String copySource, String copyProgress, OffsetDateTime copyCompletionTime, String copyStatusDescription, Boolean isServerEncrypted, Boolean isIncrementalCopy, String copyDestinationSnapshot, AccessTier accessTier, Boolean isAccessTierInferred, ArchiveStatus archiveStatus, String encryptionKeySha256, String encryptionScope, OffsetDateTime accessTierChangeTime, Map<String, String> metadata, Integer committedBlockCount, Long tagCount, String versionId, Boolean isCurrentVersion, List<ObjectReplicationPolicy> objectReplicationSourcePolicies, String objectReplicationDestinationPolicyId, RehydratePriority rehydratePriority, Boolean isSealed, OffsetDateTime lastAccessedTime, OffsetDateTime expiresOn)
+        public BlobProperties(OffsetDateTime creationTime, OffsetDateTime lastModified, String eTag, long blobSize, String contentType, byte[] contentMd5, String contentEncoding, String contentDisposition, String contentLanguage, String cacheControl, Long blobSequenceNumber, BlobType blobType, LeaseStatusType leaseStatus, LeaseStateType leaseState, LeaseDurationType leaseDuration, String copyId, CopyStatusType copyStatus, String copySource, String copyProgress, OffsetDateTime copyCompletionTime, String copyStatusDescription, Boolean isServerEncrypted, Boolean isIncrementalCopy, String copyDestinationSnapshot, AccessTier accessTier, Boolean isAccessTierInferred, ArchiveStatus archiveStatus, String encryptionKeySha256, String encryptionScope, OffsetDateTime accessTierChangeTime, Map<String, String> metadata, Integer committedBlockCount, Long tagCount, String versionId, Boolean isCurrentVersion, List<ObjectReplicationPolicy> objectReplicationSourcePolicies, String objectReplicationDestinationPolicyId, RehydratePriority rehydratePriority, Boolean isSealed, OffsetDateTime lastAccessedTime, OffsetDateTime expiresOn, BlobImmutabilityPolicy immutabilityPolicy, Boolean hasLegalHold)
+        public BlobProperties(OffsetDateTime creationTime, OffsetDateTime lastModified, String eTag, long blobSize, String contentType, byte[] contentMd5, String contentEncoding, String contentDisposition, String contentLanguage, String cacheControl, Long blobSequenceNumber, BlobType blobType, LeaseStatusType leaseStatus, LeaseStateType leaseState, LeaseDurationType leaseDuration, String copyId, CopyStatusType copyStatus, String copySource, String copyProgress, OffsetDateTime copyCompletionTime, String copyStatusDescription, Boolean isServerEncrypted, Boolean isIncrementalCopy, String copyDestinationSnapshot, AccessTier accessTier, Boolean isAccessTierInferred, ArchiveStatus archiveStatus, String encryptionKeySha256, String encryptionScope, OffsetDateTime accessTierChangeTime, Map<String, String> metadata, Integer committedBlockCount, Long tagCount, String versionId, Boolean isCurrentVersion, List<ObjectReplicationPolicy> objectReplicationSourcePolicies, String objectReplicationDestinationPolicyId, RehydratePriority rehydratePriority, Boolean isSealed, OffsetDateTime lastAccessedTime, OffsetDateTime expiresOn, BlobImmutabilityPolicy immutabilityPolicy, Boolean hasLegalHold, String requestId)
+        public AccessTier getAccessTier()
+        public OffsetDateTime getAccessTierChangeTime()
+        public Boolean isAccessTierInferred()
+        public ArchiveStatus getArchiveStatus()
+        public Long getBlobSequenceNumber()
+        public long getBlobSize()
+        public BlobType getBlobType()
+        public String getCacheControl()
+        public Integer getCommittedBlockCount()
+        public String getContentDisposition()
+        public String getContentEncoding()
+        public String getContentLanguage()
+        public byte[] getContentMd5()
+        public String getContentType()
+        public OffsetDateTime getCopyCompletionTime()
+        public String getCopyDestinationSnapshot()
+        public String getCopyId()
+        public String getCopyProgress()
+        public String getCopySource()
+        public CopyStatusType getCopyStatus()
+        public String getCopyStatusDescription()
+        public OffsetDateTime getCreationTime()
+        public Boolean isCurrentVersion()
+        public String getEncryptionKeySha256()
+        public String getEncryptionScope()
+        public String getETag()
+        public OffsetDateTime getExpiresOn()
+        public Boolean hasLegalHold()
+        public BlobImmutabilityPolicy getImmutabilityPolicy()
+        public Boolean isIncrementalCopy()
+        public OffsetDateTime getLastAccessedTime()
+        public OffsetDateTime getLastModified()
+        public LeaseDurationType getLeaseDuration()
+        public LeaseStateType getLeaseState()
+        public LeaseStatusType getLeaseStatus()
+        public Map<String, String> getMetadata()
+        public String getObjectReplicationDestinationPolicyId()
+        public List<ObjectReplicationPolicy> getObjectReplicationSourcePolicies()
+        public RehydratePriority getRehydratePriority()
+        public String getRequestId()
+        public Boolean isSealed()
+        public Boolean isServerEncrypted()
+        public AccessTier getSmartAccessTier()
+        public Long getTagCount()
+        public String getVersionId()
+    }
+    @Fluent
+    public class BlobQueryArrowField {
+        public BlobQueryArrowField(BlobQueryArrowFieldType type)
+        public String getName()
+        public BlobQueryArrowField setName(String name)
+        public Integer getPrecision()
+        public BlobQueryArrowField setPrecision(Integer precision)
+        public Integer getScale()
+        public BlobQueryArrowField setScale(Integer scale)
+        public BlobQueryArrowFieldType getType()
+    }
+    public enum BlobQueryArrowFieldType {
+        INT64("int64"),
+        BOOL("bool"),
+        TIMESTAMP("timestamp[ms]"),
+        STRING("string"),
+        DOUBLE("double"),
+        DECIMAL("decimal");
+        public static BlobQueryArrowFieldType fromString(String value)
+        @Override public String toString()
+    }
+    public class BlobQueryArrowSerialization implements BlobQuerySerialization {
+        public BlobQueryArrowSerialization()
+        public List<BlobQueryArrowField> getSchema()
+        public BlobQueryArrowSerialization setSchema(List<BlobQueryArrowField> schema)
+    }
+    public final class BlobQueryAsyncResponse extends ResponseBase<BlobQueryHeaders, Flux<ByteBuffer>> {
+        public BlobQueryAsyncResponse(HttpRequest request, int statusCode, HttpHeaders headers, Flux<ByteBuffer> value, BlobQueryHeaders deserializedHeaders)
+    }
+    public class BlobQueryDelimitedSerialization implements BlobQuerySerialization {
+        public BlobQueryDelimitedSerialization()
+        public char getColumnSeparator()
+        public BlobQueryDelimitedSerialization setColumnSeparator(char columnSeparator)
+        public char getEscapeChar()
+        public BlobQueryDelimitedSerialization setEscapeChar(char escapeChar)
+        public char getFieldQuote()
+        public BlobQueryDelimitedSerialization setFieldQuote(char fieldQuote)
+        public boolean isHeadersPresent()
+        public BlobQueryDelimitedSerialization setHeadersPresent(boolean headersPresent)
+        public char getRecordSeparator()
+        public BlobQueryDelimitedSerialization setRecordSeparator(char recordSeparator)
+    }
+    public class BlobQueryError {
+        public BlobQueryError(boolean fatal, String name, String description, long position)
+        public String getDescription()
+        public boolean isFatal()
+        public String getName()
+        public long getPosition()
+        @Override public String toString()
+    }
+    @Fluent
+    public final class BlobQueryHeaders {
+        public BlobQueryHeaders()
+        public String getAcceptRanges()
+        public BlobQueryHeaders setAcceptRanges(String acceptRanges)
+        public Integer getBlobCommittedBlockCount()
+        public BlobQueryHeaders setBlobCommittedBlockCount(Integer blobCommittedBlockCount)
+        public byte[] getBlobContentMd5()
+        public BlobQueryHeaders setBlobContentMd5(byte[] blobContentMd5)
+        public Long getBlobSequenceNumber()
+        public BlobQueryHeaders setBlobSequenceNumber(Long blobSequenceNumber)
+        public BlobType getBlobType()
+        public BlobQueryHeaders setBlobType(BlobType blobType)
+        public String getCacheControl()
+        public BlobQueryHeaders setCacheControl(String cacheControl)
+        public String getClientRequestId()
+        public BlobQueryHeaders setClientRequestId(String clientRequestId)
+        public byte[] getContentCrc64()
+        public BlobQueryHeaders setContentCrc64(byte[] contentCrc64)
+        public String getContentDisposition()
+        public BlobQueryHeaders setContentDisposition(String contentDisposition)
+        public String getContentEncoding()
+        public BlobQueryHeaders setContentEncoding(String contentEncoding)
+        public String getContentLanguage()
+        public BlobQueryHeaders setContentLanguage(String contentLanguage)
+        public Long getContentLength()
+        public BlobQueryHeaders setContentLength(Long contentLength)
+        public byte[] getContentMd5()
+        public BlobQueryHeaders setContentMd5(byte[] contentMd5)
+        public String getContentRange()
+        public BlobQueryHeaders setContentRange(String contentRange)
+        public String getContentType()
+        public BlobQueryHeaders setContentType(String contentType)
+        public OffsetDateTime getCopyCompletionTime()
+        public BlobQueryHeaders setCopyCompletionTime(OffsetDateTime copyCompletionTime)
+        public String getCopyId()
+        public BlobQueryHeaders setCopyId(String copyId)
+        public String getCopyProgress()
+        public BlobQueryHeaders setCopyProgress(String copyProgress)
+        public String getCopySource()
+        public BlobQueryHeaders setCopySource(String copySource)
+        public CopyStatusType getCopyStatus()
+        public BlobQueryHeaders setCopyStatus(CopyStatusType copyStatus)
+        public String getCopyStatusDescription()
+        public BlobQueryHeaders setCopyStatusDescription(String copyStatusDescription)
+        public OffsetDateTime getDateProperty()
+        public BlobQueryHeaders setDateProperty(OffsetDateTime dateProperty)
+        public String getEncryptionKeySha256()
+        public BlobQueryHeaders setEncryptionKeySha256(String encryptionKeySha256)
+        public String getEncryptionScope()
+        public BlobQueryHeaders setEncryptionScope(String encryptionScope)
+        public String getErrorCode()
+        public BlobQueryHeaders setErrorCode(String errorCode)
+        public String getETag()
+        public BlobQueryHeaders setETag(String eTag)
+        public OffsetDateTime getLastModified()
+        public BlobQueryHeaders setLastModified(OffsetDateTime lastModified)
+        public LeaseDurationType getLeaseDuration()
+        public BlobQueryHeaders setLeaseDuration(LeaseDurationType leaseDuration)
+        public LeaseStateType getLeaseState()
+        public BlobQueryHeaders setLeaseState(LeaseStateType leaseState)
+        public LeaseStatusType getLeaseStatus()
+        public BlobQueryHeaders setLeaseStatus(LeaseStatusType leaseStatus)
+        public Map<String, String> getMetadata()
+        public BlobQueryHeaders setMetadata(Map<String, String> metadata)
+        public String getRequestId()
+        public BlobQueryHeaders setRequestId(String requestId)
+        public Boolean isServerEncrypted()
+        public BlobQueryHeaders setServerEncrypted(Boolean serverEncrypted)
+        public String getVersion()
+        public BlobQueryHeaders setVersion(String version)
+    }
+    public class BlobQueryJsonSerialization implements BlobQuerySerialization {
+        public BlobQueryJsonSerialization()
+        public char getRecordSeparator()
+        public BlobQueryJsonSerialization setRecordSeparator(char recordSeparator)
+    }
+    public final class BlobQueryParquetSerialization implements BlobQuerySerialization {
+        public BlobQueryParquetSerialization()
+    }
+    public class BlobQueryProgress {
+        public BlobQueryProgress(long bytesScanned, long totalBytes)
+        public long getBytesScanned()
+        public long getTotalBytes()
+    }
+    public final class BlobQueryResponse extends ResponseBase<BlobQueryHeaders, Void> {
+        public BlobQueryResponse(BlobQueryAsyncResponse response)
+    }
+    public interface BlobQuerySerialization {
+        // This interface does not declare any API.
+    }
+    @Immutable
+    public final class BlobRange {
+        public BlobRange(long offset)
+        public BlobRange(long offset, Long count)
+        public Long getCount()
+        public long getOffset()
+        public String toHeaderValue()
+        @Override public String toString()
+    }
+    @Fluent
+    public class BlobRequestConditions extends BlobLeaseRequestConditions {
+        public BlobRequestConditions()
+        public OffsetDateTime getAccessTierIfModifiedSince()
+        public BlobRequestConditions setAccessTierIfModifiedSince(OffsetDateTime accessTierIfModifiedSince)
+        public OffsetDateTime getAccessTierIfUnmodifiedSince()
+        public BlobRequestConditions setAccessTierIfUnmodifiedSince(OffsetDateTime accessTierIfUnmodifiedSince)
+        @Override public BlobRequestConditions setIfMatch(String ifMatch)
+        @Override public BlobRequestConditions setIfModifiedSince(OffsetDateTime ifModifiedSince)
+        @Override public BlobRequestConditions setIfNoneMatch(String ifNoneMatch)
+        @Override public BlobRequestConditions setIfUnmodifiedSince(OffsetDateTime ifUnmodifiedSince)
+        public String getLeaseId()
+        public BlobRequestConditions setLeaseId(String leaseId)
+        @Override public BlobRequestConditions setTagsConditions(String tagsConditions)
+    }
+    @Fluent
+    public final class BlobRetentionPolicy implements XmlSerializable<BlobRetentionPolicy> {
+        @Generated public BlobRetentionPolicy()
+        @Generated public Integer getDays()
+        @Generated public BlobRetentionPolicy setDays(Integer days)
+        @Generated public boolean isEnabled()
+        @Generated public BlobRetentionPolicy setEnabled(boolean enabled)
+    }
+    public final class BlobSeekableByteChannelReadResult {
+        public BlobSeekableByteChannelReadResult(SeekableByteChannel channel, BlobProperties properties)
+        public SeekableByteChannel getChannel()
+        public BlobProperties getProperties()
+    }
+    @Fluent
+    public final class BlobServiceProperties implements XmlSerializable<BlobServiceProperties> {
+        @Generated public BlobServiceProperties()
+        @Generated public List<BlobCorsRule> getCors()
+        @Generated public BlobServiceProperties setCors(List<BlobCorsRule> cors)
+        @Generated public String getDefaultServiceVersion()
+        @Generated public BlobServiceProperties setDefaultServiceVersion(String defaultServiceVersion)
+        @Generated public BlobRetentionPolicy getDeleteRetentionPolicy()
+        @Generated public BlobServiceProperties setDeleteRetentionPolicy(BlobRetentionPolicy deleteRetentionPolicy)
+        @Generated public BlobMetrics getHourMetrics()
+        @Generated public BlobServiceProperties setHourMetrics(BlobMetrics hourMetrics)
+        @Generated public BlobAnalyticsLogging getLogging()
+        @Generated public BlobServiceProperties setLogging(BlobAnalyticsLogging logging)
+        @Generated public BlobMetrics getMinuteMetrics()
+        @Generated public BlobServiceProperties setMinuteMetrics(BlobMetrics minuteMetrics)
+        @Generated public StaticWebsite getStaticWebsite()
+        @Generated public BlobServiceProperties setStaticWebsite(StaticWebsite staticWebsite)
+    }
+    @Fluent
+    public final class BlobServiceStatistics implements XmlSerializable<BlobServiceStatistics> {
+        @Generated public BlobServiceStatistics()
+        @Generated public GeoReplication getGeoReplication()
+        @Generated public BlobServiceStatistics setGeoReplication(GeoReplication geoReplication)
+    }
+    @Fluent
+    public final class BlobSignedIdentifier implements XmlSerializable<BlobSignedIdentifier> {
+        @Generated public BlobSignedIdentifier()
+        @Generated public BlobAccessPolicy getAccessPolicy()
+        @Generated public BlobSignedIdentifier setAccessPolicy(BlobAccessPolicy accessPolicy)
+        @Generated public String getId()
+        @Generated public BlobSignedIdentifier setId(String id)
+    }
+    public final class BlobStorageException extends HttpResponseException {
+        public BlobStorageException(String message, HttpResponse response, Object value)
+        public BlobErrorCode getErrorCode()
+        public String getServiceMessage()
+        public int getStatusCode()
+    }
+    public enum BlobType {
+        BLOCK_BLOB("BlockBlob"),
+        PAGE_BLOB("PageBlob"),
+        APPEND_BLOB("AppendBlob");
+        public static BlobType fromString(String value)
+        @Override public String toString()
+    }
+    @Fluent
+    public final class Block implements XmlSerializable<Block> {
+        @Generated public Block()
+        @Generated public String getName()
+        @Generated public Block setName(String name)
+        @Deprecated @Generated public int getSize()
+        @Deprecated @Generated public Block setSize(int sizeInt)
+        @Generated public long getSizeLong()
+        @Generated public Block setSizeLong(long sizeLong)
+    }
+    @Immutable
+    public class BlockBlobItem {
+        @Deprecated public BlockBlobItem(String eTag, OffsetDateTime lastModified, byte[] contentMd5, boolean isServerEncrypted, String encryptionKeySha256)
+        @Deprecated public BlockBlobItem(String eTag, OffsetDateTime lastModified, byte[] contentMd5, boolean isServerEncrypted, String encryptionKeySha256, String encryptionScope)
+        @Deprecated public BlockBlobItem(String eTag, OffsetDateTime lastModified, byte[] contentMd5, boolean isServerEncrypted, String encryptionKeySha256, String encryptionScope, String versionId)
+        public BlockBlobItem(String eTag, OffsetDateTime lastModified, byte[] contentMd5, Boolean isServerEncrypted, String encryptionKeySha256, String encryptionScope, String versionId)
+        public byte[] getContentCrc64()
+        public byte[] getContentMd5()
+        public String getEncryptionKeySha256()
+        public String getEncryptionScope()
+        public String getETag()
+        public OffsetDateTime getLastModified()
+        public Boolean isServerEncrypted()
+        public String getVersionId()
+    }
+    @Fluent
+    public final class BlockList implements XmlSerializable<BlockList> {
+        @Generated public BlockList()
+        @Generated public List<Block> getCommittedBlocks()
+        @Generated public BlockList setCommittedBlocks(List<Block> committedBlocks)
+        @Generated public List<Block> getUncommittedBlocks()
+        @Generated public BlockList setUncommittedBlocks(List<Block> uncommittedBlocks)
+    }
+    public enum BlockListType {
+        COMMITTED("committed"),
+        UNCOMMITTED("uncommitted"),
+        ALL("all");
+        public static BlockListType fromString(String value)
+        @Override public String toString()
+    }
+    @Fluent
+    public final class BlockLookupList implements XmlSerializable<BlockLookupList> {
+        @Generated public BlockLookupList()
+        @Generated public List<String> getCommitted()
+        @Generated public BlockLookupList setCommitted(List<String> committed)
+        @Generated public List<String> getLatest()
+        @Generated public BlockLookupList setLatest(List<String> latest)
+        @Generated public List<String> getUncommitted()
+        @Generated public BlockLookupList setUncommitted(List<String> uncommitted)
+    }
+    @Fluent
+    public final class ClearRange implements XmlSerializable<ClearRange> {
+        @Generated public ClearRange()
+        @Generated public long getEnd()
+        @Generated public ClearRange setEnd(long end)
+        @Generated public long getStart()
+        @Generated public ClearRange setStart(long start)
+    }
+    public enum ConsistentReadControl {
+        NONE,
+        ETAG,
+        VERSION_ID;
+    }
+    public enum CopyStatusType {
+        PENDING("pending"),
+        SUCCESS("success"),
+        ABORTED("aborted"),
+        FAILED("failed");
+        public static CopyStatusType fromString(String value)
+        @Override public String toString()
+    }
+    @Fluent
+    public final class CpkInfo {
+        @Generated public CpkInfo()
+        @Generated public EncryptionAlgorithmType getEncryptionAlgorithm()
+        @Generated public CpkInfo setEncryptionAlgorithm(EncryptionAlgorithmType encryptionAlgorithm)
+        @Generated public String getEncryptionKey()
+        @Generated public CpkInfo setEncryptionKey(String encryptionKey)
+        @Generated public String getEncryptionKeySha256()
+        @Generated public CpkInfo setEncryptionKeySha256(String encryptionKeySha256)
+    }
+    @Immutable
+    public class CustomerProvidedKey {
+        public CustomerProvidedKey(String key)
+        public CustomerProvidedKey(byte[] key)
+        public EncryptionAlgorithmType getEncryptionAlgorithm()
+        public String getKey()
+        public String getKeySha256()
+    }
+    public enum DeleteSnapshotsOptionType {
+        INCLUDE("include"),
+        ONLY("only");
+        public static DeleteSnapshotsOptionType fromString(String value)
+        @Override public String toString()
+    }
+    @Fluent
+    public final class DownloadRetryOptions {
+        public DownloadRetryOptions()
+        public int getMaxRetryRequests()
+        public DownloadRetryOptions setMaxRetryRequests(int maxRetryRequests)
+    }
+    public enum EncryptionAlgorithmType {
+        AES256("AES256");
+        public static EncryptionAlgorithmType fromString(String value)
+        @Override public String toString()
+    }
+    public final class FileShareTokenIntent extends ExpandableStringEnum<FileShareTokenIntent> {
+        @Generated public static final FileShareTokenIntent BACKUP = fromString("backup");
+        @Deprecated @Generated public FileShareTokenIntent()
+        @Generated public static FileShareTokenIntent fromString(String name)
+        @Generated public static Collection<FileShareTokenIntent> values()
+    }
+    @Fluent
+    public final class GeoReplication implements XmlSerializable<GeoReplication> {
+        @Generated public GeoReplication()
+        @Generated public OffsetDateTime getLastSyncTime()
+        @Generated public GeoReplication setLastSyncTime(OffsetDateTime lastSyncTime)
+        @Generated public GeoReplicationStatus getStatus()
+        @Generated public GeoReplication setStatus(GeoReplicationStatus status)
+    }
+    public final class GeoReplicationStatus extends ExpandableStringEnum<GeoReplicationStatus> {
+        @Generated public static final GeoReplicationStatus LIVE = fromString("live");
+        @Generated public static final GeoReplicationStatus BOOTSTRAP = fromString("bootstrap");
+        @Generated public static final GeoReplicationStatus UNAVAILABLE = fromString("unavailable");
+        @Deprecated @Generated public GeoReplicationStatus()
+        @Generated public static GeoReplicationStatus fromString(String name)
+        @Generated public static Collection<GeoReplicationStatus> values()
+    }
+    @Fluent
+    public final class KeyInfo implements XmlSerializable<KeyInfo> {
+        @Generated public KeyInfo()
+        @Generated public String getDelegatedUserTenantId()
+        @Generated public KeyInfo setDelegatedUserTenantId(String delegatedUserTenantId)
+        @Generated public String getExpiry()
+        @Generated public KeyInfo setExpiry(String expiry)
+        @Generated public String getStart()
+        @Generated public KeyInfo setStart(String start)
+    }
+    public enum LeaseDurationType {
+        INFINITE("infinite"),
+        FIXED("fixed");
+        public static LeaseDurationType fromString(String value)
+        @Override public String toString()
+    }
+    public enum LeaseStateType {
+        AVAILABLE("available"),
+        LEASED("leased"),
+        EXPIRED("expired"),
+        BREAKING("breaking"),
+        BROKEN("broken");
+        public static LeaseStateType fromString(String value)
+        @Override public String toString()
+    }
+    public enum LeaseStatusType {
+        LOCKED("locked"),
+        UNLOCKED("unlocked");
+        public static LeaseStatusType fromString(String value)
+        @Override public String toString()
+    }
+    public enum ListBlobContainersIncludeType {
+        METADATA("metadata"),
+        DELETED("deleted"),
+        SYSTEM("system");
+        public static ListBlobContainersIncludeType fromString(String value)
+        @Override public String toString()
+    }
+    @Fluent
+    public final class ListBlobContainersOptions {
+        public ListBlobContainersOptions()
+        public BlobContainerListDetails getDetails()
+        public ListBlobContainersOptions setDetails(BlobContainerListDetails details)
+        public Integer getMaxResultsPerPage()
+        public ListBlobContainersOptions setMaxResultsPerPage(Integer maxResultsPerPage)
+        public String getPrefix()
+        public ListBlobContainersOptions setPrefix(String prefix)
+    }
+    public enum ListBlobsIncludeItem {
+        COPY("copy"),
+        DELETED("deleted"),
+        METADATA("metadata"),
+        SNAPSHOTS("snapshots"),
+        UNCOMMITTEDBLOBS("uncommittedblobs"),
+        VERSIONS("versions"),
+        TAGS("tags"),
+        IMMUTABILITY_POLICY("immutabilitypolicy"),
+        LEGAL_HOLD("legalhold"),
+        DELETED_WITH_VERSIONS("deletedwithversions");
+        public static ListBlobsIncludeItem fromString(String value)
+        @Override public String toString()
+    }
+    @Fluent
+    public final class ListBlobsOptions {
+        public ListBlobsOptions()
+        public BlobListDetails getDetails()
+        public ListBlobsOptions setDetails(BlobListDetails details)
+        public String getEndBefore()
+        public ListBlobsOptions setEndBefore(String endBefore)
+        public Integer getMaxResultsPerPage()
+        public ListBlobsOptions setMaxResultsPerPage(Integer maxResultsPerPage)
+        public String getPrefix()
+        public ListBlobsOptions setPrefix(String prefix)
+        public String getStartFrom()
+        public ListBlobsOptions setStartFrom(String startFrom)
+        public StorageResponseSerializationFormat getStorageResponseSerializationFormat()
+        public ListBlobsOptions setStorageResponseSerializationFormat(StorageResponseSerializationFormat storageResponseSerializationFormat)
+    }
+    @Immutable
+    public class ObjectReplicationPolicy {
+        public ObjectReplicationPolicy(String policyId, List<ObjectReplicationRule> rules)
+        public String getPolicyId()
+        public List<ObjectReplicationRule> getRules()
+    }
+    public class ObjectReplicationRule {
+        public ObjectReplicationRule(String ruleId, ObjectReplicationStatus status)
+        public String getRuleId()
+        public ObjectReplicationStatus getStatus()
+    }
+    public final class ObjectReplicationStatus extends ExpandableStringEnum<ObjectReplicationStatus> {
+        public static final ObjectReplicationStatus COMPLETE = fromString("complete");
+        public static final ObjectReplicationStatus FAILED = fromString("failed");
+        @Deprecated public ObjectReplicationStatus()
+        public static ObjectReplicationStatus fromString(String name)
+        public static Collection<ObjectReplicationStatus> values()
+    }
+    public class PageBlobCopyIncrementalRequestConditions extends RequestConditions {
+        public PageBlobCopyIncrementalRequestConditions()
+        @Override public PageBlobCopyIncrementalRequestConditions setIfMatch(String ifMatch)
+        @Override public PageBlobCopyIncrementalRequestConditions setIfModifiedSince(OffsetDateTime ifModifiedSince)
+        @Override public PageBlobCopyIncrementalRequestConditions setIfNoneMatch(String ifNoneMatch)
+        @Override public PageBlobCopyIncrementalRequestConditions setIfUnmodifiedSince(OffsetDateTime ifUnmodifiedSince)
+        public String getTagsConditions()
+        public PageBlobCopyIncrementalRequestConditions setTagsConditions(String tagsConditions)
+    }
+    @Immutable
+    public class PageBlobItem {
+        public PageBlobItem(String eTag, OffsetDateTime lastModified, byte[] contentMd5, Boolean isServerEncrypted, String encryptionKeySha256, Long blobSequenceNumber)
+        public PageBlobItem(String eTag, OffsetDateTime lastModified, byte[] contentMd5, Boolean isServerEncrypted, String encryptionKeySha256, String encryptionScope, Long blobSequenceNumber)
+        public PageBlobItem(String eTag, OffsetDateTime lastModified, byte[] contentMd5, Boolean isServerEncrypted, String encryptionKeySha256, String encryptionScope, Long blobSequenceNumber, String versionId)
+        public Long getBlobSequenceNumber()
+        public byte[] getContentCrc64()
+        public byte[] getContentMd5()
+        public String getEncryptionKeySha256()
+        public String getEncryptionScope()
+        public String getETag()
+        public OffsetDateTime getLastModified()
+        public Boolean isServerEncrypted()
+        public String getVersionId()
+    }
+    @Fluent
+    public final class PageBlobRequestConditions extends BlobRequestConditions {
+        public PageBlobRequestConditions()
+        @Override public PageBlobRequestConditions setIfMatch(String ifMatch)
+        @Override public PageBlobRequestConditions setIfModifiedSince(OffsetDateTime ifModifiedSince)
+        @Override public PageBlobRequestConditions setIfNoneMatch(String ifNoneMatch)
+        public Long getIfSequenceNumberEqualTo()
+        public PageBlobRequestConditions setIfSequenceNumberEqualTo(Long ifSequenceNumberEqualTo)
+        public Long getIfSequenceNumberLessThan()
+        public PageBlobRequestConditions setIfSequenceNumberLessThan(Long ifSequenceNumberLessThan)
+        public Long getIfSequenceNumberLessThanOrEqualTo()
+        public PageBlobRequestConditions setIfSequenceNumberLessThanOrEqualTo(Long ifSequenceNumberLessThanOrEqualTo)
+        @Override public PageBlobRequestConditions setIfUnmodifiedSince(OffsetDateTime ifUnmodifiedSince)
+        @Override public PageBlobRequestConditions setLeaseId(String leaseId)
+        @Override public PageBlobRequestConditions setTagsConditions(String tagsConditions)
+    }
+    @Fluent
+    public final class PageList implements XmlSerializable<PageList> {
+        @Generated public PageList()
+        @Generated public List<ClearRange> getClearRange()
+        @Generated public PageList setClearRange(List<ClearRange> clearRange)
+        @Generated public List<PageRange> getPageRange()
+        @Generated public PageList setPageRange(List<PageRange> pageRange)
+    }
+    @Fluent
+    public final class PageRange implements XmlSerializable<PageRange> {
+        @Generated public PageRange()
+        @Generated public long getEnd()
+        @Generated public PageRange setEnd(long end)
+        @Generated public long getStart()
+        @Generated public PageRange setStart(long start)
+    }
+    @Immutable
+    public final class PageRangeItem {
+        public PageRangeItem(HttpRange range, boolean isClear)
+        public boolean isClear()
+        public HttpRange getRange()
+    }
+    @Fluent
+    public final class ParallelTransferOptions {
+        public ParallelTransferOptions()
+        @Deprecated public ParallelTransferOptions(Integer blockSize, Integer maxConcurrency, ProgressReceiver progressReceiver)
+        @Deprecated public ParallelTransferOptions(Integer blockSize, Integer maxConcurrency, ProgressReceiver progressReceiver, Integer maxSingleUploadSize)
+        @Deprecated public Integer getBlockSize()
+        public Long getBlockSizeLong()
+        public ParallelTransferOptions setBlockSizeLong(Long blockSize)
+        public Integer getMaxConcurrency()
+        public ParallelTransferOptions setMaxConcurrency(Integer maxConcurrency)
+        @Deprecated public Integer getMaxSingleUploadSize()
+        public Long getMaxSingleUploadSizeLong()
+        public ParallelTransferOptions setMaxSingleUploadSizeLong(Long maxSingleUploadSize)
+        @Deprecated public Integer getNumBuffers()
+        public ProgressListener getProgressListener()
+        public ParallelTransferOptions setProgressListener(ProgressListener progressListener)
+        @Deprecated public ProgressReceiver getProgressReceiver()
+        @Deprecated public ParallelTransferOptions setProgressReceiver(ProgressReceiver progressReceiver)
+    }
+    public enum PathRenameMode {
+        LEGACY("legacy"),
+        POSIX("posix");
+        public static PathRenameMode fromString(String value)
+        @Override public String toString()
+    }
+    public final class PublicAccessType extends ExpandableStringEnum<PublicAccessType> {
+        @Generated public static final PublicAccessType CONTAINER = fromString("container");
+        @Generated public static final PublicAccessType BLOB = fromString("blob");
+        @Deprecated @Generated public PublicAccessType()
+        @Generated public static PublicAccessType fromString(String name)
+        @Generated public static Collection<PublicAccessType> values()
+    }
+    public final class RehydratePriority extends ExpandableStringEnum<RehydratePriority> {
+        @Generated public static final RehydratePriority HIGH = fromString("High");
+        @Generated public static final RehydratePriority STANDARD = fromString("Standard");
+        @Deprecated @Generated public RehydratePriority()
+        @Generated public static RehydratePriority fromString(String name)
+        @Generated public static Collection<RehydratePriority> values()
+    }
+    public enum SequenceNumberActionType {
+        MAX("max"),
+        UPDATE("update"),
+        INCREMENT("increment");
+        public static SequenceNumberActionType fromString(String value)
+        @Override public String toString()
+    }
+    public enum SkuName {
+        STANDARD_LRS("Standard_LRS"),
+        STANDARD_GRS("Standard_GRS"),
+        STANDARD_RAGRS("Standard_RAGRS"),
+        STANDARD_ZRS("Standard_ZRS"),
+        PREMIUM_LRS("Premium_LRS"),
+        STANDARD_GZRS("Standard_GZRS"),
+        PREMIUM_ZRS("Premium_ZRS"),
+        STANDARD_RAGZRS("Standard_RAGZRS");
+        public static SkuName fromString(String value)
+        @Override public String toString()
+    }
+    @Fluent
+    public final class StaticWebsite implements XmlSerializable<StaticWebsite> {
+        @Generated public StaticWebsite()
+        @Generated public String getDefaultIndexDocumentPath()
+        @Generated public StaticWebsite setDefaultIndexDocumentPath(String defaultIndexDocumentPath)
+        @Generated public boolean isEnabled()
+        @Generated public StaticWebsite setEnabled(boolean enabled)
+        @Generated public String getErrorDocument404Path()
+        @Generated public StaticWebsite setErrorDocument404Path(String errorDocument404Path)
+        @Generated public String getIndexDocument()
+        @Generated public StaticWebsite setIndexDocument(String indexDocument)
+    }
+    @Immutable
+    public class StorageAccountInfo {
+        public StorageAccountInfo(SkuName skuName, AccountKind accountKind)
+        public StorageAccountInfo(SkuName skuName, AccountKind accountKind, Boolean isHnsEnabled)
+        public AccountKind getAccountKind()
+        public boolean isHierarchicalNamespaceEnabled()
+        public SkuName getSkuName()
+    }
+    public enum StorageResponseSerializationFormat {
+        AUTO,
+        XML,
+        ARROW;
+    }
+    public enum SyncCopyStatusType {
+        SUCCESS("success");
+        public static SyncCopyStatusType fromString(String value)
+        @Override public String toString()
+    }
+    public final class TaggedBlobItem {
+        public TaggedBlobItem(String containerName, String name)
+        public TaggedBlobItem(String containerName, String name, Map<String, String> tags)
+        public String getContainerName()
+        public String getName()
+        public Map<String, String> getTags()
+    }
+    @Fluent
+    public final class UserDelegationKey implements XmlSerializable<UserDelegationKey> {
+        @Generated public UserDelegationKey()
+        @Generated public String getSignedDelegatedUserTenantId()
+        @Generated public UserDelegationKey setSignedDelegatedUserTenantId(String signedDelegatedUserTenantId)
+        @Generated public OffsetDateTime getSignedExpiry()
+        @Generated public UserDelegationKey setSignedExpiry(OffsetDateTime signedExpiry)
+        @Generated public String getSignedObjectId()
+        @Generated public UserDelegationKey setSignedObjectId(String signedObjectId)
+        @Generated public String getSignedService()
+        @Generated public UserDelegationKey setSignedService(String signedService)
+        @Generated public OffsetDateTime getSignedStart()
+        @Generated public UserDelegationKey setSignedStart(OffsetDateTime signedStart)
+        @Generated public String getSignedTenantId()
+        @Generated public UserDelegationKey setSignedTenantId(String signedTenantId)
+        @Generated public String getSignedVersion()
+        @Generated public UserDelegationKey setSignedVersion(String signedVersion)
+        @Generated public String getValue()
+        @Generated public UserDelegationKey setValue(String value)
+    }
+}
+package com.azure.storage.blob.options {
+    @Fluent
+    public final class AppendBlobAppendBlockFromUrlOptions {
+        public AppendBlobAppendBlockFromUrlOptions(String sourceUrl)
+        public AppendBlobRequestConditions getDestinationRequestConditions()
+        public AppendBlobAppendBlockFromUrlOptions setDestinationRequestConditions(AppendBlobRequestConditions destinationRequestConditions)
+        public HttpAuthorization getSourceAuthorization()
+        public AppendBlobAppendBlockFromUrlOptions setSourceAuthorization(HttpAuthorization sourceAuthorization)
+        public byte[] getSourceContentMd5()
+        public AppendBlobAppendBlockFromUrlOptions setSourceContentMd5(byte[] sourceContentMd5)
+        public CustomerProvidedKey getSourceCustomerProvidedKey()
+        public AppendBlobAppendBlockFromUrlOptions setSourceCustomerProvidedKey(CustomerProvidedKey sourceCustomerProvidedKey)
+        public BlobRange getSourceRange()
+        public AppendBlobAppendBlockFromUrlOptions setSourceRange(BlobRange sourceRange)
+        public BlobRequestConditions getSourceRequestConditions()
+        public AppendBlobAppendBlockFromUrlOptions setSourceRequestConditions(BlobRequestConditions sourceRequestConditions)
+        public FileShareTokenIntent getSourceShareTokenIntent()
+        public AppendBlobAppendBlockFromUrlOptions setSourceShareTokenIntent(FileShareTokenIntent sourceShareTokenIntent)
+        public String getSourceUrl()
+    }
+    @Fluent
+    public final class AppendBlobAppendBlockOptions {
+        public AppendBlobAppendBlockOptions()
+        public byte[] getContentMd5()
+        public AppendBlobAppendBlockOptions setContentMd5(byte[] contentMd5)
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public AppendBlobAppendBlockOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public AppendBlobRequestConditions getRequestConditions()
+        public AppendBlobAppendBlockOptions setRequestConditions(AppendBlobRequestConditions requestConditions)
+    }
+    @Fluent
+    public class AppendBlobCreateOptions {
+        public AppendBlobCreateOptions()
+        public Boolean hasLegalHold()
+        public BlobHttpHeaders getHeaders()
+        public AppendBlobCreateOptions setHeaders(BlobHttpHeaders headers)
+        public BlobImmutabilityPolicy getImmutabilityPolicy()
+        public AppendBlobCreateOptions setImmutabilityPolicy(BlobImmutabilityPolicy immutabilityPolicy)
+        public AppendBlobCreateOptions setLegalHold(Boolean legalHold)
+        public Map<String, String> getMetadata()
+        public AppendBlobCreateOptions setMetadata(Map<String, String> metadata)
+        public BlobRequestConditions getRequestConditions()
+        public AppendBlobCreateOptions setRequestConditions(BlobRequestConditions requestConditions)
+        public Map<String, String> getTags()
+        public AppendBlobCreateOptions setTags(Map<String, String> tags)
+    }
+    @Fluent
+    public final class AppendBlobOutputStreamOptions {
+        public AppendBlobOutputStreamOptions()
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public AppendBlobOutputStreamOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public AppendBlobRequestConditions getRequestConditions()
+        public AppendBlobOutputStreamOptions setRequestConditions(AppendBlobRequestConditions requestConditions)
+    }
+    @Fluent
+    public class AppendBlobSealOptions {
+        public AppendBlobSealOptions()
+        public AppendBlobRequestConditions getRequestConditions()
+        public AppendBlobSealOptions setRequestConditions(AppendBlobRequestConditions requestConditions)
+    }
+    @Fluent
+    public class BlobAcquireLeaseOptions {
+        public BlobAcquireLeaseOptions(int durationInSeconds)
+        public int getDuration()
+        public BlobLeaseRequestConditions getRequestConditions()
+        public BlobAcquireLeaseOptions setRequestConditions(BlobLeaseRequestConditions requestConditions)
+    }
+    @Fluent
+    public class BlobBeginCopyOptions {
+        public BlobBeginCopyOptions(String sourceUrl)
+        public BlobRequestConditions getDestinationRequestConditions()
+        public BlobBeginCopyOptions setDestinationRequestConditions(BlobRequestConditions destinationRequestConditions)
+        public BlobImmutabilityPolicy getImmutabilityPolicy()
+        public BlobBeginCopyOptions setImmutabilityPolicy(BlobImmutabilityPolicy immutabilityPolicy)
+        public Boolean isLegalHold()
+        public BlobBeginCopyOptions setLegalHold(Boolean legalHold)
+        public Map<String, String> getMetadata()
+        public BlobBeginCopyOptions setMetadata(Map<String, String> metadata)
+        public Duration getPollInterval()
+        public BlobBeginCopyOptions setPollInterval(Duration pollInterval)
+        public RehydratePriority getRehydratePriority()
+        public BlobBeginCopyOptions setRehydratePriority(RehydratePriority rehydratePriority)
+        public Boolean isSealDestination()
+        public BlobBeginCopyOptions setSealDestination(Boolean sealDestination)
+        public BlobBeginCopySourceRequestConditions getSourceRequestConditions()
+        public BlobBeginCopyOptions setSourceRequestConditions(BlobBeginCopySourceRequestConditions sourceRequestConditions)
+        public String getSourceUrl()
+        public Map<String, String> getTags()
+        public BlobBeginCopyOptions setTags(Map<String, String> tags)
+        public AccessTier getTier()
+        public BlobBeginCopyOptions setTier(AccessTier tier)
+    }
+    @Fluent
+    public class BlobBreakLeaseOptions {
+        public BlobBreakLeaseOptions()
+        public Duration getBreakPeriod()
+        public BlobBreakLeaseOptions setBreakPeriod(Duration breakPeriod)
+        public BlobLeaseRequestConditions getRequestConditions()
+        public BlobBreakLeaseOptions setRequestConditions(BlobLeaseRequestConditions requestConditions)
+    }
+    @Fluent
+    public class BlobChangeLeaseOptions {
+        public BlobChangeLeaseOptions(String proposedId)
+        public String getProposedId()
+        public BlobLeaseRequestConditions getRequestConditions()
+        public BlobChangeLeaseOptions setRequestConditions(BlobLeaseRequestConditions requestConditions)
+    }
+    @Fluent
+    public class BlobContainerCreateOptions {
+        public BlobContainerCreateOptions()
+        public Map<String, String> getMetadata()
+        public BlobContainerCreateOptions setMetadata(Map<String, String> metadata)
+        public PublicAccessType getPublicAccessType()
+        public BlobContainerCreateOptions setPublicAccessType(PublicAccessType accessType)
+    }
+    @Fluent
+    public class BlobCopyFromUrlOptions {
+        public BlobCopyFromUrlOptions(String copySource)
+        public String getCopySource()
+        public BlobCopySourceTagsMode getCopySourceTagsMode()
+        public BlobCopyFromUrlOptions setCopySourceTagsMode(BlobCopySourceTagsMode copySourceTags)
+        public BlobRequestConditions getDestinationRequestConditions()
+        public BlobCopyFromUrlOptions setDestinationRequestConditions(BlobRequestConditions destinationRequestConditions)
+        public Boolean hasLegalHold()
+        public BlobImmutabilityPolicy getImmutabilityPolicy()
+        public BlobCopyFromUrlOptions setImmutabilityPolicy(BlobImmutabilityPolicy immutabilityPolicy)
+        public BlobCopyFromUrlOptions setLegalHold(Boolean legalHold)
+        public Map<String, String> getMetadata()
+        public BlobCopyFromUrlOptions setMetadata(Map<String, String> metadata)
+        public HttpAuthorization getSourceAuthorization()
+        public BlobCopyFromUrlOptions setSourceAuthorization(HttpAuthorization sourceAuthorization)
+        public RequestConditions getSourceRequestConditions()
+        public BlobCopyFromUrlOptions setSourceRequestConditions(RequestConditions sourceRequestConditions)
+        public FileShareTokenIntent getSourceShareTokenIntent()
+        public BlobCopyFromUrlOptions setSourceShareTokenIntent(FileShareTokenIntent sourceShareTokenIntent)
+        public Map<String, String> getTags()
+        public BlobCopyFromUrlOptions setTags(Map<String, String> tags)
+        public AccessTier getTier()
+        public BlobCopyFromUrlOptions setTier(AccessTier tier)
+    }
+    @Fluent
+    public final class BlobDownloadContentOptions {
+        public BlobDownloadContentOptions()
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public BlobDownloadContentOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public DownloadRetryOptions getDownloadRetryOptions()
+        public BlobDownloadContentOptions setDownloadRetryOptions(DownloadRetryOptions downloadRetryOptions)
+        public BlobRange getRange()
+        public BlobDownloadContentOptions setRange(BlobRange range)
+        public BlobRequestConditions getRequestConditions()
+        public BlobDownloadContentOptions setRequestConditions(BlobRequestConditions requestConditions)
+        public boolean isRetrieveContentRangeMd5()
+        public BlobDownloadContentOptions setRetrieveContentRangeMd5(boolean retrieveContentRangeMd5)
+    }
+    @Fluent
+    public final class BlobDownloadStreamOptions {
+        public BlobDownloadStreamOptions()
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public BlobDownloadStreamOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public DownloadRetryOptions getDownloadRetryOptions()
+        public BlobDownloadStreamOptions setDownloadRetryOptions(DownloadRetryOptions downloadRetryOptions)
+        public BlobRange getRange()
+        public BlobDownloadStreamOptions setRange(BlobRange range)
+        public BlobRequestConditions getRequestConditions()
+        public BlobDownloadStreamOptions setRequestConditions(BlobRequestConditions requestConditions)
+        public boolean isRetrieveContentRangeMd5()
+        public BlobDownloadStreamOptions setRetrieveContentRangeMd5(boolean retrieveContentRangeMd5)
+    }
+    @Fluent
+    public class BlobDownloadToFileOptions {
+        public BlobDownloadToFileOptions(String filePath)
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public BlobDownloadToFileOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public DownloadRetryOptions getDownloadRetryOptions()
+        public BlobDownloadToFileOptions setDownloadRetryOptions(DownloadRetryOptions downloadRetryOptions)
+        public String getFilePath()
+        public Set<OpenOption> getOpenOptions()
+        public BlobDownloadToFileOptions setOpenOptions(Set<OpenOption> openOptions)
+        public ParallelTransferOptions getParallelTransferOptions()
+        public BlobDownloadToFileOptions setParallelTransferOptions(ParallelTransferOptions parallelTransferOptions)
+        public BlobRange getRange()
+        public BlobDownloadToFileOptions setRange(BlobRange range)
+        public BlobRequestConditions getRequestConditions()
+        public BlobDownloadToFileOptions setRequestConditions(BlobRequestConditions requestConditions)
+        public boolean isRetrieveContentRangeMd5()
+        public BlobDownloadToFileOptions setRetrieveContentRangeMd5(boolean retrieveContentRangeMd5)
+    }
+    @Fluent
+    public class BlobGetTagsOptions {
+        public BlobGetTagsOptions()
+        public BlobRequestConditions getRequestConditions()
+        public BlobGetTagsOptions setRequestConditions(BlobRequestConditions requestConditions)
+    }
+    @Fluent
+    public class BlobGetUserDelegationKeyOptions {
+        public BlobGetUserDelegationKeyOptions(OffsetDateTime expiresOn)
+        public String getDelegatedUserTenantId()
+        public BlobGetUserDelegationKeyOptions setDelegatedUserTenantId(String delegatedUserTenantId)
+        public OffsetDateTime getExpiresOn()
+        public OffsetDateTime getStartsOn()
+        public BlobGetUserDelegationKeyOptions setStartsOn(OffsetDateTime startsOn)
+    }
+    @Fluent
+    public class BlobInputStreamOptions {
+        public BlobInputStreamOptions()
+        public Integer getBlockSize()
+        public BlobInputStreamOptions setBlockSize(Integer blockSize)
+        public ConsistentReadControl getConsistentReadControl()
+        public BlobInputStreamOptions setConsistentReadControl(ConsistentReadControl consistentReadControl)
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public BlobInputStreamOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public BlobRange getRange()
+        public BlobInputStreamOptions setRange(BlobRange range)
+        public BlobRequestConditions getRequestConditions()
+        public BlobInputStreamOptions setRequestConditions(BlobRequestConditions requestConditions)
+    }
+    @Fluent
+    public class BlobParallelUploadOptions {
+        public BlobParallelUploadOptions(Flux<ByteBuffer> dataFlux)
+        public BlobParallelUploadOptions(InputStream dataStream)
+        public BlobParallelUploadOptions(BinaryData data)
+        @Deprecated public BlobParallelUploadOptions(InputStream dataStream, long length)
+        public boolean isComputeMd5()
+        public BlobParallelUploadOptions setComputeMd5(boolean computeMd5)
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public BlobParallelUploadOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public Flux<ByteBuffer> getDataFlux()
+        public InputStream getDataStream()
+        public BlobHttpHeaders getHeaders()
+        public BlobParallelUploadOptions setHeaders(BlobHttpHeaders headers)
+        public BlobImmutabilityPolicy getImmutabilityPolicy()
+        public BlobParallelUploadOptions setImmutabilityPolicy(BlobImmutabilityPolicy immutabilityPolicy)
+        public Boolean isLegalHold()
+        public BlobParallelUploadOptions setLegalHold(Boolean legalHold)
+        @Deprecated public long getLength()
+        public Map<String, String> getMetadata()
+        public BlobParallelUploadOptions setMetadata(Map<String, String> metadata)
+        public Long getOptionalLength()
+        public ParallelTransferOptions getParallelTransferOptions()
+        public BlobParallelUploadOptions setParallelTransferOptions(ParallelTransferOptions parallelTransferOptions)
+        public BlobRequestConditions getRequestConditions()
+        public BlobParallelUploadOptions setRequestConditions(BlobRequestConditions requestConditions)
+        public Map<String, String> getTags()
+        public BlobParallelUploadOptions setTags(Map<String, String> tags)
+        public AccessTier getTier()
+        public BlobParallelUploadOptions setTier(AccessTier tier)
+        @Deprecated public Duration getTimeout()
+        @Deprecated public BlobParallelUploadOptions setTimeout(Duration timeout)
+    }
+    @Fluent
+    public class BlobQueryOptions {
+        public BlobQueryOptions(String expression)
+        public BlobQueryOptions(String expression, OutputStream outputStream)
+        public Consumer<BlobQueryError> getErrorConsumer()
+        public BlobQueryOptions setErrorConsumer(Consumer<BlobQueryError> errorConsumer)
+        public String getExpression()
+        public BlobQuerySerialization getInputSerialization()
+        public BlobQueryOptions setInputSerialization(BlobQuerySerialization inputSerialization)
+        public BlobQuerySerialization getOutputSerialization()
+        public BlobQueryOptions setOutputSerialization(BlobQuerySerialization outputSerialization)
+        public OutputStream getOutputStream()
+        public Consumer<BlobQueryProgress> getProgressConsumer()
+        public BlobQueryOptions setProgressConsumer(Consumer<BlobQueryProgress> progressConsumer)
+        public BlobRequestConditions getRequestConditions()
+        public BlobQueryOptions setRequestConditions(BlobRequestConditions requestConditions)
+    }
+    @Fluent
+    public class BlobReleaseLeaseOptions {
+        public BlobReleaseLeaseOptions()
+        public BlobLeaseRequestConditions getRequestConditions()
+        public BlobReleaseLeaseOptions setRequestConditions(BlobLeaseRequestConditions requestConditions)
+    }
+    @Fluent
+    public class BlobRenewLeaseOptions {
+        public BlobRenewLeaseOptions()
+        public BlobLeaseRequestConditions getRequestConditions()
+        public BlobRenewLeaseOptions setRequestConditions(BlobLeaseRequestConditions requestConditions)
+    }
+    @Fluent
+    public final class BlobSeekableByteChannelReadOptions {
+        public BlobSeekableByteChannelReadOptions()
+        public ConsistentReadControl getConsistentReadControl()
+        public BlobSeekableByteChannelReadOptions setConsistentReadControl(ConsistentReadControl consistentReadControl)
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public BlobSeekableByteChannelReadOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public Long getInitialPosition()
+        public BlobSeekableByteChannelReadOptions setInitialPosition(Long initialPosition)
+        public Integer getReadSizeInBytes()
+        public BlobSeekableByteChannelReadOptions setReadSizeInBytes(Integer readSizeInBytes)
+        public BlobRequestConditions getRequestConditions()
+        public BlobSeekableByteChannelReadOptions setRequestConditions(BlobRequestConditions requestConditions)
+    }
+    @Fluent
+    public class BlobSetAccessTierOptions {
+        public BlobSetAccessTierOptions(AccessTier tier)
+        public String getLeaseId()
+        public BlobSetAccessTierOptions setLeaseId(String leaseId)
+        public RehydratePriority getPriority()
+        public BlobSetAccessTierOptions setPriority(RehydratePriority priority)
+        public String getTagsConditions()
+        public BlobSetAccessTierOptions setTagsConditions(String tagsConditions)
+        public AccessTier getTier()
+    }
+    @Fluent
+    public class BlobSetTagsOptions {
+        public BlobSetTagsOptions(Map<String, String> tags)
+        public BlobRequestConditions getRequestConditions()
+        public BlobSetTagsOptions setRequestConditions(BlobRequestConditions requestConditions)
+        public Map<String, String> getTags()
+    }
+    @Fluent
+    public class BlobUploadFromFileOptions {
+        public BlobUploadFromFileOptions(String filePath)
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public BlobUploadFromFileOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public String getFilePath()
+        public BlobHttpHeaders getHeaders()
+        public BlobUploadFromFileOptions setHeaders(BlobHttpHeaders headers)
+        public Map<String, String> getMetadata()
+        public BlobUploadFromFileOptions setMetadata(Map<String, String> metadata)
+        public ParallelTransferOptions getParallelTransferOptions()
+        public BlobUploadFromFileOptions setParallelTransferOptions(ParallelTransferOptions parallelTransferOptions)
+        public BlobRequestConditions getRequestConditions()
+        public BlobUploadFromFileOptions setRequestConditions(BlobRequestConditions requestConditions)
+        public Map<String, String> getTags()
+        public BlobUploadFromFileOptions setTags(Map<String, String> tags)
+        public AccessTier getTier()
+        public BlobUploadFromFileOptions setTier(AccessTier tier)
+    }
+    public class BlobUploadFromUrlOptions {
+        public BlobUploadFromUrlOptions(String sourceUrl)
+        public byte[] getContentMd5()
+        public BlobUploadFromUrlOptions setContentMd5(byte[] contentMd5)
+        public Boolean isCopySourceBlobProperties()
+        public BlobUploadFromUrlOptions setCopySourceBlobProperties(Boolean copySourceBlobProperties)
+        public BlobCopySourceTagsMode getCopySourceTagsMode()
+        public BlobUploadFromUrlOptions setCopySourceTagsMode(BlobCopySourceTagsMode copySourceTags)
+        public BlobRequestConditions getDestinationRequestConditions()
+        public BlobUploadFromUrlOptions setDestinationRequestConditions(BlobRequestConditions destinationRequestConditions)
+        public BlobHttpHeaders getHeaders()
+        public BlobUploadFromUrlOptions setHeaders(BlobHttpHeaders headers)
+        public HttpAuthorization getSourceAuthorization()
+        public BlobUploadFromUrlOptions setSourceAuthorization(HttpAuthorization sourceAuthorization)
+        public CustomerProvidedKey getSourceCustomerProvidedKey()
+        public BlobUploadFromUrlOptions setSourceCustomerProvidedKey(CustomerProvidedKey sourceCustomerProvidedKey)
+        public BlobRequestConditions getSourceRequestConditions()
+        public BlobUploadFromUrlOptions setSourceRequestConditions(BlobRequestConditions sourceRequestConditions)
+        public FileShareTokenIntent getSourceShareTokenIntent()
+        public BlobUploadFromUrlOptions setSourceShareTokenIntent(FileShareTokenIntent sourceShareTokenIntent)
+        public String getSourceUrl()
+        public Map<String, String> getTags()
+        public BlobUploadFromUrlOptions setTags(Map<String, String> tags)
+        public AccessTier getTier()
+        public BlobUploadFromUrlOptions setTier(AccessTier tier)
+    }
+    @Fluent
+    public class BlockBlobCommitBlockListOptions {
+        public BlockBlobCommitBlockListOptions(List<String> base64BlockIds)
+        public List<String> getBase64BlockIds()
+        public BlobHttpHeaders getHeaders()
+        public BlockBlobCommitBlockListOptions setHeaders(BlobHttpHeaders headers)
+        public BlobImmutabilityPolicy getImmutabilityPolicy()
+        public BlockBlobCommitBlockListOptions setImmutabilityPolicy(BlobImmutabilityPolicy immutabilityPolicy)
+        public Boolean isLegalHold()
+        public BlockBlobCommitBlockListOptions setLegalHold(Boolean legalHold)
+        public Map<String, String> getMetadata()
+        public BlockBlobCommitBlockListOptions setMetadata(Map<String, String> metadata)
+        public BlobRequestConditions getRequestConditions()
+        public BlockBlobCommitBlockListOptions setRequestConditions(BlobRequestConditions requestConditions)
+        public Map<String, String> getTags()
+        public BlockBlobCommitBlockListOptions setTags(Map<String, String> tags)
+        public AccessTier getTier()
+        public BlockBlobCommitBlockListOptions setTier(AccessTier tier)
+    }
+    @Fluent
+    public class BlockBlobListBlocksOptions {
+        public BlockBlobListBlocksOptions(BlockListType type)
+        public String getIfTagsMatch()
+        public BlockBlobListBlocksOptions setIfTagsMatch(String ifTagsMatch)
+        public String getLeaseId()
+        public BlockBlobListBlocksOptions setLeaseId(String leaseId)
+        public BlockListType getType()
+    }
+    public class BlockBlobOutputStreamOptions {
+        public BlockBlobOutputStreamOptions()
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public BlockBlobOutputStreamOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public BlobHttpHeaders getHeaders()
+        public BlockBlobOutputStreamOptions setHeaders(BlobHttpHeaders headers)
+        public Map<String, String> getMetadata()
+        public BlockBlobOutputStreamOptions setMetadata(Map<String, String> metadata)
+        public ParallelTransferOptions getParallelTransferOptions()
+        public BlockBlobOutputStreamOptions setParallelTransferOptions(ParallelTransferOptions parallelTransferOptions)
+        public BlobRequestConditions getRequestConditions()
+        public BlockBlobOutputStreamOptions setRequestConditions(BlobRequestConditions requestConditions)
+        public Map<String, String> getTags()
+        public BlockBlobOutputStreamOptions setTags(Map<String, String> tags)
+        public AccessTier getTier()
+        public BlockBlobOutputStreamOptions setTier(AccessTier tier)
+    }
+    public final class BlockBlobSeekableByteChannelWriteOptions {
+        public BlockBlobSeekableByteChannelWriteOptions(WriteMode mode)
+        public Long getBlockSizeInBytes()
+        public BlockBlobSeekableByteChannelWriteOptions setBlockSizeInBytes(Long blockSizeInBytes)
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public BlockBlobSeekableByteChannelWriteOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public BlobHttpHeaders getHeaders()
+        public BlockBlobSeekableByteChannelWriteOptions setHeaders(BlobHttpHeaders headers)
+        public Map<String, String> getMetadata()
+        public BlockBlobSeekableByteChannelWriteOptions setMetadata(Map<String, String> metadata)
+        public BlobRequestConditions getRequestConditions()
+        public BlockBlobSeekableByteChannelWriteOptions setRequestConditions(BlobRequestConditions conditions)
+        public Map<String, String> getTags()
+        public BlockBlobSeekableByteChannelWriteOptions setTags(Map<String, String> tags)
+        public AccessTier getTier()
+        public BlockBlobSeekableByteChannelWriteOptions setTier(AccessTier tier)
+        public WriteMode getWriteMode()
+        public static final class WriteMode extends ExpandableStringEnum<WriteMode> {
+            public static final WriteMode OVERWRITE = fromString("Overwrite");
+            @Deprecated public WriteMode()
+            public static WriteMode fromString(String name)
+            public static Collection<WriteMode> values()
+        }
+    }
+    public class BlockBlobSimpleUploadOptions {
+        public BlockBlobSimpleUploadOptions(BinaryData data)
+        public BlockBlobSimpleUploadOptions(Flux<ByteBuffer> data, long length)
+        public BlockBlobSimpleUploadOptions(InputStream data, long length)
+        public byte[] getContentMd5()
+        public BlockBlobSimpleUploadOptions setContentMd5(byte[] contentMd5)
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public BlockBlobSimpleUploadOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public BinaryData getData()
+        public Flux<ByteBuffer> getDataFlux()
+        public InputStream getDataStream()
+        public BlobHttpHeaders getHeaders()
+        public BlockBlobSimpleUploadOptions setHeaders(BlobHttpHeaders headers)
+        public BlobImmutabilityPolicy getImmutabilityPolicy()
+        public BlockBlobSimpleUploadOptions setImmutabilityPolicy(BlobImmutabilityPolicy immutabilityPolicy)
+        public Boolean isLegalHold()
+        public BlockBlobSimpleUploadOptions setLegalHold(Boolean legalHold)
+        public long getLength()
+        public Map<String, String> getMetadata()
+        public BlockBlobSimpleUploadOptions setMetadata(Map<String, String> metadata)
+        public BlobRequestConditions getRequestConditions()
+        public BlockBlobSimpleUploadOptions setRequestConditions(BlobRequestConditions requestConditions)
+        public Map<String, String> getTags()
+        public BlockBlobSimpleUploadOptions setTags(Map<String, String> tags)
+        public AccessTier getTier()
+        public BlockBlobSimpleUploadOptions setTier(AccessTier tier)
+    }
+    @Fluent
+    public final class BlockBlobStageBlockFromUrlOptions {
+        public BlockBlobStageBlockFromUrlOptions(String base64BlockId, String sourceUrl)
+        public String getBase64BlockId()
+        public String getLeaseId()
+        public BlockBlobStageBlockFromUrlOptions setLeaseId(String leaseId)
+        public HttpAuthorization getSourceAuthorization()
+        public BlockBlobStageBlockFromUrlOptions setSourceAuthorization(HttpAuthorization sourceAuthorization)
+        public byte[] getSourceContentMd5()
+        public BlockBlobStageBlockFromUrlOptions setSourceContentMd5(byte[] sourceContentMd5)
+        public CustomerProvidedKey getSourceCustomerProvidedKey()
+        public BlockBlobStageBlockFromUrlOptions setSourceCustomerProvidedKey(CustomerProvidedKey sourceCustomerProvidedKey)
+        public BlobRange getSourceRange()
+        public BlockBlobStageBlockFromUrlOptions setSourceRange(BlobRange sourceRange)
+        public BlobRequestConditions getSourceRequestConditions()
+        public BlockBlobStageBlockFromUrlOptions setSourceRequestConditions(BlobRequestConditions sourceRequestConditions)
+        public FileShareTokenIntent getSourceShareTokenIntent()
+        public BlockBlobStageBlockFromUrlOptions setSourceShareTokenIntent(FileShareTokenIntent sourceShareTokenIntent)
+        public String getSourceUrl()
+    }
+    @Fluent
+    public final class BlockBlobStageBlockOptions {
+        public BlockBlobStageBlockOptions(String base64BlockId, BinaryData data)
+        public String getBase64BlockId()
+        public byte[] getContentMd5()
+        public BlockBlobStageBlockOptions setContentMd5(byte[] contentMd5)
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public BlockBlobStageBlockOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public BinaryData getData()
+        public String getLeaseId()
+        public BlockBlobStageBlockOptions setLeaseId(String leaseId)
+    }
+    public class FindBlobsOptions {
+        public FindBlobsOptions(String query)
+        public Integer getMaxResultsPerPage()
+        public FindBlobsOptions setMaxResultsPerPage(Integer maxResultsPerPage)
+        public String getQuery()
+    }
+    @Fluent
+    public class ListPageRangesDiffOptions {
+        public ListPageRangesDiffOptions(BlobRange range, String previousSnapshot)
+        public Integer getMaxResultsPerPage()
+        public ListPageRangesDiffOptions setMaxResultsPerPage(Integer pageSize)
+        public String getPreviousSnapshot()
+        public BlobRange getRange()
+        public BlobRequestConditions getRequestConditions()
+        public ListPageRangesDiffOptions setRequestConditions(BlobRequestConditions requestConditions)
+    }
+    @Fluent
+    public class ListPageRangesOptions {
+        public ListPageRangesOptions(BlobRange range)
+        public Integer getMaxResultsPerPage()
+        public ListPageRangesOptions setMaxResultsPerPage(Integer pageSize)
+        public BlobRange getRange()
+        public BlobRequestConditions getRequestConditions()
+        public ListPageRangesOptions setRequestConditions(BlobRequestConditions requestConditions)
+    }
+    @Fluent
+    public class PageBlobCopyIncrementalOptions {
+        public PageBlobCopyIncrementalOptions(String source, String snapshot)
+        public PageBlobCopyIncrementalRequestConditions getRequestConditions()
+        public PageBlobCopyIncrementalOptions setRequestConditions(PageBlobCopyIncrementalRequestConditions requestConditions)
+        public String getSnapshot()
+        public String getSource()
+    }
+    public class PageBlobCreateOptions {
+        public PageBlobCreateOptions(long size)
+        public BlobHttpHeaders getHeaders()
+        public PageBlobCreateOptions setHeaders(BlobHttpHeaders headers)
+        public BlobImmutabilityPolicy getImmutabilityPolicy()
+        public PageBlobCreateOptions setImmutabilityPolicy(BlobImmutabilityPolicy immutabilityPolicy)
+        public Boolean isLegalHold()
+        public PageBlobCreateOptions setLegalHold(Boolean legalHold)
+        public Map<String, String> getMetadata()
+        public PageBlobCreateOptions setMetadata(Map<String, String> metadata)
+        public BlobRequestConditions getRequestConditions()
+        public PageBlobCreateOptions setRequestConditions(BlobRequestConditions requestConditions)
+        public Long getSequenceNumber()
+        public PageBlobCreateOptions setSequenceNumber(Long sequenceNumber)
+        public long getSize()
+        public Map<String, String> getTags()
+        public PageBlobCreateOptions setTags(Map<String, String> tags)
+    }
+    @Fluent
+    public final class PageBlobOutputStreamOptions {
+        public PageBlobOutputStreamOptions(PageRange pageRange)
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public PageBlobOutputStreamOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public PageRange getPageRange()
+        public BlobRequestConditions getRequestConditions()
+        public PageBlobOutputStreamOptions setRequestConditions(BlobRequestConditions requestConditions)
+    }
+    @Fluent
+    public final class PageBlobUploadPagesFromUrlOptions {
+        public PageBlobUploadPagesFromUrlOptions(PageRange range, String sourceUrl)
+        public PageBlobRequestConditions getDestinationRequestConditions()
+        public PageBlobUploadPagesFromUrlOptions setDestinationRequestConditions(PageBlobRequestConditions destinationRequestConditions)
+        public PageRange getRange()
+        public HttpAuthorization getSourceAuthorization()
+        public PageBlobUploadPagesFromUrlOptions setSourceAuthorization(HttpAuthorization sourceAuthorization)
+        public byte[] getSourceContentMd5()
+        public PageBlobUploadPagesFromUrlOptions setSourceContentMd5(byte[] sourceContentMd5)
+        public CustomerProvidedKey getSourceCustomerProvidedKey()
+        public PageBlobUploadPagesFromUrlOptions setSourceCustomerProvidedKey(CustomerProvidedKey sourceCustomerProvidedKey)
+        public Long getSourceOffset()
+        public PageBlobUploadPagesFromUrlOptions setSourceOffset(Long sourceOffset)
+        public BlobRequestConditions getSourceRequestConditions()
+        public PageBlobUploadPagesFromUrlOptions setSourceRequestConditions(BlobRequestConditions sourceRequestConditions)
+        public FileShareTokenIntent getSourceShareTokenIntent()
+        public PageBlobUploadPagesFromUrlOptions setSourceShareTokenIntent(FileShareTokenIntent sourceShareTokenIntent)
+        public String getSourceUrl()
+    }
+    @Fluent
+    public final class PageBlobUploadPagesOptions {
+        public PageBlobUploadPagesOptions()
+        public byte[] getContentMd5()
+        public PageBlobUploadPagesOptions setContentMd5(byte[] contentMd5)
+        public ContentValidationAlgorithm getContentValidationAlgorithm()
+        public PageBlobUploadPagesOptions setContentValidationAlgorithm(ContentValidationAlgorithm contentValidationAlgorithm)
+        public PageBlobRequestConditions getRequestConditions()
+        public PageBlobUploadPagesOptions setRequestConditions(PageBlobRequestConditions requestConditions)
+    }
+    @Fluent
+    public class UndeleteBlobContainerOptions {
+        public UndeleteBlobContainerOptions(String deletedContainerName, String deletedContainerVersion)
+        public String getDeletedContainerName()
+        public String getDeletedContainerVersion()
+        @Deprecated public String getDestinationContainerName()
+        @Deprecated public UndeleteBlobContainerOptions setDestinationContainerName(String destinationContainerName)
+    }
+}
+package com.azure.storage.blob.sas {
+    public final class BlobContainerSasPermission {
+        public BlobContainerSasPermission()
+        public BlobContainerSasPermission setAddPermission(boolean hasAddPermission)
+        public BlobContainerSasPermission setCreatePermission(boolean hasCreatePermission)
+        public BlobContainerSasPermission setDeletePermission(boolean hasDeletePermission)
+        public BlobContainerSasPermission setDeleteVersionPermission(boolean hasDeleteVersionPermission)
+        public BlobContainerSasPermission setExecutePermission(boolean hasExecutePermission)
+        public BlobContainerSasPermission setFilterPermission(boolean hasFilterPermission)
+        public boolean hasAddPermission()
+        public boolean hasCreatePermission()
+        public boolean hasDeletePermission()
+        public boolean hasDeleteVersionPermission()
+        public boolean hasExecutePermission()
+        public boolean hasFilterPermission()
+        public boolean hasImmutabilityPolicyPermission()
+        public boolean hasListPermission()
+        public boolean hasMovePermission()
+        public boolean hasReadPermission()
+        public boolean hasTagsPermission()
+        public boolean hasWritePermission()
+        public BlobContainerSasPermission setImmutabilityPolicyPermission(boolean immutabilityPolicyPermission)
+        public BlobContainerSasPermission setListPermission(boolean hasListPermission)
+        public BlobContainerSasPermission setMovePermission(boolean hasMovePermission)
+        public static BlobContainerSasPermission parse(String permissionString)
+        public BlobContainerSasPermission setReadPermission(boolean hasReadPermission)
+        public BlobContainerSasPermission setTagsPermission(boolean tagsPermission)
+        @Override public String toString()
+        public BlobContainerSasPermission setWritePermission(boolean hasWritePermission)
+    }
+    public final class BlobSasPermission {
+        public BlobSasPermission()
+        public BlobSasPermission setAddPermission(boolean hasAddPermission)
+        public BlobSasPermission setCreatePermission(boolean hasCreatePermission)
+        public BlobSasPermission setDeletePermission(boolean hasDeletePermission)
+        public BlobSasPermission setDeleteVersionPermission(boolean hasDeleteVersionPermission)
+        public BlobSasPermission setExecutePermission(boolean hasExecutePermission)
+        public boolean hasAddPermission()
+        public boolean hasCreatePermission()
+        public boolean hasDeletePermission()
+        public boolean hasDeleteVersionPermission()
+        public boolean hasExecutePermission()
+        public boolean hasImmutabilityPolicyPermission()
+        public boolean hasListPermission()
+        public boolean hasMovePermission()
+        public boolean hasPermanentDeletePermission()
+        public boolean hasReadPermission()
+        public boolean hasTagsPermission()
+        public boolean hasWritePermission()
+        public BlobSasPermission setImmutabilityPolicyPermission(boolean immutabilityPolicyPermission)
+        public BlobSasPermission setListPermission(boolean hasListPermission)
+        public BlobSasPermission setMovePermission(boolean hasMovePermission)
+        public static BlobSasPermission parse(String permissionString)
+        public BlobSasPermission setPermanentDeletePermission(boolean permanentDeletePermission)
+        public BlobSasPermission setReadPermission(boolean hasReadPermission)
+        public BlobSasPermission setTagsPermission(boolean tagsPermission)
+        @Override public String toString()
+        public BlobSasPermission setWritePermission(boolean hasWritePermission)
+    }
+    @Deprecated
+    public enum BlobSasServiceVersion implements ServiceVersion {
+        V2019_02_02("2019-02-02"),
+        V2019_07_07("2019-07-07"),
+        V2019_12_12("2019-12-12"),
+        V2020_02_10("2020-02-10"),
+        V2020_04_08("2020-04-08"),
+        V2020_06_12("2020-06-12"),
+        V2020_08_04("2020-08-04");
+        public static BlobSasServiceVersion getLatest(// returns V2020_08_04 )
+        @Override public String getVersion()
+    }
+    @Deprecated
+    public final class BlobServiceSasQueryParameters extends BaseSasQueryParameters {
+        @Deprecated public BlobServiceSasQueryParameters(Map<String, String[]> queryParamsMap, boolean removeSasParametersFromMap)
+        @Deprecated public String getCacheControl()
+        @Deprecated public String getContentDisposition()
+        @Deprecated public String getContentEncoding()
+        @Deprecated public String getContentLanguage()
+        @Deprecated public String getContentType()
+        @Deprecated public String encode()
+        @Deprecated public String getIdentifier()
+        @Deprecated public OffsetDateTime getKeyExpiry()
+        @Deprecated public String getKeyObjectId()
+        @Deprecated public String getKeyService()
+        @Deprecated public OffsetDateTime getKeyStart()
+        @Deprecated public String getKeyTenantId()
+        @Deprecated public String getKeyVersion()
+        @Deprecated public String getResource()
+    }
+    public final class BlobServiceSasSignatureValues {
+        @Deprecated public BlobServiceSasSignatureValues()
+        public BlobServiceSasSignatureValues(String identifier)
+        public BlobServiceSasSignatureValues(OffsetDateTime expiryTime, BlobContainerSasPermission permissions)
+        public BlobServiceSasSignatureValues(OffsetDateTime expiryTime, BlobSasPermission permissions)
+        @Deprecated public BlobServiceSasSignatureValues(String version, SasProtocol sasProtocol, OffsetDateTime startTime, OffsetDateTime expiryTime, String permission, SasIpRange sasIpRange, String identifier, String cacheControl, String contentDisposition, String contentEncoding, String contentLanguage, String contentType)
+        @Deprecated public String getBlobName()
+        @Deprecated public BlobServiceSasSignatureValues setBlobName(String blobName)
+        public String getCacheControl()
+        public BlobServiceSasSignatureValues setCacheControl(String cacheControl)
+        @Deprecated public String getContainerName()
+        @Deprecated public BlobServiceSasSignatureValues setContainerName(String containerName)
+        public String getContentDisposition()
+        public BlobServiceSasSignatureValues setContentDisposition(String contentDisposition)
+        public String getContentEncoding()
+        public BlobServiceSasSignatureValues setContentEncoding(String contentEncoding)
+        public String getContentLanguage()
+        public BlobServiceSasSignatureValues setContentLanguage(String contentLanguage)
+        public String getContentType()
+        public BlobServiceSasSignatureValues setContentType(String contentType)
+        public String getCorrelationId()
+        public BlobServiceSasSignatureValues setCorrelationId(String correlationId)
+        public String getDelegatedUserObjectId()
+        public BlobServiceSasSignatureValues setDelegatedUserObjectId(String delegatedUserObjectId)
+        public Boolean isDirectory()
+        public BlobServiceSasSignatureValues setDirectory(Boolean isDirectory)
+        public OffsetDateTime getExpiryTime()
+        public BlobServiceSasSignatureValues setExpiryTime(OffsetDateTime expiryTime)
+        @Deprecated public BlobServiceSasQueryParameters generateSasQueryParameters(StorageSharedKeyCredential storageSharedKeyCredentials)
+        @Deprecated public BlobServiceSasQueryParameters generateSasQueryParameters(UserDelegationKey delegationKey, String accountName)
+        public String getIdentifier()
+        public BlobServiceSasSignatureValues setIdentifier(String identifier)
+        public String getPermissions()
+        public BlobServiceSasSignatureValues setPermissions(BlobSasPermission permissions)
+        public BlobServiceSasSignatureValues setPermissions(BlobContainerSasPermission permissions)
+        public String getPreauthorizedAgentObjectId()
+        public BlobServiceSasSignatureValues setPreauthorizedAgentObjectId(String preauthorizedAgentObjectId)
+        public SasProtocol getProtocol()
+        public BlobServiceSasSignatureValues setProtocol(SasProtocol protocol)
+        public Map<String, String> getRequestHeaders()
+        public BlobServiceSasSignatureValues setRequestHeaders(Map<String, String> requestHeaders)
+        public Map<String, String> getRequestQueryParameters()
+        public BlobServiceSasSignatureValues setRequestQueryParameters(Map<String, String> requestQueryParameters)
+        public SasIpRange getSasIpRange()
+        public BlobServiceSasSignatureValues setSasIpRange(SasIpRange sasIpRange)
+        @Deprecated public String getSnapshotId()
+        @Deprecated public BlobServiceSasSignatureValues setSnapshotId(String snapshotId)
+        public OffsetDateTime getStartTime()
+        public BlobServiceSasSignatureValues setStartTime(OffsetDateTime startTime)
+        public String getVersion()
+        @Deprecated public BlobServiceSasSignatureValues setVersion(String version)
+    }
+}
+package com.azure.storage.blob.specialized {
+    @ServiceClient(builder  =  SpecializedBlobClientBuilder, isAsync  =  true)
+    public final class AppendBlobAsyncClient extends BlobAsyncClientBase {
+        @Deprecated public static final int MAX_APPEND_BLOCK_BYTES = 4 *  Constants.MB;
+        @Deprecated public static final int MAX_BLOCKS = 50000;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public Mono<AppendBlobItem> appendBlock(Flux<ByteBuffer> data, long length)
+        public Mono<AppendBlobItem> appendBlockFromUrl(String sourceUrl, BlobRange sourceRange)
+        public Mono<Response<AppendBlobItem>> appendBlockFromUrlWithResponse(AppendBlobAppendBlockFromUrlOptions options)
+        public Mono<Response<AppendBlobItem>> appendBlockFromUrlWithResponse(String sourceUrl, BlobRange sourceRange, byte[] sourceContentMD5, AppendBlobRequestConditions destRequestConditions, BlobRequestConditions sourceRequestConditions)
+        public Mono<Response<AppendBlobItem>> appendBlockWithResponse(Flux<ByteBuffer> data, long length, AppendBlobAppendBlockOptions options)
+        @Deprecated public Mono<Response<AppendBlobItem>> appendBlockWithResponse(Flux<ByteBuffer> data, long length, byte[] contentMd5, AppendBlobRequestConditions appendBlobRequestConditions)
+        public Mono<AppendBlobItem> create()
+        public Mono<AppendBlobItem> create(boolean overwrite)
+        public Mono<AppendBlobItem> createIfNotExists()
+        public Mono<Response<AppendBlobItem>> createIfNotExistsWithResponse(AppendBlobCreateOptions options)
+        public Mono<Response<AppendBlobItem>> createWithResponse(AppendBlobCreateOptions options)
+        public Mono<Response<AppendBlobItem>> createWithResponse(BlobHttpHeaders headers, Map<String, String> metadata, BlobRequestConditions requestConditions)
+        public Mono<Void> seal()
+        public Mono<Response<Void>> sealWithResponse(AppendBlobSealOptions options)
+        // Non-Service Methods:
+        @Override public AppendBlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
+        @Override public AppendBlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
+        public int getMaxAppendBlockBytes()
+        public int getMaxBlocks()
+    }
+    @ServiceClient(builder  =  SpecializedBlobClientBuilder)
+    public final class AppendBlobClient extends BlobClientBase {
+        @Deprecated public static final int MAX_APPEND_BLOCK_BYTES = 4 *  Constants.MB;
+        @Deprecated public static final int MAX_BLOCKS = 50000;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public AppendBlobItem appendBlock(InputStream data, long length)
+        public AppendBlobItem appendBlockFromUrl(String sourceUrl, BlobRange sourceRange)
+        public Response<AppendBlobItem> appendBlockFromUrlWithResponse(AppendBlobAppendBlockFromUrlOptions options, Duration timeout, Context context)
+        public Response<AppendBlobItem> appendBlockFromUrlWithResponse(String sourceUrl, BlobRange sourceRange, byte[] sourceContentMd5, AppendBlobRequestConditions destRequestConditions, BlobRequestConditions sourceRequestConditions, Duration timeout, Context context)
+        public Response<AppendBlobItem> appendBlockWithResponse(InputStream data, long length, AppendBlobAppendBlockOptions options, Duration timeout, Context context)
+        @Deprecated public Response<AppendBlobItem> appendBlockWithResponse(InputStream data, long length, byte[] contentMd5, AppendBlobRequestConditions appendBlobRequestConditions, Duration timeout, Context context)
+        public AppendBlobItem create()
+        public AppendBlobItem create(boolean overwrite)
+        public AppendBlobItem createIfNotExists()
+        public Response<AppendBlobItem> createIfNotExistsWithResponse(AppendBlobCreateOptions options, Duration timeout, Context context)
+        public Response<AppendBlobItem> createWithResponse(AppendBlobCreateOptions options, Duration timeout, Context context)
+        public Response<AppendBlobItem> createWithResponse(BlobHttpHeaders headers, Map<String, String> metadata, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public void seal()
+        public Response<Void> sealWithResponse(AppendBlobSealOptions options, Duration timeout, Context context)
+        // Non-Service Methods:
+        public BlobOutputStream getBlobOutputStream()
+        public BlobOutputStream getBlobOutputStream(boolean overwrite)
+        public BlobOutputStream getBlobOutputStream(AppendBlobRequestConditions requestConditions)
+        public BlobOutputStream getBlobOutputStream(AppendBlobOutputStreamOptions options)
+        @Override public AppendBlobClient getCustomerProvidedKeyClient(CustomerProvidedKey customerProvidedKey)
+        @Override public AppendBlobClient getEncryptionScopeClient(String encryptionScope)
+        public int getMaxAppendBlockBytes()
+        public int getMaxBlocks()
+    }
+    public class BlobAsyncClientBase {
+        protected final AzureBlobStorageImpl azureBlobStorage ;
+        protected final EncryptionScope encryptionScope ;
+        protected final String accountName ;
+        protected final String containerName ;
+        protected final String blobName ;
+        protected final BlobServiceVersion serviceVersion ;
+        protected BlobAsyncClientBase(HttpPipeline pipeline, String url, BlobServiceVersion serviceVersion, String accountName, String containerName, String blobName, String snapshot, CpkInfo customerProvidedKey)
+        protected BlobAsyncClientBase(HttpPipeline pipeline, String url, BlobServiceVersion serviceVersion, String accountName, String containerName, String blobName, String snapshot, CpkInfo customerProvidedKey, EncryptionScope encryptionScope)
+        protected BlobAsyncClientBase(HttpPipeline pipeline, String url, BlobServiceVersion serviceVersion, String accountName, String containerName, String blobName, String snapshot, CpkInfo customerProvidedKey, EncryptionScope encryptionScope, String versionId)
+        public Mono<Void> abortCopyFromUrl(String copyId)
+        public Mono<Response<Void>> abortCopyFromUrlWithResponse(String copyId, String leaseId)
+        public Mono<Void> setAccessTier(AccessTier tier)
+        public Mono<Response<Void>> setAccessTierWithResponse(BlobSetAccessTierOptions options)
+        public Mono<Response<Void>> setAccessTierWithResponse(AccessTier tier, RehydratePriority priority, String leaseId)
+        public Mono<StorageAccountInfo> getAccountInfo()
+        public Mono<Response<StorageAccountInfo>> getAccountInfoWithResponse()
+        public String getAccountName()
+        public String getAccountUrl()
+        public PollerFlux<BlobCopyInfo, Void> beginCopy(BlobBeginCopyOptions options)
+        public PollerFlux<BlobCopyInfo, Void> beginCopy(String sourceUrl, Duration pollInterval)
+        public PollerFlux<BlobCopyInfo, Void> beginCopy(String sourceUrl, Map<String, String> metadata, AccessTier tier, RehydratePriority priority, RequestConditions sourceModifiedRequestConditions, BlobRequestConditions destRequestConditions, Duration pollInterval)
+        public final String getBlobName()
+        public String getBlobUrl()
+        public BlobContainerAsyncClient getContainerAsyncClient()
+        public final String getContainerName()
+        public Mono<String> copyFromUrl(String copySource)
+        public Mono<Response<String>> copyFromUrlWithResponse(BlobCopyFromUrlOptions options)
+        public Mono<Response<String>> copyFromUrlWithResponse(String copySource, Map<String, String> metadata, AccessTier tier, RequestConditions sourceModifiedRequestConditions, BlobRequestConditions destRequestConditions)
+        public Mono<BlobAsyncClientBase> createSnapshot()
+        public Mono<Response<BlobAsyncClientBase>> createSnapshotWithResponse(Map<String, String> metadata, BlobRequestConditions requestConditions)
+        public CpkInfo getCustomerProvidedKey()
+        public BlobAsyncClientBase getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
+        public Mono<Void> delete()
+        public Mono<Boolean> deleteIfExists()
+        public Mono<Response<Boolean>> deleteIfExistsWithResponse(DeleteSnapshotsOptionType deleteBlobSnapshotOptions, BlobRequestConditions requestConditions)
+        public Mono<Void> deleteImmutabilityPolicy()
+        public Mono<Response<Void>> deleteImmutabilityPolicyWithResponse()
+        public Mono<Response<Void>> deleteWithResponse(DeleteSnapshotsOptionType deleteBlobSnapshotOptions, BlobRequestConditions requestConditions)
+        @Deprecated public Flux<ByteBuffer> download()
+        public Mono<BinaryData> downloadContent()
+        public Mono<BlobDownloadContentAsyncResponse> downloadContentWithResponse(BlobDownloadContentOptions options)
+        public Mono<BlobDownloadContentAsyncResponse> downloadContentWithResponse(DownloadRetryOptions options, BlobRequestConditions requestConditions)
+        public Flux<ByteBuffer> downloadStream()
+        public Mono<BlobDownloadAsyncResponse> downloadStreamWithResponse(BlobDownloadStreamOptions options)
+        public Mono<BlobDownloadAsyncResponse> downloadStreamWithResponse(BlobRange range, DownloadRetryOptions options, BlobRequestConditions requestConditions, boolean getRangeContentMd5)
+        public Mono<BlobProperties> downloadToFile(String filePath)
+        public Mono<BlobProperties> downloadToFile(String filePath, boolean overwrite)
+        public Mono<Response<BlobProperties>> downloadToFileWithResponse(BlobDownloadToFileOptions options)
+        public Mono<Response<BlobProperties>> downloadToFileWithResponse(String filePath, BlobRange range, ParallelTransferOptions parallelTransferOptions, DownloadRetryOptions options, BlobRequestConditions requestConditions, boolean rangeGetContentMd5)
+        public Mono<Response<BlobProperties>> downloadToFileWithResponse(String filePath, BlobRange range, ParallelTransferOptions parallelTransferOptions, DownloadRetryOptions options, BlobRequestConditions requestConditions, boolean rangeGetContentMd5, Set<OpenOption> openOptions)
+        @Deprecated public Mono<BlobDownloadAsyncResponse> downloadWithResponse(BlobRange range, DownloadRetryOptions options, BlobRequestConditions requestConditions, boolean getRangeContentMd5)
+        protected String getEncryptionScope()
+        public BlobAsyncClientBase getEncryptionScopeAsyncClient(String encryptionScope)
+        public Mono<Boolean> exists()
+        public Mono<Response<Boolean>> existsWithResponse()
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues)
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, Context context)
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, Consumer<String> stringToSignHandler, Context context)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey, String accountName, Context context)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey, String accountName, Consumer<String> stringToSignHandler, Context context)
+        public Mono<Void> setHttpHeaders(BlobHttpHeaders headers)
+        public Mono<Response<Void>> setHttpHeadersWithResponse(BlobHttpHeaders headers, BlobRequestConditions requestConditions)
+        public HttpPipeline getHttpPipeline()
+        public Mono<BlobImmutabilityPolicy> setImmutabilityPolicy(BlobImmutabilityPolicy immutabilityPolicy)
+        public Mono<Response<BlobImmutabilityPolicy>> setImmutabilityPolicyWithResponse(BlobImmutabilityPolicy immutabilityPolicy, BlobRequestConditions requestConditions)
+        public Mono<BlobLegalHoldResult> setLegalHold(boolean legalHold)
+        public Mono<Response<BlobLegalHoldResult>> setLegalHoldWithResponse(boolean legalHold)
+        public Mono<Void> setMetadata(Map<String, String> metadata)
+        public Mono<Response<Void>> setMetadataWithResponse(Map<String, String> metadata, BlobRequestConditions requestConditions)
+        public Mono<BlobProperties> getProperties()
+        public Mono<Response<BlobProperties>> getPropertiesWithResponse(BlobRequestConditions requestConditions)
+        public Flux<ByteBuffer> query(String expression)
+        public Mono<BlobQueryAsyncResponse> queryWithResponse(BlobQueryOptions queryOptions)
+        public BlobServiceVersion getServiceVersion()
+        public boolean isSnapshot()
+        public BlobAsyncClientBase getSnapshotClient(String snapshot)
+        public String getSnapshotId()
+        public Mono<Map<String, String>> getTags()
+        public Mono<Void> setTags(Map<String, String> tags)
+        public Mono<Response<Map<String, String>>> getTagsWithResponse(BlobGetTagsOptions options)
+        public Mono<Response<Void>> setTagsWithResponse(BlobSetTagsOptions options)
+        public Mono<Void> undelete()
+        public Mono<Response<Void>> undeleteWithResponse()
+        public BlobAsyncClientBase getVersionClient(String versionId)
+        public String getVersionId()
+    }
+    public class BlobClientBase {
+        protected final String accountName ;
+        protected final String containerName ;
+        protected final String blobName ;
+        protected final BlobServiceVersion serviceVersion ;
+        protected BlobClientBase(BlobAsyncClientBase client)
+        protected BlobClientBase(BlobAsyncClientBase client, HttpPipeline pipeline, String url, BlobServiceVersion serviceVersion, String accountName, String containerName, String blobName, String snapshot, CpkInfo customerProvidedKey, EncryptionScope encryptionScope, String versionId)
+        public void abortCopyFromUrl(String copyId)
+        public Response<Void> abortCopyFromUrlWithResponse(String copyId, String leaseId, Duration timeout, Context context)
+        public void setAccessTier(AccessTier tier)
+        public Response<Void> setAccessTierWithResponse(BlobSetAccessTierOptions options, Duration timeout, Context context)
+        public Response<Void> setAccessTierWithResponse(AccessTier tier, RehydratePriority priority, String leaseId, Duration timeout, Context context)
+        public StorageAccountInfo getAccountInfo()
+        public Response<StorageAccountInfo> getAccountInfoWithResponse(Duration timeout, Context context)
+        public String getAccountName()
+        public String getAccountUrl()
+        public SyncPoller<BlobCopyInfo, Void> beginCopy(BlobBeginCopyOptions options)
+        public SyncPoller<BlobCopyInfo, Void> beginCopy(String sourceUrl, Duration pollInterval)
+        public SyncPoller<BlobCopyInfo, Void> beginCopy(String sourceUrl, Map<String, String> metadata, AccessTier tier, RehydratePriority priority, RequestConditions sourceModifiedRequestConditions, BlobRequestConditions destRequestConditions, Duration pollInterval)
+        public final String getBlobName()
+        public String getBlobUrl()
+        public BlobContainerClient getContainerClient()
+        public final String getContainerName()
+        public String copyFromUrl(String copySource)
+        public Response<String> copyFromUrlWithResponse(BlobCopyFromUrlOptions options, Duration timeout, Context context)
+        public Response<String> copyFromUrlWithResponse(String copySource, Map<String, String> metadata, AccessTier tier, RequestConditions sourceModifiedRequestConditions, BlobRequestConditions destRequestConditions, Duration timeout, Context context)
+        public BlobClientBase createSnapshot()
+        public Response<BlobClientBase> createSnapshotWithResponse(Map<String, String> metadata, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public CpkInfo getCustomerProvidedKey()
+        public BlobClientBase getCustomerProvidedKeyClient(CustomerProvidedKey customerProvidedKey)
+        public void delete()
+        public boolean deleteIfExists()
+        public Response<Boolean> deleteIfExistsWithResponse(DeleteSnapshotsOptionType deleteBlobSnapshotOptions, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public void deleteImmutabilityPolicy()
+        public Response<Void> deleteImmutabilityPolicyWithResponse(Duration timeout, Context context)
+        public Response<Void> deleteWithResponse(DeleteSnapshotsOptionType deleteBlobSnapshotOptions, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        @Deprecated public void download(OutputStream stream)
+        public BinaryData downloadContent()
+        public BlobDownloadContentResponse downloadContentWithResponse(BlobDownloadContentOptions options, Duration timeout, Context context)
+        public BlobDownloadContentResponse downloadContentWithResponse(DownloadRetryOptions options, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public BlobDownloadContentResponse downloadContentWithResponse(DownloadRetryOptions options, BlobRequestConditions requestConditions, BlobRange range, boolean getRangeContentMd5, Duration timeout, Context context)
+        public void downloadStream(OutputStream stream)
+        public BlobDownloadResponse downloadStreamWithResponse(OutputStream stream, BlobDownloadStreamOptions options, Duration timeout, Context context)
+        public BlobDownloadResponse downloadStreamWithResponse(OutputStream stream, BlobRange range, DownloadRetryOptions options, BlobRequestConditions requestConditions, boolean getRangeContentMd5, Duration timeout, Context context)
+        public BlobProperties downloadToFile(String filePath)
+        public BlobProperties downloadToFile(String filePath, boolean overwrite)
+        public Response<BlobProperties> downloadToFileWithResponse(BlobDownloadToFileOptions options, Duration timeout, Context context)
+        public Response<BlobProperties> downloadToFileWithResponse(String filePath, BlobRange range, ParallelTransferOptions parallelTransferOptions, DownloadRetryOptions downloadRetryOptions, BlobRequestConditions requestConditions, boolean rangeGetContentMd5, Duration timeout, Context context)
+        public Response<BlobProperties> downloadToFileWithResponse(String filePath, BlobRange range, ParallelTransferOptions parallelTransferOptions, DownloadRetryOptions downloadRetryOptions, BlobRequestConditions requestConditions, boolean rangeGetContentMd5, Set<OpenOption> openOptions, Duration timeout, Context context)
+        @Deprecated public BlobDownloadResponse downloadWithResponse(OutputStream stream, BlobRange range, DownloadRetryOptions options, BlobRequestConditions requestConditions, boolean getRangeContentMd5, Duration timeout, Context context)
+        public String getEncryptionScope()
+        public BlobClientBase getEncryptionScopeClient(String encryptionScope)
+        public Boolean exists()
+        public Response<Boolean> existsWithResponse(Duration timeout, Context context)
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues)
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, Context context)
+        public String generateSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, Consumer<String> stringToSignHandler, Context context)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey, String accountName, Context context)
+        public String generateUserDelegationSas(BlobServiceSasSignatureValues blobServiceSasSignatureValues, UserDelegationKey userDelegationKey, String accountName, Consumer<String> stringToSignHandler, Context context)
+        public void setHttpHeaders(BlobHttpHeaders headers)
+        public Response<Void> setHttpHeadersWithResponse(BlobHttpHeaders headers, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public HttpPipeline getHttpPipeline()
+        public BlobImmutabilityPolicy setImmutabilityPolicy(BlobImmutabilityPolicy immutabilityPolicy)
+        public Response<BlobImmutabilityPolicy> setImmutabilityPolicyWithResponse(BlobImmutabilityPolicy immutabilityPolicy, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public BlobLegalHoldResult setLegalHold(boolean legalHold)
+        public Response<BlobLegalHoldResult> setLegalHoldWithResponse(boolean legalHold, Duration timeout, Context context)
+        public void setMetadata(Map<String, String> metadata)
+        public Response<Void> setMetadataWithResponse(Map<String, String> metadata, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public BlobInputStream openInputStream()
+        public BlobInputStream openInputStream(BlobInputStreamOptions options)
+        public BlobInputStream openInputStream(BlobRange range, BlobRequestConditions requestConditions)
+        public BlobInputStream openInputStream(BlobInputStreamOptions options, Context context)
+        public InputStream openQueryInputStream(String expression)
+        public Response<InputStream> openQueryInputStreamWithResponse(BlobQueryOptions queryOptions)
+        public BlobSeekableByteChannelReadResult openSeekableByteChannelRead(BlobSeekableByteChannelReadOptions options, Context context)
+        public BlobProperties getProperties()
+        public Response<BlobProperties> getPropertiesWithResponse(BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public void query(OutputStream stream, String expression)
+        public BlobQueryResponse queryWithResponse(BlobQueryOptions queryOptions, Duration timeout, Context context)
+        public BlobServiceVersion getServiceVersion()
+        public boolean isSnapshot()
+        public BlobClientBase getSnapshotClient(String snapshot)
+        public String getSnapshotId()
+        public Map<String, String> getTags()
+        public void setTags(Map<String, String> tags)
+        public Response<Map<String, String>> getTagsWithResponse(BlobGetTagsOptions options, Duration timeout, Context context)
+        public Response<Void> setTagsWithResponse(BlobSetTagsOptions options, Duration timeout, Context context)
+        public void undelete()
+        public Response<Void> undeleteWithResponse(Duration timeout, Context context)
+        public BlobClientBase getVersionClient(String versionId)
+        public String getVersionId()
+    }
+    public final class BlobInputStream extends StorageInputStream {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        @Override protected synchronized ByteBuffer dispatchRead(int readLength, long offset) throws IOException
+        public BlobProperties getProperties()
+    }
+    @ServiceClient(builder  =  BlobLeaseClientBuilder, isAsync  =  true)
+    public final class BlobLeaseAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public Mono<String> acquireLease(int durationInSeconds)
+        public Mono<Response<String>> acquireLeaseWithResponse(BlobAcquireLeaseOptions options)
+        public Mono<Response<String>> acquireLeaseWithResponse(int durationInSeconds, RequestConditions modifiedRequestConditions)
+        public Mono<Integer> breakLease()
+        public Mono<Response<Integer>> breakLeaseWithResponse(BlobBreakLeaseOptions options)
+        public Mono<Response<Integer>> breakLeaseWithResponse(Integer breakPeriodInSeconds, RequestConditions modifiedRequestConditions)
+        public Mono<String> changeLease(String proposedId)
+        public Mono<Response<String>> changeLeaseWithResponse(BlobChangeLeaseOptions options)
+        public Mono<Response<String>> changeLeaseWithResponse(String proposedId, RequestConditions modifiedRequestConditions)
+        public Mono<Void> releaseLease()
+        public Mono<Response<Void>> releaseLeaseWithResponse(RequestConditions modifiedRequestConditions)
+        public Mono<Response<Void>> releaseLeaseWithResponse(BlobReleaseLeaseOptions options)
+        public Mono<String> renewLease()
+        public Mono<Response<String>> renewLeaseWithResponse(RequestConditions modifiedRequestConditions)
+        public Mono<Response<String>> renewLeaseWithResponse(BlobRenewLeaseOptions options)
+        // Non-Service Methods:
+        public String getAccountName()
+        public String getLeaseId()
+        public String getResourceUrl()
+    }
+    @ServiceClient(builder  =  BlobLeaseClientBuilder)
+    public final class BlobLeaseClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public String acquireLease(int durationInSeconds)
+        public Response<String> acquireLeaseWithResponse(BlobAcquireLeaseOptions options, Duration timeout, Context context)
+        public Response<String> acquireLeaseWithResponse(int durationInSeconds, RequestConditions modifiedRequestConditions, Duration timeout, Context context)
+        public Integer breakLease()
+        public Response<Integer> breakLeaseWithResponse(BlobBreakLeaseOptions options, Duration timeout, Context context)
+        public Response<Integer> breakLeaseWithResponse(Integer breakPeriodInSeconds, RequestConditions modifiedRequestConditions, Duration timeout, Context context)
+        public String changeLease(String proposedId)
+        public Response<String> changeLeaseWithResponse(BlobChangeLeaseOptions options, Duration timeout, Context context)
+        public Response<String> changeLeaseWithResponse(String proposedId, RequestConditions modifiedRequestConditions, Duration timeout, Context context)
+        public void releaseLease()
+        public Response<Void> releaseLeaseWithResponse(RequestConditions modifiedRequestConditions, Duration timeout, Context context)
+        public Response<Void> releaseLeaseWithResponse(BlobReleaseLeaseOptions options, Duration timeout, Context context)
+        public String renewLease()
+        public Response<String> renewLeaseWithResponse(RequestConditions modifiedRequestConditions, Duration timeout, Context context)
+        public Response<String> renewLeaseWithResponse(BlobRenewLeaseOptions options, Duration timeout, Context context)
+        // Non-Service Methods:
+        public String getAccountName()
+        public String getLeaseId()
+        public String getResourceUrl()
+    }
+    @ServiceClientBuilder(serviceClients  =  { BlobLeaseClient, BlobLeaseAsyncClient })
+    public final class BlobLeaseClientBuilder {
+        public BlobLeaseClientBuilder()
+        public BlobLeaseClientBuilder blobAsyncClient(BlobAsyncClientBase blobAsyncClient)
+        public BlobLeaseClientBuilder blobClient(BlobClientBase blobClient)
+        public BlobLeaseClientBuilder containerAsyncClient(BlobContainerAsyncClient blobContainerAsyncClient)
+        public BlobLeaseClientBuilder containerClient(BlobContainerClient blobContainerClient)
+        public BlobLeaseClientBuilder leaseId(String leaseId)
+        public BlobLeaseAsyncClient buildAsyncClient()
+        public BlobLeaseClient buildClient()
+    }
+    public abstract class BlobOutputStream extends StorageOutputStream {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        public static BlobOutputStream blockBlobOutputStream(BlobAsyncClient client, BlockBlobOutputStreamOptions options, Context context)
+        public static BlobOutputStream blockBlobOutputStream(BlobAsyncClient client, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions)
+        public static BlobOutputStream blockBlobOutputStream(BlobAsyncClient client, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions, Context context)
+        @Override public synchronized void close() throws IOException
+    }
+    @ServiceClient(builder  =  SpecializedBlobClientBuilder, isAsync  =  true)
+    public final class BlockBlobAsyncClient extends BlobAsyncClientBase {
+        @Deprecated public static final int MAX_UPLOAD_BLOB_BYTES = 256 *  Constants.MB;
+        public static final long MAX_UPLOAD_BLOB_BYTES_LONG = BlobConstants.MAX_UPLOAD_BLOB_BYTES_LONG;
+        @Deprecated public static final int MAX_STAGE_BLOCK_BYTES = 100 *  Constants.MB;
+        public static final long MAX_STAGE_BLOCK_BYTES_LONG = BlobConstants.MAX_STAGE_BLOCK_BYTES_LONG;
+        public static final int MAX_BLOCKS = BlobConstants.MAX_BLOCKS;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public Mono<BlockBlobItem> commitBlockList(List<String> base64BlockIds)
+        public Mono<BlockBlobItem> commitBlockList(List<String> base64BlockIds, boolean overwrite)
+        public Mono<Response<BlockBlobItem>> commitBlockListWithResponse(BlockBlobCommitBlockListOptions options)
+        public Mono<Response<BlockBlobItem>> commitBlockListWithResponse(List<String> base64BlockIds, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions)
+        public Mono<BlockList> listBlocks(BlockListType listType)
+        public Mono<Response<BlockList>> listBlocksWithResponse(BlockBlobListBlocksOptions options)
+        public Mono<Response<BlockList>> listBlocksWithResponse(BlockListType listType, String leaseId)
+        public Mono<Void> stageBlock(String base64BlockId, BinaryData data)
+        public Mono<Void> stageBlock(String base64BlockId, Flux<ByteBuffer> data, long length)
+        public Mono<Void> stageBlockFromUrl(String base64BlockId, String sourceUrl, BlobRange sourceRange)
+        public Mono<Response<Void>> stageBlockFromUrlWithResponse(BlockBlobStageBlockFromUrlOptions options)
+        public Mono<Response<Void>> stageBlockFromUrlWithResponse(String base64BlockId, String sourceUrl, BlobRange sourceRange, byte[] sourceContentMd5, String leaseId, BlobRequestConditions sourceRequestConditions)
+        public Mono<Response<Void>> stageBlockWithResponse(BlockBlobStageBlockOptions options)
+        public Mono<Response<Void>> stageBlockWithResponse(String base64BlockId, Flux<ByteBuffer> data, long length, byte[] contentMd5, String leaseId)
+        public Mono<BlockBlobItem> upload(BinaryData data)
+        public Mono<BlockBlobItem> upload(Flux<ByteBuffer> data, long length)
+        public Mono<BlockBlobItem> upload(BinaryData data, boolean overwrite)
+        public Mono<BlockBlobItem> upload(Flux<ByteBuffer> data, long length, boolean overwrite)
+        public Mono<BlockBlobItem> uploadFromUrl(String sourceUrl)
+        public Mono<BlockBlobItem> uploadFromUrl(String sourceUrl, boolean overwrite)
+        public Mono<Response<BlockBlobItem>> uploadFromUrlWithResponse(BlobUploadFromUrlOptions options)
+        public Mono<Response<BlockBlobItem>> uploadWithResponse(BlockBlobSimpleUploadOptions options)
+        public Mono<Response<BlockBlobItem>> uploadWithResponse(Flux<ByteBuffer> data, long length, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, byte[] contentMd5, BlobRequestConditions requestConditions)
+        // Non-Service Methods:
+        @Override public BlockBlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
+        @Override public BlockBlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
+    }
+    @ServiceClient(builder  =  SpecializedBlobClientBuilder)
+    public final class BlockBlobClient extends BlobClientBase {
+        @Deprecated public static final int MAX_UPLOAD_BLOB_BYTES = 256 *  Constants.MB;
+        public static final long MAX_UPLOAD_BLOB_BYTES_LONG = BlobConstants.MAX_UPLOAD_BLOB_BYTES_LONG;
+        @Deprecated public static final int MAX_STAGE_BLOCK_BYTES = 100 *  Constants.MB;
+        public static final long MAX_STAGE_BLOCK_BYTES_LONG = BlobConstants.MAX_STAGE_BLOCK_BYTES_LONG;
+        public static final int MAX_BLOCKS = BlobConstants.MAX_BLOCKS;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public BlockBlobItem commitBlockList(List<String> base64BlockIds)
+        public BlockBlobItem commitBlockList(List<String> base64BlockIds, boolean overwrite)
+        public Response<BlockBlobItem> commitBlockListWithResponse(BlockBlobCommitBlockListOptions options, Duration timeout, Context context)
+        public Response<BlockBlobItem> commitBlockListWithResponse(List<String> base64BlockIds, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public BlockList listBlocks(BlockListType listType)
+        public Response<BlockList> listBlocksWithResponse(BlockBlobListBlocksOptions options, Duration timeout, Context context)
+        public Response<BlockList> listBlocksWithResponse(BlockListType listType, String leaseId, Duration timeout, Context context)
+        public void stageBlock(String base64BlockId, BinaryData data)
+        public void stageBlock(String base64BlockId, InputStream data, long length)
+        public void stageBlockFromUrl(String base64BlockId, String sourceUrl, BlobRange sourceRange)
+        public Response<Void> stageBlockFromUrlWithResponse(BlockBlobStageBlockFromUrlOptions options, Duration timeout, Context context)
+        public Response<Void> stageBlockFromUrlWithResponse(String base64BlockId, String sourceUrl, BlobRange sourceRange, byte[] sourceContentMd5, String leaseId, BlobRequestConditions sourceRequestConditions, Duration timeout, Context context)
+        public Response<Void> stageBlockWithResponse(BlockBlobStageBlockOptions options, Duration timeout, Context context)
+        public Response<Void> stageBlockWithResponse(String base64BlockId, InputStream data, long length, byte[] contentMd5, String leaseId, Duration timeout, Context context)
+        public BlockBlobItem upload(BinaryData data)
+        public BlockBlobItem upload(InputStream data, long length)
+        public BlockBlobItem upload(BinaryData data, boolean overwrite)
+        public BlockBlobItem upload(InputStream data, long length, boolean overwrite)
+        public BlockBlobItem uploadFromUrl(String sourceUrl)
+        public BlockBlobItem uploadFromUrl(String sourceUrl, boolean overwrite)
+        public Response<BlockBlobItem> uploadFromUrlWithResponse(BlobUploadFromUrlOptions options, Duration timeout, Context context)
+        public Response<BlockBlobItem> uploadWithResponse(BlockBlobSimpleUploadOptions options, Duration timeout, Context context)
+        public Response<BlockBlobItem> uploadWithResponse(InputStream data, long length, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, byte[] contentMd5, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        // Non-Service Methods:
+        public BlobOutputStream getBlobOutputStream()
+        public BlobOutputStream getBlobOutputStream(boolean overwrite)
+        public BlobOutputStream getBlobOutputStream(BlobRequestConditions requestConditions)
+        public BlobOutputStream getBlobOutputStream(BlockBlobOutputStreamOptions options)
+        public BlobOutputStream getBlobOutputStream(BlockBlobOutputStreamOptions options, Context context)
+        public BlobOutputStream getBlobOutputStream(ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions)
+        @Override public BlockBlobClient getCustomerProvidedKeyClient(CustomerProvidedKey customerProvidedKey)
+        @Override public BlockBlobClient getEncryptionScopeClient(String encryptionScope)
+        public SeekableByteChannel openSeekableByteChannelWrite(BlockBlobSeekableByteChannelWriteOptions options)
+    }
+    @ServiceClient(builder  =  SpecializedBlobClientBuilder, isAsync  =  true)
+    public final class PageBlobAsyncClient extends BlobAsyncClientBase {
+        public static final int PAGE_BYTES = BlobConstants.PAGE_BYTES;
+        public static final int MAX_PUT_PAGES_BYTES = BlobConstants.MAX_PUT_PAGES_BYTES;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public Mono<PageBlobItem> clearPages(PageRange pageRange)
+        public Mono<Response<PageBlobItem>> clearPagesWithResponse(PageRange pageRange, PageBlobRequestConditions pageBlobRequestConditions)
+        public Mono<CopyStatusType> copyIncremental(String source, String snapshot)
+        public Mono<Response<CopyStatusType>> copyIncrementalWithResponse(PageBlobCopyIncrementalOptions options)
+        public Mono<Response<CopyStatusType>> copyIncrementalWithResponse(String source, String snapshot, RequestConditions modifiedRequestConditions)
+        public Mono<PageBlobItem> create(long size)
+        public Mono<PageBlobItem> create(long size, boolean overwrite)
+        public Mono<PageBlobItem> createIfNotExists(long size)
+        public Mono<Response<PageBlobItem>> createIfNotExistsWithResponse(PageBlobCreateOptions options)
+        public Mono<Response<PageBlobItem>> createWithResponse(PageBlobCreateOptions options)
+        public Mono<Response<PageBlobItem>> createWithResponse(long size, Long sequenceNumber, BlobHttpHeaders headers, Map<String, String> metadata, BlobRequestConditions requestConditions)
+        public PagedFlux<PageRangeItem> listPageRanges(BlobRange blobRange)
+        public PagedFlux<PageRangeItem> listPageRanges(ListPageRangesOptions options)
+        public PagedFlux<PageRangeItem> listPageRangesDiff(ListPageRangesDiffOptions options)
+        public PagedFlux<PageRangeItem> listPageRangesDiff(BlobRange blobRange, String prevSnapshot)
+        public Mono<PageList> getManagedDiskPageRangesDiff(BlobRange blobRange, String prevSnapshotUrl)
+        public Mono<Response<PageList>> getManagedDiskPageRangesDiffWithResponse(BlobRange blobRange, String prevSnapshotUrl, BlobRequestConditions requestConditions)
+        @Deprecated public Mono<PageList> getPageRanges(BlobRange blobRange)
+        @Deprecated public Mono<PageList> getPageRangesDiff(BlobRange blobRange, String prevSnapshot)
+        @Deprecated public Mono<Response<PageList>> getPageRangesDiffWithResponse(BlobRange blobRange, String prevSnapshot, BlobRequestConditions requestConditions)
+        @Deprecated public Mono<Response<PageList>> getPageRangesWithResponse(BlobRange blobRange, BlobRequestConditions requestConditions)
+        public Mono<PageBlobItem> resize(long size)
+        public Mono<Response<PageBlobItem>> resizeWithResponse(long size, BlobRequestConditions requestConditions)
+        public Mono<PageBlobItem> updateSequenceNumber(SequenceNumberActionType action, Long sequenceNumber)
+        public Mono<Response<PageBlobItem>> updateSequenceNumberWithResponse(SequenceNumberActionType action, Long sequenceNumber, BlobRequestConditions requestConditions)
+        public Mono<PageBlobItem> uploadPages(PageRange pageRange, Flux<ByteBuffer> body)
+        public Mono<PageBlobItem> uploadPagesFromUrl(PageRange range, String sourceUrl, Long sourceOffset)
+        public Mono<Response<PageBlobItem>> uploadPagesFromUrlWithResponse(PageBlobUploadPagesFromUrlOptions options)
+        public Mono<Response<PageBlobItem>> uploadPagesFromUrlWithResponse(PageRange range, String sourceUrl, Long sourceOffset, byte[] sourceContentMd5, PageBlobRequestConditions destRequestConditions, BlobRequestConditions sourceRequestConditions)
+        public Mono<Response<PageBlobItem>> uploadPagesWithResponse(PageRange pageRange, Flux<ByteBuffer> body, PageBlobUploadPagesOptions options)
+        @Deprecated public Mono<Response<PageBlobItem>> uploadPagesWithResponse(PageRange pageRange, Flux<ByteBuffer> body, byte[] contentMd5, PageBlobRequestConditions pageBlobRequestConditions)
+        // Non-Service Methods:
+        @Override public PageBlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
+        @Override public PageBlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
+    }
+    @ServiceClient(builder  =  SpecializedBlobClientBuilder)
+    public final class PageBlobClient extends BlobClientBase {
+        public static final int PAGE_BYTES = BlobConstants.PAGE_BYTES;
+        public static final int MAX_PUT_PAGES_BYTES = BlobConstants.MAX_PUT_PAGES_BYTES;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
+        public PageBlobItem clearPages(PageRange pageRange)
+        public Response<PageBlobItem> clearPagesWithResponse(PageRange pageRange, PageBlobRequestConditions pageBlobRequestConditions, Duration timeout, Context context)
+        public CopyStatusType copyIncremental(String source, String snapshot)
+        public Response<CopyStatusType> copyIncrementalWithResponse(PageBlobCopyIncrementalOptions options, Duration timeout, Context context)
+        public Response<CopyStatusType> copyIncrementalWithResponse(String source, String snapshot, RequestConditions modifiedRequestConditions, Duration timeout, Context context)
+        public PageBlobItem create(long size)
+        public PageBlobItem create(long size, boolean overwrite)
+        public PageBlobItem createIfNotExists(long size)
+        public Response<PageBlobItem> createIfNotExistsWithResponse(PageBlobCreateOptions options, Duration timeout, Context context)
+        public Response<PageBlobItem> createWithResponse(PageBlobCreateOptions options, Duration timeout, Context context)
+        public Response<PageBlobItem> createWithResponse(long size, Long sequenceNumber, BlobHttpHeaders headers, Map<String, String> metadata, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public PagedIterable<PageRangeItem> listPageRanges(BlobRange blobRange)
+        public PagedIterable<PageRangeItem> listPageRanges(ListPageRangesOptions options, Duration timeout, Context context)
+        public PagedIterable<PageRangeItem> listPageRangesDiff(BlobRange blobRange, String prevSnapshot)
+        public PagedIterable<PageRangeItem> listPageRangesDiff(ListPageRangesDiffOptions options, Duration timeout, Context context)
+        public PageList getManagedDiskPageRangesDiff(BlobRange blobRange, String prevSnapshotUrl)
+        public Response<PageList> getManagedDiskPageRangesDiffWithResponse(BlobRange blobRange, String prevSnapshotUrl, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        @Deprecated public PageList getPageRanges(BlobRange blobRange)
+        @Deprecated public PageList getPageRangesDiff(BlobRange blobRange, String prevSnapshot)
+        @Deprecated public Response<PageList> getPageRangesDiffWithResponse(BlobRange blobRange, String prevSnapshot, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        @Deprecated public Response<PageList> getPageRangesWithResponse(BlobRange blobRange, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public PageBlobItem resize(long size)
+        public Response<PageBlobItem> resizeWithResponse(long size, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public PageBlobItem updateSequenceNumber(SequenceNumberActionType action, Long sequenceNumber)
+        public Response<PageBlobItem> updateSequenceNumberWithResponse(SequenceNumberActionType action, Long sequenceNumber, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        public PageBlobItem uploadPages(PageRange pageRange, InputStream body)
+        public PageBlobItem uploadPagesFromUrl(PageRange range, String sourceUrl, Long sourceOffset)
+        public Response<PageBlobItem> uploadPagesFromUrlWithResponse(PageBlobUploadPagesFromUrlOptions options, Duration timeout, Context context)
+        public Response<PageBlobItem> uploadPagesFromUrlWithResponse(PageRange range, String sourceUrl, Long sourceOffset, byte[] sourceContentMd5, PageBlobRequestConditions destRequestConditions, BlobRequestConditions sourceRequestConditions, Duration timeout, Context context)
+        public Response<PageBlobItem> uploadPagesWithResponse(PageRange pageRange, InputStream body, PageBlobUploadPagesOptions options, Duration timeout, Context context)
+        @Deprecated public Response<PageBlobItem> uploadPagesWithResponse(PageRange pageRange, InputStream body, byte[] contentMd5, PageBlobRequestConditions pageBlobRequestConditions, Duration timeout, Context context)
+        // Non-Service Methods:
+        public BlobOutputStream getBlobOutputStream(PageRange pageRange)
+        public BlobOutputStream getBlobOutputStream(PageBlobOutputStreamOptions options)
+        public BlobOutputStream getBlobOutputStream(PageRange pageRange, BlobRequestConditions requestConditions)
+        @Override public PageBlobClient getCustomerProvidedKeyClient(CustomerProvidedKey customerProvidedKey)
+        @Override public PageBlobClient getEncryptionScopeClient(String encryptionScope)
+    }
+    @ServiceClientBuilder(serviceClients  =  { AppendBlobClient, AppendBlobAsyncClient, BlockBlobClient, BlockBlobAsyncClient, PageBlobClient, PageBlobAsyncClient })
+    public final class SpecializedBlobClientBuilder implements TokenCredentialTrait<SpecializedBlobClientBuilder> , ConnectionStringTrait<SpecializedBlobClientBuilder> , AzureNamedKeyCredentialTrait<SpecializedBlobClientBuilder> , AzureSasCredentialTrait<SpecializedBlobClientBuilder> , HttpTrait<SpecializedBlobClientBuilder> , ConfigurationTrait<SpecializedBlobClientBuilder> , EndpointTrait<SpecializedBlobClientBuilder> {
+        public SpecializedBlobClientBuilder()
+        @Override public SpecializedBlobClientBuilder addPolicy(HttpPipelinePolicy pipelinePolicy)
+        public SpecializedBlobClientBuilder setAnonymousAccess()
+        public SpecializedBlobClientBuilder audience(BlobAudience audience)
+        public SpecializedBlobClientBuilder blobAsyncClient(BlobAsyncClientBase blobAsyncClient)
+        public SpecializedBlobClientBuilder blobClient(BlobClientBase blobClient)
+        public SpecializedBlobClientBuilder blobName(String blobName)
+        @Override public SpecializedBlobClientBuilder clientOptions(ClientOptions clientOptions)
+        @Override public SpecializedBlobClientBuilder configuration(Configuration configuration)
+        @Override public SpecializedBlobClientBuilder connectionString(String connectionString)
+        public SpecializedBlobClientBuilder containerAsyncClient(BlobContainerAsyncClient blobContainerAsyncClient, String blobName)
+        public SpecializedBlobClientBuilder containerClient(BlobContainerClient blobContainerClient, String blobName)
+        public SpecializedBlobClientBuilder containerName(String containerName)
+        public SpecializedBlobClientBuilder credential(StorageSharedKeyCredential credential)
+        @Override public SpecializedBlobClientBuilder credential(AzureNamedKeyCredential credential)
+        @Override public SpecializedBlobClientBuilder credential(TokenCredential credential)
+        @Override public SpecializedBlobClientBuilder credential(AzureSasCredential credential)
+        public SpecializedBlobClientBuilder customerProvidedKey(CustomerProvidedKey customerProvidedKey)
+        public static HttpLogOptions getDefaultHttpLogOptions()
+        public SpecializedBlobClientBuilder encryptionScope(String encryptionScope)
+        @Override public SpecializedBlobClientBuilder endpoint(String endpoint)
+        @Override public SpecializedBlobClientBuilder httpClient(HttpClient httpClient)
+        @Override public SpecializedBlobClientBuilder httpLogOptions(HttpLogOptions logOptions)
+        @Override public SpecializedBlobClientBuilder pipeline(HttpPipeline httpPipeline)
+        public SpecializedBlobClientBuilder retryOptions(RequestRetryOptions retryOptions)
+        @Override public SpecializedBlobClientBuilder retryOptions(RetryOptions retryOptions)
+        public SpecializedBlobClientBuilder sasToken(String sasToken)
+        public SpecializedBlobClientBuilder serviceVersion(BlobServiceVersion version)
+        public SpecializedBlobClientBuilder snapshot(String snapshot)
+        public SpecializedBlobClientBuilder versionId(String versionId)
+        public AppendBlobAsyncClient buildAppendBlobAsyncClient()
+        public AppendBlobClient buildAppendBlobClient()
+        public BlockBlobAsyncClient buildBlockBlobAsyncClient()
+        public BlockBlobClient buildBlockBlobClient()
+        public PageBlobAsyncClient buildPageBlobAsyncClient()
+        public PageBlobClient buildPageBlobClient()
+    }
+}
+```

--- a/sdk/storage/azure-storage-blob/api.md
+++ b/sdk/storage/azure-storage-blob/api.md
@@ -57,7 +57,7 @@ package com.azure.storage.blob {
         public Mono<Response<BlockBlobItem>> uploadWithResponse(Flux<ByteBuffer> data, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions)
         @Override public BlobAsyncClient getVersionClient(String versionId)
     }
-    @ServiceClient(builder  =  BlobClientBuilder)
+    @ServiceClient(builder = BlobClientBuilder)
     public class BlobClient extends BlobClientBase {
         public static final int BLOB_DEFAULT_UPLOAD_BLOCK_SIZE = BlobConstants.BLOB_DEFAULT_UPLOAD_BLOCK_SIZE;
         public static final int BLOB_DEFAULT_NUMBER_OF_BUFFERS = BlobConstants.BLOB_DEFAULT_NUMBER_OF_BUFFERS;
@@ -87,7 +87,7 @@ package com.azure.storage.blob {
         @Override public BlobClient getSnapshotClient(String snapshot)
         @Override public BlobClient getVersionClient(String versionId)
     }
-    @ServiceClientBuilder(serviceClients  =  { BlobClient, BlobAsyncClient })
+    @ServiceClientBuilder(serviceClients = { BlobClient, BlobAsyncClient })
     public final class BlobClientBuilder implements TokenCredentialTrait<BlobClientBuilder> , ConnectionStringTrait<BlobClientBuilder> , AzureNamedKeyCredentialTrait<BlobClientBuilder> , AzureSasCredentialTrait<BlobClientBuilder> , HttpTrait<BlobClientBuilder> , ConfigurationTrait<BlobClientBuilder> , EndpointTrait<BlobClientBuilder> {
         public BlobClientBuilder()
         @Override public BlobClientBuilder addPolicy(HttpPipelinePolicy pipelinePolicy)
@@ -118,7 +118,7 @@ package com.azure.storage.blob {
         public BlobAsyncClient buildAsyncClient()
         public BlobClient buildClient()
     }
-    @ServiceClient(builder  =  BlobContainerClientBuilder, isAsync  =  true)
+    @ServiceClient(builder = BlobContainerClientBuilder, isAsync = true)
     public final class BlobContainerAsyncClient {
         public static final String ROOT_CONTAINER_NAME = BlobConstants.ROOT_CONTAINER_NAME;
         public static final String STATIC_WEBSITE_CONTAINER_NAME = BlobConstants.STATIC_WEBSITE_CONTAINER_NAME;
@@ -172,7 +172,7 @@ package com.azure.storage.blob {
         public BlobServiceAsyncClient getServiceAsyncClient()
         public BlobServiceVersion getServiceVersion()
     }
-    @ServiceClient(builder  =  BlobContainerClientBuilder)
+    @ServiceClient(builder = BlobContainerClientBuilder)
     public final class BlobContainerClient {
         public static final String ROOT_CONTAINER_NAME = BlobConstants.ROOT_CONTAINER_NAME;
         public static final String STATIC_WEBSITE_CONTAINER_NAME = BlobConstants.STATIC_WEBSITE_CONTAINER_NAME;
@@ -226,7 +226,7 @@ package com.azure.storage.blob {
         public BlobServiceClient getServiceClient()
         public BlobServiceVersion getServiceVersion()
     }
-    @ServiceClientBuilder(serviceClients  =  { BlobContainerClient, BlobContainerAsyncClient })
+    @ServiceClientBuilder(serviceClients = { BlobContainerClient, BlobContainerAsyncClient })
     public final class BlobContainerClientBuilder implements TokenCredentialTrait<BlobContainerClientBuilder> , ConnectionStringTrait<BlobContainerClientBuilder> , AzureSasCredentialTrait<BlobContainerClientBuilder> , AzureNamedKeyCredentialTrait<BlobContainerClientBuilder> , HttpTrait<BlobContainerClientBuilder> , ConfigurationTrait<BlobContainerClientBuilder> , EndpointTrait<BlobContainerClientBuilder> {
         public BlobContainerClientBuilder()
         @Override public BlobContainerClientBuilder addPolicy(HttpPipelinePolicy pipelinePolicy)
@@ -255,7 +255,7 @@ package com.azure.storage.blob {
         public BlobContainerAsyncClient buildAsyncClient()
         public BlobContainerClient buildClient()
     }
-    @ServiceClient(builder  =  BlobServiceClientBuilder, isAsync  =  true)
+    @ServiceClient(builder = BlobServiceClientBuilder, isAsync = true)
     public final class BlobServiceAsyncClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -294,7 +294,7 @@ package com.azure.storage.blob {
         public HttpPipeline getHttpPipeline()
         public BlobServiceVersion getServiceVersion()
     }
-    @ServiceClient(builder  =  BlobServiceClientBuilder)
+    @ServiceClient(builder = BlobServiceClientBuilder)
     public final class BlobServiceClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -333,7 +333,7 @@ package com.azure.storage.blob {
         public HttpPipeline getHttpPipeline()
         public BlobServiceVersion getServiceVersion()
     }
-    @ServiceClientBuilder(serviceClients  =  { BlobServiceClient, BlobServiceAsyncClient })
+    @ServiceClientBuilder(serviceClients = { BlobServiceClient, BlobServiceAsyncClient })
     public final class BlobServiceClientBuilder implements TokenCredentialTrait<BlobServiceClientBuilder> , ConnectionStringTrait<BlobServiceClientBuilder> , AzureNamedKeyCredentialTrait<BlobServiceClientBuilder> , AzureSasCredentialTrait<BlobServiceClientBuilder> , HttpTrait<BlobServiceClientBuilder> , ConfigurationTrait<BlobServiceClientBuilder> , EndpointTrait<BlobServiceClientBuilder> {
         public BlobServiceClientBuilder()
         @Override public BlobServiceClientBuilder addPolicy(HttpPipelinePolicy pipelinePolicy)
@@ -2504,9 +2504,9 @@ package com.azure.storage.blob.sas {
     }
 }
 package com.azure.storage.blob.specialized {
-    @ServiceClient(builder  =  SpecializedBlobClientBuilder, isAsync  =  true)
+    @ServiceClient(builder = SpecializedBlobClientBuilder, isAsync = true)
     public final class AppendBlobAsyncClient extends BlobAsyncClientBase {
-        @Deprecated public static final int MAX_APPEND_BLOCK_BYTES = 4 *  Constants.MB;
+        @Deprecated public static final int MAX_APPEND_BLOCK_BYTES = 4 * Constants.MB;
         @Deprecated public static final int MAX_BLOCKS = 50000;
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -2530,9 +2530,9 @@ package com.azure.storage.blob.specialized {
         public int getMaxAppendBlockBytes()
         public int getMaxBlocks()
     }
-    @ServiceClient(builder  =  SpecializedBlobClientBuilder)
+    @ServiceClient(builder = SpecializedBlobClientBuilder)
     public final class AppendBlobClient extends BlobClientBase {
-        @Deprecated public static final int MAX_APPEND_BLOCK_BYTES = 4 *  Constants.MB;
+        @Deprecated public static final int MAX_APPEND_BLOCK_BYTES = 4 * Constants.MB;
         @Deprecated public static final int MAX_BLOCKS = 50000;
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -2746,7 +2746,7 @@ package com.azure.storage.blob.specialized {
         @Override protected synchronized ByteBuffer dispatchRead(int readLength, long offset) throws IOException
         public BlobProperties getProperties()
     }
-    @ServiceClient(builder  =  BlobLeaseClientBuilder, isAsync  =  true)
+    @ServiceClient(builder = BlobLeaseClientBuilder, isAsync = true)
     public final class BlobLeaseAsyncClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -2770,7 +2770,7 @@ package com.azure.storage.blob.specialized {
         public String getLeaseId()
         public String getResourceUrl()
     }
-    @ServiceClient(builder  =  BlobLeaseClientBuilder)
+    @ServiceClient(builder = BlobLeaseClientBuilder)
     public final class BlobLeaseClient {
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         // Service Methods:
@@ -2794,7 +2794,7 @@ package com.azure.storage.blob.specialized {
         public String getLeaseId()
         public String getResourceUrl()
     }
-    @ServiceClientBuilder(serviceClients  =  { BlobLeaseClient, BlobLeaseAsyncClient })
+    @ServiceClientBuilder(serviceClients = { BlobLeaseClient, BlobLeaseAsyncClient })
     public final class BlobLeaseClientBuilder {
         public BlobLeaseClientBuilder()
         public BlobLeaseClientBuilder blobAsyncClient(BlobAsyncClientBase blobAsyncClient)
@@ -2812,11 +2812,11 @@ package com.azure.storage.blob.specialized {
         public static BlobOutputStream blockBlobOutputStream(BlobAsyncClient client, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions, Context context)
         @Override public synchronized void close() throws IOException
     }
-    @ServiceClient(builder  =  SpecializedBlobClientBuilder, isAsync  =  true)
+    @ServiceClient(builder = SpecializedBlobClientBuilder, isAsync = true)
     public final class BlockBlobAsyncClient extends BlobAsyncClientBase {
-        @Deprecated public static final int MAX_UPLOAD_BLOB_BYTES = 256 *  Constants.MB;
+        @Deprecated public static final int MAX_UPLOAD_BLOB_BYTES = 256 * Constants.MB;
         public static final long MAX_UPLOAD_BLOB_BYTES_LONG = BlobConstants.MAX_UPLOAD_BLOB_BYTES_LONG;
-        @Deprecated public static final int MAX_STAGE_BLOCK_BYTES = 100 *  Constants.MB;
+        @Deprecated public static final int MAX_STAGE_BLOCK_BYTES = 100 * Constants.MB;
         public static final long MAX_STAGE_BLOCK_BYTES_LONG = BlobConstants.MAX_STAGE_BLOCK_BYTES_LONG;
         public static final int MAX_BLOCKS = BlobConstants.MAX_BLOCKS;
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
@@ -2848,11 +2848,11 @@ package com.azure.storage.blob.specialized {
         @Override public BlockBlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
         @Override public BlockBlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
     }
-    @ServiceClient(builder  =  SpecializedBlobClientBuilder)
+    @ServiceClient(builder = SpecializedBlobClientBuilder)
     public final class BlockBlobClient extends BlobClientBase {
-        @Deprecated public static final int MAX_UPLOAD_BLOB_BYTES = 256 *  Constants.MB;
+        @Deprecated public static final int MAX_UPLOAD_BLOB_BYTES = 256 * Constants.MB;
         public static final long MAX_UPLOAD_BLOB_BYTES_LONG = BlobConstants.MAX_UPLOAD_BLOB_BYTES_LONG;
-        @Deprecated public static final int MAX_STAGE_BLOCK_BYTES = 100 *  Constants.MB;
+        @Deprecated public static final int MAX_STAGE_BLOCK_BYTES = 100 * Constants.MB;
         public static final long MAX_STAGE_BLOCK_BYTES_LONG = BlobConstants.MAX_STAGE_BLOCK_BYTES_LONG;
         public static final int MAX_BLOCKS = BlobConstants.MAX_BLOCKS;
         // This class does not have any public constructors, and is not able to be instantiated using 'new'.
@@ -2891,7 +2891,7 @@ package com.azure.storage.blob.specialized {
         @Override public BlockBlobClient getEncryptionScopeClient(String encryptionScope)
         public SeekableByteChannel openSeekableByteChannelWrite(BlockBlobSeekableByteChannelWriteOptions options)
     }
-    @ServiceClient(builder  =  SpecializedBlobClientBuilder, isAsync  =  true)
+    @ServiceClient(builder = SpecializedBlobClientBuilder, isAsync = true)
     public final class PageBlobAsyncClient extends BlobAsyncClientBase {
         public static final int PAGE_BYTES = BlobConstants.PAGE_BYTES;
         public static final int MAX_PUT_PAGES_BYTES = BlobConstants.MAX_PUT_PAGES_BYTES;
@@ -2932,7 +2932,7 @@ package com.azure.storage.blob.specialized {
         @Override public PageBlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
         @Override public PageBlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
     }
-    @ServiceClient(builder  =  SpecializedBlobClientBuilder)
+    @ServiceClient(builder = SpecializedBlobClientBuilder)
     public final class PageBlobClient extends BlobClientBase {
         public static final int PAGE_BYTES = BlobConstants.PAGE_BYTES;
         public static final int MAX_PUT_PAGES_BYTES = BlobConstants.MAX_PUT_PAGES_BYTES;
@@ -2976,7 +2976,7 @@ package com.azure.storage.blob.specialized {
         @Override public PageBlobClient getCustomerProvidedKeyClient(CustomerProvidedKey customerProvidedKey)
         @Override public PageBlobClient getEncryptionScopeClient(String encryptionScope)
     }
-    @ServiceClientBuilder(serviceClients  =  { AppendBlobClient, AppendBlobAsyncClient, BlockBlobClient, BlockBlobAsyncClient, PageBlobClient, PageBlobAsyncClient })
+    @ServiceClientBuilder(serviceClients = { AppendBlobClient, AppendBlobAsyncClient, BlockBlobClient, BlockBlobAsyncClient, PageBlobClient, PageBlobAsyncClient })
     public final class SpecializedBlobClientBuilder implements TokenCredentialTrait<SpecializedBlobClientBuilder> , ConnectionStringTrait<SpecializedBlobClientBuilder> , AzureNamedKeyCredentialTrait<SpecializedBlobClientBuilder> , AzureSasCredentialTrait<SpecializedBlobClientBuilder> , HttpTrait<SpecializedBlobClientBuilder> , ConfigurationTrait<SpecializedBlobClientBuilder> , EndpointTrait<SpecializedBlobClientBuilder> {
         public SpecializedBlobClientBuilder()
         @Override public SpecializedBlobClientBuilder addPolicy(HttpPipelinePolicy pipelinePolicy)

--- a/sdk/storage/azure-storage-blob/api.md
+++ b/sdk/storage/azure-storage-blob/api.md
@@ -393,7 +393,7 @@ package com.azure.storage.blob {
         V2026_04_06("2026-04-06"),
         V2026_06_06("2026-06-06"),
         V2026_10_06("2026-10-06");
-        public static BlobServiceVersion getLatest(// returns V2026_10_06 )
+        public static BlobServiceVersion getLatest() // returns V2026_10_06
         @Override public String getVersion()
     }
     public final class BlobUrlParts {
@@ -2429,7 +2429,7 @@ package com.azure.storage.blob.sas {
         V2020_04_08("2020-04-08"),
         V2020_06_12("2020-06-12"),
         V2020_08_04("2020-08-04");
-        public static BlobSasServiceVersion getLatest(// returns V2020_08_04 )
+        public static BlobSasServiceVersion getLatest() // returns V2020_08_04
         @Override public String getVersion()
     }
     @Deprecated

--- a/sdk/storage/azure-storage-blob/api.md
+++ b/sdk/storage/azure-storage-blob/api.md
@@ -5,11 +5,13 @@ maven {
     name : Microsoft Azure client library for Blob Storage
     description : This module contains client library for Microsoft Azure Blob Storage.
     dependencies {
+        // compile scope
         com.azure:azure-xml 1.2.1
         com.azure:azure-core 1.59.0
         com.azure:azure-core-http-netty 1.16.6
         com.azure:azure-storage-common 12.35.0-beta.2
         com.azure:azure-storage-internal-avro 12.21.0-beta.2
+        // provided scope
         com.google.code.findbugs:jsr305 3.0.2
     }
 }
@@ -62,6 +64,7 @@ package com.azure.storage.blob {
         public static final int BLOB_DEFAULT_HTBB_UPLOAD_BLOCK_SIZE = BlobConstants.BLOB_DEFAULT_HTBB_UPLOAD_BLOCK_SIZE;
         protected BlobClient(BlobAsyncClient client)
         protected BlobClient(BlobAsyncClient client, HttpPipeline pipeline, String url, BlobServiceVersion serviceVersion, String accountName, String containerName, String blobName, String snapshot, CpkInfo customerProvidedKey, EncryptionScope encryptionScope, String versionId)
+        // Service Methods:
         public void upload(InputStream data)
         public void upload(BinaryData data)
         public void upload(InputStream data, long length)
@@ -75,6 +78,7 @@ package com.azure.storage.blob {
         @Deprecated public Response<BlockBlobItem> uploadWithResponse(BlobParallelUploadOptions options, Context context)
         public Response<BlockBlobItem> uploadWithResponse(BlobParallelUploadOptions options, Duration timeout, Context context)
         @Deprecated public void uploadWithResponse(InputStream data, long length, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        // Non-Service Methods:
         public AppendBlobClient getAppendBlobClient()
         public BlockBlobClient getBlockBlobClient()
         @Override public BlobClient getCustomerProvidedKeyClient(CustomerProvidedKey customerProvidedKey)
@@ -119,6 +123,8 @@ package com.azure.storage.blob {
         public static final String ROOT_CONTAINER_NAME = BlobConstants.ROOT_CONTAINER_NAME;
         public static final String STATIC_WEBSITE_CONTAINER_NAME = BlobConstants.STATIC_WEBSITE_CONTAINER_NAME;
         public static final String LOG_CONTAINER_NAME = BlobConstants.LOG_CONTAINER_NAME;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public Mono<BlobContainerAccessPolicies> getAccessPolicy()
         public Mono<Void> setAccessPolicy(PublicAccessType accessType, List<BlobSignedIdentifier> identifiers)
         public Mono<Response<BlobContainerAccessPolicies>> getAccessPolicyWithResponse(String leaseId)
@@ -146,6 +152,7 @@ package com.azure.storage.blob {
         public Mono<Response<Void>> setMetadataWithResponse(Map<String, String> metadata, BlobRequestConditions requestConditions)
         public Mono<BlobContainerProperties> getProperties()
         public Mono<Response<BlobContainerProperties>> getPropertiesWithResponse(String leaseId)
+        // Non-Service Methods:
         public String getAccountName()
         public String getAccountUrl()
         public BlobAsyncClient getBlobAsyncClient(String blobName)
@@ -170,6 +177,8 @@ package com.azure.storage.blob {
         public static final String ROOT_CONTAINER_NAME = BlobConstants.ROOT_CONTAINER_NAME;
         public static final String STATIC_WEBSITE_CONTAINER_NAME = BlobConstants.STATIC_WEBSITE_CONTAINER_NAME;
         public static final String LOG_CONTAINER_NAME = BlobConstants.LOG_CONTAINER_NAME;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public BlobContainerAccessPolicies getAccessPolicy()
         public void setAccessPolicy(PublicAccessType accessType, List<BlobSignedIdentifier> identifiers)
         public Response<BlobContainerAccessPolicies> getAccessPolicyWithResponse(String leaseId, Duration timeout, Context context)
@@ -197,6 +206,7 @@ package com.azure.storage.blob {
         public Response<Void> setMetadataWithResponse(Map<String, String> metadata, BlobRequestConditions requestConditions, Duration timeout, Context context)
         public BlobContainerProperties getProperties()
         public Response<BlobContainerProperties> getPropertiesWithResponse(String leaseId, Duration timeout, Context context)
+        // Non-Service Methods:
         public String getAccountName()
         public String getAccountUrl()
         public BlobClient getBlobClient(String blobName)
@@ -247,6 +257,8 @@ package com.azure.storage.blob {
     }
     @ServiceClient(builder  =  BlobServiceClientBuilder, isAsync  =  true)
     public final class BlobServiceAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public Mono<StorageAccountInfo> getAccountInfo()
         public Mono<Response<StorageAccountInfo>> getAccountInfoWithResponse()
         public Mono<BlobContainerAsyncClient> createBlobContainer(String containerName)
@@ -272,6 +284,7 @@ package com.azure.storage.blob {
         public Mono<UserDelegationKey> getUserDelegationKey(OffsetDateTime start, OffsetDateTime expiry)
         public Mono<Response<UserDelegationKey>> getUserDelegationKeyWithResponse(BlobGetUserDelegationKeyOptions options)
         public Mono<Response<UserDelegationKey>> getUserDelegationKeyWithResponse(OffsetDateTime start, OffsetDateTime expiry)
+        // Non-Service Methods:
         public String getAccountName()
         public String getAccountUrl()
         public BlobContainerAsyncClient getBlobContainerAsyncClient(String containerName)
@@ -283,6 +296,8 @@ package com.azure.storage.blob {
     }
     @ServiceClient(builder  =  BlobServiceClientBuilder)
     public final class BlobServiceClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public StorageAccountInfo getAccountInfo()
         public Response<StorageAccountInfo> getAccountInfoWithResponse(Duration timeout, Context context)
         public BlobContainerClient createBlobContainer(String containerName)
@@ -308,6 +323,7 @@ package com.azure.storage.blob {
         public UserDelegationKey getUserDelegationKey(OffsetDateTime start, OffsetDateTime expiry)
         public Response<UserDelegationKey> getUserDelegationKeyWithResponse(BlobGetUserDelegationKeyOptions options, Duration timeout, Context context)
         public Response<UserDelegationKey> getUserDelegationKeyWithResponse(OffsetDateTime start, OffsetDateTime expiry, Duration timeout, Context context)
+        // Non-Service Methods:
         public String getAccountName()
         public String getAccountUrl()
         public BlobContainerClient getBlobContainerClient(String containerName)
@@ -1277,6 +1293,7 @@ package com.azure.storage.blob.models {
         public BlobQueryResponse(BlobQueryAsyncResponse response)
     }
     public interface BlobQuerySerialization {
+        // This interface does not declare any API.
     }
     @Immutable
     public final class BlobRange {
@@ -2491,6 +2508,8 @@ package com.azure.storage.blob.specialized {
     public final class AppendBlobAsyncClient extends BlobAsyncClientBase {
         @Deprecated public static final int MAX_APPEND_BLOCK_BYTES = 4 *  Constants.MB;
         @Deprecated public static final int MAX_BLOCKS = 50000;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public Mono<AppendBlobItem> appendBlock(Flux<ByteBuffer> data, long length)
         public Mono<AppendBlobItem> appendBlockFromUrl(String sourceUrl, BlobRange sourceRange)
         public Mono<Response<AppendBlobItem>> appendBlockFromUrlWithResponse(AppendBlobAppendBlockFromUrlOptions options)
@@ -2505,6 +2524,7 @@ package com.azure.storage.blob.specialized {
         public Mono<Response<AppendBlobItem>> createWithResponse(BlobHttpHeaders headers, Map<String, String> metadata, BlobRequestConditions requestConditions)
         public Mono<Void> seal()
         public Mono<Response<Void>> sealWithResponse(AppendBlobSealOptions options)
+        // Non-Service Methods:
         @Override public AppendBlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
         @Override public AppendBlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
         public int getMaxAppendBlockBytes()
@@ -2514,6 +2534,8 @@ package com.azure.storage.blob.specialized {
     public final class AppendBlobClient extends BlobClientBase {
         @Deprecated public static final int MAX_APPEND_BLOCK_BYTES = 4 *  Constants.MB;
         @Deprecated public static final int MAX_BLOCKS = 50000;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public AppendBlobItem appendBlock(InputStream data, long length)
         public AppendBlobItem appendBlockFromUrl(String sourceUrl, BlobRange sourceRange)
         public Response<AppendBlobItem> appendBlockFromUrlWithResponse(AppendBlobAppendBlockFromUrlOptions options, Duration timeout, Context context)
@@ -2528,6 +2550,7 @@ package com.azure.storage.blob.specialized {
         public Response<AppendBlobItem> createWithResponse(BlobHttpHeaders headers, Map<String, String> metadata, BlobRequestConditions requestConditions, Duration timeout, Context context)
         public void seal()
         public Response<Void> sealWithResponse(AppendBlobSealOptions options, Duration timeout, Context context)
+        // Non-Service Methods:
         public BlobOutputStream getBlobOutputStream()
         public BlobOutputStream getBlobOutputStream(boolean overwrite)
         public BlobOutputStream getBlobOutputStream(AppendBlobRequestConditions requestConditions)
@@ -2719,11 +2742,14 @@ package com.azure.storage.blob.specialized {
         public String getVersionId()
     }
     public final class BlobInputStream extends StorageInputStream {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         @Override protected synchronized ByteBuffer dispatchRead(int readLength, long offset) throws IOException
         public BlobProperties getProperties()
     }
     @ServiceClient(builder  =  BlobLeaseClientBuilder, isAsync  =  true)
     public final class BlobLeaseAsyncClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public Mono<String> acquireLease(int durationInSeconds)
         public Mono<Response<String>> acquireLeaseWithResponse(BlobAcquireLeaseOptions options)
         public Mono<Response<String>> acquireLeaseWithResponse(int durationInSeconds, RequestConditions modifiedRequestConditions)
@@ -2739,12 +2765,15 @@ package com.azure.storage.blob.specialized {
         public Mono<String> renewLease()
         public Mono<Response<String>> renewLeaseWithResponse(RequestConditions modifiedRequestConditions)
         public Mono<Response<String>> renewLeaseWithResponse(BlobRenewLeaseOptions options)
+        // Non-Service Methods:
         public String getAccountName()
         public String getLeaseId()
         public String getResourceUrl()
     }
     @ServiceClient(builder  =  BlobLeaseClientBuilder)
     public final class BlobLeaseClient {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public String acquireLease(int durationInSeconds)
         public Response<String> acquireLeaseWithResponse(BlobAcquireLeaseOptions options, Duration timeout, Context context)
         public Response<String> acquireLeaseWithResponse(int durationInSeconds, RequestConditions modifiedRequestConditions, Duration timeout, Context context)
@@ -2760,6 +2789,7 @@ package com.azure.storage.blob.specialized {
         public String renewLease()
         public Response<String> renewLeaseWithResponse(RequestConditions modifiedRequestConditions, Duration timeout, Context context)
         public Response<String> renewLeaseWithResponse(BlobRenewLeaseOptions options, Duration timeout, Context context)
+        // Non-Service Methods:
         public String getAccountName()
         public String getLeaseId()
         public String getResourceUrl()
@@ -2776,6 +2806,7 @@ package com.azure.storage.blob.specialized {
         public BlobLeaseClient buildClient()
     }
     public abstract class BlobOutputStream extends StorageOutputStream {
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
         public static BlobOutputStream blockBlobOutputStream(BlobAsyncClient client, BlockBlobOutputStreamOptions options, Context context)
         public static BlobOutputStream blockBlobOutputStream(BlobAsyncClient client, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions)
         public static BlobOutputStream blockBlobOutputStream(BlobAsyncClient client, ParallelTransferOptions parallelTransferOptions, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, BlobRequestConditions requestConditions, Context context)
@@ -2788,6 +2819,8 @@ package com.azure.storage.blob.specialized {
         @Deprecated public static final int MAX_STAGE_BLOCK_BYTES = 100 *  Constants.MB;
         public static final long MAX_STAGE_BLOCK_BYTES_LONG = BlobConstants.MAX_STAGE_BLOCK_BYTES_LONG;
         public static final int MAX_BLOCKS = BlobConstants.MAX_BLOCKS;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public Mono<BlockBlobItem> commitBlockList(List<String> base64BlockIds)
         public Mono<BlockBlobItem> commitBlockList(List<String> base64BlockIds, boolean overwrite)
         public Mono<Response<BlockBlobItem>> commitBlockListWithResponse(BlockBlobCommitBlockListOptions options)
@@ -2811,6 +2844,7 @@ package com.azure.storage.blob.specialized {
         public Mono<Response<BlockBlobItem>> uploadFromUrlWithResponse(BlobUploadFromUrlOptions options)
         public Mono<Response<BlockBlobItem>> uploadWithResponse(BlockBlobSimpleUploadOptions options)
         public Mono<Response<BlockBlobItem>> uploadWithResponse(Flux<ByteBuffer> data, long length, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, byte[] contentMd5, BlobRequestConditions requestConditions)
+        // Non-Service Methods:
         @Override public BlockBlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
         @Override public BlockBlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
     }
@@ -2821,6 +2855,8 @@ package com.azure.storage.blob.specialized {
         @Deprecated public static final int MAX_STAGE_BLOCK_BYTES = 100 *  Constants.MB;
         public static final long MAX_STAGE_BLOCK_BYTES_LONG = BlobConstants.MAX_STAGE_BLOCK_BYTES_LONG;
         public static final int MAX_BLOCKS = BlobConstants.MAX_BLOCKS;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public BlockBlobItem commitBlockList(List<String> base64BlockIds)
         public BlockBlobItem commitBlockList(List<String> base64BlockIds, boolean overwrite)
         public Response<BlockBlobItem> commitBlockListWithResponse(BlockBlobCommitBlockListOptions options, Duration timeout, Context context)
@@ -2844,6 +2880,7 @@ package com.azure.storage.blob.specialized {
         public Response<BlockBlobItem> uploadFromUrlWithResponse(BlobUploadFromUrlOptions options, Duration timeout, Context context)
         public Response<BlockBlobItem> uploadWithResponse(BlockBlobSimpleUploadOptions options, Duration timeout, Context context)
         public Response<BlockBlobItem> uploadWithResponse(InputStream data, long length, BlobHttpHeaders headers, Map<String, String> metadata, AccessTier tier, byte[] contentMd5, BlobRequestConditions requestConditions, Duration timeout, Context context)
+        // Non-Service Methods:
         public BlobOutputStream getBlobOutputStream()
         public BlobOutputStream getBlobOutputStream(boolean overwrite)
         public BlobOutputStream getBlobOutputStream(BlobRequestConditions requestConditions)
@@ -2858,6 +2895,8 @@ package com.azure.storage.blob.specialized {
     public final class PageBlobAsyncClient extends BlobAsyncClientBase {
         public static final int PAGE_BYTES = BlobConstants.PAGE_BYTES;
         public static final int MAX_PUT_PAGES_BYTES = BlobConstants.MAX_PUT_PAGES_BYTES;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public Mono<PageBlobItem> clearPages(PageRange pageRange)
         public Mono<Response<PageBlobItem>> clearPagesWithResponse(PageRange pageRange, PageBlobRequestConditions pageBlobRequestConditions)
         public Mono<CopyStatusType> copyIncremental(String source, String snapshot)
@@ -2889,6 +2928,7 @@ package com.azure.storage.blob.specialized {
         public Mono<Response<PageBlobItem>> uploadPagesFromUrlWithResponse(PageRange range, String sourceUrl, Long sourceOffset, byte[] sourceContentMd5, PageBlobRequestConditions destRequestConditions, BlobRequestConditions sourceRequestConditions)
         public Mono<Response<PageBlobItem>> uploadPagesWithResponse(PageRange pageRange, Flux<ByteBuffer> body, PageBlobUploadPagesOptions options)
         @Deprecated public Mono<Response<PageBlobItem>> uploadPagesWithResponse(PageRange pageRange, Flux<ByteBuffer> body, byte[] contentMd5, PageBlobRequestConditions pageBlobRequestConditions)
+        // Non-Service Methods:
         @Override public PageBlobAsyncClient getCustomerProvidedKeyAsyncClient(CustomerProvidedKey customerProvidedKey)
         @Override public PageBlobAsyncClient getEncryptionScopeAsyncClient(String encryptionScope)
     }
@@ -2896,6 +2936,8 @@ package com.azure.storage.blob.specialized {
     public final class PageBlobClient extends BlobClientBase {
         public static final int PAGE_BYTES = BlobConstants.PAGE_BYTES;
         public static final int MAX_PUT_PAGES_BYTES = BlobConstants.MAX_PUT_PAGES_BYTES;
+        // This class does not have any public constructors, and is not able to be instantiated using 'new'.
+        // Service Methods:
         public PageBlobItem clearPages(PageRange pageRange)
         public Response<PageBlobItem> clearPagesWithResponse(PageRange pageRange, PageBlobRequestConditions pageBlobRequestConditions, Duration timeout, Context context)
         public CopyStatusType copyIncremental(String source, String snapshot)
@@ -2927,6 +2969,7 @@ package com.azure.storage.blob.specialized {
         public Response<PageBlobItem> uploadPagesFromUrlWithResponse(PageRange range, String sourceUrl, Long sourceOffset, byte[] sourceContentMd5, PageBlobRequestConditions destRequestConditions, BlobRequestConditions sourceRequestConditions, Duration timeout, Context context)
         public Response<PageBlobItem> uploadPagesWithResponse(PageRange pageRange, InputStream body, PageBlobUploadPagesOptions options, Duration timeout, Context context)
         @Deprecated public Response<PageBlobItem> uploadPagesWithResponse(PageRange pageRange, InputStream body, byte[] contentMd5, PageBlobRequestConditions pageBlobRequestConditions, Duration timeout, Context context)
+        // Non-Service Methods:
         public BlobOutputStream getBlobOutputStream(PageRange pageRange)
         public BlobOutputStream getBlobOutputStream(PageBlobOutputStreamOptions options)
         public BlobOutputStream getBlobOutputStream(PageRange pageRange, BlobRequestConditions requestConditions)


### PR DESCRIPTION
## Summary

- add compact public API snapshots for `azure-core`, `azure-storage-blob`, and `azure-analytics-planetarycomputer`
- generate each snapshot directly from its Maven sources JAR
- omit Javadoc while retaining complete API signatures and APIView comments

## Purpose

This demonstrates supplying deterministic public API input to an automated SDK reviewer instead of requiring it to discover API issues across large source trees. `azure-core` and `azure-storage-blob` were added in response to the validation request on Azure/azure-sdk-tools#16809.

Direct Markdown generation is implemented by Azure/azure-sdk-tools#16809.

| Module | Size | Lines |
|---|---:|---:|
| `azure-core` | 132 KB | 2,242 |
| `azure-storage-blob` | 219 KB | 3,019 |
| `azure-analytics-planetarycomputer` | 291 KB | 2,360 |

## Generation

```text
java -jar apiview-java-processor-<version>.jar --renderer=markdown \
  <module>-<version>-sources.jar \
  <module-directory>
```

The processor derives the Markdown filename from the sources JAR; each generated file is renamed to `api.md` for its module snapshot.

The snapshots preserve complete signatures, method groupings, API shape hints, elided initializer placeholders, and service-version value mappings needed for API review.
