### PR TITLE
Fix Text Translation custom endpoint request URLs

### DIFF
--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -57,7 +57,7 @@ com.azure:azure-ai-projects;2.4.0;2.5.0-beta.1
 com.azure:azure-ai-speech-transcription;1.0.0;1.1.0-beta.1
 com.azure:azure-ai-textanalytics;5.5.15;5.6.0-beta.1
 com.azure:azure-ai-textanalytics-perf;1.0.0-beta.1;1.0.0-beta.1
-com.azure:azure-ai-translation-text;2.0.2;2.1.0-beta.1
+com.azure:azure-ai-translation-text;2.0.2;2.0.3
 com.azure:azure-ai-translation-document;2.0.1;2.1.0-beta.1
 com.azure:azure-ai-vision-face;1.0.0-beta.2;1.0.0-beta.3
 com.azure:azure-ai-voicelive;1.1.0;1.2.0-beta.1

--- a/sdk/translation/azure-ai-translation-text/CHANGELOG.md
+++ b/sdk/translation/azure-ai-translation-text/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 2.1.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 2.0.3 (2026-08-28)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed request URLs when using custom endpoints.
 
 ## 2.0.2 (2026-08-18)
 

--- a/sdk/translation/azure-ai-translation-text/pom.xml
+++ b/sdk/translation/azure-ai-translation-text/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.azure</groupId>
   <artifactId>azure-ai-translation-text</artifactId>
-  <version>2.1.0-beta.1</version> <!-- {x-version-update;com.azure:azure-ai-translation-text;current} -->
+  <version>2.0.3</version> <!-- {x-version-update;com.azure:azure-ai-translation-text;current} -->
 
   <name>Microsoft Azure client library for Text Translation</name>
   <description>This package contains Microsoft Azure Text Translation client library.</description>

--- a/sdk/translation/azure-ai-translation-text/src/main/java/com/azure/ai/translation/text/TextTranslationClientBuilder.java
+++ b/sdk/translation/azure-ai-translation-text/src/main/java/com/azure/ai/translation/text/TextTranslationClientBuilder.java
@@ -337,7 +337,7 @@ public final class TextTranslationClientBuilder implements HttpTrait<TextTransla
         } else if (CustomEndpointUtils.isPlatformHost(endpoint)) {
             try {
                 URL hostUri = new URL(endpoint);
-                URL fullUri = new URL(hostUri, "/translator/text/v" + localServiceVersion.getVersion());
+                URL fullUri = new URL(hostUri, "/translator/text");
                 serviceEndpoint = fullUri.toString();
             } catch (MalformedURLException ex) {
                 serviceEndpoint = endpoint;

--- a/sdk/translation/azure-ai-translation-text/src/test/java/com/azure/ai/translation/text/TextTranslationClientBuilderTests.java
+++ b/sdk/translation/azure-ai-translation-text/src/test/java/com/azure/ai/translation/text/TextTranslationClientBuilderTests.java
@@ -27,7 +27,7 @@ public class TextTranslationClientBuilderTests {
     public void customEndpointUsesApiVersionQueryParameter() {
         RecordingHttpClient httpClient = new RecordingHttpClient();
         TextTranslationClient client
-            = new TextTranslationClientBuilder().endpoint("https://trsl-ats-dev-nordlb.cognitiveservices.azure.com")
+            = new TextTranslationClientBuilder().endpoint("https://fakeCustomEndpoint.cognitiveservices.azure.com")
                 .credential(new AzureKeyCredential("key"))
                 .httpClient(httpClient)
                 .buildClient();
@@ -35,7 +35,7 @@ public class TextTranslationClientBuilderTests {
         client.translate("cs", "Hello");
 
         assertEquals(
-            "https://trsl-ats-dev-nordlb.cognitiveservices.azure.com/translator/text/translate?api-version=2026-06-06",
+            "https://fakeCustomEndpoint.cognitiveservices.azure.com/translator/text/translate?api-version=2026-06-06",
             httpClient.getRequest().getUrl().toString());
     }
 

--- a/sdk/translation/azure-ai-translation-text/src/test/java/com/azure/ai/translation/text/TextTranslationClientBuilderTests.java
+++ b/sdk/translation/azure-ai-translation-text/src/test/java/com/azure/ai/translation/text/TextTranslationClientBuilderTests.java
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.ai.translation.text;
+
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.test.http.MockHttpResponse;
+import com.azure.core.util.Context;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TextTranslationClientBuilderTests {
+    private static final String TRANSLATE_RESPONSE
+        = "{\"value\":[{\"detectedLanguage\":{\"language\":\"en\",\"score\":1.0},"
+            + "\"translations\":[{\"language\":\"cs\",\"sourceCharacters\":5,\"text\":\"Ahoj\"}]}]}";
+
+    @Test
+    public void customEndpointUsesApiVersionQueryParameter() {
+        RecordingHttpClient httpClient = new RecordingHttpClient();
+        TextTranslationClient client
+            = new TextTranslationClientBuilder().endpoint("https://trsl-ats-dev-nordlb.cognitiveservices.azure.com")
+                .credential(new AzureKeyCredential("key"))
+                .httpClient(httpClient)
+                .buildClient();
+
+        client.translate("cs", "Hello");
+
+        assertEquals(
+            "https://trsl-ats-dev-nordlb.cognitiveservices.azure.com/translator/text/translate?api-version=2026-06-06",
+            httpClient.getRequest().getUrl().toString());
+    }
+
+    private static final class RecordingHttpClient implements HttpClient {
+        private HttpRequest request;
+
+        @Override
+        public Mono<HttpResponse> send(HttpRequest request) {
+            this.request = request;
+            HttpHeaders headers = new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/json");
+            return Mono
+                .just(new MockHttpResponse(request, 200, headers, TRANSLATE_RESPONSE.getBytes(StandardCharsets.UTF_8)));
+        }
+
+        @Override
+        public Mono<HttpResponse> send(HttpRequest request, Context context) {
+            return send(request);
+        }
+
+        private HttpRequest getRequest() {
+            return request;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fix Text Translation request URL construction for custom endpoints by keeping the service version in the `api-version` query parameter.
- Add a regression test that verifies the complete translation request URL.
- Prepare `azure-ai-translation-text` version `2.0.3` and update its changelog.

## Reason

Custom Cognitive Services endpoints incorrectly included the service API version in the request path, producing URLs such as `/translator/text/v2026-06-06/...`. The 2026-06-06 API expects `/translator/text/...` with `api-version=2026-06-06` in the query string.

## Validation

- Live tests passed.
- Playback tests passed: 22 tests, 0 failures, 0 errors.
- Checkstyle, SpotBugs, RevAPI, Javadoc, formatting, dependency, and changelog checks passed for version `2.0.3`.
- No SDK breaking changes detected.