### PR TITLE
Update Maven credential provider installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,10 +107,7 @@ This repository routes all Maven dependencies through an Azure Artifacts feed, w
 Internal contributors should set up the Maven credential provider to authenticate with the Azure Artifacts feed.
 
 To set up the credential provider:
-1. Bootstrap the Maven Credential Provider. Run the following command from a folder **outside** the `azure-sdk-for-java` repository:
-   ```bash
-   mvn dependency:get "-Dartifact=com.microsoft.azure:artifacts-maven-credprovider:3.1" "-DremoteRepositories=central::::https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1"
-   ```
+1. Install the Maven Credential Provider by following the [official installation instructions on 1ES EngHub](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/maven-credprovider).
 2. Add the Maven extension to `.mvn/extensions.xml` at the repository root:
    ```xml
    <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/docs/contributor/getting-started.md
+++ b/docs/contributor/getting-started.md
@@ -82,14 +82,8 @@ This repo routes Maven through an Azure Artifacts feed.
 </settings>
 ```
 
-**Internal contributors (Microsoft)** — set up the Maven Credential Provider:
-
-```bash
-# Run from outside the azure-sdk-for-java directory
-mvn dependency:get \
-  "-Dartifact=com.microsoft.azure:artifacts-maven-credprovider:3.1" \
-  "-DremoteRepositories=central::::https://pkgs.dev.azure.com/artifacts-public/PublicTools/_packaging/AzureArtifacts/maven/v1"
-```
+**Internal contributors (Microsoft)** — install the Maven Credential Provider by following the
+[official installation instructions on 1ES EngHub](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/azure-artifacts/maven-credprovider).
 
 Then add to `.mvn/extensions.xml`:
 ```xml


### PR DESCRIPTION
## Summary

- replace the inline Maven Credential Provider bootstrap command with a link to the official 1ES EngHub installation instructions
- keep the repository-specific Maven extension configuration steps unchanged

## Motivation

The official installation documentation is the authoritative source for setting up the credential provider and can remain current as the installation process evolves.

## Testing

Not applicable; documentation-only change.