### PR TITLE
[Storage] Increment versions post Storage patch

### DIFF
--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -200,7 +200,7 @@ com.azure.v2:azure-sdk-template-three;1.0.0-beta.1;1.0.0-beta.1
 com.azure:azure-storage-blob;12.35.1;12.36.0-beta.2
 com.azure:azure-storage-blob-batch;12.31.1;12.32.0-beta.2
 com.azure:azure-storage-blob-changefeed;12.0.0-beta.39;12.0.0-beta.40
-com.azure:azure-storage-blob-cryptography;12.34.1;12.35.0-beta.2
+com.azure:azure-storage-blob-cryptography;12.34.0;12.34.2
 com.azure:azure-storage-blob-nio;12.0.0-beta.40;12.0.0-beta.41
 com.azure:azure-storage-common;12.34.1;12.35.0-beta.2
 com.azure:azure-storage-file-share;12.31.1;12.32.0-beta.2

--- a/eng/versioning/version_client.txt
+++ b/eng/versioning/version_client.txt
@@ -200,7 +200,7 @@ com.azure.v2:azure-sdk-template-three;1.0.0-beta.1;1.0.0-beta.1
 com.azure:azure-storage-blob;12.35.1;12.36.0-beta.2
 com.azure:azure-storage-blob-batch;12.31.1;12.32.0-beta.2
 com.azure:azure-storage-blob-changefeed;12.0.0-beta.39;12.0.0-beta.40
-com.azure:azure-storage-blob-cryptography;12.34.0;12.34.2
+com.azure:azure-storage-blob-cryptography;12.34.2;12.35.0-beta.2
 com.azure:azure-storage-blob-nio;12.0.0-beta.40;12.0.0-beta.41
 com.azure:azure-storage-common;12.34.1;12.35.0-beta.2
 com.azure:azure-storage-file-share;12.31.1;12.32.0-beta.2

--- a/sdk/storage/azure-storage-blob-cryptography/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob-cryptography/CHANGELOG.md
@@ -7,6 +7,12 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+
+### Other Changes
+
+## 12.34.2 (2026-08-26)
+
+### Bugs Fixed
 - Fixed a bug where client-side encryption 2.0 could not detect a rearrangement of otherwise-untampered authenticated regions in blob content. This is now detected and an exception is thrown. For data recovery purposes, this behavior can be reverted by setting the `AZURE_STORAGE_CSE_V2_ALLOW_MISORDERED_AUTH_REGIONS` environment variable (or the `Azure.Storage.CseV2AllowMisorderedAuthRegions` system property) to `true`.
 - Fixed an issue where the client-side encryption (v2) region nonce counter was truncated to 32 bits, which could
   cause GCM nonce reuse for blobs exceeding 2^32 authenticated regions. The full 64-bit region index is now used so

--- a/sdk/storage/azure-storage-blob-cryptography/README.md
+++ b/sdk/storage/azure-storage-blob-cryptography/README.md
@@ -58,7 +58,7 @@ add the direct dependency to your project as follows.
 <dependency>
   <groupId>com.azure</groupId>
   <artifactId>azure-storage-blob-cryptography</artifactId>
-  <version>12.34.2</version>
+  <version>12.35.0-beta.2</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/storage/azure-storage-blob-cryptography/README.md
+++ b/sdk/storage/azure-storage-blob-cryptography/README.md
@@ -58,7 +58,7 @@ add the direct dependency to your project as follows.
 <dependency>
   <groupId>com.azure</groupId>
   <artifactId>azure-storage-blob-cryptography</artifactId>
-  <version>12.35.0-beta.1</version>
+  <version>12.34.2</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/storage/azure-storage-blob-cryptography/pom.xml
+++ b/sdk/storage/azure-storage-blob-cryptography/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.azure</groupId>
   <artifactId>azure-storage-blob-cryptography</artifactId>
-  <version>12.34.2</version> <!-- {x-version-update;com.azure:azure-storage-blob-cryptography;current} -->
+  <version>12.35.0-beta.2</version> <!-- {x-version-update;com.azure:azure-storage-blob-cryptography;current} -->
 
   <name>Microsoft Azure client library for Blob Storage cryptography</name>
   <description>This module contains client library for Microsoft Azure Blob Storage cryptography.</description>

--- a/sdk/storage/azure-storage-blob-cryptography/pom.xml
+++ b/sdk/storage/azure-storage-blob-cryptography/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.azure</groupId>
   <artifactId>azure-storage-blob-cryptography</artifactId>
-  <version>12.35.0-beta.2</version> <!-- {x-version-update;com.azure:azure-storage-blob-cryptography;current} -->
+  <version>12.34.2</version> <!-- {x-version-update;com.azure:azure-storage-blob-cryptography;current} -->
 
   <name>Microsoft Azure client library for Blob Storage cryptography</name>
   <description>This module contains client library for Microsoft Azure Blob Storage cryptography.</description>

--- a/sdk/storage/azure-storage-perf/pom.xml
+++ b/sdk/storage/azure-storage-perf/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-storage-blob-cryptography</artifactId>
-      <version>12.35.0-beta.2</version> <!-- {x-version-update;com.azure:azure-storage-blob-cryptography;current} -->
+      <version>12.34.2</version> <!-- {x-version-update;com.azure:azure-storage-blob-cryptography;current} -->
     </dependency>
 
     <dependency>

--- a/sdk/storage/azure-storage-perf/pom.xml
+++ b/sdk/storage/azure-storage-perf/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-storage-blob-cryptography</artifactId>
-      <version>12.34.2</version> <!-- {x-version-update;com.azure:azure-storage-blob-cryptography;current} -->
+      <version>12.35.0-beta.2</version> <!-- {x-version-update;com.azure:azure-storage-blob-cryptography;current} -->
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Version update PR for Storage's August 2026 crypto package patch. [Autogenerated](https://github.com/Azure/azure-sdk-for-java/pull/50258) PR pointed to the release branch instead of main. 