### PR TITLE
Close gaps in functionality between annotation-processor and Java TypeSpec generator

### DIFF
--- a/sdk/clientcore/annotation-processor-test/CHANGELOG.md
+++ b/sdk/clientcore/annotation-processor-test/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Release History
 
 ## 1.0.0-beta.1 (Unreleased)
+
+### Other Changes
+- Expanded annotation processor integration coverage for forms, multipart payloads, typed responses, streaming bodies,
+  response lifecycle, headers, and server-sent events.

--- a/sdk/clientcore/annotation-processor-test/pom.xml
+++ b/sdk/clientcore/annotation-processor-test/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>io.clientcore</groupId>
       <artifactId>core</artifactId>
-      <version>1.0.0-beta.11</version> <!-- {x-version-update;io.clientcore:core;dependency} -->
+      <version>1.0.0-beta.12</version> <!-- {x-version-update;io.clientcore:core;dependency} -->
     </dependency>
     <dependency>
       <groupId>io.clientcore</groupId>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>io.clientcore</groupId>
       <artifactId>core</artifactId>
-      <version>1.0.0-beta.11</version> <!-- {x-version-update;io.clientcore:core;dependency} -->
+      <version>1.0.0-beta.12</version> <!-- {x-version-update;io.clientcore:core;dependency} -->
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -132,7 +132,7 @@
                 <annotationProcessorPath>
                   <groupId>io.clientcore</groupId>
                   <artifactId>annotation-processor</artifactId>
-                  <version>1.0.0-beta.4</version> <!-- {x-version-update;io.clientcore:annotation-processor;dependency} -->
+                  <version>1.0.0-beta.5</version> <!-- {x-version-update;io.clientcore:annotation-processor;dependency} -->
                 </annotationProcessorPath>
               </annotationProcessorPaths>
               <annotationProcessors>
@@ -153,7 +153,7 @@
           <dependency>
             <groupId>io.clientcore</groupId>
             <artifactId>annotation-processor</artifactId>
-            <version>1.0.0-beta.4</version> <!-- {x-version-update;io.clientcore:annotation-processor;dependency} -->
+            <version>1.0.0-beta.5</version> <!-- {x-version-update;io.clientcore:annotation-processor;dependency} -->
           </dependency>
         </dependencies>
       </plugin>

--- a/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/HostEdgeCase1ServiceImpl.java
+++ b/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/HostEdgeCase1ServiceImpl.java
@@ -14,6 +14,10 @@ import io.clientcore.core.instrumentation.logging.ClientLogger;
 import io.clientcore.core.serialization.json.JsonSerializer;
 import io.clientcore.core.serialization.xml.XmlSerializer;
 import io.clientcore.core.utils.GeneratedCodeUtils;
+import java.util.Arrays;
+import java.util.Base64;
+import io.clientcore.core.utils.CoreUtils;
+import io.clientcore.core.serialization.SerializationFormat;
 
 /**
  * Initializes a new instance of the HostEdgeCase1ServiceImpl type.
@@ -43,21 +47,23 @@ public class HostEdgeCase1ServiceImpl implements HostEdgeCase1Service {
         return new HostEdgeCase1ServiceImpl(httpPipeline);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public byte[] getByteArray(String url, int numberOfBytes) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(url + "/bytes/" + numberOfBytes);
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((url == null ? "" : url) + "/bytes/" + UriEscapers.PATH_ESCAPER.escape(String.valueOf(numberOfBytes)));
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            BinaryData responseBody = networkResponse.getValue();
-            return responseBody != null ? responseBody.toBytes() : null;
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            BinaryData responseBody = networkResponseToClose.getValue();
+            byte[] responseBytes = responseBody != null ? responseBody.toBytes() : null;
+            boolean quotedBase64 = responseBytes != null && responseBytes.length >= 2 && responseBytes[0] == '"' && responseBytes[responseBytes.length - 1] == '"' && GeneratedCodeUtils.isJsonContentType(networkResponseToClose.getHeaders());
+            return quotedBase64 ? Base64.getDecoder().decode(Arrays.copyOfRange(responseBytes, 1, responseBytes.length - 1)) : responseBytes;
         }
     }
 }

--- a/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/HostEdgeCase2ServiceImpl.java
+++ b/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/HostEdgeCase2ServiceImpl.java
@@ -14,6 +14,10 @@ import io.clientcore.core.instrumentation.logging.ClientLogger;
 import io.clientcore.core.serialization.json.JsonSerializer;
 import io.clientcore.core.serialization.xml.XmlSerializer;
 import io.clientcore.core.utils.GeneratedCodeUtils;
+import java.util.Arrays;
+import java.util.Base64;
+import io.clientcore.core.utils.CoreUtils;
+import io.clientcore.core.serialization.SerializationFormat;
 
 /**
  * Initializes a new instance of the HostEdgeCase2ServiceImpl type.
@@ -43,21 +47,23 @@ public class HostEdgeCase2ServiceImpl implements HostEdgeCase2Service {
         return new HostEdgeCase2ServiceImpl(httpPipeline);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public byte[] getByteArray(String uri, int numberOfBytes) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri + "/bytes/" + numberOfBytes);
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((uri == null ? "" : uri) + "/bytes/" + UriEscapers.PATH_ESCAPER.escape(String.valueOf(numberOfBytes)));
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            BinaryData responseBody = networkResponse.getValue();
-            return responseBody != null ? responseBody.toBytes() : null;
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            BinaryData responseBody = networkResponseToClose.getValue();
+            byte[] responseBytes = responseBody != null ? responseBody.toBytes() : null;
+            boolean quotedBase64 = responseBytes != null && responseBytes.length >= 2 && responseBytes[0] == '"' && responseBytes[responseBytes.length - 1] == '"' && GeneratedCodeUtils.isJsonContentType(networkResponseToClose.getHeaders());
+            return quotedBase64 ? Base64.getDecoder().decode(Arrays.copyOfRange(responseBytes, 1, responseBytes.length - 1)) : responseBytes;
         }
     }
 }

--- a/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/HostPathEdgeCase3ServiceImpl.java
+++ b/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/HostPathEdgeCase3ServiceImpl.java
@@ -44,22 +44,22 @@ public class HostPathEdgeCase3ServiceImpl implements HostPathEdgeCase3Service {
         return new HostPathEdgeCase3ServiceImpl(httpPipeline);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<Void> noOperationParams(String endpoint, String apiVersion, RequestContext requestContext) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(endpoint + "/server/path/multiple/" + apiVersion + "/");
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((endpoint == null ? "" : endpoint) + "/server/path/multiple/" + (apiVersion == null ? "" : apiVersion) + "/");
         httpRequest.setContext(requestContext);
         httpRequest.getContext().getRequestCallback().accept(httpRequest);
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 204;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), null);
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 204;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), null);
         }
     }
 }

--- a/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/ParameterizedHostServiceImpl.java
+++ b/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/ParameterizedHostServiceImpl.java
@@ -14,6 +14,10 @@ import io.clientcore.core.instrumentation.logging.ClientLogger;
 import io.clientcore.core.serialization.json.JsonSerializer;
 import io.clientcore.core.serialization.xml.XmlSerializer;
 import io.clientcore.core.utils.GeneratedCodeUtils;
+import java.util.Arrays;
+import java.util.Base64;
+import io.clientcore.core.utils.CoreUtils;
+import io.clientcore.core.serialization.SerializationFormat;
 
 /**
  * Initializes a new instance of the ParameterizedHostServiceImpl type.
@@ -43,21 +47,23 @@ public class ParameterizedHostServiceImpl implements ParameterizedHostService {
         return new ParameterizedHostServiceImpl(httpPipeline);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public byte[] getByteArray(String scheme, String host, int numberOfBytes) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(scheme + "://" + host + "/bytes/" + numberOfBytes);
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((scheme == null ? "" : scheme) + "://" + (host == null ? "" : host) + "/bytes/" + UriEscapers.PATH_ESCAPER.escape(String.valueOf(numberOfBytes)));
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            BinaryData responseBody = networkResponse.getValue();
-            return responseBody != null ? responseBody.toBytes() : null;
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            BinaryData responseBody = networkResponseToClose.getValue();
+            byte[] responseBytes = responseBody != null ? responseBody.toBytes() : null;
+            boolean quotedBase64 = responseBytes != null && responseBytes.length >= 2 && responseBytes[0] == '"' && responseBytes[responseBytes.length - 1] == '"' && GeneratedCodeUtils.isJsonContentType(networkResponseToClose.getHeaders());
+            return quotedBase64 ? Base64.getDecoder().decode(Arrays.copyOfRange(responseBytes, 1, responseBytes.length - 1)) : responseBytes;
         }
     }
 }

--- a/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/ParameterizedMultipleHostServiceImpl.java
+++ b/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/ParameterizedMultipleHostServiceImpl.java
@@ -47,11 +47,10 @@ public class ParameterizedMultipleHostServiceImpl implements ParameterizedMultip
         return new ParameterizedMultipleHostServiceImpl(httpPipeline);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON get(String scheme, String hostPart1, String hostPart2) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(scheme + "://" + hostPart1 + hostPart2 + "/get");
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((scheme == null ? "" : scheme) + "://" + (hostPart1 == null ? "" : hostPart1) + (hostPart2 == null ? "" : hostPart2) + "/get");
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -59,18 +58,19 @@ public class ParameterizedMultipleHostServiceImpl implements ParameterizedMultip
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 }

--- a/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/SimpleXmlSerializableServiceImpl.java
+++ b/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/SimpleXmlSerializableServiceImpl.java
@@ -17,6 +17,7 @@ import io.clientcore.core.serialization.xml.XmlSerializer;
 import io.clientcore.core.serialization.SerializationFormat;
 import io.clientcore.core.utils.CoreUtils;
 import io.clientcore.core.utils.GeneratedCodeUtils;
+import io.clientcore.core.http.models.HttpHeader;
 import java.lang.reflect.ParameterizedType;
 
 /**
@@ -47,15 +48,14 @@ public class SimpleXmlSerializableServiceImpl implements SimpleXmlSerializableSe
         return new SimpleXmlSerializableServiceImpl(httpPipeline);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void sendApplicationXml(SimpleXmlSerializable simpleXmlSerializable) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri("http://localhost/sendApplicationXml");
         if (simpleXmlSerializable != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/xml");
-            SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-            if (xmlSerializer.supportsFormat(serializationFormat)) {
+            SerializationFormat requestSerializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
+            if (xmlSerializer.supportsFormat(requestSerializationFormat)) {
                 httpRequest.setBody(BinaryData.fromObject(simpleXmlSerializable, xmlSerializer));
             } else {
                 httpRequest.setBody(BinaryData.fromObject(simpleXmlSerializable, jsonSerializer));
@@ -68,20 +68,18 @@ public class SimpleXmlSerializableServiceImpl implements SimpleXmlSerializableSe
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void sendTextXml(SimpleXmlSerializable simpleXmlSerializable) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri("http://localhost/sendTextXml");
         if (simpleXmlSerializable != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "text/xml");
-            SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-            if (xmlSerializer.supportsFormat(serializationFormat)) {
+            SerializationFormat requestSerializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
+            if (xmlSerializer.supportsFormat(requestSerializationFormat)) {
                 httpRequest.setBody(BinaryData.fromObject(simpleXmlSerializable, xmlSerializer));
             } else {
                 httpRequest.setBody(BinaryData.fromObject(simpleXmlSerializable, jsonSerializer));
@@ -94,16 +92,17 @@ public class SimpleXmlSerializableServiceImpl implements SimpleXmlSerializableSe
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public SimpleXmlSerializable getXml(String contentType) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri("http://localhost/getXml");
+        if (contentType != null) {
+            httpRequest.getHeaders().add(new HttpHeader(HttpHeaderName.CONTENT_TYPE, contentType));
+        }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -111,26 +110,29 @@ public class SimpleXmlSerializableServiceImpl implements SimpleXmlSerializableSe
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        SimpleXmlSerializable deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(SimpleXmlSerializable.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            SimpleXmlSerializable deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.SimpleXmlSerializable.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public SimpleXmlSerializable getInvalidXml(String contentType) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri("http://localhost/getInvalidXml");
+        if (contentType != null) {
+            httpRequest.getHeaders().add(new HttpHeader(HttpHeaderName.CONTENT_TYPE, contentType));
+        }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -138,18 +140,19 @@ public class SimpleXmlSerializableServiceImpl implements SimpleXmlSerializableSe
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        SimpleXmlSerializable deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(SimpleXmlSerializable.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            SimpleXmlSerializable deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.SimpleXmlSerializable.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 }

--- a/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/SpecialReturnBodiesServiceImpl.java
+++ b/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/SpecialReturnBodiesServiceImpl.java
@@ -18,9 +18,11 @@ import io.clientcore.core.instrumentation.logging.ClientLogger;
 import io.clientcore.core.serialization.json.JsonSerializer;
 import io.clientcore.core.serialization.xml.XmlSerializer;
 import io.clientcore.core.utils.GeneratedCodeUtils;
+import java.util.Arrays;
+import java.util.Base64;
 import io.clientcore.core.utils.CoreUtils;
-import java.lang.reflect.ParameterizedType;
 import io.clientcore.core.serialization.SerializationFormat;
+import java.lang.reflect.ParameterizedType;
 import io.clientcore.core.utils.Base64Uri;
 import io.clientcore.core.http.models.HttpHeader;
 import java.time.format.DateTimeFormatter;
@@ -55,11 +57,10 @@ public class SpecialReturnBodiesServiceImpl implements SpecialReturnBodiesServic
         return new SpecialReturnBodiesServiceImpl(httpPipeline);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public BinaryData getBinaryData(String url) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(url + "/bytes");
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((url == null ? "" : url) + "/bytes");
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -67,16 +68,14 @@ public class SpecialReturnBodiesServiceImpl implements SpecialReturnBodiesServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         return networkResponse.getValue();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<BinaryData> getBinaryDataWithResponse(String url) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(url + "/bytes");
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((url == null ? "" : url) + "/bytes");
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -84,52 +83,14 @@ public class SpecialReturnBodiesServiceImpl implements SpecialReturnBodiesServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         return networkResponse;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public byte[] getByteArray(String url) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(url + "/bytes");
-        // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            BinaryData responseBody = networkResponse.getValue();
-            return responseBody != null ? responseBody.toBytes() : null;
-        }
-    }
-
-    @SuppressWarnings("cast")
-    @Override
-    public Response<byte[]> getByteArrayWithResponse(String url) {
-        // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(url + "/bytes");
-        // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            BinaryData responseBody = networkResponse.getValue();
-            return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), responseBody != null ? responseBody.toBytes() : null);
-        }
-    }
-
-    @SuppressWarnings("cast")
-    @Override
-    public InputStream getInputStream(String url) {
-        // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(url + "/bytes");
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((url == null ? "" : url) + "/bytes");
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -137,16 +98,54 @@ public class SpecialReturnBodiesServiceImpl implements SpecialReturnBodiesServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            BinaryData responseBody = networkResponseToClose.getValue();
+            byte[] responseBytes = responseBody != null ? responseBody.toBytes() : null;
+            boolean quotedBase64 = responseBytes != null && responseBytes.length >= 2 && responseBytes[0] == '"' && responseBytes[responseBytes.length - 1] == '"' && GeneratedCodeUtils.isJsonContentType(networkResponseToClose.getHeaders());
+            return quotedBase64 ? Base64.getDecoder().decode(Arrays.copyOfRange(responseBytes, 1, responseBytes.length - 1)) : responseBytes;
+        }
+    }
+
+    @Override
+    public Response<byte[]> getByteArrayWithResponse(String url) {
+        // Create the HttpRequest.
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((url == null ? "" : url) + "/bytes");
+        // Send the request through the httpPipeline
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            BinaryData responseBody = networkResponseToClose.getValue();
+            byte[] responseBytes = responseBody != null ? responseBody.toBytes() : null;
+            boolean quotedBase64 = responseBytes != null && responseBytes.length >= 2 && responseBytes[0] == '"' && responseBytes[responseBytes.length - 1] == '"' && GeneratedCodeUtils.isJsonContentType(networkResponseToClose.getHeaders());
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), quotedBase64 ? Base64.getDecoder().decode(Arrays.copyOfRange(responseBytes, 1, responseBytes.length - 1)) : responseBytes);
+        }
+    }
+
+    @Override
+    public InputStream getInputStream(String url) {
+        // Create the HttpRequest.
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((url == null ? "" : url) + "/bytes");
+        // Send the request through the httpPipeline
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
         }
         return networkResponse.getValue().toStream();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<InputStream> getInputStreamWithResponse(String url) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(url + "/bytes");
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((url == null ? "" : url) + "/bytes");
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -154,16 +153,14 @@ public class SpecialReturnBodiesServiceImpl implements SpecialReturnBodiesServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), networkResponse.getValue().toStream());
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<List<BinaryData>> getListOfBinaryData(String endpoint) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(endpoint + "/type/array/unknown");
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((endpoint == null ? "" : endpoint) + "/type/array/unknown");
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -171,92 +168,142 @@ public class SpecialReturnBodiesServiceImpl implements SpecialReturnBodiesServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         List<BinaryData> deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(List.class, BinaryData.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
+        ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, CoreUtils.createParameterizedType(java.util.List.class, io.clientcore.core.models.binarydata.BinaryData.class));
+        SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
+        if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
             deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
+        } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
             deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
         } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
         }
         networkResponse.close();
         return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<byte[]> base64url(String endpoint, String contentType, byte[] value) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(endpoint + "/encode/bytes/body/response/base64url");
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((endpoint == null ? "" : endpoint) + "/encode/bytes/body/response/base64url");
         if (value != null) {
-            httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, contentType);
-            SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-            if (xmlSerializer.supportsFormat(serializationFormat)) {
-                httpRequest.setBody(BinaryData.fromObject(value, xmlSerializer));
-            } else {
+            if (contentType != null) {
+                httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, contentType);
+            }
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
                 httpRequest.setBody(BinaryData.fromObject(value, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromBytes(value));
             }
         }
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            BinaryData responseBody = networkResponse.getValue();
-            return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), responseBody != null ? new Base64Uri(responseBody.toBytes()).decodedBytes() : null);
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            BinaryData responseBody = networkResponseToClose.getValue();
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), responseBody != null ? new Base64Uri(responseBody.toBytes()).decodedBytes() : null);
         }
     }
 
-    @SuppressWarnings("cast")
+    @Override
+    public Response<byte[]> base64(String endpoint) {
+        // Create the HttpRequest.
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((endpoint == null ? "" : endpoint) + "/encode/bytes/body/response/base64");
+        // Send the request through the httpPipeline
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            BinaryData responseBody = networkResponseToClose.getValue();
+            byte[] responseBytes = responseBody != null ? responseBody.toBytes() : null;
+            boolean quotedBase64 = responseBytes != null && responseBytes.length >= 2 && responseBytes[0] == '"' && responseBytes[responseBytes.length - 1] == '"' && GeneratedCodeUtils.isJsonContentType(networkResponseToClose.getHeaders());
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), quotedBase64 ? Base64.getDecoder().decode(Arrays.copyOfRange(responseBytes, 1, responseBytes.length - 1)) : responseBytes);
+        }
+    }
+
+    @Override
+    public Response<String> getText(String endpoint) {
+        // Create the HttpRequest.
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((endpoint == null ? "" : endpoint) + "/text");
+        // Send the request through the httpPipeline
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            String deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, java.lang.String.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (responseSerializationFormat == SerializationFormat.TEXT) {
+                BinaryData responseBody = networkResponseToClose.getValue();
+                deserializedResult = responseBody == null ? null : responseBody.toString();
+            } else if (jsonSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
+        }
+    }
+
     @Override
     public Response<Void> rfc3339(String endpoint, OffsetDateTime value) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(endpoint + "/encode/datetime/header/rfc3339");
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri((endpoint == null ? "" : endpoint) + "/encode/datetime/header/rfc3339");
         if (value != null) {
             httpRequest.getHeaders().add(new HttpHeader(VALUE, value.format(DateTimeFormatter.ISO_INSTANT)));
         }
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 204;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), null);
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 204;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), null);
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<Void> omit(String endpoint, Foo body) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.POST).setUri(endpoint + "/parameters/body-optionality/optional-explicit/omit");
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.POST).setUri((endpoint == null ? "" : endpoint) + "/parameters/body-optionality/optional-explicit/omit");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/json");
-            SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-            if (xmlSerializer.supportsFormat(serializationFormat)) {
+            SerializationFormat requestSerializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
+            if (xmlSerializer.supportsFormat(requestSerializationFormat)) {
                 httpRequest.setBody(BinaryData.fromObject(body, xmlSerializer));
             } else {
                 httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
             }
         }
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 204;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), null);
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 204;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), null);
         }
     }
 }

--- a/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/implementation/SpecialReturnBodiesService.java
+++ b/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/implementation/SpecialReturnBodiesService.java
@@ -136,6 +136,27 @@ public interface SpecialReturnBodiesService {
         @BodyParam("application/json") byte[] value);
 
     /**
+     * Gets standard Base64 encoded binary data from the specified URL.
+     *
+     * @param endpoint The URL.
+     * @return A response containing decoded binary data.
+     */
+    @HttpRequestInformation(
+        method = HttpMethod.GET,
+        path = "/encode/bytes/body/response/base64",
+        expectedStatusCodes = { 200 })
+    Response<byte[]> base64(@HostParam("url") String endpoint);
+
+    /**
+     * Gets a plain text response from the specified URL.
+     *
+     * @param endpoint The URL.
+     * @return A response containing the text body.
+     */
+    @HttpRequestInformation(method = HttpMethod.GET, path = "/text", expectedStatusCodes = { 200 })
+    Response<String> getText(@HostParam("url") String endpoint);
+
+    /**
      * Gets Base64 encoded binary data from the specified URL.
      * @param endpoint The URL.
      * @param value The value to encode.

--- a/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/implementation/TestInterfaceClientImpl.java
+++ b/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/implementation/TestInterfaceClientImpl.java
@@ -10,6 +10,7 @@ import io.clientcore.annotation.processor.test.implementation.models.ServiceErro
 import io.clientcore.annotation.processor.test.implementation.models.OperationError;
 import io.clientcore.core.annotations.ServiceInterface;
 import io.clientcore.core.http.annotations.BodyParam;
+import io.clientcore.core.http.annotations.FormParam;
 import io.clientcore.core.http.annotations.HeaderParam;
 import io.clientcore.core.http.annotations.HostParam;
 import io.clientcore.core.http.annotations.HttpRequestInformation;
@@ -91,6 +92,9 @@ public final class TestInterfaceClientImpl {
         @HttpRequestInformation(method = HttpMethod.GET, path = "{nextLink}", expectedStatusCodes = { 200 })
         Response<List<Foo>> listNextFoo(@PathParam(value = "nextLink", encoded = true) String nextLink,
             RequestContext requestContext);
+
+        @HttpRequestInformation(method = HttpMethod.GET, path = "foo-map", expectedStatusCodes = { 200 })
+        Response<Map<String, Foo>> getFooMap(@HostParam("uri") String uri);
 
         // HttpClientTests
         // Need to add RequestContext to specify ResponseBodyMode, which is otherwise provided by convenience methods
@@ -276,6 +280,14 @@ public final class TestInterfaceClientImpl {
 
         @HttpRequestInformation(method = HttpMethod.PUT, path = "put")
         HttpBinJSON put(@HostParam("uri") String uri, @HeaderParam("ABC") Map<String, String> headerCollection);
+
+        @HttpRequestInformation(method = HttpMethod.POST, path = "form", expectedStatusCodes = { 200 })
+        Response<Void> submitForm(@HostParam("uri") String uri, @FormParam("display name") String displayName,
+            @FormParam(value = "alreadyEncoded", encoded = true) String alreadyEncoded);
+
+        @HttpRequestInformation(method = HttpMethod.POST, path = "multipart", expectedStatusCodes = { 200 })
+        Response<Void> submitMultipart(@HostParam("uri") String uri,
+            @HeaderParam("Content-Type") String mediaType, @BodyParam("multipart/form-data") BinaryData body);
 
         @HttpRequestInformation(method = HttpMethod.HEAD, path = "voideagerreadoom", expectedStatusCodes = { 200 })
         void headvoid(@HostParam("uri") String uri);

--- a/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/implementation/TestInterfaceClientServiceImpl.java
+++ b/sdk/clientcore/annotation-processor-test/src/main/java/io/clientcore/annotation/processor/test/implementation/TestInterfaceClientServiceImpl.java
@@ -30,6 +30,8 @@ import io.clientcore.core.utils.UriBuilder;
 import java.util.HashMap;
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
+import java.util.Base64;
+import java.util.ArrayList;
 
 /**
  * Initializes a new instance of the TestInterfaceClientServiceImpl type.
@@ -37,8 +39,6 @@ import java.util.Arrays;
 public class TestInterfaceClientServiceImpl implements TestInterfaceClientService {
 
     private static final HttpHeaderName A = HttpHeaderName.fromString("a");
-
-    private static final HttpHeaderName ABC = HttpHeaderName.fromString("ABC");
 
     private static final HttpHeaderName B = HttpHeaderName.fromString("b");
 
@@ -71,7 +71,6 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         return new TestInterfaceClientServiceImpl(httpPipeline);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<Void> testMethod(String uri, ByteBuffer request, String contentType, Long contentLength) {
         // Create the HttpRequest.
@@ -80,22 +79,24 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
             httpRequest.getHeaders().add(new HttpHeader(HttpHeaderName.CONTENT_LENGTH, String.valueOf(contentLength)));
         }
         if (request != null) {
-            httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, contentType);
-            httpRequest.setBody(BinaryData.fromBytes(request.array()));
+            if (contentType != null) {
+                httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, contentType);
+            }
+            httpRequest.setBody(BinaryData.fromBytes(io.clientcore.core.implementation.utils.ImplUtils.byteBufferToArray(request.duplicate())));
         }
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), null);
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), null);
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<Void> testMethod(String uri, BinaryData data, String contentType, Long contentLength) {
         // Create the HttpRequest.
@@ -104,64 +105,68 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
             httpRequest.getHeaders().add(new HttpHeader(HttpHeaderName.CONTENT_LENGTH, String.valueOf(contentLength)));
         }
         if (data != null) {
-            httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, contentType);
-            BinaryData binaryData = data;
-            if (binaryData.getLength() != null) {
-                httpRequest.getHeaders().set(HttpHeaderName.CONTENT_LENGTH, String.valueOf(binaryData.getLength()));
-                httpRequest.setBody(binaryData);
+            if (contentType != null) {
+                httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, contentType);
             }
+            BinaryData binaryData = data;
+            if (binaryData.getLength() != null && httpRequest.getHeaders().get(HttpHeaderName.CONTENT_LENGTH) == null) {
+                httpRequest.getHeaders().set(HttpHeaderName.CONTENT_LENGTH, String.valueOf(binaryData.getLength()));
+            }
+            httpRequest.setBody(binaryData);
         }
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), null);
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), null);
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<Void> testListNext(String nextLink) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(nextLink);
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), null);
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), null);
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Void testMethodReturnsVoid(String uri) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri + "/" + "my/uri/path");
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try {
             return null;
+        } finally {
+            networkResponse.close();
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<Foo> getFoo(String key, String label, String syncToken) {
         // Append the query parameters.
-        UriBuilder uri = UriBuilder.parse("kv/" + UriEscapers.PATH_ESCAPER.escape(key));
+        UriBuilder uri = UriBuilder.parse("kv/" + (key == null ? "" : UriEscapers.PATH_ESCAPER.escape(key)));
         GeneratedCodeUtils.addQueryParameter(uri, "label", true, label, true);
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri.toString());
@@ -178,22 +183,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
             statusToExceptionTypeMap.put(403, CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.OperationError.class));
             java.lang.reflect.ParameterizedType defaultErrorBodyType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.ServiceError.class);
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, defaultErrorBodyType, statusToExceptionTypeMap, LOGGER);
-            networkResponse.close();
         }
-        Foo deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, Foo.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            Foo deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, io.clientcore.annotation.processor.test.implementation.models.Foo.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
         }
-        return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<FooListResult> listFooListResult(String uri, RequestContext requestContext) {
         // Create the HttpRequest.
@@ -207,22 +212,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        FooListResult deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, FooListResult.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            FooListResult deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, io.clientcore.annotation.processor.test.implementation.models.FooListResult.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
         }
-        return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<FooListResult> listNextFooListResult(String nextLink, RequestContext requestContext) {
         // Create the HttpRequest.
@@ -236,22 +241,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        FooListResult deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, FooListResult.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            FooListResult deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, io.clientcore.annotation.processor.test.implementation.models.FooListResult.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
         }
-        return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<List<Foo>> listFoo(String uri, List<String> tags, List<String> tags2, RequestContext requestContext) {
         // Append the query parameters.
@@ -269,22 +274,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        List<Foo> deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(List.class, Foo.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            List<Foo> deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, CoreUtils.createParameterizedType(java.util.List.class, io.clientcore.annotation.processor.test.implementation.models.Foo.class));
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
         }
-        return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<List<Foo>> listNextFoo(String nextLink, RequestContext requestContext) {
         // Create the HttpRequest.
@@ -298,29 +303,56 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        List<Foo> deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(List.class, Foo.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            List<Foo> deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, CoreUtils.createParameterizedType(java.util.List.class, io.clientcore.annotation.processor.test.implementation.models.Foo.class));
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
         }
-        return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
+    @Override
+    public Response<Map<String, Foo>> getFooMap(String uri) {
+        // Create the HttpRequest.
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri + "/" + "foo-map");
+        // Send the request through the httpPipeline
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            Map<String, Foo> deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, CoreUtils.createParameterizedType(java.util.Map.class, java.lang.String.class, io.clientcore.annotation.processor.test.implementation.models.Foo.class));
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
+        }
+    }
+
     @Override
     public Response<HttpBinJSON> putResponse(String uri, int putBody, RequestContext requestContext) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-        if (xmlSerializer.supportsFormat(serializationFormat)) {
+        SerializationFormat requestSerializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
+        if (xmlSerializer.supportsFormat(requestSerializationFormat)) {
             httpRequest.setBody(BinaryData.fromObject(putBody, xmlSerializer));
         } else {
             httpRequest.setBody(BinaryData.fromObject(putBody, jsonSerializer));
@@ -334,28 +366,29 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, HttpBinJSON.class);
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
         }
-        return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<HttpBinJSON> postStreamResponse(String uri, int putBody, RequestContext requestContext) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.POST).setUri(uri + "/" + "stream");
         httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-        if (xmlSerializer.supportsFormat(serializationFormat)) {
+        SerializationFormat requestSerializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
+        if (xmlSerializer.supportsFormat(requestSerializationFormat)) {
             httpRequest.setBody(BinaryData.fromObject(putBody, xmlSerializer));
         } else {
             httpRequest.setBody(BinaryData.fromObject(putBody, jsonSerializer));
@@ -369,39 +402,42 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, HttpBinJSON.class);
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
         }
-        return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public byte[] getByteArray(String uri) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri + "/" + "bytes/100");
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            BinaryData responseBody = networkResponse.getValue();
-            return responseBody != null ? responseBody.toBytes() : null;
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            BinaryData responseBody = networkResponseToClose.getValue();
+            byte[] responseBytes = responseBody != null ? responseBody.toBytes() : null;
+            boolean quotedBase64 = responseBytes != null && responseBytes.length >= 2 && responseBytes[0] == '"' && responseBytes[responseBytes.length - 1] == '"' && GeneratedCodeUtils.isJsonContentType(networkResponseToClose.getHeaders());
+            return quotedBase64 ? Base64.getDecoder().decode(Arrays.copyOfRange(responseBytes, 1, responseBytes.length - 1)) : responseBytes;
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void getNothing(String uri) {
         // Create the HttpRequest.
@@ -413,12 +449,10 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON getAnything(String uri) {
         // Create the HttpRequest.
@@ -430,22 +464,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON getAnythingWithPlus(String uri) {
         // Create the HttpRequest.
@@ -457,26 +491,26 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON getAnythingWithPathParam(String uri, String pathParam) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri + "/" + "anything/" + UriEscapers.PATH_ESCAPER.escape(pathParam));
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri + "/" + "anything/" + (pathParam == null ? "" : UriEscapers.PATH_ESCAPER.escape(pathParam)));
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -484,26 +518,26 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON getAnythingWithEncodedPathParam(String uri, String pathParam) {
         // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri + "/" + "anything/" + pathParam);
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri + "/" + "anything/" + (pathParam == null ? "" : pathParam));
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -511,22 +545,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON getAnything(String uri, String a, int b) {
         // Append the query parameters.
@@ -542,22 +576,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON getAnythingWithHeaderParam(String uri, String a, int b) {
         // Create the HttpRequest.
@@ -573,22 +607,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON getAnythingWithEncoded(String uri, String a, int b) {
         // Append the query parameters.
@@ -604,29 +638,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithNoContentTypeAndStringBody(String uri, String body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(body));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(body));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -635,29 +673,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithNoContentTypeAndByteArrayBody(String uri, byte[] body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromBytes(body));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromBytes(body));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -666,33 +708,32 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithHeaderApplicationJsonContentTypeAndStringBody(String uri, String body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/json");
-            SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-            if (xmlSerializer.supportsFormat(serializationFormat)) {
-                httpRequest.setBody(BinaryData.fromObject(body, xmlSerializer));
-            } else {
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
                 httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(body));
             }
         }
         // Send the request through the httpPipeline
@@ -702,33 +743,32 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithHeaderApplicationJsonContentTypeAndByteArrayBody(String uri, byte[] body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/json");
-            SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-            if (xmlSerializer.supportsFormat(serializationFormat)) {
-                httpRequest.setBody(BinaryData.fromObject(body, xmlSerializer));
-            } else {
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
                 httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromBytes(body));
             }
         }
         // Send the request through the httpPipeline
@@ -738,29 +778,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithHeaderApplicationJsonContentTypeAndCharsetAndStringBody(String uri, String body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
-            httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(body));
+            httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/json; charset=utf-8");
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(body));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -769,29 +813,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<HttpBinJSON> putWithHeaderApplicationOctetStreamContentTypeAndStringBody(String uri, String body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(body));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(body));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -800,29 +848,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
         }
-        return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithHeaderApplicationOctetStreamContentTypeAndByteArrayBody(String uri, byte[] body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromBytes(body));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromBytes(body));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -831,33 +883,32 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<HttpBinJSON> putWithBodyParamApplicationJsonContentTypeAndStringBody(String uri, String body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/json");
-            SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-            if (xmlSerializer.supportsFormat(serializationFormat)) {
-                httpRequest.setBody(BinaryData.fromObject(body, xmlSerializer));
-            } else {
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
                 httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(body));
             }
         }
         // Send the request through the httpPipeline
@@ -867,64 +918,32 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
         }
-        return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithBodyParamApplicationJsonContentTypeAndCharsetAndStringBody(String uri, String body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/json; charset=utf-8");
-            httpRequest.setBody(BinaryData.fromString(body));
-        }
-        // Send the request through the httpPipeline
-        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
-        int responseCode = networkResponse.getStatusCode();
-        boolean expectedResponse = responseCode >= 200 && responseCode < 300;
-        if (!expectedResponse) {
-            // Handle unexpected response
-            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
-        }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
-        }
-        return deserializedResult;
-    }
-
-    @SuppressWarnings("cast")
-    @Override
-    public HttpBinJSON putWithBodyParamApplicationJsonContentTypeAndByteArrayBody(String uri, byte[] body) {
-        // Create the HttpRequest.
-        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
-        if (body != null) {
-            httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/json");
-            SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-            if (xmlSerializer.supportsFormat(serializationFormat)) {
-                httpRequest.setBody(BinaryData.fromObject(body, xmlSerializer));
-            } else {
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
                 httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(body));
             }
         }
         // Send the request through the httpPipeline
@@ -934,29 +953,68 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
+    @Override
+    public HttpBinJSON putWithBodyParamApplicationJsonContentTypeAndByteArrayBody(String uri, byte[] body) {
+        // Create the HttpRequest.
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
+        if (body != null) {
+            httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/json");
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromBytes(body));
+            }
+        }
+        // Send the request through the httpPipeline
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode >= 200 && responseCode < 300;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
+        }
+    }
+
     @Override
     public HttpBinJSON putWithBodyParamApplicationOctetStreamContentTypeAndStringBody(String uri, String body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(body));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(body));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -965,29 +1023,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithBodyParamApplicationOctetStreamContentTypeAndByteArrayBody(String uri, byte[] body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromBytes(body));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromBytes(body));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -996,29 +1058,29 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON put(String uri, int putBody, RequestContext requestContext) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-        if (xmlSerializer.supportsFormat(serializationFormat)) {
+        SerializationFormat requestSerializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
+        if (xmlSerializer.supportsFormat(requestSerializationFormat)) {
             httpRequest.setBody(BinaryData.fromObject(putBody, xmlSerializer));
         } else {
             httpRequest.setBody(BinaryData.fromObject(putBody, jsonSerializer));
@@ -1032,21 +1094,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON get1(String uri, String queryParam) {
         // Append the query parameters.
@@ -1063,22 +1126,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON get2(String uri, String queryParam) {
         // Append the query parameters.
@@ -1093,22 +1156,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON get3(String uri, String queryParam) {
         // Append the query parameters.
@@ -1123,22 +1186,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON get4(String uri) {
         // Append the query parameters.
@@ -1154,22 +1217,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON get5(String uri) {
         // Append the query parameters.
@@ -1184,22 +1247,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON get6(String uri) {
         // Append the query parameters.
@@ -1213,22 +1276,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON get7(String uri) {
         // Append the query parameters.
@@ -1242,46 +1305,50 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<Void> getVoidResponse(String uri) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri + "/" + "bytes/100");
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), null);
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), null);
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<HttpBinJSON> putBody(String uri, String body) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(body));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(body, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(body));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1290,22 +1357,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
         }
-        return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<InputStream> getBytes(String uri) {
         // Create the HttpRequest.
@@ -1317,30 +1384,30 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), networkResponse.getValue().toStream());
     }
 
-    @SuppressWarnings("cast")
     @Override
     public byte[] getBytes100(String uri) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri + "/" + "bytes/100");
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            BinaryData responseBody = networkResponse.getValue();
-            return responseBody != null ? responseBody.toBytes() : null;
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            BinaryData responseBody = networkResponseToClose.getValue();
+            byte[] responseBytes = responseBody != null ? responseBody.toBytes() : null;
+            boolean quotedBase64 = responseBytes != null && responseBytes.length >= 2 && responseBytes[0] == '"' && responseBytes[responseBytes.length - 1] == '"' && GeneratedCodeUtils.isJsonContentType(networkResponseToClose.getHeaders());
+            return quotedBase64 ? Base64.getDecoder().decode(Arrays.copyOfRange(responseBytes, 1, responseBytes.length - 1)) : responseBytes;
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<HttpBinJSON> put(String host, BinaryData content, long contentLength) {
         // Create the HttpRequest.
@@ -1349,10 +1416,10 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (content != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "text/plain");
             BinaryData binaryData = content;
-            if (binaryData.getLength() != null) {
+            if (binaryData.getLength() != null && httpRequest.getHeaders().get(HttpHeaderName.CONTENT_LENGTH) == null) {
                 httpRequest.getHeaders().set(HttpHeaderName.CONTENT_LENGTH, String.valueOf(binaryData.getLength()));
-                httpRequest.setBody(binaryData);
             }
+            httpRequest.setBody(binaryData);
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1361,28 +1428,32 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), deserializedResult);
         }
-        return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), deserializedResult);
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON put(String uri, Map<String, String> headerCollection) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (headerCollection != null) {
-            httpRequest.getHeaders().add(new HttpHeader(ABC, String.valueOf(headerCollection)));
+            for (Map.Entry<?, ?> headerCollectionHeaderEntry : headerCollection.entrySet()) {
+                if (headerCollectionHeaderEntry.getKey() != null && headerCollectionHeaderEntry.getValue() != null) {
+                    httpRequest.getHeaders().set(HttpHeaderName.fromString("ABC" + headerCollectionHeaderEntry.getKey()), String.valueOf(headerCollectionHeaderEntry.getValue()));
+                }
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1391,22 +1462,75 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
+    @Override
+    public Response<Void> submitForm(String uri, String displayName, String alreadyEncoded) {
+        // Create the HttpRequest.
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.POST).setUri(uri + "/" + "form");
+        List<String> formDataValues = new ArrayList<>();
+        if (displayName != null) {
+            formDataValues.add("display+name=" + UriEscapers.FORM_ESCAPER.escape(String.valueOf(displayName)));
+        }
+        if (alreadyEncoded != null) {
+            formDataValues.add("alreadyEncoded=" + String.valueOf(alreadyEncoded));
+        }
+        httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        httpRequest.setBody(BinaryData.fromString(String.join("&", formDataValues)));
+        // Send the request through the httpPipeline
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), null);
+        }
+    }
+
+    @Override
+    public Response<Void> submitMultipart(String uri, String mediaType, BinaryData body) {
+        // Create the HttpRequest.
+        HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.POST).setUri(uri + "/" + "multipart");
+        if (body != null) {
+            if (mediaType != null) {
+                httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, mediaType);
+            }
+            BinaryData binaryData = body;
+            if (binaryData.getLength() != null && httpRequest.getHeaders().get(HttpHeaderName.CONTENT_LENGTH) == null) {
+                httpRequest.getHeaders().set(HttpHeaderName.CONTENT_LENGTH, String.valueOf(binaryData.getLength()));
+            }
+            httpRequest.setBody(binaryData);
+        }
+        // Send the request through the httpPipeline
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), null);
+        }
+    }
+
     @Override
     public void headvoid(String uri) {
         // Create the HttpRequest.
@@ -1418,80 +1542,82 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Void headVoid(String uri) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.HEAD).setUri(uri + "/" + "voideagerreadoom");
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try {
             return null;
+        } finally {
+            networkResponse.close();
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<Void> headResponseVoid(String uri) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.HEAD).setUri(uri + "/" + "voideagerreadoom");
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), null);
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), null);
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<Void> head(String uri) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.HEAD).setUri(uri + "/" + "anything");
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
-            return new Response<>(networkResponse.getRequest(), responseCode, networkResponse.getHeaders(), null);
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            return new Response<>(networkResponseToClose.getRequest(), responseCode, networkResponseToClose.getHeaders(), null);
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public boolean headBoolean(String uri) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.HEAD).setUri(uri + "/" + "anything");
         // Send the request through the httpPipeline
-        try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {
-            int responseCode = networkResponse.getStatusCode();
-            boolean expectedResponse = responseCode == 200;
-            if (!expectedResponse) {
-                // Handle unexpected response
-                GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            }
+        Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
+        int responseCode = networkResponse.getStatusCode();
+        boolean expectedResponse = responseCode == 200;
+        if (!expectedResponse) {
+            // Handle unexpected response
+            GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
+        }
+        try {
             return expectedResponse;
+        } finally {
+            networkResponse.close();
         }
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void voidHead(String uri) {
         // Create the HttpRequest.
@@ -1503,19 +1629,17 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON put(String uri, int putBody) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-        if (xmlSerializer.supportsFormat(serializationFormat)) {
+        SerializationFormat requestSerializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
+        if (xmlSerializer.supportsFormat(requestSerializationFormat)) {
             httpRequest.setBody(BinaryData.fromObject(putBody, xmlSerializer));
         } else {
             httpRequest.setBody(BinaryData.fromObject(putBody, jsonSerializer));
@@ -1527,21 +1651,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putBodyAndContentLength(String uri, ByteBuffer body, long contentLength) {
         // Create the HttpRequest.
@@ -1549,7 +1674,7 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         httpRequest.getHeaders().add(new HttpHeader(HttpHeaderName.CONTENT_LENGTH, String.valueOf(contentLength)));
         if (body != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromBytes(body.array()));
+            httpRequest.setBody(BinaryData.fromBytes(io.clientcore.core.implementation.utils.ImplUtils.byteBufferToArray(body.duplicate())));
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1558,29 +1683,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             java.lang.reflect.ParameterizedType defaultErrorBodyType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, defaultErrorBodyType, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithUnexpectedResponse(String uri, String putBody) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (putBody != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(putBody));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(putBody, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(putBody));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1589,29 +1718,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithUnexpectedResponseAndExceptionType(String uri, String putBody) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (putBody != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(putBody));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(putBody, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(putBody));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1620,29 +1753,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             java.lang.reflect.ParameterizedType defaultErrorBodyType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.ServiceError.class);
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, defaultErrorBodyType, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithUnexpectedResponseAndDeterminedExceptionType(String uri, String putBody) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (putBody != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(putBody));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(putBody, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(putBody));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1652,29 +1789,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
             Map<Integer, java.lang.reflect.ParameterizedType> statusToExceptionTypeMap = new HashMap<>();
             statusToExceptionTypeMap.put(200, CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.ServiceError.class));
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, statusToExceptionTypeMap, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithUnexpectedResponseAndFallthroughExceptionType(String uri, String putBody) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (putBody != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(putBody));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(putBody, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(putBody));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1685,29 +1826,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
             statusToExceptionTypeMap.put(400, CoreUtils.createParameterizedType(Object.class));
             statusToExceptionTypeMap.put(403, CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.ServiceError.class));
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, statusToExceptionTypeMap, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putWithUnexpectedResponseAndNoFallthroughExceptionType(String uri, String putBody) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (putBody != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(putBody));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(putBody, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(putBody));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1717,29 +1862,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
             Map<Integer, java.lang.reflect.ParameterizedType> statusToExceptionTypeMap = new HashMap<>();
             statusToExceptionTypeMap.put(400, CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.ServiceError.class));
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, statusToExceptionTypeMap, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON unexpectedResponseWithStatusCodeAndExceptionType(String uri, String putBody) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (putBody != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(putBody));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(putBody, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(putBody));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1750,29 +1899,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
             statusToExceptionTypeMap.put(400, CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.ServiceError.class));
             statusToExceptionTypeMap.put(403, CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.OperationError.class));
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, statusToExceptionTypeMap, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON post(String uri, String postBody) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.POST).setUri(uri + "/" + "post");
         if (postBody != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(postBody));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(postBody, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(postBody));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1781,29 +1934,29 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON delete(String uri, boolean bodyBoolean) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.DELETE).setUri(uri + "/" + "delete");
         httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
-        if (xmlSerializer.supportsFormat(serializationFormat)) {
+        SerializationFormat requestSerializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());
+        if (xmlSerializer.supportsFormat(requestSerializationFormat)) {
             httpRequest.setBody(BinaryData.fromObject(bodyBoolean, xmlSerializer));
         } else {
             httpRequest.setBody(BinaryData.fromObject(bodyBoolean, jsonSerializer));
@@ -1815,28 +1968,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON patch(String uri, String bodyString) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PATCH).setUri(uri + "/" + "patch");
         if (bodyString != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromString(bodyString));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(bodyString, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromString(bodyString));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1845,22 +2003,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON get(String uri) {
         // Create the HttpRequest.
@@ -1874,29 +2032,33 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public HttpBinJSON putByteArray(String uri, byte[] bytes) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.PUT).setUri(uri + "/" + "put");
         if (bytes != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
-            httpRequest.setBody(BinaryData.fromBytes(bytes));
+            if (io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())) {
+                httpRequest.setBody(BinaryData.fromObject(bytes, jsonSerializer));
+            } else {
+                httpRequest.setBody(BinaryData.fromBytes(bytes));
+            }
         }
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
@@ -1905,22 +2067,22 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
-        HttpBinJSON deserializedResult;
-        ParameterizedType returnType = CoreUtils.createParameterizedType(HttpBinJSON.class);
-        SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());
-        if (jsonSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType);
-        } else if (xmlSerializer.supportsFormat(serializationFormat)) {
-            deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType);
-        } else {
-            throw LOGGER.throwableAtError().addKeyValue("serializationFormat", serializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+        try (Response<BinaryData> networkResponseToClose = networkResponse) {
+            HttpBinJSON deserializedResult;
+            ParameterizedType returnType = CoreUtils.createParameterizedType(io.clientcore.annotation.processor.test.implementation.models.HttpBinJSON.class);
+            SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponseToClose.getHeaders());
+            if (jsonSerializer.supportsFormat(responseSerializationFormat) || responseSerializationFormat == SerializationFormat.TEXT) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), jsonSerializer, returnType);
+            } else if (xmlSerializer.supportsFormat(responseSerializationFormat)) {
+                deserializedResult = CoreUtils.decodeNetworkResponse(networkResponseToClose.getValue(), xmlSerializer, returnType);
+            } else {
+                throw LOGGER.throwableAtError().addKeyValue("serializationFormat", responseSerializationFormat.name()).log("None of the provided serializers support the format.", UnsupportedOperationException::new);
+            }
+            return deserializedResult;
         }
-        return deserializedResult;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void getStatus200(String uri) {
         // Create the HttpRequest.
@@ -1932,12 +2094,10 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void getStatus200WithExpectedResponse200(String uri) {
         // Create the HttpRequest.
@@ -1949,12 +2109,10 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void getStatus300(String uri) {
         // Create the HttpRequest.
@@ -1966,12 +2124,10 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void getStatus300WithExpectedResponse300(String uri) {
         // Create the HttpRequest.
@@ -1983,12 +2139,10 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void getStatus400(String uri) {
         // Create the HttpRequest.
@@ -2000,12 +2154,10 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void getStatus400WithExpectedResponse400(String uri) {
         // Create the HttpRequest.
@@ -2017,12 +2169,10 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void getStatus500(String uri) {
         // Create the HttpRequest.
@@ -2034,12 +2184,10 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public void getStatus500WithExpectedResponse500(String uri) {
         // Create the HttpRequest.
@@ -2051,12 +2199,10 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         networkResponse.close();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<BinaryData> put(String uri, BinaryData putBody, ServerSentEventListener serverSentEventListener) {
         // Create the HttpRequest.
@@ -2064,11 +2210,12 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (putBody != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
             BinaryData binaryData = putBody;
-            if (binaryData.getLength() != null) {
+            if (binaryData.getLength() != null && httpRequest.getHeaders().get(HttpHeaderName.CONTENT_LENGTH) == null) {
                 httpRequest.getHeaders().set(HttpHeaderName.CONTENT_LENGTH, String.valueOf(binaryData.getLength()));
-                httpRequest.setBody(binaryData);
             }
+            httpRequest.setBody(binaryData);
         }
+        httpRequest.setServerSentEventListener(serverSentEventListener);
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -2076,16 +2223,15 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         return networkResponse;
     }
 
-    @SuppressWarnings("cast")
     @Override
     public BinaryData get(String uri, ServerSentEventListener serverSentEventListener) {
         // Create the HttpRequest.
         HttpRequest httpRequest = new HttpRequest().setMethod(HttpMethod.GET).setUri(uri + "/" + "serversentevent");
+        httpRequest.setServerSentEventListener(serverSentEventListener);
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -2093,12 +2239,10 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         return networkResponse.getValue();
     }
 
-    @SuppressWarnings("cast")
     @Override
     public Response<BinaryData> post(String uri, BinaryData postBody, ServerSentEventListener serverSentEventListener, RequestContext requestOptions) {
         // Create the HttpRequest.
@@ -2106,11 +2250,14 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (postBody != null) {
             httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream");
             BinaryData binaryData = postBody;
-            if (binaryData.getLength() != null) {
+            if (binaryData.getLength() != null && httpRequest.getHeaders().get(HttpHeaderName.CONTENT_LENGTH) == null) {
                 httpRequest.getHeaders().set(HttpHeaderName.CONTENT_LENGTH, String.valueOf(binaryData.getLength()));
-                httpRequest.setBody(binaryData);
             }
+            httpRequest.setBody(binaryData);
         }
+        httpRequest.setContext(requestOptions);
+        httpRequest.getContext().getRequestCallback().accept(httpRequest);
+        httpRequest.setServerSentEventListener(serverSentEventListener);
         // Send the request through the httpPipeline
         Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);
         int responseCode = networkResponse.getStatusCode();
@@ -2118,7 +2265,6 @@ public class TestInterfaceClientServiceImpl implements TestInterfaceClientServic
         if (!expectedResponse) {
             // Handle unexpected response
             GeneratedCodeUtils.handleUnexpectedResponse(responseCode, networkResponse, jsonSerializer, xmlSerializer, null, null, LOGGER);
-            networkResponse.close();
         }
         return networkResponse;
     }

--- a/sdk/clientcore/annotation-processor-test/src/test/java/io/clientcore/annotation/processor/test/SpecialReturnBodiesServiceTests.java
+++ b/sdk/clientcore/annotation-processor-test/src/test/java/io/clientcore/annotation/processor/test/SpecialReturnBodiesServiceTests.java
@@ -19,6 +19,7 @@ import java.io.UncheckedIOException;
 import java.security.SecureRandom;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests {@link SpecialReturnBodiesService} APIs with a response payload that would've cause invalid deserialization if
@@ -81,6 +82,40 @@ public class SpecialReturnBodiesServiceTests {
         try (Response<InputStream> response = getService().getInputStreamWithResponse("https://localhost")) {
             assertArrayEquals(RESPONSE_BODY_BYTES, fullyReadInputStream(response.getValue()));
         }
+    }
+
+    @Test
+    public void getStandardBase64() {
+        SpecialReturnBodiesService service = SpecialReturnBodiesService.getNewInstance(new HttpPipelineBuilder()
+            .httpClient(request -> new Response<>(request, 200,
+                new HttpHeaders().add(HttpHeaderName.CONTENT_TYPE, "application/json"),
+                BinaryData.fromString("\"dGVzdA==\"")))
+            .build());
+
+        assertArrayEquals("test".getBytes(java.nio.charset.StandardCharsets.UTF_8),
+            service.base64("https://localhost").getValue());
+    }
+
+    @Test
+    public void quotedOctetStreamRemainsRawBytes() {
+        byte[] rawBytes = "\"dGVzdA==\"".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        SpecialReturnBodiesService service = SpecialReturnBodiesService.getNewInstance(new HttpPipelineBuilder()
+            .httpClient(request -> new Response<>(request, 200,
+                new HttpHeaders().add(HttpHeaderName.CONTENT_TYPE, "application/octet-stream"),
+                BinaryData.fromBytes(rawBytes)))
+            .build());
+
+        assertArrayEquals(rawBytes, service.getByteArray("https://localhost"));
+    }
+
+    @Test
+    public void getTextResponse() {
+        SpecialReturnBodiesService service = SpecialReturnBodiesService.getNewInstance(new HttpPipelineBuilder()
+            .httpClient(request -> new Response<>(request, 200,
+                new HttpHeaders().add(HttpHeaderName.CONTENT_TYPE, "text/plain"), BinaryData.fromString("{cat}")))
+            .build());
+
+        assertEquals("{cat}", service.getText("https://localhost").getValue());
     }
 
     private static byte[] fullyReadInputStream(InputStream inputStream) {

--- a/sdk/clientcore/annotation-processor-test/src/test/java/io/clientcore/annotation/processor/test/TestInterfaceServiceClientGenerationTests.java
+++ b/sdk/clientcore/annotation-processor-test/src/test/java/io/clientcore/annotation/processor/test/TestInterfaceServiceClientGenerationTests.java
@@ -67,7 +67,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -82,6 +81,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -498,7 +498,7 @@ public class TestInterfaceServiceClientGenerationTests {
         final HttpBinJSON result
             = service.putWithHeaderApplicationJsonContentTypeAndCharsetAndStringBody(getServerUri(false), "");
 
-        assertEquals("", result.data());
+        assertEquals("\"\"", result.data());
     }
 
     @Test
@@ -509,7 +509,7 @@ public class TestInterfaceServiceClientGenerationTests {
         final HttpBinJSON result = service
             .putWithHeaderApplicationJsonContentTypeAndCharsetAndStringBody(getServerUri(false), requestBody);
 
-        assertEquals("soups and stuff", result.data());
+        assertEquals("\"soups and stuff\"", result.data());
     }
 
     @Test
@@ -625,7 +625,7 @@ public class TestInterfaceServiceClientGenerationTests {
         final HttpBinJSON result
             = service.putWithBodyParamApplicationJsonContentTypeAndCharsetAndStringBody(getServerUri(false), "");
 
-        assertEquals("", result.data());
+        assertEquals("\"\"", result.data());
     }
 
     @Test
@@ -636,7 +636,7 @@ public class TestInterfaceServiceClientGenerationTests {
         final HttpBinJSON result = service
             .putWithBodyParamApplicationJsonContentTypeAndCharsetAndStringBody(getServerUri(false), "soups and stuff");
 
-        assertEquals("soups and stuff", result.data());
+        assertEquals("\"soups and stuff\"", result.data());
     }
 
     @Test
@@ -1464,7 +1464,6 @@ public class TestInterfaceServiceClientGenerationTests {
     }
 
     @Test
-    @Disabled("None of the provided serializers support the format: TEXT.")
     public void binaryDataUploadTest() throws Exception {
         Path filePath = Paths.get(getClass().getClassLoader().getResource("upload.txt").toURI());
         BinaryData data = BinaryData.fromFile(filePath);
@@ -1487,7 +1486,6 @@ public class TestInterfaceServiceClientGenerationTests {
     }
 
     @Test
-    @Disabled("Add support for header collection")
     public void service24Put() {
         final Map<String, String> headerCollection = new HashMap<>();
 
@@ -1506,6 +1504,42 @@ public class TestInterfaceServiceClientGenerationTests {
 
         assertEquals("GHIJ", resultHeaders.getValue(HttpHeaderName.fromString("ABCDEF")));
         assertEquals("45", resultHeaders.getValue(HttpHeaderName.fromString("ABC123")));
+    }
+
+    @Test
+    public void formParametersAreEncodedIntoRequestBody() {
+        HttpPipeline pipeline = new HttpPipelineBuilder().httpClient(request -> {
+            assertEquals("application/x-www-form-urlencoded",
+                request.getHeaders().getValue(HttpHeaderName.CONTENT_TYPE));
+            assertEquals("display+name=Ada+Lovelace&alreadyEncoded=a%2Fb", request.getBody().toString());
+            return new Response<>(request, 200, new HttpHeaders(), BinaryData.empty());
+        }).build();
+
+        TestInterfaceClientImpl.TestInterfaceClientService service
+            = TestInterfaceClientImpl.TestInterfaceClientService.getNewInstance(pipeline);
+
+        try (Response<Void> response
+            = service.submitForm("https://example.test", "Ada Lovelace", "a%2Fb")) {
+            assertEquals(200, response.getStatusCode());
+        }
+    }
+
+    @Test
+    public void preSerializedMultipartBodyIsPassedThrough() {
+        BinaryData multipartBody = BinaryData.fromString("--boundary\r\ncontent\r\n--boundary--");
+        HttpPipeline pipeline = new HttpPipelineBuilder().httpClient(request -> {
+            assertEquals("multipart/form-data; boundary=boundary",
+                request.getHeaders().getValue(HttpHeaderName.CONTENT_TYPE));
+            assertSame(multipartBody, request.getBody());
+            return new Response<>(request, 200, new HttpHeaders(), BinaryData.empty());
+        }).build();
+        TestInterfaceClientImpl.TestInterfaceClientService service
+            = TestInterfaceClientImpl.TestInterfaceClientService.getNewInstance(pipeline);
+
+        try (Response<Void> response = service.submitMultipart("https://example.test",
+            "multipart/form-data; boundary=boundary", multipartBody)) {
+            assertEquals(200, response.getStatusCode());
+        }
     }
 
     @Test
@@ -1601,7 +1635,6 @@ public class TestInterfaceServiceClientGenerationTests {
     }
 
     @Test
-    @Disabled("https://github.com/Azure/azure-sdk-for-java/issues/44746")
     public void canReceiveServerSentEvents() {
         final int[] i = { 0 };
         TestInterfaceClientImpl.TestInterfaceClientService service
@@ -1635,7 +1668,6 @@ public class TestInterfaceServiceClientGenerationTests {
      * Tests that eagerly converting implementation HTTP headers to Client Core Headers is done.
      */
     @Test
-    @Disabled("https://github.com/Azure/azure-sdk-for-java/issues/44746")
     public void canRecognizeServerSentEvent() {
         BinaryData requestBody = BinaryData.fromString("test body");
         TestInterfaceClientImpl.TestInterfaceClientService service
@@ -1652,7 +1684,6 @@ public class TestInterfaceServiceClientGenerationTests {
     }
 
     @Test
-    @Disabled("https://github.com/Azure/azure-sdk-for-java/issues/44746")
     public void onErrorServerSentEvents() throws IOException {
         TestInterfaceClientImpl.TestInterfaceClientService service
             = createService(TestInterfaceClientImpl.TestInterfaceClientService.class);
@@ -1675,7 +1706,6 @@ public class TestInterfaceServiceClientGenerationTests {
     }
 
     @Test
-    @Disabled("https://github.com/Azure/azure-sdk-for-java/issues/44746")
     public void onRetryWithLastEventIdReceiveServerSentEvents() throws IOException {
         TestInterfaceClientImpl.TestInterfaceClientService service
             = createService(TestInterfaceClientImpl.TestInterfaceClientService.class);
@@ -1707,7 +1737,6 @@ public class TestInterfaceServiceClientGenerationTests {
      * Test throws Runtime exception for no listener attached.
      */
     @Test
-    @Disabled("https://github.com/Azure/azure-sdk-for-java/issues/44746")
     public void throwsExceptionForNoListener() {
         TestInterfaceClientImpl.TestInterfaceClientService service
             = createService(TestInterfaceClientImpl.TestInterfaceClientService.class);

--- a/sdk/clientcore/annotation-processor-test/src/test/java/io/clientcore/annotation/processor/test/http/TestInterfaceGenerationTests.java
+++ b/sdk/clientcore/annotation-processor-test/src/test/java/io/clientcore/annotation/processor/test/http/TestInterfaceGenerationTests.java
@@ -33,6 +33,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -96,6 +98,36 @@ public class TestInterfaceGenerationTests {
 
         assertEquals(200, response.getStatusCode());
         assertSame(data, client.getLastHttpRequest().getBody());
+    }
+
+    @Test
+    public void unknownLengthBinaryDataIsPassThrough() {
+        BinaryData data = BinaryData.fromStream(new ByteArrayInputStream(new byte[] { 1, 2, 3 }));
+        LocalHttpClient client = new LocalHttpClient();
+        TestInterfaceClientImpl.TestInterfaceClientService service
+            = TestInterfaceClientImpl.TestInterfaceClientService.getNewInstance(
+                new HttpPipelineBuilder().httpClient(client).build());
+
+        service.testMethod("https://somecloud.com", data, ContentType.APPLICATION_JSON, null);
+
+        assertSame(data, client.getLastHttpRequest().getBody());
+    }
+
+    @Test
+    public void directByteBufferUsesRemainingView() {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(4);
+        buffer.put(new byte[] { 0, 1, 2, 3 }).flip();
+        buffer.get();
+        LocalHttpClient client = new LocalHttpClient();
+        TestInterfaceClientImpl.TestInterfaceClientService service
+            = TestInterfaceClientImpl.TestInterfaceClientService.getNewInstance(
+                new HttpPipelineBuilder().httpClient(client).build());
+
+        service.testMethod("https://somecloud.com", buffer, ContentType.APPLICATION_JSON, 3L);
+
+        assertEquals(1, buffer.position());
+        org.junit.jupiter.api.Assertions.assertArrayEquals(new byte[] { 1, 2, 3 },
+            client.getLastHttpRequest().getBody().toBytes());
     }
 
     private static Stream<Arguments> knownLengthBinaryDataIsPassThroughArgumentProvider() throws Exception {
@@ -175,6 +207,48 @@ public class TestInterfaceGenerationTests {
         testInterface.testMethodReturnsVoid(uri);
 
         assertTrue(client.closeCalledOnResponse);
+    }
+
+    @Test
+    public void decodedResponseClosesNetworkResponse() {
+        AtomicBoolean closed = new AtomicBoolean();
+        HttpPipeline pipeline = new HttpPipelineBuilder().httpClient(request -> new Response<BinaryData>(request, 200,
+            new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, ContentType.APPLICATION_JSON),
+            BinaryData.fromString("{\"bar\":\"value\"}")) {
+            @Override
+            public void close() {
+                closed.set(true);
+                super.close();
+            }
+        }).build();
+        TestInterfaceClientImpl.TestInterfaceClientService service
+            = TestInterfaceClientImpl.TestInterfaceClientService.getNewInstance(pipeline);
+
+        Response<Foo> response = service.getFoo("key", null, null);
+
+        assertEquals("value", response.getValue().bar());
+        assertTrue(closed.get());
+    }
+
+    @Test
+    public void errorResponseIsClosedExactlyOnce() {
+        AtomicInteger closeCount = new AtomicInteger();
+        HttpPipeline pipeline = new HttpPipelineBuilder().httpClient(request -> new Response<BinaryData>(request, 500,
+            new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, ContentType.APPLICATION_JSON),
+            BinaryData.fromString("{\"message\":\"error\"}")) {
+            @Override
+            public void close() {
+                closeCount.incrementAndGet();
+                super.close();
+            }
+        }).build();
+        TestInterfaceClientImpl.TestInterfaceClientService service
+            = TestInterfaceClientImpl.TestInterfaceClientService.getNewInstance(pipeline);
+
+        org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class,
+            () -> service.getFoo("key", null, null));
+
+        assertEquals(1, closeCount.get());
     }
 
     private static Stream<Arguments> doesNotChangeBinaryDataContentTypeDataProvider() throws Exception {
@@ -335,6 +409,19 @@ public class TestInterfaceGenerationTests {
         assertNotNull(pagedIterable);
         Set<Foo> allItems = pagedIterable.stream().collect(Collectors.toSet());
         assertEquals(1, allItems.size());
+    }
+
+    @Test
+    public void deserializesTypedDictionaryResponse() {
+        HttpPipeline pipeline = new HttpPipelineBuilder().httpClient(request -> new Response<>(request, 200,
+            new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, ContentType.APPLICATION_JSON),
+            BinaryData.fromString("{\"first\":{\"bar\":\"value\"}}"))).build();
+        TestInterfaceClientImpl.TestInterfaceClientService service
+            = TestInterfaceClientImpl.TestInterfaceClientService.getNewInstance(pipeline);
+
+        Response<java.util.Map<String, Foo>> response = service.getFooMap("https://example.test");
+
+        assertEquals("value", response.getValue().get("first").bar());
     }
 
     /**

--- a/sdk/clientcore/annotation-processor/CHANGELOG.md
+++ b/sdk/clientcore/annotation-processor/CHANGELOG.md
@@ -3,10 +3,18 @@
 ## 1.0.0-beta.5 (Unreleased)
 
 ### Features Added
+- Added support for `FormParam`, header collections, server-sent event listeners, and nested generic response types.
+- Added support for text responses, standard Base64 responses, optional path parameters, and pre-serialized multipart
+  request bodies.
 
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed response lifecycle handling so eagerly decoded responses are closed exactly once while streaming responses
+  remain open for callers.
+- Fixed request body handling for unknown-length `BinaryData`, direct and sliced `ByteBuffer` values, dynamic content
+  types, and JSON media types with parameters.
+- Fixed dynamic headers replacing static headers and collection query parameters honoring their expansion setting.
 
 ### Other Changes
 

--- a/sdk/clientcore/annotation-processor/pom.xml
+++ b/sdk/clientcore/annotation-processor/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>io.clientcore</groupId>
       <artifactId>core</artifactId>
-      <version>1.0.0-beta.11</version> <!-- {x-version-update;io.clientcore:core;dependency} -->
+      <version>1.0.0-beta.12</version> <!-- {x-version-update;io.clientcore:core;dependency} -->
     </dependency>
 
     <!-- Unit Test -->

--- a/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/AnnotationProcessor.java
+++ b/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/AnnotationProcessor.java
@@ -10,6 +10,7 @@ import io.clientcore.annotation.processor.templating.TemplateProcessor;
 import io.clientcore.annotation.processor.utils.PathBuilder;
 import io.clientcore.core.annotations.ServiceInterface;
 import io.clientcore.core.http.annotations.BodyParam;
+import io.clientcore.core.http.annotations.FormParam;
 import io.clientcore.core.http.annotations.HeaderParam;
 import io.clientcore.core.http.annotations.HostParam;
 import io.clientcore.core.http.annotations.HttpRequestInformation;
@@ -223,6 +224,7 @@ public class AnnotationProcessor extends AbstractProcessor {
             PathParam pathParam = param.getAnnotation(PathParam.class);
             HeaderParam headerParam = param.getAnnotation(HeaderParam.class);
             QueryParam queryParam = param.getAnnotation(QueryParam.class);
+            FormParam formParam = param.getAnnotation(FormParam.class);
             BodyParam bodyParam = param.getAnnotation(BodyParam.class);
 
             // Switch based on annotations
@@ -237,11 +239,7 @@ public class AnnotationProcessor extends AbstractProcessor {
                 method.addSubstitution(
                     new Substitution(pathParam.value(), param.getSimpleName().toString(), !pathParam.encoded()));
             } else if (headerParam != null) {
-                // Only add header param if the key is not already present (e.g., set by static header params)
-                String key = headerParam.value();
-                if (!method.getHeaders().containsKey(key)) {
-                    method.addHeader(headerParam.value(), param.getSimpleName().toString());
-                }
+                method.setHeader(headerParam.value(), param.getSimpleName().toString());
             } else if (queryParam != null) {
                 // Only add query param if the key is not already present (e.g., set by static query params)
                 String key = queryParam.value();
@@ -249,6 +247,9 @@ public class AnnotationProcessor extends AbstractProcessor {
                     method.addQueryParam(key, param.getSimpleName().toString(), queryParam.multipleQueryParams(),
                         !queryParam.encoded(), false);
                 }
+            } else if (formParam != null) {
+                method.addFormParameter(new HttpRequestContext.FormParameter(formParam.value(), param.asType(),
+                    param.getSimpleName().toString(), !formParam.encoded()));
             } else if (bodyParam != null) {
                 method.setBody(
                     new HttpRequestContext.Body(bodyParam.value(), param.asType(), param.getSimpleName().toString()));

--- a/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/models/HttpRequestContext.java
+++ b/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/models/HttpRequestContext.java
@@ -50,6 +50,7 @@ public final class HttpRequestContext {
 
     private final Map<String, List<String>> headers;
     private final Map<String, QueryParameter> queryParams;
+    private final List<FormParameter> formParameters;
 
     private final Map<String, Substitution> substitutions;
 
@@ -65,6 +66,7 @@ public final class HttpRequestContext {
         this.parameters = new ArrayList<>();
         this.headers = new HashMap<>();
         this.queryParams = new LinkedHashMap<>();
+        this.formParameters = new ArrayList<>();
         this.substitutions = new HashMap<>();
     }
 
@@ -238,6 +240,17 @@ public final class HttpRequestContext {
     }
 
     /**
+     * Replaces a header value, matching existing header names case-insensitively.
+     *
+     * @param key the header key.
+     * @param value the header value.
+     */
+    public void setHeader(String key, String value) {
+        headers.keySet().removeIf(existingKey -> existingKey.equalsIgnoreCase(key));
+        headers.put(key, new ArrayList<>(Collections.singletonList(value)));
+    }
+
+    /**
      * Gets the query parameters.
      *
      * @return the query parameters.
@@ -262,6 +275,24 @@ public final class HttpRequestContext {
         } else {
             queryParams.put(key, new QueryParameter(value, isMultiple, shouldEncode, isStatic));
         }
+    }
+
+    /**
+     * Adds a form parameter.
+     *
+     * @param formParameter The form parameter to add.
+     */
+    public void addFormParameter(FormParameter formParameter) {
+        formParameters.add(formParameter);
+    }
+
+    /**
+     * Gets the form parameters.
+     *
+     * @return The form parameters.
+     */
+    public List<FormParameter> getFormParameters() {
+        return Collections.unmodifiableList(formParameters);
     }
 
     /**
@@ -575,6 +606,67 @@ public final class HttpRequestContext {
          */
         public String getParameterName() {
             return parameterName;
+        }
+    }
+
+    /**
+     * Represents an application/x-www-form-urlencoded request parameter.
+     */
+    public static class FormParameter {
+        private final String name;
+        private final TypeMirror parameterType;
+        private final String parameterName;
+        private final boolean shouldEncode;
+
+        /**
+         * Creates a form parameter.
+         *
+         * @param name The wire name.
+         * @param parameterType The parameter type.
+         * @param parameterName The Java parameter name.
+         * @param shouldEncode Whether the value should be encoded.
+         */
+        public FormParameter(String name, TypeMirror parameterType, String parameterName, boolean shouldEncode) {
+            this.name = name;
+            this.parameterType = parameterType;
+            this.parameterName = parameterName;
+            this.shouldEncode = shouldEncode;
+        }
+
+        /**
+         * Gets the wire name.
+         *
+         * @return The wire name.
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Gets the parameter type.
+         *
+         * @return The parameter type.
+         */
+        public TypeMirror getParameterType() {
+            return parameterType;
+        }
+
+        /**
+         * Gets the Java parameter name.
+         *
+         * @return The Java parameter name.
+         */
+        public String getParameterName() {
+            return parameterName;
+        }
+
+        /**
+         * Whether the value should be encoded.
+         *
+         * @return Whether the value should be encoded.
+         */
+        public boolean shouldEncode() {
+            return shouldEncode;
         }
     }
 

--- a/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/templating/JavaParserTemplateProcessor.java
+++ b/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/templating/JavaParserTemplateProcessor.java
@@ -16,11 +16,9 @@ import com.github.javaparser.ast.comments.LineComment;
 import com.github.javaparser.ast.expr.BooleanLiteralExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
-import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
-import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
@@ -37,8 +35,11 @@ import io.clientcore.core.http.models.HttpHeader;
 import io.clientcore.core.http.models.HttpHeaderName;
 import io.clientcore.core.http.models.HttpMethod;
 import io.clientcore.core.http.models.HttpRequest;
+import io.clientcore.core.http.models.RequestContext;
+import io.clientcore.core.http.models.ServerSentEventListener;
 import io.clientcore.core.http.pipeline.HttpPipeline;
 import io.clientcore.core.instrumentation.logging.ClientLogger;
+import io.clientcore.core.models.binarydata.BinaryData;
 import io.clientcore.core.serialization.json.JsonSerializer;
 import io.clientcore.core.serialization.xml.XmlSerializer;
 import io.clientcore.core.utils.CoreUtils;
@@ -51,6 +52,7 @@ import java.net.URI;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -59,6 +61,8 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
@@ -237,10 +241,7 @@ public class JavaParserTemplateProcessor implements TemplateProcessor {
     // Helper methods
     private void configureInternalMethod(MethodDeclaration internalMethod, HttpRequestContext method,
         ProcessingEnvironment processingEnv) {
-        // TODO (alzimmer): For now throw @SuppressWarnings("cast") on generated methods while we
-        //  improve / fix the generated code to no longer need it.
         internalMethod.setName(method.getMethodName())
-            .addAnnotation(new SingleMemberAnnotationExpr(new Name("SuppressWarnings"), new StringLiteralExpr("cast")))
             .addMarkerAnnotation(Override.class)
             .setType(TypeConverter.getAstType(method.getMethodReturnType()));
 
@@ -256,9 +257,9 @@ public class JavaParserTemplateProcessor implements TemplateProcessor {
         BlockStmt body = internalMethod.getBody().get();
 
         initializeHttpRequest(body, method);
-        boolean serializationFormatSet = RequestBodyHandler.configureRequestBody(body, method, processingEnv);
-        addRequestContextToRequestIfPresent(body, method);
-        finalizeHttpRequest(body, method.getMethodReturnType(), method, serializationFormatSet);
+        RequestBodyHandler.configureRequestBody(body, method, processingEnv);
+        addRequestConfigurationToRequest(body, method);
+        finalizeHttpRequest(body, method.getMethodReturnType(), method);
 
         internalMethod.setBody(body);
     }
@@ -277,22 +278,33 @@ public class JavaParserTemplateProcessor implements TemplateProcessor {
         }
     }
 
-    private void addRequestContextToRequestIfPresent(BlockStmt body, HttpRequestContext method) {
-        boolean hasRequestContext = method.getParameters()
+    void addRequestConfigurationToRequest(BlockStmt body, HttpRequestContext method) {
+        findParameterByType(method, RequestContext.class).ifPresent(parameter -> {
+            String parameterName = parameter.getName();
+            body.addStatement(StaticJavaParser.parseStatement("httpRequest.setContext(" + parameterName + ");"));
+            body.addStatement(
+                StaticJavaParser.parseStatement("httpRequest.getContext().getRequestCallback().accept(httpRequest);"));
+        });
+
+        findParameterByType(method, ServerSentEventListener.class).ifPresent(parameter -> body.addStatement(
+            StaticJavaParser.parseStatement("httpRequest.setServerSentEventListener(" + parameter.getName() + ");")));
+    }
+
+    private static Optional<HttpRequestContext.MethodParameter> findParameterByType(HttpRequestContext method,
+        Class<?> expectedType) {
+        return method.getParameters()
             .stream()
-            .anyMatch(parameter -> "requestContext".equals(parameter.getName())
-                && "RequestContext".equals(parameter.getShortTypeName()));
+            .filter(parameter -> isType(parameter.getTypeMirror(), expectedType))
+            .findFirst();
+    }
 
-        if (hasRequestContext) {
-            // Create a statement for setting request options
-            Statement statement1 = StaticJavaParser.parseStatement("httpRequest.setContext(requestContext);");
-
-            Statement statement2
-                = StaticJavaParser.parseStatement("httpRequest.getContext().getRequestCallback().accept(httpRequest);");
-
-            body.addStatement(statement1);
-            body.addStatement(statement2);
+    private static boolean isType(TypeMirror type, Class<?> expectedType) {
+        if (!(type instanceof DeclaredType)) {
+            return false;
         }
+
+        return expectedType.getCanonicalName()
+            .contentEquals(((TypeElement) ((DeclaredType) type).asElement()).getQualifiedName());
     }
 
     void initializeHttpRequest(BlockStmt body, HttpRequestContext method) {
@@ -389,7 +401,19 @@ public class JavaParserTemplateProcessor implements TemplateProcessor {
                     }
                 } else {
                     // For non-static query parameters the value should be the name of the method parameter.
-                    valueExpression = StaticJavaParser.parseExpression(value);
+                    Optional<HttpRequestContext.MethodParameter> parameter = method.getParameters()
+                        .stream()
+                        .filter(methodParameter -> methodParameter.getName().equals(value))
+                        .findFirst();
+                    if (!queryParameter.isMultiple()
+                        && parameter.isPresent()
+                        && isCollectionType(parameter.get().getTypeMirror())) {
+                        body.tryAddImportToParentCompilationUnit(BinaryData.class);
+                        valueExpression = StaticJavaParser
+                            .parseExpression("BinaryData.fromObject(" + value + ", jsonSerializer).toString()");
+                    } else {
+                        valueExpression = StaticJavaParser.parseExpression(value);
+                    }
                 }
             } else {
                 body.tryAddImportToParentCompilationUnit(Arrays.class);
@@ -428,7 +452,7 @@ public class JavaParserTemplateProcessor implements TemplateProcessor {
      * always applied.
      * <p>
      */
-    private void addHeadersToRequest(BlockStmt body, HttpRequestContext method) {
+    void addHeadersToRequest(BlockStmt body, HttpRequestContext method) {
         if (method.getHeaders().isEmpty()) {
             // No headers to add; exit early for clarity and efficiency.
             return;
@@ -442,7 +466,8 @@ public class JavaParserTemplateProcessor implements TemplateProcessor {
             StringBuilder addHeader = new StringBuilder();
 
             String constantName = LOWERCASE_HEADER_TO_HTTPHEADENAME_CONSTANT.get(headerKey.toLowerCase(Locale.ROOT));
-            if ("CONTENT_TYPE".equals(constantName)) {
+            if ("CONTENT_TYPE".equals(constantName)
+                && (method.getBody() != null || !method.getFormParameters().isEmpty())) {
                 continue;
             }
             if (headerValues.isEmpty()) {
@@ -468,6 +493,11 @@ public class JavaParserTemplateProcessor implements TemplateProcessor {
                 Optional<HttpRequestContext.MethodParameter> paramOpt
                     = method.getParameters().stream().filter(p -> p.getName().equals(value)).findFirst();
                 if (paramOpt.isPresent()) {
+                    if (isMapType(paramOpt.get().getTypeMirror())) {
+                        addHeaderCollection(body, method, headerKey, value);
+                        continue;
+                    }
+
                     String paramType = paramOpt.get().getShortTypeName();
                     if ("String".equals(paramType)) {
                         // Dynamic header: use parameter name directly.
@@ -516,8 +546,53 @@ public class JavaParserTemplateProcessor implements TemplateProcessor {
         }
     }
 
-    private void finalizeHttpRequest(BlockStmt body, TypeMirror returnTypeName, HttpRequestContext method,
-        boolean serializationFormatSet) {
-        generateResponseHandling(body, returnTypeName, method, serializationFormatSet);
+    private static boolean isMapType(TypeMirror type) {
+        if (!(type instanceof DeclaredType)) {
+            return false;
+        }
+
+        TypeElement typeElement = (TypeElement) ((DeclaredType) type).asElement();
+        return Map.class.getCanonicalName().contentEquals(typeElement.getQualifiedName());
+    }
+
+    private static boolean isCollectionType(TypeMirror type) {
+        if (!(type instanceof DeclaredType)) {
+            return false;
+        }
+
+        String typeName = ((TypeElement) ((DeclaredType) type).asElement()).getQualifiedName().toString();
+        return Collection.class.getCanonicalName().equals(typeName)
+            || List.class.getCanonicalName().equals(typeName)
+            || Iterable.class.getCanonicalName().equals(typeName);
+    }
+
+    private static void addHeaderCollection(BlockStmt body, HttpRequestContext method, String prefix,
+        String parameterName) {
+        body.tryAddImportToParentCompilationUnit(Map.class);
+        body.tryAddImportToParentCompilationUnit(HttpHeaderName.class);
+        String entryName = getAvailableLocalName(method, parameterName + "HeaderEntry");
+        String prefixLiteral = new StringLiteralExpr(prefix).toString();
+        body.addStatement(StaticJavaParser
+            .parseStatement("if (" + parameterName + " != null) { " + "for (Map.Entry<?, ?> " + entryName + " : "
+                + parameterName + ".entrySet()) { " + "if (" + entryName + ".getKey() != null && " + entryName
+                + ".getValue() != null) { " + "httpRequest.getHeaders().set(HttpHeaderName.fromString(" + prefixLiteral
+                + " + " + entryName + ".getKey()), String.valueOf(" + entryName + ".getValue())); } } }"));
+    }
+
+    private static String getAvailableLocalName(HttpRequestContext method, String preferredName) {
+        String name = preferredName;
+        int suffix = 2;
+        while (containsParameter(method, name)) {
+            name = preferredName + suffix++;
+        }
+        return name;
+    }
+
+    private static boolean containsParameter(HttpRequestContext method, String name) {
+        return method.getParameters().stream().anyMatch(parameter -> parameter.getName().equals(name));
+    }
+
+    private void finalizeHttpRequest(BlockStmt body, TypeMirror returnTypeName, HttpRequestContext method) {
+        generateResponseHandling(body, returnTypeName, method);
     }
 }

--- a/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/utils/AnnotationProcessorUtils.java
+++ b/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/utils/AnnotationProcessorUtils.java
@@ -8,10 +8,11 @@ import com.github.javaparser.ast.stmt.Statement;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.WildcardType;
 
 /**
  * Utility class for annotation processor.
@@ -27,45 +28,45 @@ public final class AnnotationProcessorUtils {
      * @return A JavaParser {@link Statement} that creates a {@code ParameterizedType} for the given return type.
      */
     public static String createParameterizedTypeStatement(TypeMirror returnType, BlockStmt body) {
-        if (returnType.getKind() == TypeKind.DECLARED) {
-            DeclaredType declaredType = (DeclaredType) returnType;
-            String outerType = ((TypeElement) declaredType.asElement()).getQualifiedName().toString() + ".class";
-
-            if (!declaredType.getTypeArguments().isEmpty()) {
-                TypeMirror firstGenericType = declaredType.getTypeArguments().get(0);
-                if (firstGenericType.getKind() == TypeKind.ARRAY) {
-                    ArrayType arrayType = (ArrayType) firstGenericType;
-                    String componentTypeName = arrayType.getComponentType().toString();
-                    return "CoreUtils.createParameterizedType(" + outerType + ", " + componentTypeName + "[].class)";
-                } else if (firstGenericType instanceof DeclaredType) {
-                    DeclaredType genericDeclaredType = (DeclaredType) firstGenericType;
-                    TypeElement genericTypeElement = (TypeElement) genericDeclaredType.asElement();
-
-                    body.findCompilationUnit()
-                        .ifPresent(compilationUnit -> compilationUnit
-                            .addImport(genericTypeElement.getQualifiedName().toString()));
-
-                    String genericType = ((DeclaredType) declaredType.getTypeArguments().get(0)).asElement()
-                        .getSimpleName()
-                        .toString();
-                    if (genericTypeElement.getQualifiedName().contentEquals(List.class.getCanonicalName())) {
-                        if (!genericDeclaredType.getTypeArguments().isEmpty()) {
-                            String innerType
-                                = ((DeclaredType) genericDeclaredType.getTypeArguments().get(0)).asElement()
-                                    .getSimpleName()
-                                    .toString();
-                            return "CoreUtils.createParameterizedType(" + genericType + ".class, " + innerType
-                                + ".class)";
-                        }
-                    } else {
-                        return "CoreUtils.createParameterizedType(" + outerType + ", " + genericType + ".class)";
-                    }
-                }
-            }
-            return "CoreUtils.createParameterizedType(" + outerType + ")";
-        } else {
-            return "null;";
+        if (!(returnType instanceof DeclaredType)) {
+            return "CoreUtils.createParameterizedType(" + createTypeExpression(returnType) + ")";
         }
+
+        DeclaredType declaredType = (DeclaredType) returnType;
+        String rawType = ((TypeElement) declaredType.asElement()).getQualifiedName().toString() + ".class";
+        if (declaredType.getTypeArguments().isEmpty()) {
+            return "CoreUtils.createParameterizedType(" + rawType + ")";
+        }
+
+        String typeArguments = declaredType.getTypeArguments()
+            .stream()
+            .map(AnnotationProcessorUtils::createTypeExpression)
+            .collect(Collectors.joining(", "));
+        return "CoreUtils.createParameterizedType(" + rawType + ", " + typeArguments + ")";
+    }
+
+    private static String createTypeExpression(TypeMirror type) {
+        if (type instanceof DeclaredType) {
+            DeclaredType declaredType = (DeclaredType) type;
+            if (!declaredType.getTypeArguments().isEmpty()) {
+                return createParameterizedTypeStatement(declaredType, null);
+            }
+
+            return ((TypeElement) declaredType.asElement()).getQualifiedName().toString() + ".class";
+        }
+
+        if (type.getKind() == TypeKind.WILDCARD) {
+            WildcardType wildcardType = (WildcardType) type;
+            TypeMirror bound = wildcardType.getExtendsBound();
+            return bound == null ? "Object.class" : createTypeExpression(bound);
+        }
+
+        if (type.getKind() == TypeKind.TYPEVAR) {
+            TypeMirror upperBound = ((TypeVariable) type).getUpperBound();
+            return upperBound == null ? "Object.class" : createTypeExpression(upperBound);
+        }
+
+        return type + ".class";
     }
 
     /**

--- a/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/utils/PathBuilder.java
+++ b/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/utils/PathBuilder.java
@@ -6,15 +6,6 @@ package io.clientcore.annotation.processor.utils;
 import io.clientcore.annotation.processor.exceptions.MissingSubstitutionException;
 import io.clientcore.annotation.processor.models.HttpRequestContext;
 import io.clientcore.annotation.processor.models.Substitution;
-import io.clientcore.core.implementation.AccessibleByteArrayOutputStream;
-import io.clientcore.core.serialization.json.JsonSerializer;
-import io.clientcore.core.utils.DateTimeRfc1123;
-import io.clientcore.core.utils.ExpandableEnum;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -58,8 +49,7 @@ public final class PathBuilder {
             Substitution substitution = method.getSubstitution(paramName);
 
             if (substitution != null) {
-                String substitutionValue
-                    = serialize(JsonSerializer.getInstance(), substitution.getParameterVariableName());
+                String substitutionValue = substitution.getParameterVariableName();
                 // Special case: if the path is for "{nextLink}", use the variable
                 if (rawPath.contains("{nextLink}")) {
                     Substitution nextLinkSubstitution = method.getSubstitution("nextLink");
@@ -77,11 +67,19 @@ public final class PathBuilder {
                     .stream()
                     .filter(parameter -> parameter.getName().equals(substitution.getParameterVariableName()))
                     .findFirst();
-                boolean isValueTypeString = paramOpt.isPresent() && "String".equals(paramOpt.get().getShortTypeName());
-                if (isValueTypeString && substitution.shouldEncode()) {
-                    replacementValue = "UriEscapers.PATH_ESCAPER.escape(" + substitutionValue + ")";
+                if (paramOpt.isPresent()) {
+                    HttpRequestContext.MethodParameter parameter = paramOpt.get();
+                    String stringValue = "String".equals(parameter.getShortTypeName())
+                        ? substitutionValue
+                        : "String.valueOf(" + substitutionValue + ")";
+                    if (substitution.shouldEncode()) {
+                        stringValue = "UriEscapers.PATH_ESCAPER.escape(" + stringValue + ")";
+                    }
+                    replacementValue = parameter.getTypeMirror().getKind().isPrimitive()
+                        ? stringValue
+                        : "(" + substitutionValue + " == null ? \"\" : " + stringValue + ")";
                 } else {
-                    replacementValue = substitutionValue != null ? Objects.toString(substitutionValue, "null") : "";
+                    replacementValue = substitutionValue;
                 }
 
                 matcher.appendReplacement(buffer, "");
@@ -127,38 +125,6 @@ public final class PathBuilder {
             throw new MissingSubstitutionException("Mismatched braces in raw host: " + rawPath);
         }
         return result;
-    }
-
-    private static String serialize(JsonSerializer serializer, Object value) {
-        if (value == null) {
-            return null;
-        }
-
-        if (value instanceof ExpandableEnum) {
-            value = serialize(serializer, ((ExpandableEnum<?>) value).getValue());
-        }
-
-        if (value instanceof String) {
-            return (String) value;
-        } else if (value.getClass().isPrimitive()
-            || value.getClass().isEnum()
-            || value instanceof Number
-            || value instanceof Boolean
-            || value instanceof Character
-            || value instanceof DateTimeRfc1123) {
-
-            return String.valueOf(value);
-        } else if (value instanceof OffsetDateTime) {
-            return ((OffsetDateTime) value).format(DateTimeFormatter.ISO_INSTANT);
-        } else {
-            try (AccessibleByteArrayOutputStream outputStream = new AccessibleByteArrayOutputStream()) {
-                serializer.serializeToStream(outputStream, value);
-
-                return outputStream.toString(StandardCharsets.UTF_8);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
     }
 
     private PathBuilder() {

--- a/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/utils/RequestBodyHandler.java
+++ b/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/utils/RequestBodyHandler.java
@@ -8,14 +8,22 @@ import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.IfStmt;
 import io.clientcore.annotation.processor.models.HttpRequestContext;
 import io.clientcore.core.implementation.http.ContentType;
+import io.clientcore.core.implementation.utils.ImplUtils;
+import io.clientcore.core.implementation.utils.UriEscapers;
 import io.clientcore.core.models.binarydata.BinaryData;
 import io.clientcore.core.serialization.SerializationFormat;
 import io.clientcore.core.utils.CoreUtils;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
@@ -37,6 +45,11 @@ public final class RequestBodyHandler {
      */
     public static boolean configureRequestBody(BlockStmt body, HttpRequestContext requestContext,
         ProcessingEnvironment processingEnv) {
+        if (!requestContext.getFormParameters().isEmpty()) {
+            configureFormRequestBody(body, requestContext);
+            return false;
+        }
+
         HttpRequestContext.Body requestBody = requestContext.getBody();
         if (requestBody == null) {
             return false;
@@ -48,18 +61,103 @@ public final class RequestBodyHandler {
             setEmptyBody(body);
             return false;
         }
-        Optional<HttpRequestContext.MethodParameter> contentTypeParamParamOpt
-            = requestContext.getParameters().stream().filter(p -> p.getName().equals("contentType")).findFirst();
+        ContentTypeInfo contentType = resolveContentType(requestContext, requestBody);
 
         if (parameterType.getKind().isPrimitive()) {
             return addRequestBodyStatements(body, parameterType, requestBody, processingEnv.getElementUtils(),
-                processingEnv.getTypeUtils(), contentTypeParamParamOpt);
+                processingEnv.getTypeUtils(), contentType);
         } else {
             addRequestBodyWithNullCheck(body, parameterType, requestBody, processingEnv.getElementUtils(),
-                processingEnv.getTypeUtils(), contentTypeParamParamOpt);
+                processingEnv.getTypeUtils(), contentType);
             // serializationFormat could be set but not in scope to use for response body handling
             return false;
         }
+    }
+
+    private static ContentTypeInfo resolveContentType(HttpRequestContext requestContext,
+        HttpRequestContext.Body requestBody) {
+        Optional<java.util.Map.Entry<String, List<String>>> contentTypeHeader = requestContext.getHeaders()
+            .entrySet()
+            .stream()
+            .filter(header -> "Content-Type".equalsIgnoreCase(header.getKey()))
+            .findFirst();
+        if (contentTypeHeader.isPresent()) {
+            for (String value : contentTypeHeader.get().getValue()) {
+                Optional<HttpRequestContext.MethodParameter> parameter = requestContext.getParameters()
+                    .stream()
+                    .filter(methodParameter -> methodParameter.getName().equals(value))
+                    .findFirst();
+                if (parameter.isPresent()) {
+                    return new ContentTypeInfo(parameter.get(), requestBody.getContentType());
+                }
+            }
+
+            if (!contentTypeHeader.get().getValue().isEmpty()) {
+                return new ContentTypeInfo(null, contentTypeHeader.get().getValue().get(0));
+            }
+        }
+
+        return new ContentTypeInfo(null,
+            requestBody.getContentType() == null ? ContentType.APPLICATION_JSON : requestBody.getContentType());
+    }
+
+    static void configureFormRequestBody(BlockStmt body, HttpRequestContext requestContext) {
+        body.tryAddImportToParentCompilationUnit(ArrayList.class);
+        body.tryAddImportToParentCompilationUnit(List.class);
+        String formValuesName = getAvailableVariableName(requestContext, "formDataValues");
+        body.addStatement("List<String> " + formValuesName + " = new ArrayList<>();");
+
+        for (HttpRequestContext.FormParameter formParameter : requestContext.getFormParameters()) {
+            String parameterName = formParameter.getParameterName();
+            String formName = UriEscapers.FORM_ESCAPER.escape(formParameter.getName());
+            if (isCollectionType(formParameter.getParameterType())) {
+                String itemName = getAvailableVariableName(requestContext, parameterName + "Item");
+                String valueExpression = createFormValueExpression(itemName, formParameter.shouldEncode());
+                String statement = "if (" + parameterName + " != null) { for (Object " + itemName + " : "
+                    + parameterName + ") { if (" + itemName + " != null) { " + formValuesName + ".add(\"" + formName
+                    + "=\" + " + valueExpression + "); } } }";
+                body.addStatement(StaticJavaParser.parseStatement(statement));
+            } else {
+                String condition
+                    = formParameter.getParameterType().getKind().isPrimitive() ? "true" : parameterName + " != null";
+                String valueExpression = createFormValueExpression(parameterName, formParameter.shouldEncode());
+                String statement = "if (" + condition + ") { " + formValuesName + ".add(\"" + formName + "=\" + "
+                    + valueExpression + "); }";
+                body.addStatement(StaticJavaParser.parseStatement(statement));
+            }
+        }
+
+        setContentTypeHeader(body, ContentType.APPLICATION_X_WWW_FORM_URLENCODED);
+        body.addStatement(StaticJavaParser
+            .parseStatement("httpRequest.setBody(BinaryData.fromString(String.join(\"&\", " + formValuesName + ")));"));
+    }
+
+    private static String createFormValueExpression(String valueName, boolean shouldEncode) {
+        String stringValue = "String.valueOf(" + valueName + ")";
+        return shouldEncode ? "UriEscapers.FORM_ESCAPER.escape(" + stringValue + ")" : stringValue;
+    }
+
+    private static boolean isCollectionType(TypeMirror type) {
+        if (!(type instanceof DeclaredType)) {
+            return false;
+        }
+
+        String typeName = ((TypeElement) ((DeclaredType) type).asElement()).getQualifiedName().toString();
+        return Collection.class.getCanonicalName().equals(typeName)
+            || List.class.getCanonicalName().equals(typeName)
+            || Set.class.getCanonicalName().equals(typeName)
+            || Iterable.class.getCanonicalName().equals(typeName);
+    }
+
+    private static String getAvailableVariableName(HttpRequestContext requestContext, String preferredName) {
+        Set<String> parameterNames = new HashSet<>();
+        requestContext.getParameters().forEach(parameter -> parameterNames.add(parameter.getName()));
+        String name = preferredName;
+        int suffix = 2;
+        while (parameterNames.contains(name)) {
+            name = preferredName + suffix++;
+        }
+        return name;
     }
 
     /**
@@ -84,9 +182,11 @@ public final class RequestBodyHandler {
     public static void addBinaryDataRequestBody(BlockStmt body, String parameterName) {
         body.tryAddImportToParentCompilationUnit(BinaryData.class);
         body.addStatement(StaticJavaParser.parseStatement(String.format("BinaryData binaryData = %s;", parameterName)));
-        body.addStatement(StaticJavaParser.parseStatement("if (binaryData.getLength() != null) { "
+        body.addStatement(StaticJavaParser.parseStatement("if (binaryData.getLength() != null "
+            + "&& httpRequest.getHeaders().get(HttpHeaderName.CONTENT_LENGTH) == null) { "
             + "httpRequest.getHeaders().set(HttpHeaderName.CONTENT_LENGTH, String.valueOf(binaryData.getLength())); "
-            + "httpRequest.setBody(binaryData); }"));
+            + "}"));
+        body.addStatement(StaticJavaParser.parseStatement("httpRequest.setBody(binaryData);"));
     }
 
     /**
@@ -167,8 +267,9 @@ public final class RequestBodyHandler {
      */
     public static void addByteBufferRequestBody(BlockStmt body, String parameterName) {
         body.tryAddImportToParentCompilationUnit(ByteBuffer.class);
-        body.addStatement(StaticJavaParser
-            .parseStatement(String.format("httpRequest.setBody(BinaryData.fromBytes(%s.array()));", parameterName)));
+        body.addStatement(StaticJavaParser.parseStatement(
+            String.format("httpRequest.setBody(BinaryData.fromBytes(%s.byteBufferToArray(%s.duplicate())));",
+                ImplUtils.class.getCanonicalName(), parameterName)));
     }
 
     /**
@@ -203,17 +304,16 @@ public final class RequestBodyHandler {
     public static void handleRequestBodySerialization(BlockStmt body, String parameterName) {
         body.tryAddImportToParentCompilationUnit(SerializationFormat.class);
         body.addStatement(StaticJavaParser.parseStatement(
-            "SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());"));
+            "SerializationFormat requestSerializationFormat = CoreUtils.serializationFormatFromContentType(httpRequest.getHeaders());"));
         body.addStatement(StaticJavaParser.parseStatement(String.format(
-            "if (xmlSerializer.supportsFormat(serializationFormat)) {"
+            "if (xmlSerializer.supportsFormat(requestSerializationFormat)) {"
                 + "httpRequest.setBody(BinaryData.fromObject(%s, xmlSerializer));" + "} else {"
                 + "httpRequest.setBody(BinaryData.fromObject(%s, jsonSerializer));" + "}",
             parameterName, parameterName)));
     }
 
     private static void addRequestBodyWithNullCheck(BlockStmt body, TypeMirror parameterType,
-        HttpRequestContext.Body requestBody, Elements elementUtils, Types typeUtils,
-        Optional<HttpRequestContext.MethodParameter> contentTypeParam) {
+        HttpRequestContext.Body requestBody, Elements elementUtils, Types typeUtils, ContentTypeInfo contentType) {
         body.tryAddImportToParentCompilationUnit(SerializationFormat.class);
         body.tryAddImportToParentCompilationUnit(CoreUtils.class);
         String parameterName = requestBody.getParameterName();
@@ -221,59 +321,77 @@ public final class RequestBodyHandler {
         BlockStmt ifBlock = new BlockStmt();
         IfStmt ifStatement = new IfStmt(StaticJavaParser.parseExpression(parameterName + " != null"), ifBlock, null);
 
-        addRequestBodyStatements(ifBlock, parameterType, requestBody, elementUtils, typeUtils, contentTypeParam);
+        addRequestBodyStatements(ifBlock, parameterType, requestBody, elementUtils, typeUtils, contentType);
         body.addStatement(ifStatement);
     }
 
     private static boolean addRequestBodyStatements(BlockStmt body, TypeMirror parameterType,
-        HttpRequestContext.Body requestBody, Elements elementUtils, Types typeUtils,
-        Optional<HttpRequestContext.MethodParameter> contentTypeParam) {
-        String bodyContentType = requestBody.getContentType();
+        HttpRequestContext.Body requestBody, Elements elementUtils, Types typeUtils, ContentTypeInfo contentType) {
         String parameterName = requestBody.getParameterName();
-        if (contentTypeParam.isPresent()) {
-            String paramType = contentTypeParam.get().getShortTypeName();
+        if (contentType.parameter != null) {
+            String contentTypeParameterName = contentType.parameter.getName();
+            String paramType = contentType.parameter.getShortTypeName();
+            String valueExpression;
             if ("String".equals(paramType)) {
-                body.addStatement(StaticJavaParser
-                    .parseStatement("httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, contentType);"));
+                valueExpression = contentTypeParameterName;
             } else {
-                // use String.valueOf to convert the content type to a string
+                valueExpression = "String.valueOf(" + contentTypeParameterName + ")";
+            }
+            if (contentType.parameter.getTypeMirror().getKind().isPrimitive()) {
                 body.addStatement(StaticJavaParser.parseStatement(
-                    "httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, String" + ".valueOf(contentType));"));
+                    "httpRequest.getHeaders().set(" + "HttpHeaderName.CONTENT_TYPE, " + valueExpression + ");"));
+            } else {
+                body.addStatement(StaticJavaParser.parseStatement("if (" + contentTypeParameterName + " != null) { "
+                    + "httpRequest.getHeaders().set(HttpHeaderName.CONTENT_TYPE, " + valueExpression + "); }"));
             }
         } else {
-            setContentTypeHeader(body, bodyContentType == null ? ContentType.APPLICATION_JSON : bodyContentType);
-        }
-        // Use content type to decide serialization
-        if (bodyContentType != null && bodyContentType.trim().equalsIgnoreCase(ContentType.APPLICATION_JSON)) {
-            handleRequestBodySerialization(body, parameterName);
-            return true;
+            setContentTypeHeader(body, contentType.fallback);
         }
 
-        if (handleTypeBasedRequestBody(body, parameterType, parameterName, elementUtils, typeUtils)) {
+        if (isBinaryDataType(parameterType, elementUtils, typeUtils)) {
+            addBinaryDataRequestBody(body, parameterName);
             return false;
         }
 
-        // If no specific type handling was done, default to serialization
+        if (isStringType(parameterType, elementUtils, typeUtils) || isByteArray(parameterType)) {
+            addTextOrBinaryRequestBody(body, parameterType, parameterName, elementUtils, typeUtils);
+            return false;
+        }
+
+        if (isByteBufferType(parameterType, elementUtils, typeUtils)) {
+            addByteBufferRequestBody(body, parameterName);
+            return false;
+        }
+
         handleRequestBodySerialization(body, parameterName);
         return true;
     }
 
-    private static boolean handleTypeBasedRequestBody(BlockStmt body, TypeMirror parameterType, String parameterName,
+    private static void addTextOrBinaryRequestBody(BlockStmt body, TypeMirror parameterType, String parameterName,
         Elements elementUtils, Types typeUtils) {
-        if (isBinaryDataType(parameterType, elementUtils, typeUtils)) {
-            addBinaryDataRequestBody(body, parameterName);
-            return true;
-        } else if (isByteArray(parameterType)) {
-            addByteArrayRequestBody(body, parameterName);
-            return true;
+        body.tryAddImportToParentCompilationUnit(SerializationFormat.class);
+        BlockStmt jsonBody = new BlockStmt().addStatement(StaticJavaParser
+            .parseStatement("httpRequest.setBody(BinaryData.fromObject(" + parameterName + ", jsonSerializer));"));
+        BlockStmt rawBody = new BlockStmt();
+        if (isByteArray(parameterType)) {
+            addByteArrayRequestBody(rawBody, parameterName);
         } else if (isStringType(parameterType, elementUtils, typeUtils)) {
-            addStringRequestBody(body, parameterName);
-            return true;
-        } else if (isByteBufferType(parameterType, elementUtils, typeUtils)) {
-            addByteBufferRequestBody(body, parameterName);
-            return true;
+            addStringRequestBody(rawBody, parameterName);
         }
-        return false;
+        body.addStatement(new IfStmt(
+            StaticJavaParser.parseExpression(
+                "io.clientcore.core.utils.GeneratedCodeUtils.isJsonContentType(httpRequest.getHeaders())"),
+            jsonBody, rawBody));
+    }
+
+    private static final class ContentTypeInfo {
+        private final HttpRequestContext.MethodParameter parameter;
+        private final String fallback;
+
+        private ContentTypeInfo(HttpRequestContext.MethodParameter parameter, String fallback) {
+            this.parameter = parameter;
+            this.fallback = fallback == null ? ContentType.APPLICATION_JSON : fallback;
+        }
     }
 
     private RequestBodyHandler() {

--- a/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/utils/ResponseHandler.java
+++ b/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/utils/ResponseHandler.java
@@ -20,12 +20,12 @@ import io.clientcore.core.utils.CoreUtils;
 import io.clientcore.core.utils.GeneratedCodeUtils;
 import java.io.InputStream;
 import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -41,53 +41,58 @@ public final class ResponseHandler {
      * @param body the method builder to append generated code.
      * @param returnType the return type of the method.
      * @param method whether request options are used.
-     * @param serializationFormatSet indicates if a serialization format is set.
      */
-    public static void generateResponseHandling(BlockStmt body, TypeMirror returnType, HttpRequestContext method,
-        boolean serializationFormatSet) {
+    public static void generateResponseHandling(BlockStmt body, TypeMirror returnType, HttpRequestContext method) {
         java.lang.reflect.Type entityType = TypeConverter.getEntityType(returnType);
 
-        boolean usingTryWithResources = useTryWithResources(entityType, method);
-        if (usingTryWithResources) {
-            TryStmt statement = StaticJavaParser
-                .parseStatement("try (Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest)) {}")
-                .asTryStmt();
-            statement.setLineComment("\n Send the request through the httpPipeline");
+        boolean usingTryWithResources = useTryWithResources(entityType);
+        Statement sendStatement = StaticJavaParser
+            .parseStatement("Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);");
+        sendStatement.setLineComment("\n Send the request through the httpPipeline");
+        body.addStatement(sendStatement);
 
-            body.addStatement(statement);
-            body = statement.getTryBlock();
-        } else {
-            Statement statement = StaticJavaParser
-                .parseStatement("Response<BinaryData> networkResponse = this.httpPipeline.send(httpRequest);");
-            statement.setLineComment("\n Send the request through the httpPipeline");
-            body.addStatement(statement);
+        validateResponseStatus(body, method);
+
+        TryStmt closingStatement = null;
+        if (usingTryWithResources) {
+            closingStatement = StaticJavaParser
+                .parseStatement("try (Response<BinaryData> networkResponseToClose = networkResponse) {}")
+                .asTryStmt();
+            body.addStatement(closingStatement);
+            body = closingStatement.getTryBlock();
         }
 
-        validateResponseStatus(body, method, usingTryWithResources);
-
-        handleRequestReturn(body, returnType, entityType, method, serializationFormatSet);
+        handleRequestReturn(body, returnType, entityType, method);
+        if (usingTryWithResources) {
+            body.findAll(NameExpr.class)
+                .stream()
+                .filter(expression -> "networkResponse".equals(expression.getNameAsString()))
+                .forEach(expression -> expression.setName("networkResponseToClose"));
+            boolean responseIsReferenced = body.findAll(NameExpr.class)
+                .stream()
+                .anyMatch(expression -> "networkResponseToClose".equals(expression.getNameAsString()));
+            if (!responseIsReferenced) {
+                closingStatement.getResources().clear();
+                closingStatement.setFinallyBlock(
+                    new BlockStmt().addStatement(StaticJavaParser.parseStatement("networkResponse.close();")));
+            }
+        }
     }
 
-    private static boolean useTryWithResources(java.lang.reflect.Type entityType, HttpRequestContext method) {
+    static boolean useTryWithResources(java.lang.reflect.Type entityType) {
         // Use try-with-resources, where the Response<BinaryData> is the resource, if one of the following are true:
         // - Return type is a Void.class, exclude void.class as that will be handled separately.
         // - The request used method HEAD and return type boolean.
         // - Return type is byte[], which will consume the entire network response eagerly.
         // - Return type isn't InputStream or BinaryData, both will need to have the network response remain open.
-        if (TypeUtil.isTypeOrSubTypeOf(entityType, InputStream.class)
-            || TypeUtil.isTypeOrSubTypeOf(entityType, BinaryData.class)) {
-            return false;
-        }
-
-        return entityType == Void.class
-            || (method.getHttpMethod() == HttpMethod.HEAD && isBooleanType(entityType))
-            || TypeUtil.isTypeOrSubTypeOf(entityType, byte[].class);
+        return entityType != Void.TYPE
+            && !TypeUtil.isTypeOrSubTypeOf(entityType, InputStream.class)
+            && !TypeUtil.isTypeOrSubTypeOf(entityType, BinaryData.class);
     }
 
-    private static void validateResponseStatus(BlockStmt body, HttpRequestContext method,
-        boolean usingTryWithResources) {
+    private static void validateResponseStatus(BlockStmt body, HttpRequestContext method) {
         addStatusCodeCheck(body, method);
-        addExceptionHandling(body, method, usingTryWithResources);
+        addExceptionHandling(body, method);
     }
 
     private static void addStatusCodeCheck(BlockStmt body, HttpRequestContext method) {
@@ -97,7 +102,7 @@ public final class ResponseHandler {
         body.addStatement(StaticJavaParser.parseStatement("boolean expectedResponse = " + expectedResponseCheck + ";"));
     }
 
-    private static void addExceptionHandling(BlockStmt body, HttpRequestContext method, boolean usingTryWithResources) {
+    static void addExceptionHandling(BlockStmt body, HttpRequestContext method) {
         BlockStmt errorBlock = new BlockStmt();
         body.tryAddImportToParentCompilationUnit(GeneratedCodeUtils.class);
         Map<Integer, HttpRequestContext.ExceptionBodyTypeInfo> mappings = method.getExceptionBodyMappings();
@@ -129,9 +134,6 @@ public final class ResponseHandler {
             stmt.setLineComment("\n Handle unexpected response");
             errorBlock.addStatement(stmt);
         }
-        if (!usingTryWithResources) {
-            closeResponse(errorBlock);
-        }
         IfStmt ifStmt = new IfStmt()
             .setCondition(new UnaryExpr(new NameExpr("expectedResponse"), UnaryExpr.Operator.LOGICAL_COMPLEMENT))
             .setThenStmt(errorBlock);
@@ -158,11 +160,9 @@ public final class ResponseHandler {
     }
 
     private static void handleRequestReturn(BlockStmt body, TypeMirror returnType, java.lang.reflect.Type entityType,
-        HttpRequestContext method, boolean serializationFormatSet) {
+        HttpRequestContext method) {
         boolean returnIsResponse = TypeConverter.isResponseType(returnType);
 
-        // TODO (alzimmer): Base64Uri needs to be handled. Determine how this will show up in code generation and then
-        //  add support for it.
         if (returnType.getKind() == TypeKind.VOID) {
             // This handles the case where the API returns 'void' itself. This will result in code such as
             // "networkResponse.close()" as 'void' return doesn't use try-with-resources as the compiler will complain
@@ -177,28 +177,7 @@ public final class ResponseHandler {
             // HTTP method was either HEAD or the return is a boolean. Use the status code to determine response value.
             addReturnStatement(body, returnIsResponse, "expectedResponse");
         } else if (TypeUtil.isTypeOrSubTypeOf(entityType, byte[].class)) {
-            // Return is a byte[]. Convert the network response body into a byte[].
-            body.addStatement(StaticJavaParser.parseStatement("BinaryData responseBody = networkResponse.getValue();"));
-            // If the wire type is Base64Uri, decode it accordingly.
-            boolean isBase64Uri = false;
-            TypeMirror wireType = method.getReturnValueWireType();
-            if (wireType != null && wireType.getKind() == TypeKind.DECLARED) {
-                DeclaredType declaredWireType = (DeclaredType) wireType;
-                TypeElement wireTypeElement = (TypeElement) declaredWireType.asElement();
-                isBase64Uri = Base64Uri.class.getCanonicalName().equals(wireTypeElement.getQualifiedName().toString());
-            }
-            String returnExpr;
-            if (isBase64Uri) {
-                body.tryAddImportToParentCompilationUnit(Base64Uri.class);
-                returnExpr = "responseBody != null ? new Base64Uri(responseBody.toBytes()).decodedBytes() : null";
-            } else {
-                returnExpr = "responseBody != null ? responseBody.toBytes() : null";
-            }
-
-            // Return responseBody.toBytes(), or null if it was null, as-is which will have the behavior of
-            // null -> null, empty -> empty, and data -> data, which offers three unique states for knowing information
-            // about the network response shape, as nullness != emptiness.
-            addReturnStatement(body, returnIsResponse, returnExpr);
+            handleByteArrayReturn(body, returnIsResponse, method.getReturnValueWireType());
         } else if (TypeUtil.isTypeOrSubTypeOf(entityType, InputStream.class)) {
             // Return type is an InputStream. Return the network response body as an InputStream.
             // DO NOT close the network response for this return as it will result in the InputStream either being
@@ -215,7 +194,7 @@ public final class ResponseHandler {
                             .getQualifiedName()
                             .contentEquals(List.class.getCanonicalName())) {
                         // Response<List<BinaryData>> or other generics
-                        handleDeclaredTypes(body, returnType, serializationFormatSet, true, true);
+                        handleDeclaredTypes(body, returnType, true, true);
                         return;
                     }
                 }
@@ -227,17 +206,46 @@ public final class ResponseHandler {
         } else {
             // Fallback to a generalized code path that handles declared types as the entity, which uses deserialization
             // to create the return.
-            handleDeclaredTypes(body, returnType, serializationFormatSet, returnIsResponse, false);
+            handleDeclaredTypes(body, returnType, returnIsResponse, false);
         }
     }
 
-    private static void handleDeclaredTypes(BlockStmt body, TypeMirror returnType, boolean serializationFormatSet,
-        boolean returnIsResponse, boolean closeResponse) {
-        String typeCast = determineTypeCast(returnType, body);
+    static void handleByteArrayReturn(BlockStmt body, boolean returnIsResponse, TypeMirror wireType) {
+        body.addStatement(StaticJavaParser.parseStatement("BinaryData responseBody = networkResponse.getValue();"));
+        boolean isBase64Uri = false;
+        if (wireType != null && wireType.getKind() == TypeKind.DECLARED) {
+            DeclaredType declaredWireType = (DeclaredType) wireType;
+            TypeElement wireTypeElement = (TypeElement) declaredWireType.asElement();
+            isBase64Uri = Base64Uri.class.getCanonicalName().equals(wireTypeElement.getQualifiedName().toString());
+        }
+
+        String returnExpression;
+        if (isBase64Uri) {
+            body.tryAddImportToParentCompilationUnit(Base64Uri.class);
+            returnExpression = "responseBody != null ? new Base64Uri(responseBody.toBytes()).decodedBytes() : null";
+        } else {
+            body.tryAddImportToParentCompilationUnit(Arrays.class);
+            body.tryAddImportToParentCompilationUnit(Base64.class);
+            body.tryAddImportToParentCompilationUnit(CoreUtils.class);
+            body.tryAddImportToParentCompilationUnit(SerializationFormat.class);
+            body.addStatement("byte[] responseBytes = responseBody != null ? responseBody.toBytes() : null;");
+            body.addStatement("boolean quotedBase64 = responseBytes != null && responseBytes.length >= 2 "
+                + "&& responseBytes[0] == '\"' && responseBytes[responseBytes.length - 1] == '\"' "
+                + "&& GeneratedCodeUtils.isJsonContentType(networkResponse.getHeaders());");
+            returnExpression = "quotedBase64 ? Base64.getDecoder().decode(Arrays.copyOfRange(responseBytes, 1, "
+                + "responseBytes.length - 1)) : responseBytes";
+        }
+
+        addReturnStatement(body, returnIsResponse, returnExpression);
+    }
+
+    private static void handleDeclaredTypes(BlockStmt body, TypeMirror returnType, boolean returnIsResponse,
+        boolean closeResponse) {
+        String typeCast = determineTypeCast(returnType);
 
         // Initialize the variable that will be used in the return statement.
         body.addStatement(StaticJavaParser.parseStatement(typeCast + " deserializedResult;"));
-        handleDeclaredTypeResponse(body, (DeclaredType) returnType, serializationFormatSet, typeCast);
+        handleTypeResponse(body, returnType, typeCast);
         if (closeResponse) {
             body.addStatement(StaticJavaParser.parseStatement("networkResponse.close();"));
         }
@@ -254,40 +262,15 @@ public final class ResponseHandler {
         }
     }
 
-    private static String determineTypeCast(TypeMirror returnType, BlockStmt body) {
-        if (returnType instanceof DeclaredType) {
-            DeclaredType declaredType = (DeclaredType) returnType;
-            TypeElement typeElement = (TypeElement) declaredType.asElement();
-            body.tryAddImportToParentCompilationUnit(CoreUtils.class);
-
-            if (!declaredType.getTypeArguments().isEmpty()) {
-                TypeMirror firstGenericType = declaredType.getTypeArguments().get(0);
-                if (firstGenericType.getKind() == TypeKind.ARRAY) {
-                    ArrayType arrayType = (ArrayType) firstGenericType;
-                    String componentTypeName = arrayType.getComponentType().toString();
-                    return componentTypeName + "[]";
-                } else if (firstGenericType instanceof DeclaredType) {
-                    DeclaredType genericDeclaredType = (DeclaredType) firstGenericType;
-                    TypeElement genericTypeElement = (TypeElement) genericDeclaredType.asElement();
-                    body.findCompilationUnit()
-                        .ifPresent(compilationUnit -> compilationUnit
-                            .addImport(genericTypeElement.getQualifiedName().toString()));
-                    if (genericTypeElement.getQualifiedName().contentEquals(List.class.getCanonicalName())) {
-                        String typeArgs = genericDeclaredType.getTypeArguments()
-                            .stream()
-                            .map(arg -> ((DeclaredType) arg).asElement().getSimpleName().toString())
-                            .collect(Collectors.joining(", "));
-
-                        return ((DeclaredType) firstGenericType).asElement().getSimpleName().toString() + "<" + typeArgs
-                            + ">";
-                    } else {
-                        return genericTypeElement.getSimpleName().toString();
-                    }
-                }
+    static String determineTypeCast(TypeMirror returnType) {
+        if (TypeConverter.isResponseType(returnType)) {
+            DeclaredType responseType = (DeclaredType) returnType;
+            if (!responseType.getTypeArguments().isEmpty()) {
+                return TypeConverter.getAstType(responseType.getTypeArguments().get(0)).toString();
             }
-            return typeElement.getSimpleName().toString();
         }
-        return returnType.toString();
+
+        return TypeConverter.getAstType(returnType).toString();
     }
 
     private static boolean isBooleanType(java.lang.reflect.Type entityType) {
@@ -295,40 +278,39 @@ public final class ResponseHandler {
             || TypeUtil.isTypeOrSubTypeOf(entityType, Boolean.class);
     }
 
-    private static void handleDeclaredTypeResponse(BlockStmt body, DeclaredType returnType,
-        boolean serializationFormatSet, String typeCast) {
+    private static void handleTypeResponse(BlockStmt body, TypeMirror returnType, String typeCast) {
         body.tryAddImportToParentCompilationUnit(CoreUtils.class);
         body.tryAddImportToParentCompilationUnit(ParameterizedType.class);
+        body.addStatement(StaticJavaParser.parseStatement("ParameterizedType returnType = "
+            + AnnotationProcessorUtils.createParameterizedTypeStatement(returnType, body) + ";"));
 
-        if (!returnType.getTypeArguments().isEmpty()) {
-            body.addStatement(StaticJavaParser.parseStatement("ParameterizedType returnType = "
-                + AnnotationProcessorUtils.createParameterizedTypeStatement(returnType, body) + ";"));
-        } else {
-            body.addStatement(
-                "ParameterizedType returnType = CoreUtils.createParameterizedType(" + typeCast + ".class);");
-        }
-
-        if (serializationFormatSet) {
-            addSerializationFormatResponseBodyStatements(body);
-        } else {
-            body.tryAddImportToParentCompilationUnit(SerializationFormat.class);
-            body.addStatement(
-                "SerializationFormat serializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());");
-            addSerializationFormatResponseBodyStatements(body);
-        }
+        body.tryAddImportToParentCompilationUnit(SerializationFormat.class);
+        body.addStatement(
+            "SerializationFormat responseSerializationFormat = CoreUtils.serializationFormatFromContentType(networkResponse.getHeaders());");
+        addSerializationFormatResponseBodyStatements(body,
+            "String".equals(typeCast) || String.class.getCanonicalName().equals(typeCast));
     }
 
     private static void closeResponse(BlockStmt body) {
         body.addStatement(StaticJavaParser.parseStatement("networkResponse.close();"));
     }
 
-    private static void addSerializationFormatResponseBodyStatements(BlockStmt body) {
-        body.addStatement("if (jsonSerializer.supportsFormat(serializationFormat)) { "
+    static void addSerializationFormatResponseBodyStatements(BlockStmt body, boolean supportsText) {
+        String textHandling = supportsText
+            ? "if (responseSerializationFormat == SerializationFormat.TEXT) { "
+                + "    BinaryData responseBody = networkResponse.getValue(); "
+                + "    deserializedResult = responseBody == null ? null : responseBody.toString(); " + "} else "
+            : "";
+        String jsonCondition = supportsText
+            ? "jsonSerializer.supportsFormat(responseSerializationFormat)"
+            : "jsonSerializer.supportsFormat(responseSerializationFormat) "
+                + "|| responseSerializationFormat == SerializationFormat.TEXT";
+        body.addStatement(textHandling + "if (" + jsonCondition + ") { "
             + "    deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), jsonSerializer, returnType); "
-            + "} else if (xmlSerializer.supportsFormat(serializationFormat)) { "
+            + "} else if (xmlSerializer.supportsFormat(responseSerializationFormat)) { "
             + "    deserializedResult = CoreUtils.decodeNetworkResponse(networkResponse.getValue(), xmlSerializer, returnType); "
             + "} else { "
-            + "    throw LOGGER.throwableAtError().addKeyValue(\"serializationFormat\", serializationFormat.name())\n"
+            + "    throw LOGGER.throwableAtError().addKeyValue(\"serializationFormat\", responseSerializationFormat.name())\n"
             + "                .log(\"None of the provided serializers support the format.\", UnsupportedOperationException::new);"
             + "}");
     }

--- a/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/utils/TypeConverter.java
+++ b/sdk/clientcore/annotation-processor/src/main/java/io/clientcore/annotation/processor/utils/TypeConverter.java
@@ -118,6 +118,9 @@ public final class TypeConverter {
                 // Convert JavaParser's PrimitiveType to Java Reflection Type
                 return getPrimitiveClass(returnType);
 
+            case VOID:
+                return void.class;
+
             case DECLARED:
                 return handleDeclaredType(returnType);
 

--- a/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/models/HttpRequestContextTest.java
+++ b/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/models/HttpRequestContextTest.java
@@ -5,6 +5,8 @@ package io.clientcore.annotation.processor.models;
 
 import java.util.List;
 import java.util.Map;
+import javax.lang.model.type.TypeKind;
+import io.clientcore.annotation.processor.mocks.MockTypeMirror;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,6 +48,17 @@ public class HttpRequestContextTest {
         assertEquals(2, values.size());
         assertTrue(values.contains("v1"));
         assertTrue(values.contains("v2"));
+    }
+
+    @Test
+    void testDynamicHeaderReplacesStaticHeaderCaseInsensitively() {
+        HttpRequestContext context = new HttpRequestContext();
+        context.addStaticHeaders(new String[] { "X-Test:static" });
+
+        context.setHeader("x-test", "dynamicValue");
+
+        assertEquals(1, context.getHeaders().size());
+        assertEquals("dynamicValue", context.getHeaders().get("x-test").get(0));
     }
 
     @Test
@@ -98,5 +111,16 @@ public class HttpRequestContextTest {
         assertEquals(body, ctx.getBody());
         assertEquals("application/json", ctx.getBody().getContentType());
         assertEquals("param", ctx.getBody().getParameterName());
+    }
+
+    @Test
+    void testAddFormParameter() {
+        HttpRequestContext context = new HttpRequestContext();
+        context.addFormParameter(new HttpRequestContext.FormParameter("display name",
+            new MockTypeMirror(TypeKind.DECLARED, "java.lang.String"), "displayName", true));
+
+        assertEquals(1, context.getFormParameters().size());
+        assertEquals("display name", context.getFormParameters().get(0).getName());
+        assertTrue(context.getFormParameters().get(0).shouldEncode());
     }
 }

--- a/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/templating/HeaderCollectionGenerationTest.java
+++ b/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/templating/HeaderCollectionGenerationTest.java
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package io.clientcore.annotation.processor.templating;
+
+import com.github.javaparser.ast.stmt.BlockStmt;
+import io.clientcore.annotation.processor.mocks.MockDeclaredType;
+import io.clientcore.annotation.processor.models.HttpRequestContext;
+import javax.lang.model.type.TypeKind;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HeaderCollectionGenerationTest {
+    @Test
+    public void expandsMapIntoPrefixedHeaders() {
+        HttpRequestContext requestContext = new HttpRequestContext();
+        requestContext.addHeader("x-ms-meta-", "metadata");
+        requestContext.addParameter(new HttpRequestContext.MethodParameter(new MockDeclaredType(TypeKind.DECLARED,
+            "java.util.Map", new MockDeclaredType(TypeKind.DECLARED, "java.lang.String"),
+            new MockDeclaredType(TypeKind.DECLARED, "java.lang.String")), "Map<String, String>", "metadata", null));
+        BlockStmt body = new BlockStmt();
+
+        new JavaParserTemplateProcessor().addHeadersToRequest(body, requestContext);
+
+        String generatedCode = body.toString();
+        assertTrue(generatedCode.contains("for (Map.Entry<?, ?> metadataHeaderEntry : metadata.entrySet())"));
+        assertTrue(generatedCode.contains("HttpHeaderName.fromString(\"x-ms-meta-\" + metadataHeaderEntry.getKey())"));
+        assertTrue(generatedCode.contains("String.valueOf(metadataHeaderEntry.getValue())"));
+    }
+}

--- a/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/templating/RequestConfigurationGenerationTest.java
+++ b/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/templating/RequestConfigurationGenerationTest.java
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package io.clientcore.annotation.processor.templating;
+
+import com.github.javaparser.ast.stmt.BlockStmt;
+import io.clientcore.annotation.processor.mocks.MockDeclaredType;
+import io.clientcore.annotation.processor.models.HttpRequestContext;
+import javax.lang.model.type.TypeKind;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RequestConfigurationGenerationTest {
+    @Test
+    public void usesRequestConfigurationParameterNames() {
+        HttpRequestContext requestContext = new HttpRequestContext();
+        requestContext.addParameter(parameter("options", "io.clientcore.core.http.models.RequestContext"));
+        requestContext.addParameter(parameter("listener", "io.clientcore.core.http.models.ServerSentEventListener"));
+        BlockStmt body = new BlockStmt();
+
+        new JavaParserTemplateProcessor().addRequestConfigurationToRequest(body, requestContext);
+
+        String generatedCode = body.toString();
+        assertTrue(generatedCode.contains("httpRequest.setContext(options)"));
+        assertTrue(generatedCode.contains("httpRequest.setServerSentEventListener(listener)"));
+    }
+
+    @Test
+    public void serializesNonExplodedCollectionQueryAsSingleValue() {
+        HttpRequestContext requestContext = new HttpRequestContext();
+        requestContext.setHost("\"https://example.test\"");
+        requestContext.setTemplateHasHost(true);
+        requestContext.addQueryParam("colors", "colors", false, true, false);
+        requestContext.addParameter(parameter("colors", "java.util.List"));
+        BlockStmt body = new BlockStmt();
+
+        new JavaParserTemplateProcessor().setHttpRequestUri(body,
+            com.github.javaparser.StaticJavaParser.parseExpression("new HttpRequest().setMethod(HttpMethod.GET)"),
+            requestContext);
+
+        assertTrue(body.toString().contains("BinaryData.fromObject(colors, jsonSerializer).toString()"));
+    }
+
+    private static HttpRequestContext.MethodParameter parameter(String name, String type) {
+        return new HttpRequestContext.MethodParameter(new MockDeclaredType(TypeKind.DECLARED, type), type, name, null);
+    }
+}

--- a/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/utils/AnnotationProcessorUtilsTest.java
+++ b/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/utils/AnnotationProcessorUtilsTest.java
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package io.clientcore.annotation.processor.utils;
+
+import com.github.javaparser.ast.stmt.BlockStmt;
+import io.clientcore.annotation.processor.mocks.MockDeclaredType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AnnotationProcessorUtilsTest {
+    @Test
+    public void createsNestedParameterizedType() {
+        DeclaredType modelType = declaredType("com.example.Model");
+        DeclaredType mapType = declaredType("java.util.Map", declaredType("java.lang.String"), modelType);
+        DeclaredType responseType = declaredType("io.clientcore.core.http.models.Response", mapType);
+
+        assertEquals(
+            "CoreUtils.createParameterizedType(io.clientcore.core.http.models.Response.class, "
+                + "CoreUtils.createParameterizedType(java.util.Map.class, java.lang.String.class, "
+                + "com.example.Model.class))",
+            AnnotationProcessorUtils.createParameterizedTypeStatement(responseType, new BlockStmt()));
+    }
+
+    @Test
+    public void determinesNestedResponseEntityType() {
+        DeclaredType mapType
+            = declaredType("java.util.Map", declaredType("java.lang.String"), declaredType("com.example.Model"));
+        DeclaredType responseType = declaredType("io.clientcore.core.http.models.Response", mapType);
+
+        assertEquals("java.util.Map<java.lang.String, com.example.Model>",
+            ResponseHandler.determineTypeCast(responseType));
+    }
+
+    private static DeclaredType declaredType(String name, DeclaredType... typeArguments) {
+        return new MockDeclaredType(TypeKind.DECLARED, name, typeArguments);
+    }
+}

--- a/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/utils/PathBuilderTest.java
+++ b/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/utils/PathBuilderTest.java
@@ -4,8 +4,11 @@
 package io.clientcore.annotation.processor.utils;
 
 import io.clientcore.annotation.processor.exceptions.MissingSubstitutionException;
+import io.clientcore.annotation.processor.mocks.MockDeclaredType;
+import io.clientcore.annotation.processor.mocks.MockTypeMirror;
 import io.clientcore.annotation.processor.models.HttpRequestContext;
 import io.clientcore.annotation.processor.models.Substitution;
+import javax.lang.model.type.TypeKind;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -414,5 +417,31 @@ public class PathBuilderTest {
         context.addSubstitution(new Substitution("nextLink", "nextLinkVar"));
         String result = PathBuilder.buildPath("{nextLink}", context);
         assertEquals("nextLinkVar", result);
+    }
+
+    @Test
+    public void omitsNullOptionalPathParameter() {
+        HttpRequestContext context = new HttpRequestContext();
+        context.addSubstitution(new Substitution("name", "name", true));
+        context.addParameter(new HttpRequestContext.MethodParameter(
+            new MockDeclaredType(TypeKind.DECLARED, "java.lang.String"), "String", "name", null));
+
+        String result = PathBuilder.buildPath("/parameters/path/optional{name}", context);
+
+        assertEquals(
+            "\"/parameters/path/optional\" + (name == null ? \"\" : " + "UriEscapers.PATH_ESCAPER.escape(name))",
+            result);
+    }
+
+    @Test
+    public void encodesPrimitivePathParameter() {
+        HttpRequestContext context = new HttpRequestContext();
+        context.addSubstitution(new Substitution("id", "id", true));
+        context.addParameter(
+            new HttpRequestContext.MethodParameter(new MockTypeMirror(TypeKind.INT, "int"), "int", "id", null));
+
+        String result = PathBuilder.buildPath("/items/{id}", context);
+
+        assertEquals("\"/items/\" + UriEscapers.PATH_ESCAPER.escape(String.valueOf(id))", result);
     }
 }

--- a/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/utils/RequestBodyHandlerTest.java
+++ b/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/utils/RequestBodyHandlerTest.java
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package io.clientcore.annotation.processor.utils;
+
+import com.github.javaparser.ast.stmt.BlockStmt;
+import io.clientcore.annotation.processor.mocks.MockTypeMirror;
+import io.clientcore.annotation.processor.models.HttpRequestContext;
+import javax.lang.model.type.TypeKind;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RequestBodyHandlerTest {
+    @Test
+    public void binaryDataBodyIsSetOutsideLengthCheck() {
+        BlockStmt body = new BlockStmt();
+
+        RequestBodyHandler.addBinaryDataRequestBody(body, "content");
+
+        String generatedCode = body.toString();
+        assertEquals(3, body.getStatements().size());
+        assertEquals("httpRequest.setBody(binaryData);", body.getStatement(2).toString());
+        assertTrue(generatedCode.contains("get(HttpHeaderName.CONTENT_LENGTH) == null"));
+    }
+
+    @Test
+    public void byteBufferConversionUsesRemainingViewWithoutMutatingInput() {
+        BlockStmt body = new BlockStmt();
+
+        RequestBodyHandler.addByteBufferRequestBody(body, "content");
+
+        assertTrue(body.toString().contains("ImplUtils.byteBufferToArray(content.duplicate())"));
+    }
+
+    @Test
+    public void configuresFormUrlEncodedBody() {
+        HttpRequestContext requestContext = new HttpRequestContext();
+        requestContext.addFormParameter(new HttpRequestContext.FormParameter("display name",
+            new MockTypeMirror(TypeKind.DECLARED, "java.lang.String"), "displayName", true));
+        BlockStmt body = new BlockStmt();
+
+        RequestBodyHandler.configureFormRequestBody(body, requestContext);
+
+        String generatedCode = body.toString();
+        assertTrue(generatedCode.contains("display+name="));
+        assertTrue(generatedCode.contains("UriEscapers.FORM_ESCAPER.escape(String.valueOf(displayName))"));
+        assertTrue(generatedCode.contains("application/x-www-form-urlencoded"));
+        assertTrue(generatedCode.contains("String.join(\"&\", formDataValues)"));
+    }
+}

--- a/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/utils/ResponseHandlerTest.java
+++ b/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/utils/ResponseHandlerTest.java
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package io.clientcore.annotation.processor.utils;
+
+import io.clientcore.core.models.binarydata.BinaryData;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import java.io.InputStream;
+import java.util.List;
+import io.clientcore.annotation.processor.mocks.MockTypeMirror;
+import io.clientcore.annotation.processor.models.HttpRequestContext;
+import io.clientcore.core.http.models.HttpMethod;
+import javax.lang.model.type.TypeKind;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ResponseHandlerTest {
+    @Test
+    public void eagerlyConsumedResponsesUseTryWithResources() {
+        assertTrue(ResponseHandler.useTryWithResources(String.class));
+        assertTrue(ResponseHandler.useTryWithResources(List.class));
+        assertTrue(ResponseHandler.useTryWithResources(byte[].class));
+        assertTrue(ResponseHandler.useTryWithResources(Void.class));
+    }
+
+    @Test
+    public void streamingResponsesRemainOpen() {
+        assertFalse(ResponseHandler.useTryWithResources(InputStream.class));
+        assertFalse(ResponseHandler.useTryWithResources(BinaryData.class));
+        assertFalse(ResponseHandler.useTryWithResources(void.class));
+    }
+
+    @Test
+    public void decodesQuotedStandardBase64AndPreservesRawBytes() {
+        BlockStmt body = new BlockStmt();
+
+        ResponseHandler.handleByteArrayReturn(body, false, null);
+
+        String generatedCode = body.toString();
+        assertTrue(generatedCode.contains("boolean quotedBase64"));
+        assertTrue(generatedCode.contains("GeneratedCodeUtils.isJsonContentType"));
+        assertTrue(generatedCode.contains("Base64.getDecoder().decode(Arrays.copyOfRange"));
+        assertTrue(generatedCode.contains(": responseBytes"));
+    }
+
+    @Test
+    public void textResponseUsesRawBodyString() {
+        BlockStmt body = new BlockStmt();
+
+        ResponseHandler.addSerializationFormatResponseBodyStatements(body, true);
+
+        String generatedCode = body.toString();
+        assertTrue(generatedCode.contains("responseSerializationFormat == SerializationFormat.TEXT"));
+        assertTrue(generatedCode.contains("responseBody.toString()"));
+    }
+
+    @Test
+    public void textModelResponseUsesJsonDecoder() {
+        BlockStmt body = new BlockStmt();
+
+        ResponseHandler.addSerializationFormatResponseBodyStatements(body, false);
+
+        assertTrue(body.toString().contains("responseSerializationFormat == SerializationFormat.TEXT"));
+    }
+
+    @Test
+    public void generatesPrimitiveReturnHandling() {
+        HttpRequestContext requestContext = new HttpRequestContext();
+        requestContext.setExpectedStatusCodes(new int[] { 200 });
+        requestContext.setHttpMethod(HttpMethod.GET);
+        BlockStmt body = new BlockStmt();
+
+        ResponseHandler.generateResponseHandling(body, new MockTypeMirror(TypeKind.INT, "int"), requestContext);
+
+        String generatedCode = body.toString();
+        assertTrue(generatedCode.contains("int deserializedResult"));
+        assertTrue(generatedCode.contains("CoreUtils.createParameterizedType(int.class)"));
+    }
+
+    @Test
+    public void unexpectedResponseHandlerOwnsResponseClosure() {
+        HttpRequestContext requestContext = new HttpRequestContext();
+        BlockStmt body = new BlockStmt();
+
+        ResponseHandler.addExceptionHandling(body, requestContext);
+
+        String generatedCode = body.toString();
+        assertTrue(generatedCode.contains("GeneratedCodeUtils.handleUnexpectedResponse"));
+        assertFalse(generatedCode.contains("networkResponse.close()"));
+    }
+
+    @Test
+    public void eagerResponseClosingScopeStartsAfterErrorHandling() {
+        HttpRequestContext requestContext = new HttpRequestContext();
+        requestContext.setExpectedStatusCodes(new int[] { 200 });
+        requestContext.setHttpMethod(HttpMethod.GET);
+        BlockStmt body = new BlockStmt();
+
+        ResponseHandler.generateResponseHandling(body,
+            new io.clientcore.annotation.processor.mocks.MockDeclaredType(TypeKind.DECLARED, "java.lang.String"),
+            requestContext);
+
+        String generatedCode = body.toString();
+        assertTrue(generatedCode.indexOf("GeneratedCodeUtils.handleUnexpectedResponse")
+            < generatedCode.indexOf("networkResponseToClose = networkResponse"));
+        assertTrue(generatedCode.contains("networkResponseToClose.getValue()"));
+    }
+
+    @Test
+    public void eagerResponseWithoutBodyUseClosesInFinally() {
+        HttpRequestContext requestContext = new HttpRequestContext();
+        requestContext.setExpectedStatusCodes(new int[] { 200 });
+        requestContext.setHttpMethod(HttpMethod.GET);
+        BlockStmt body = new BlockStmt();
+
+        ResponseHandler.generateResponseHandling(body,
+            new io.clientcore.annotation.processor.mocks.MockDeclaredType(TypeKind.DECLARED, "java.lang.Void"),
+            requestContext);
+
+        String generatedCode = body.toString();
+        assertFalse(generatedCode.contains("networkResponseToClose = networkResponse"));
+        assertTrue(generatedCode.contains("finally"));
+        assertTrue(generatedCode.contains("networkResponse.close()"));
+    }
+}

--- a/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/utils/TypeConverterTest.java
+++ b/sdk/clientcore/annotation-processor/src/test/java/io/clientcore/annotation/processor/utils/TypeConverterTest.java
@@ -80,6 +80,11 @@ public class TypeConverterTest {
     }
 
     @Test
+    public void getEntityTypeVoid() {
+        assertEquals(void.class, TypeConverter.getEntityType(mockPrimitiveType(TypeKind.VOID)));
+    }
+
+    @Test
     public void isResponseTypeResponseType() {
         DeclaredType responseType = new MockDeclaredType(TypeKind.DECLARED, "io.clientcore.core.http.models.Response");
         boolean result = TypeConverter.isResponseType(responseType);

--- a/sdk/clientcore/core/CHANGELOG.md
+++ b/sdk/clientcore/core/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.0.0-beta.12 (Unreleased)
 
 ### Features Added
+- Added recursive JSON deserialization for typed lists and maps containing models, enums, binary data, temporal values,
+  and numeric values.
+- Added `CoreUtils.durationToStringWithDays` for ISO-8601 duration formatting that preserves day components.
 
 ### Breaking Changes
 - Changed `HttpRetryOptions.delayFromHeaders` to `HttpRetryOptions.delayFromRetryCondition`. The `Function` is now a
@@ -10,6 +13,9 @@
   of the reason the request failed and is being retried when calculating the delay. ([#46384](https://github.com/Azure/azure-sdk-for-java/pull/46384))
 
 ### Bugs Fixed
+- Fixed untyped JSON serialization of durations, date-times, and arbitrary numeric values in collection and dictionary
+  payloads.
+- Fixed generic network response decoding to preserve nested type information.
 
 ### Other Changes
 

--- a/sdk/clientcore/core/src/main/java/io/clientcore/core/serialization/json/JsonSerializer.java
+++ b/sdk/clientcore/core/src/main/java/io/clientcore/core/serialization/json/JsonSerializer.java
@@ -19,7 +19,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Class providing basic JSON serialization and deserialization methods.
@@ -73,7 +80,7 @@ public class JsonSerializer implements ObjectSerializer {
                 } else if (BinaryData.class.isAssignableFrom(TypeUtil.getRawClass(listElementType))) {
                     return deserializeListOfBinaryData(jsonReader);
                 } else {
-                    return (T) jsonReader.readUntyped();
+                    return (T) convertValue(jsonReader.readUntyped(), parameterizedType);
                 }
             } else if (type instanceof Class<?>
                 && JsonSerializable.class.isAssignableFrom(TypeUtil.getRawClass(type))) {
@@ -81,7 +88,7 @@ public class JsonSerializer implements ObjectSerializer {
 
                 return (T) clazz.getMethod("fromJson", JsonReader.class).invoke(null, jsonReader);
             }
-            return (T) jsonReader.readUntyped();
+            return (T) convertValue(jsonReader.readUntyped(), type);
         } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
             throw LOGGER.throwableAtError().log(e, RuntimeException::new);
         }
@@ -138,12 +145,130 @@ public class JsonSerializer implements ObjectSerializer {
                 Class<T> clazz = (Class<T>) type;
 
                 return (T) clazz.getMethod("fromJson", JsonReader.class).invoke(null, jsonReader);
-            } else {
-                return (T) jsonReader.readUntyped();
             }
+            return (T) convertValue(jsonReader.readUntyped(), type);
         } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
             throw LOGGER.throwableAtError().log(e, RuntimeException::new);
         }
+    }
+
+    private Object convertValue(Object value, Type targetType) throws IOException {
+        if (value == null || targetType == null || targetType == Object.class) {
+            return value;
+        }
+
+        if (targetType instanceof WildcardType) {
+            Type[] upperBounds = ((WildcardType) targetType).getUpperBounds();
+            return upperBounds.length == 0 ? value : convertValue(value, upperBounds[0]);
+        }
+
+        if (targetType instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) targetType;
+            Class<?> rawType = TypeUtil.getRawClass(parameterizedType);
+            Type[] typeArguments = parameterizedType.getActualTypeArguments();
+            if (List.class.isAssignableFrom(rawType) && value instanceof List<?> && typeArguments.length == 1) {
+                List<?> values = (List<?>) value;
+                List<Object> convertedValues = new ArrayList<>(values.size());
+                for (Object item : values) {
+                    convertedValues.add(convertValue(item, typeArguments[0]));
+                }
+                return convertedValues;
+            }
+
+            if (Map.class.isAssignableFrom(rawType) && value instanceof Map<?, ?> && typeArguments.length == 2) {
+                Map<?, ?> values = (Map<?, ?>) value;
+                Map<Object, Object> convertedValues = new LinkedHashMap<>(values.size());
+                for (Map.Entry<?, ?> entry : values.entrySet()) {
+                    convertedValues.put(convertValue(entry.getKey(), typeArguments[0]),
+                        convertValue(entry.getValue(), typeArguments[1]));
+                }
+                return convertedValues;
+            }
+
+            return convertValue(value, rawType);
+        }
+
+        if (!(targetType instanceof Class<?>)) {
+            return value;
+        }
+
+        Class<?> targetClass = (Class<?>) targetType;
+        if (targetClass.isInstance(value)) {
+            return value;
+        }
+        if (targetClass == BinaryData.class) {
+            return BinaryData.fromObject(value, this);
+        }
+        if (JsonSerializable.class.isAssignableFrom(targetClass)) {
+            return deserializeFromBytes(serializeToBytes(value), targetClass);
+        }
+        if (targetClass == OffsetDateTime.class && value instanceof String) {
+            return OffsetDateTime.parse((String) value);
+        }
+        if (targetClass == Duration.class && value instanceof String) {
+            return Duration.parse((String) value);
+        }
+        if (targetClass == byte[].class && value instanceof String) {
+            return Base64.getDecoder().decode((String) value);
+        }
+        if (targetClass.isEnum() && value instanceof String) {
+            return convertEnumValue(targetClass, (String) value);
+        }
+        if (value instanceof Number) {
+            return convertNumber((Number) value, targetClass);
+        }
+        if (targetClass == String.class) {
+            return String.valueOf(value);
+        }
+        if ((targetClass == Character.class || targetClass == Character.TYPE)
+            && value instanceof String
+            && !((String) value).isEmpty()) {
+            return ((String) value).charAt(0);
+        }
+
+        return value;
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static Object convertEnumValue(Class<?> targetClass, String value) throws IOException {
+        try {
+            Method fromString = targetClass.getMethod("fromString", String.class);
+            return fromString.invoke(null, value);
+        } catch (NoSuchMethodException ignored) {
+            return convertJavaEnumValue(targetClass, value);
+        } catch (IllegalAccessException | InvocationTargetException exception) {
+            throw LOGGER.throwableAtError()
+                .log("Unable to deserialize enum value '" + value + "' as " + targetClass.getName(), exception,
+                    IOException::new);
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static Object convertJavaEnumValue(Class<?> targetClass, String value) throws IOException {
+        try {
+            return Enum.valueOf((Class<? extends Enum>) targetClass, value);
+        } catch (IllegalArgumentException exception) {
+            throw LOGGER.throwableAtError()
+                .log("Unable to deserialize enum value '" + value + "' as " + targetClass.getName(), exception,
+                    IOException::new);
+        }
+    }
+
+    private static Object convertNumber(Number value, Class<?> targetClass) {
+        if (targetClass == Byte.class || targetClass == Byte.TYPE) {
+            return value.byteValue();
+        } else if (targetClass == Short.class || targetClass == Short.TYPE) {
+            return value.shortValue();
+        } else if (targetClass == Integer.class || targetClass == Integer.TYPE) {
+            return value.intValue();
+        } else if (targetClass == Long.class || targetClass == Long.TYPE) {
+            return value.longValue();
+        } else if (targetClass == Float.class || targetClass == Float.TYPE) {
+            return value.floatValue();
+        } else if (targetClass == Double.class || targetClass == Double.TYPE) {
+            return value.doubleValue();
+        }
+        return value;
     }
 
     /**

--- a/sdk/clientcore/core/src/main/java/io/clientcore/core/serialization/json/JsonWriter.java
+++ b/sdk/clientcore/core/src/main/java/io/clientcore/core/serialization/json/JsonWriter.java
@@ -6,6 +6,7 @@ package io.clientcore.core.serialization.json;
 import io.clientcore.core.models.binarydata.BinaryData;
 import io.clientcore.core.serialization.json.implementation.jackson.core.JsonFactory;
 import io.clientcore.core.serialization.json.implementation.jackson.core.JsonGenerator;
+import io.clientcore.core.utils.CoreUtils;
 import io.clientcore.core.utils.IOExceptionCheckedBiConsumer;
 
 import java.io.Closeable;
@@ -13,6 +14,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -1313,6 +1317,8 @@ public final class JsonWriter implements Closeable {
             return writeFloat((float) value);
         } else if (value instanceof Double) {
             return writeDouble((double) value);
+        } else if (value instanceof Number) {
+            return writeNumber((Number) value);
         } else if (value instanceof Boolean) {
             return writeBoolean((boolean) value);
         } else if (value instanceof byte[]) {
@@ -1326,6 +1332,10 @@ public final class JsonWriter implements Closeable {
         } else if (value instanceof BinaryData) {
             ((BinaryData) value).writeTo(this);
             return this;
+        } else if (value instanceof Duration) {
+            return writeString(CoreUtils.durationToStringWithDays((Duration) value));
+        } else if (value instanceof OffsetDateTime) {
+            return writeString(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format((OffsetDateTime) value));
         } else if (value instanceof Object[]) {
             writeStartArray();
             for (Object element : (Object[]) value) {

--- a/sdk/clientcore/core/src/main/java/io/clientcore/core/utils/CoreUtils.java
+++ b/sdk/clientcore/core/src/main/java/io/clientcore/core/utils/CoreUtils.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.time.DateTimeException;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -291,6 +292,85 @@ public final class CoreUtils {
     }
 
     /**
+     * Converts a duration to ISO-8601 while retaining a day component for complete 24-hour periods.
+     *
+     * @param duration The duration to convert.
+     * @return The ISO-8601 duration, or null if the duration is null.
+     */
+    public static String durationToStringWithDays(Duration duration) {
+        if (duration == null) {
+            return null;
+        }
+        if (duration.isZero()) {
+            return "PT0S";
+        }
+
+        StringBuilder builder = new StringBuilder();
+        if (duration.isNegative()) {
+            builder.append("-P");
+            duration = duration.negated();
+        } else {
+            builder.append('P');
+        }
+
+        long days = duration.toDays();
+        if (days > 0) {
+            builder.append(days).append('D');
+            duration = duration.minusDays(days);
+        }
+
+        long hours = duration.toHours();
+        if (hours > 0) {
+            builder.append('T').append(hours).append('H');
+            duration = duration.minusHours(hours);
+        }
+
+        long minutes = duration.toMinutes();
+        if (minutes > 0) {
+            if (hours == 0) {
+                builder.append('T');
+            }
+            builder.append(minutes).append('M');
+            duration = duration.minusMinutes(minutes);
+        }
+
+        long seconds = duration.getSeconds();
+        if (seconds > 0) {
+            if (hours == 0 && minutes == 0) {
+                builder.append('T');
+            }
+            builder.append(seconds);
+            duration = duration.minusSeconds(seconds);
+        }
+
+        long milliseconds = duration.toMillis();
+        if (milliseconds > 0) {
+            if (hours == 0 && minutes == 0 && seconds == 0) {
+                builder.append('T');
+            }
+            if (seconds == 0) {
+                builder.append('0');
+            }
+            builder.append('.');
+            if (milliseconds <= 99) {
+                builder.append('0');
+                if (milliseconds <= 9) {
+                    builder.append('0');
+                }
+            }
+            while (milliseconds % 10 == 0) {
+                milliseconds /= 10;
+            }
+            builder.append(milliseconds);
+        }
+
+        if (seconds > 0 || milliseconds > 0) {
+            builder.append('S');
+        }
+        return builder.toString();
+    }
+
+    /**
      * Helper method to create an instance of {@link ParameterizedType}.
      * @param rawType The raw type.
      * @param typeArguments The type arguments.
@@ -485,11 +565,9 @@ public final class CoreUtils {
             return null;
         }
         try {
-            if (List.class.isAssignableFrom((Class<?>) returnType.getRawType())) {
-                return serializer.deserializeFromBytes(data.toBytes(), returnType);
-            }
-            Type token = returnType.getRawType();
-            if (Response.class.isAssignableFrom((Class<?>) token)) {
+            Type token = returnType.getActualTypeArguments().length == 0 ? returnType.getRawType() : returnType;
+            Type rawToken = token instanceof ParameterizedType ? ((ParameterizedType) token).getRawType() : token;
+            if (Response.class.isAssignableFrom((Class<?>) rawToken)) {
                 token = returnType.getActualTypeArguments()[0];
             }
             return serializer.deserializeFromBytes(data.toBytes(), token);

--- a/sdk/clientcore/core/src/main/java/io/clientcore/core/utils/GeneratedCodeUtils.java
+++ b/sdk/clientcore/core/src/main/java/io/clientcore/core/utils/GeneratedCodeUtils.java
@@ -4,6 +4,7 @@ package io.clientcore.core.utils;
 
 import io.clientcore.core.http.models.HttpHeader;
 import io.clientcore.core.http.models.HttpHeaderName;
+import io.clientcore.core.http.models.HttpHeaders;
 import io.clientcore.core.http.models.HttpResponseException;
 import io.clientcore.core.http.models.Response;
 import io.clientcore.core.implementation.utils.UriEscapers;
@@ -18,6 +19,7 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static io.clientcore.core.implementation.instrumentation.AttributeKeys.HTTP_RESPONSE_BODY_CONTENT_KEY;
@@ -76,6 +78,28 @@ public final class GeneratedCodeUtils {
 
             uriBuilder.addQueryParameter(nameToAdd, valueToAdd);
         }
+    }
+
+    /**
+     * Determines whether the headers declare a JSON media type.
+     *
+     * @param headers The headers to inspect.
+     * @return Whether the Content-Type is application/json or uses the +json structured syntax suffix.
+     */
+    public static boolean isJsonContentType(HttpHeaders headers) {
+        if (headers == null) {
+            return false;
+        }
+
+        String contentType = headers.getValue(HttpHeaderName.CONTENT_TYPE);
+        if (CoreUtils.isNullOrEmpty(contentType)) {
+            return false;
+        }
+
+        int parameterSeparator = contentType.indexOf(';');
+        String mediaType = (parameterSeparator < 0 ? contentType : contentType.substring(0, parameterSeparator)).trim()
+            .toLowerCase(Locale.ROOT);
+        return "application/json".equals(mediaType) || mediaType.endsWith("+json");
     }
 
     /**

--- a/sdk/clientcore/core/src/test/java/io/clientcore/core/serialization/json/JsonSerializerTests.java
+++ b/sdk/clientcore/core/src/test/java/io/clientcore/core/serialization/json/JsonSerializerTests.java
@@ -19,10 +19,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
+import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.time.Duration;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
@@ -348,6 +350,79 @@ public class JsonSerializerTests {
         if (models.get(0) instanceof LinkedHashMap) {
             LinkedHashMap<String, String> model = (LinkedHashMap<String, String>) models.get(0);
             assertEquals("value1", model.get("property"));
+        }
+    }
+
+    @Test
+    public void deserializeParameterizedMapOfJsonSerializableTypes() throws IOException {
+        byte[] bytes = "{\"first\":{\"property\":\"value1\"}}".getBytes(StandardCharsets.UTF_8);
+        ParameterizedType type = TypeUtil.createParameterizedType(Map.class, String.class, FooModel.class);
+
+        Map<String, FooModel> models = SERIALIZER.deserializeFromBytes(bytes, type);
+
+        assertEquals("value1", models.get("first").getProperty());
+    }
+
+    @Test
+    public void deserializeNestedParameterizedCollections() throws IOException {
+        byte[] bytes = "{\"first\":[{\"property\":\"value1\"}]}".getBytes(StandardCharsets.UTF_8);
+        ParameterizedType listType = TypeUtil.createParameterizedType(List.class, FooModel.class);
+        ParameterizedType mapType = TypeUtil.createParameterizedType(Map.class, String.class, listType);
+
+        Map<String, List<FooModel>> models = SERIALIZER.deserializeFromBytes(bytes, mapType);
+
+        assertEquals("value1", models.get("first").get(0).getProperty());
+    }
+
+    @Test
+    public void deserializeTypedScalarList() throws IOException {
+        ParameterizedType offsetDateTimeList = TypeUtil.createParameterizedType(List.class, OffsetDateTime.class);
+        ParameterizedType durationList = TypeUtil.createParameterizedType(List.class, Duration.class);
+
+        List<OffsetDateTime> dateTimes = SERIALIZER
+            .deserializeFromBytes("[\"2022-08-26T18:38:00Z\"]".getBytes(StandardCharsets.UTF_8), offsetDateTimeList);
+        List<Duration> durations
+            = SERIALIZER.deserializeFromBytes("[\"P2D\"]".getBytes(StandardCharsets.UTF_8), durationList);
+
+        assertEquals(OffsetDateTime.parse("2022-08-26T18:38:00Z"), dateTimes.get(0));
+        assertEquals(Duration.ofDays(2), durations.get(0));
+    }
+
+    @Test
+    public void deserializeGeneratedEnumValue() throws IOException {
+        WireEnum value = SERIALIZER.deserializeFromBytes("\"Monday\"".getBytes(StandardCharsets.UTF_8), WireEnum.class);
+
+        assertEquals(WireEnum.MONDAY, value);
+    }
+
+    @Test
+    public void serializesDurationCollectionsWithDays() throws IOException {
+        Map<String, Duration> durations = Collections.singletonMap("value", Duration.ofDays(2));
+
+        assertEquals("{\"value\":\"P2D\"}", new String(SERIALIZER.serializeToBytes(durations), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void serializesUntypedWireScalars() throws IOException {
+        Map<String, Object> values = new LinkedHashMap<>();
+        values.put("decimal", new BigDecimal("0.33333"));
+        values.put("dateTime", OffsetDateTime.parse("2022-08-26T18:38Z"));
+
+        assertEquals("{\"decimal\":0.33333,\"dateTime\":\"2022-08-26T18:38:00Z\"}",
+            new String(SERIALIZER.serializeToBytes(values), StandardCharsets.UTF_8));
+    }
+
+    private enum WireEnum {
+        MONDAY("Monday");
+
+        private final String value;
+
+        WireEnum(String value) {
+            this.value = value;
+        }
+
+        public static WireEnum fromString(String value) {
+            return MONDAY.value.equals(value) ? MONDAY : null;
         }
     }
 

--- a/sdk/clientcore/core/src/test/java/io/clientcore/core/utils/CoreUtilsTests.java
+++ b/sdk/clientcore/core/src/test/java/io/clientcore/core/utils/CoreUtilsTests.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.OffsetDateTime;
+import java.time.Duration;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -314,6 +315,16 @@ public class CoreUtilsTests {
         assertEquals(new Person().setName("A"), result);
     }
 
+    @Test
+    void decodeNetworkResponseMapType() {
+        BinaryData data = BinaryData.fromString("{\"first\":{\"name\":\"A\",\"age\":0}}");
+        ParameterizedType mapType = CoreUtils.createParameterizedType(Map.class, String.class, Person.class);
+
+        Map<String, Person> result = CoreUtils.decodeNetworkResponse(data, SERIALIZER, mapType);
+
+        assertEquals(new Person().setName("A"), result.get("first"));
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     void decodeNetworkResponseThrowsCoreException() {
@@ -356,5 +367,11 @@ public class CoreUtilsTests {
                 "red,blue,yellow,green,orange,purple,brown,indigo,violet,black"),
             Arguments.of(",", Arrays.asList("red", "blue", "yellow", "green", "orange", "purple", "brown", "indigo",
                 "violet", "black", "white"), "red,blue,yellow,green,orange,purple,brown,indigo,violet,black,white"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "PT0S, PT0S", "PT48H, P2D", "P2DT3H4M5.006S, P2DT3H4M5.006S", "-PT48H, -P2D" })
+    void durationToStringWithDays(String value, String expected) {
+        assertEquals(expected, CoreUtils.durationToStringWithDays(Duration.parse(value)));
     }
 }

--- a/sdk/clientcore/core/src/test/java/io/clientcore/core/utils/GeneratedCodeUtilsTests.java
+++ b/sdk/clientcore/core/src/test/java/io/clientcore/core/utils/GeneratedCodeUtilsTests.java
@@ -80,6 +80,22 @@ public class GeneratedCodeUtilsTests {
     }
 
     @Test
+    void identifiesJsonContentTypes() {
+        assertTrue(GeneratedCodeUtils
+            .isJsonContentType(new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/json; charset=utf-8")));
+        assertTrue(GeneratedCodeUtils
+            .isJsonContentType(new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/merge-patch+json")));
+    }
+
+    @Test
+    void rejectsNonJsonContentTypes() {
+        assertTrue(!GeneratedCodeUtils
+            .isJsonContentType(new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream")));
+        assertTrue(!GeneratedCodeUtils.isJsonContentType(new HttpHeaders()));
+        assertTrue(!GeneratedCodeUtils.isJsonContentType(null));
+    }
+
+    @Test
     void handleUnexpectedResponseOctetStream() {
         HttpHeaders headers = new HttpHeaders().set(HttpHeaderName.CONTENT_TYPE, "application/octet-stream")
             .set(HttpHeaderName.CONTENT_LENGTH, "1024");

--- a/sdk/clientcore/http-okhttp3/CHANGELOG.md
+++ b/sdk/clientcore/http-okhttp3/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Closed server-sent event response bodies before rejecting requests that do not provide an event listener.
 
 ### Other Changes
 

--- a/sdk/clientcore/http-okhttp3/src/main/java/io/clientcore/http/okhttp3/OkHttpHttpClient.java
+++ b/sdk/clientcore/http-okhttp3/src/main/java/io/clientcore/http/okhttp3/OkHttpHttpClient.java
@@ -151,7 +151,11 @@ class OkHttpHttpClient implements HttpClient {
             ServerSentEventListener listener = request.getServerSentEventListener();
 
             if (listener != null) {
-                serverSentResult = processTextEventStream(response.body().byteStream(), listener);
+                try {
+                    serverSentResult = processTextEventStream(response.body().byteStream(), listener);
+                } finally {
+                    response.body().close();
+                }
 
                 if (serverSentResult.getException() != null) {
                     // If an exception occurred while processing the text event stream, emit listener onError.
@@ -163,6 +167,7 @@ class OkHttpHttpClient implements HttpClient {
                     return this.send(request);
                 }
             } else {
+                response.body().close();
                 throw LOGGER.throwableAtError().log(NO_LISTENER_ERROR_MESSAGE, IllegalStateException::new);
             }
         }

--- a/sdk/clientcore/http-okhttp3/src/test/java/io/clientcore/http/okhttp3/OkHttpHttpClientTests.java
+++ b/sdk/clientcore/http-okhttp3/src/test/java/io/clientcore/http/okhttp3/OkHttpHttpClientTests.java
@@ -14,6 +14,14 @@ import io.clientcore.core.http.models.Response;
 import io.clientcore.core.models.CoreException;
 import io.clientcore.core.models.binarydata.BinaryData;
 import io.clientcore.core.shared.LocalTestServer;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.ForwardingSource;
+import okio.Okio;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,6 +40,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.clientcore.http.okhttp3.TestUtils.assertArraysEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -167,6 +176,85 @@ public class OkHttpHttpClientTests {
 
             assertEquals(multiValueHeaderName.getCaseSensitiveName(), multiValueHeader.getName().toString());
             assertLinesMatch(multiValueHeaderValue, multiValueHeader.getValues());
+        }
+    }
+
+    @Test
+    public void missingServerSentEventListenerClosesResponseBody() {
+        AtomicBoolean bodyClosed = new AtomicBoolean();
+        ResponseBody responseBody = new TrackingResponseBody(bodyClosed);
+        OkHttpClient okHttpClient = createServerSentEventClient(responseBody);
+        HttpClient client = new OkHttpHttpClient(okHttpClient);
+        HttpRequest request
+            = new HttpRequest().setMethod(HttpMethod.GET).setUri("https://localhost/server-sent-events");
+
+        assertThrows(IllegalStateException.class, () -> client.send(request));
+
+        assertTrue(bodyClosed.get());
+    }
+
+    @Test
+    public void processedServerSentEventClosesResponseBody() {
+        AtomicBoolean bodyClosed = new AtomicBoolean();
+        HttpClient client = new OkHttpHttpClient(createServerSentEventClient(new TrackingResponseBody(bodyClosed)));
+        HttpRequest request = new HttpRequest().setMethod(HttpMethod.GET)
+            .setUri("https://localhost/server-sent-events")
+            .setServerSentEventListener(event -> {
+            });
+
+        try (Response<BinaryData> response = client.send(request)) {
+            assertEquals(200, response.getStatusCode());
+            assertTrue(bodyClosed.get());
+        }
+    }
+
+    private static OkHttpClient createServerSentEventClient(ResponseBody responseBody) {
+        return new OkHttpClient.Builder()
+            .addInterceptor(chain -> new okhttp3.Response.Builder().request(chain.request())
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .header("Content-Type", "text/event-stream")
+                .body(responseBody)
+                .build())
+            .build();
+    }
+
+    private static final class TrackingResponseBody extends ResponseBody {
+        private final BufferedSource source;
+
+        private TrackingResponseBody(AtomicBoolean closed) {
+            this.source = Okio.buffer(new TrackingSource(new Buffer().writeUtf8("data: value\n\n"), closed));
+        }
+
+        @Override
+        public MediaType contentType() {
+            return MediaType.parse("text/event-stream");
+        }
+
+        @Override
+        public long contentLength() {
+            return -1;
+        }
+
+        @Override
+        public BufferedSource source() {
+            return source;
+        }
+    }
+
+    private static final class TrackingSource extends ForwardingSource {
+        private final AtomicBoolean closed;
+
+        private TrackingSource(Buffer source, AtomicBoolean closed) {
+            super(source);
+            this.closed = closed;
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed.set(true);
+            super.close();
         }
     }
 


### PR DESCRIPTION
# Description

- Added `@FormParam` URL-encoded bodies using `FORM_ESCAPER`.
- Added header-collection expansion and correct dynamic-header precedence.
- Added optional/non-string path handling and collection-query semantics.
- Fixed unknown-length `BinaryData`, direct/sliced `ByteBuffer`, dynamic content types, JSON charset handling, and pre-serialized multipart bodies.
- Added type-based `RequestContext` and SSE listener wiring.
- Fixed response closure so eager responses close exactly once while streaming responses remain open.
- Added text, standard Base64, primitive, enum, list, map, and nested generic response decoding.
- Extended JsonSerializer.java, JsonWriter.java, and CoreUtils.java for typed collections, temporal values, decimals, enums, BinaryData, and ISO durations with day components.
- Fixed SSE response-body ownership in OkHttpHttpClient.java.
- Removed generated @SuppressWarnings("cast"), enabled all previously disabled processor integration tests, aligned tests with processor beta.5/Core beta.12, and regenerated checked-in service implementations.
Updated changelogs and added focused unit/integration coverage.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [ ] Pull request includes test coverage for the included changes.
