### PR TITLE
Test documentation-only CI preflight

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Azure SDK for Java – Documentation Hub
 
+<!-- This comment validates documentation-only pull request classification. -->
+
 This directory is the **canonical documentation hub** for the Azure SDK for Java repository.
 It is structured so that both humans and LLM/agent tooling can navigate directly to any topic.
 


### PR DESCRIPTION
## Purpose

Validates the documentation-only path in the CI preflight proof of concept.

## Change

Adds a harmless HTML comment to `docs/README.md`. The diff against `pipelinev3-vcolin7-ci-doc-preflight-poc` contains no functional files.

## Expected pipeline behavior

- `Build`, `Analyze`, and `generate_job_matrix` run.
- `Classify PR changes for Java test matrix` reports `RunTests=False`.
- The job-local PackageInfo files are removed and each generated test matrix is `{}`.
- Test jobs do not initialize and receive no worker/VM.