### PR TITLE
Fix storage service-version gates for all-version tests

### DIFF
--- a/sdk/storage/azure-storage-common/src/test-shared/java/com/azure/storage/common/test/shared/extensions/RequiredServiceVersionExtension.java
+++ b/sdk/storage/azure-storage-common/src/test-shared/java/com/azure/storage/common/test/shared/extensions/RequiredServiceVersionExtension.java
@@ -25,6 +25,20 @@ public class RequiredServiceVersionExtension implements ExecutionCondition {
     private static final Map<Class<? extends Enum<? extends ServiceVersion>>, ServiceVersion> LATEST_SERVICE_VERSIONS
         = new ConcurrentHashMap<>();
 
+    static boolean shouldSkip(Class<? extends Enum<? extends ServiceVersion>> targetEnumClass,
+        String minServiceVersion, String environmentServiceVersion) {
+        ServiceVersion[] serviceVersions = getServiceVersions(targetEnumClass);
+        if (environmentServiceVersion == null) {
+            // Fall back to "latest" service version if environment variable is not set.
+            environmentServiceVersion = getLatestServiceVersion(targetEnumClass).getVersion();
+        }
+
+        int minOrdinal = getOrdinal(serviceVersions, minServiceVersion, "minimum");
+        int environmentOrdinal = getOrdinal(serviceVersions, environmentServiceVersion, "configured");
+
+        return environmentOrdinal < minOrdinal;
+    }
+
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
         // Check for the RequiredServiceVersion annotation on the test method.
@@ -47,17 +61,8 @@ public class RequiredServiceVersionExtension implements ExecutionCondition {
 
     private static boolean shouldSkip(Class<? extends Enum<? extends ServiceVersion>> targetEnumClass,
         String minServiceVersion) {
-        ServiceVersion[] serviceVersions = getServiceVersions(targetEnumClass);
         String environmentServiceVersion = TestEnvironment.getInstance().getServiceVersion();
-        if (environmentServiceVersion == null) {
-            // Fall back to "latest" service version if environment variable is not set.
-            environmentServiceVersion = getLatestServiceVersion(targetEnumClass).toString();
-        }
-
-        int minOrdinal = getOrdinal(serviceVersions, minServiceVersion);
-        int environmentOrdinal = getOrdinal(serviceVersions, environmentServiceVersion);
-
-        return environmentOrdinal < minOrdinal;
+        return shouldSkip(targetEnumClass, minServiceVersion, environmentServiceVersion);
     }
 
     private static ServiceVersion[] getServiceVersions(Class<? extends Enum<? extends ServiceVersion>> clazz) {
@@ -74,12 +79,14 @@ public class RequiredServiceVersionExtension implements ExecutionCondition {
         });
     }
 
-    private static int getOrdinal(ServiceVersion[] serviceVersions, String target) {
+    private static int getOrdinal(ServiceVersion[] serviceVersions, String target, String description) {
         for (int i = 0; i < serviceVersions.length; i++) {
-            if (Objects.equals(String.valueOf(serviceVersions[i]), target)) {
+            ServiceVersion serviceVersion = serviceVersions[i];
+            if (Objects.equals(serviceVersion.getVersion(), target)
+                || Objects.equals(((Enum<?>) serviceVersion).name(), target)) {
                 return i;
             }
         }
-        return -1;
+        throw new IllegalArgumentException("Unknown " + description + " service version '" + target + "'.");
     }
 }

--- a/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/test/shared/extensions/RequiredServiceVersionExtensionTests.java
+++ b/sdk/storage/azure-storage-common/src/test/java/com/azure/storage/common/test/shared/extensions/RequiredServiceVersionExtensionTests.java
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.storage.common.test.shared.extensions;
+
+import com.azure.core.util.ServiceVersion;
+import org.junit.jupiter.api.Test;
+
+import static com.azure.storage.common.test.shared.extensions.RequiredServiceVersionExtension.shouldSkip;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RequiredServiceVersionExtensionTests {
+    private static final String UNKNOWN_SERVICE_VERSION = "0001-01-01";
+
+    @Test
+    public void comparesRequiredWireValueToConfiguredEnumNameInServiceVersionOrder() {
+        assertTrue(shouldSkip(TestServiceVersion.class, TestServiceVersion.V2026_08_06.getVersion(),
+            TestServiceVersion.V2026_06_06.name()));
+        assertFalse(shouldSkip(TestServiceVersion.class, TestServiceVersion.V2026_08_06.getVersion(),
+            TestServiceVersion.V2026_08_06.name()));
+        assertFalse(shouldSkip(TestServiceVersion.class, TestServiceVersion.V2026_08_06.getVersion(),
+            TestServiceVersion.V2026_10_06.name()));
+    }
+
+    @Test
+    public void resolvesEnumNames() {
+        assertFalse(shouldSkip(TestServiceVersion.class, TestServiceVersion.V2026_08_06.name(),
+            TestServiceVersion.V2026_10_06.name()));
+    }
+
+    @Test
+    public void defaultsToLatestWireValue() {
+        assertFalse(shouldSkip(TestServiceVersion.class, TestServiceVersion.V2026_10_06.getVersion(), null));
+    }
+
+    @Test
+    public void rejectsUnknownConfiguredVersion() {
+        IllegalArgumentException exception
+            = assertThrows(IllegalArgumentException.class, () -> shouldSkip(TestServiceVersion.class,
+                TestServiceVersion.V2026_08_06.getVersion(), UNKNOWN_SERVICE_VERSION));
+
+        assertTrue(exception.getMessage().contains("configured"));
+    }
+
+    @Test
+    public void rejectsUnknownMinimumVersion() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> shouldSkip(TestServiceVersion.class, UNKNOWN_SERVICE_VERSION, TestServiceVersion.V2026_10_06.name()));
+
+        assertTrue(exception.getMessage().contains("minimum"));
+    }
+
+    enum TestServiceVersion implements ServiceVersion {
+        V2026_06_06("2026-06-06"), V2026_08_06("2026-08-06"), V2026_10_06("2026-10-06");
+
+        private final String version;
+
+        TestServiceVersion(String version) {
+            this.version = version;
+        }
+
+        @Override
+        public String getVersion() {
+            return version;
+        }
+
+        public static TestServiceVersion getLatest() {
+            return V2026_10_06;
+        }
+    }
+}


### PR DESCRIPTION
# Description

## Problem

`RequiredServiceVersionExtension` receives service versions in two different string representations:

- The all-versions test matrix sets `AZURE_LIVE_TEST_SERVICE_VERSION` to an enum name such as `V2021_06_08`.
- `@RequiredServiceVersion` annotations use the service wire value, such as `"2026-02-06"`.

For example, `QueueServiceAsyncApiTests.queueServiceGetUserDelegationKey`, which requires `"2026-02-06"`, while `platform-matrix-all-versions.json` includes runs configured with `V2021_06_08`.

The extension previously resolved both inputs by comparing them with `String.valueOf(serviceVersion)`. Storage service-version enums do not override `Enum.toString()`, so that expression produces the enum name (`V2026_02_06`) rather than the wire value (`2026-02-06`).

Consequently, the required wire value could not be found and received ordinal `-1` even though the value actual exists (see screenshots below):

<img width="274" height="28" alt="image" src="https://github.com/user-attachments/assets/cc100fb6-e76a-4c2c-878a-d90f67c3cc49" />

<img width="376" height="79" alt="image" src="https://github.com/user-attachments/assets/3a449b4f-35df-453a-9a17-d38a39acfa2f" />


<img width="595" height="188" alt="image" src="https://github.com/user-attachments/assets/65a66065-3d12-4153-bd83-966688129114" />

The extension therefore enabled a test requiring service version `2026-02-06` during a `V2021_06_08` matrix run instead of skipping it. Unknown versions also returned `-1`, allowing malformed annotations or configuration to fail open in the same way.

## Fix

- Resolve each service version by either its explicit wire value (`ServiceVersion.getVersion()`) or its exact enum name (`Enum.name()`).
- Throw a descriptive exception for unknown minimum or configured versions instead of returning `-1`.
- Use the latest version's wire value when no environment version is configured.
- Add an injectable overload for deterministic unit testing while retaining the existing environment lookup for production test execution.

This does not change how `x-ms-version` is sent to Storage. The test infrastructure still converts the configured enum name to a `ServiceVersion`, and the client sends that enum's `getVersion()` value over the wire.

## Testing

Added focused unit coverage for:

- Configured versions older than, equal to, and newer than the required version.
- Required wire values compared with configured enum names.
- The latest-version fallback.
- Unknown configured and minimum versions.

Validated with the focused `RequiredServiceVersionExtensionTests`, Spotless, and Checkstyle. The Maven test compilation covered both Java 8 and Java 21.

# All SDK Contribution checklist

- [x] **The pull request does not introduce breaking changes.**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.** Not applicable because this only changes test infrastructure.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)

- [x] Title of the pull request is clear and informative.
- [x] There is one commit with an informative message.

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)

- [x] Pull request includes test coverage for the included changes.
