### PR TITLE
Add configurable Blob endpoint for Data Lake clients

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 12.29.0-beta.2 (Unreleased)
 
 ### Features Added
+- Added `DataLakeServiceClientBuilder.blobEndpoint(String)` to configure the Blob service endpoint separately from
+  the Data Lake service endpoint for custom endpoint and proxy scenarios.
 
 ### Breaking Changes
 
@@ -897,4 +899,3 @@ This package's
 [documentation](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/storage/azure-storage-file-datalake/README.md)
 and
 [samples](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/storage/azure-storage-file-datalake/src/samples/java/com/azure/storage/file/datalake)
-

--- a/sdk/storage/azure-storage-file-datalake/README.md
+++ b/sdk/storage/azure-storage-file-datalake/README.md
@@ -220,6 +220,17 @@ DataLakeServiceClient dataLakeServiceClient = new DataLakeServiceClientBuilder()
     .buildClient();
 ```
 
+Some environments expose the Data Lake and Blob services through separate custom or proxy URLs. In that case, set
+the Data Lake endpoint with `endpoint` and the Blob endpoint with `blobEndpoint`:
+
+```java readme-sample-getDataLakeServiceClientWithCustomEndpoints
+DataLakeServiceClient dataLakeServiceClient = new DataLakeServiceClientBuilder()
+    .endpoint("https://dfs-proxy.example.com")
+    .blobEndpoint("https://blob-proxy.example.com")
+    .sasToken("<your-sasToken>")
+    .buildClient();
+```
+
 or
 
 ```java readme-sample-getDataLakeServiceClient2
@@ -446,5 +457,3 @@ This project has adopted the [Microsoft Open Source Code of Conduct][coc]. For m
 [coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
 [coc_contact]: mailto:opencode@microsoft.com
 [performance_tuning]: https://github.com/Azure/azure-sdk-for-java/blob/main/docs/performance-tuning.md
-
-

--- a/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeServiceClientBuilder.java
+++ b/sdk/storage/azure-storage-file-datalake/src/main/java/com/azure/storage/file/datalake/DataLakeServiceClientBuilder.java
@@ -70,6 +70,7 @@ public class DataLakeServiceClientBuilder implements TokenCredentialTrait<DataLa
     private final BlobServiceClientBuilder blobServiceClientBuilder;
 
     private String endpoint;
+    private String blobEndpoint;
     private String accountName;
 
     private StorageSharedKeyCredential storageSharedKeyCredential;
@@ -160,7 +161,9 @@ public class DataLakeServiceClientBuilder implements TokenCredentialTrait<DataLa
     public DataLakeServiceClientBuilder endpoint(String endpoint) {
         // Ensure endpoint provided is dfs endpoint
         endpoint = DataLakeImplUtils.endpointToDesiredEndpoint(endpoint, "dfs", "blob");
-        blobServiceClientBuilder.endpoint(DataLakeImplUtils.endpointToDesiredEndpoint(endpoint, "blob", "dfs"));
+        if (blobEndpoint == null) {
+            blobServiceClientBuilder.endpoint(DataLakeImplUtils.endpointToDesiredEndpoint(endpoint, "blob", "dfs"));
+        }
         try {
             BlobUrlParts parts = BlobUrlParts.parse(new URL(endpoint));
 
@@ -176,6 +179,24 @@ public class DataLakeServiceClientBuilder implements TokenCredentialTrait<DataLa
                 .logExceptionAsError(new IllegalArgumentException("The Azure Storage endpoint url is malformed.", ex));
         }
 
+        return this;
+    }
+
+    /**
+     * Sets the Blob service endpoint used for operations that are routed through the Blob service. If this is not set,
+     * the Blob service endpoint is derived from the endpoint set by {@link #endpoint(String)}.
+     *
+     * @param blobEndpoint URL of the Blob service.
+     * @return the updated DataLakeServiceClientBuilder object.
+     * @throws IllegalArgumentException If {@code blobEndpoint} is {@code null} or is a malformed URL.
+     */
+    public DataLakeServiceClientBuilder blobEndpoint(String blobEndpoint) {
+        if (blobEndpoint == null) {
+            throw LOGGER.logExceptionAsError(new IllegalArgumentException("'blobEndpoint' cannot be null."));
+        }
+        blobEndpoint = DataLakeImplUtils.endpointToDesiredEndpoint(blobEndpoint, "blob", "dfs");
+        blobServiceClientBuilder.endpoint(blobEndpoint);
+        this.blobEndpoint = blobEndpoint;
         return this;
     }
 

--- a/sdk/storage/azure-storage-file-datalake/src/samples/java/com/azure/storage/file/datalake/ReadmeSamples.java
+++ b/sdk/storage/azure-storage-file-datalake/src/samples/java/com/azure/storage/file/datalake/ReadmeSamples.java
@@ -181,5 +181,14 @@ public class ReadmeSamples {
         // END: readme-sample-authWithIdentity
     }
 
-}
+    public void getDataLakeServiceClientWithCustomEndpoints() {
+        // BEGIN: readme-sample-getDataLakeServiceClientWithCustomEndpoints
+        DataLakeServiceClient dataLakeServiceClient = new DataLakeServiceClientBuilder()
+            .endpoint("https://dfs-proxy.example.com")
+            .blobEndpoint("https://blob-proxy.example.com")
+            .sasToken("<your-sasToken>")
+            .buildClient();
+        // END: readme-sample-getDataLakeServiceClientWithCustomEndpoints
+    }
 
+}

--- a/sdk/storage/azure-storage-file-datalake/src/test/java/com/azure/storage/file/datalake/UrlTests.java
+++ b/sdk/storage/azure-storage-file-datalake/src/test/java/com/azure/storage/file/datalake/UrlTests.java
@@ -3,11 +3,13 @@
 package com.azure.storage.file.datalake;
 
 import com.azure.storage.common.StorageSharedKeyCredential;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UrlTests {
     private static final StorageSharedKeyCredential CREDENTIAL
@@ -53,5 +55,49 @@ public class UrlTests {
         assertEquals(expectedBlobUrl + "/container", fileSystemClient.blobContainerClient.getBlobContainerUrl());
         assertEquals(expectedDfsUrl + "/container/blob", pathClient.getPathUrl());
         assertEquals(expectedBlobUrl + "/container/blob", pathClient.blockBlobClient.getBlobUrl());
+    }
+
+    @Test
+    public void testExplicitBlobServiceUrl() {
+        String dfsEndpoint = "https://dfs-proxy.example.com";
+        String blobEndpoint = "https://blob-proxy.example.com";
+        DataLakeServiceClient serviceClient = new DataLakeServiceClientBuilder().credential(CREDENTIAL)
+            .endpoint(dfsEndpoint)
+            .blobEndpoint(blobEndpoint)
+            .buildClient();
+
+        assertEquals(dfsEndpoint, serviceClient.getAccountUrl());
+        assertEquals(blobEndpoint, serviceClient.blobServiceClient.getAccountUrl());
+    }
+
+    @Test
+    public void testExplicitBlobServiceUrlAsyncEndpointOrderIndependent() {
+        String dfsEndpoint = "https://dfs-proxy.example.com";
+        String blobEndpoint = "https://blob-proxy.example.com";
+        DataLakeServiceAsyncClient serviceAsyncClient = new DataLakeServiceClientBuilder().credential(CREDENTIAL)
+            .blobEndpoint(blobEndpoint)
+            .endpoint(dfsEndpoint)
+            .buildAsyncClient();
+
+        assertEquals(dfsEndpoint, serviceAsyncClient.getAccountUrl());
+        assertEquals(blobEndpoint + "/container",
+            serviceAsyncClient.getFileSystemAsyncClient("container")
+                .getBlobContainerAsyncClient()
+                .getBlobContainerUrl());
+    }
+
+    @Test
+    public void testExplicitBlobServiceUrlNormalizesDfsEndpoint() {
+        DataLakeServiceClient serviceClient = new DataLakeServiceClientBuilder().credential(CREDENTIAL)
+            .endpoint("https://account.dfs.core.windows.net")
+            .blobEndpoint("https://account.dfs.core.windows.net")
+            .buildClient();
+
+        assertEquals("https://account.blob.core.windows.net", serviceClient.blobServiceClient.getAccountUrl());
+    }
+
+    @Test
+    public void testExplicitBlobServiceUrlRejectsNullEndpoint() {
+        assertThrows(IllegalArgumentException.class, () -> new DataLakeServiceClientBuilder().blobEndpoint(null));
     }
 }


### PR DESCRIPTION
# Description

Adds support for configuring the Blob service endpoint separately from the Data Lake service endpoint through `DataLakeServiceClientBuilder.blobEndpoint(String)`.

Previously, the Blob endpoint was always derived from the configured Data Lake endpoint by converting the `.dfs.` hostname segment to `.blob.`. This does not work when the two services are exposed through distinct custom or reverse-proxy hostnames.

The existing endpoint derivation remains the default when `blobEndpoint(String)` is not configured, preserving backward compatibility. The explicit Blob endpoint is also preserved regardless of whether it is configured before or after `endpoint(String)`.

Fixes #49781 

This change includes:

- The new `DataLakeServiceClientBuilder.blobEndpoint(String)` API.
- Separate synchronous and asynchronous endpoint tests.
- README documentation and a synchronized code sample.
- An entry in the unreleased CHANGELOG.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
