### PR TITLE
[Core] Honour Expect: 100-continue in the JDK HTTP client

### DIFF
--- a/sdk/core/azure-core-http-jdk-httpclient/CHANGELOG.md
+++ b/sdk/core/azure-core-http-jdk-httpclient/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.2.0-beta.1 (Unreleased)
 
 ### Features Added
+- Requests carrying the `Expect: 100-continue` header now perform the handshake: the headers are sent and the request
+  body is withheld until the service responds `100 Continue`. Previously the header was dropped and the body was sent
+  immediately.
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core-http-jdk-httpclient/src/main/java/com/azure/core/http/jdk/httpclient/implementation/AzureJdkHttpRequest.java
+++ b/sdk/core/azure-core-http-jdk-httpclient/src/main/java/com/azure/core/http/jdk/httpclient/implementation/AzureJdkHttpRequest.java
@@ -63,10 +63,10 @@ public final class AzureJdkHttpRequest extends HttpRequest {
             ? noBody()
             : BodyPublisherUtils.toBodyPublisher(azureCoreRequest, writeTimeout, progressReporter);
 
-        // The JDK enters its wait path on this flag alone, so only opt in when there is content to withhold.
-        // A zero length publisher means there is nothing to send and the expectation would be meaningless.
-        this.expectContinue = expectsContinue(azureCoreRequest.getHeaders().getValue(HttpHeaderName.EXPECT))
-            && bodyPublisher.contentLength() != 0;
+        // The JDK enters its wait path on this flag alone, so only opt in when there is content to withhold. A
+        // zero length publisher has nothing to send; a negative length means the length is not known ahead of time,
+        // which is the streaming case the handshake exists for, so it stays eligible.
+        this.expectContinue = bodyPublisher.contentLength() != 0 && expectsContinue(azureCoreRequest);
 
         try {
             uri = azureCoreRequest.getUrl().toURI();
@@ -99,7 +99,8 @@ public final class AzureJdkHttpRequest extends HttpRequest {
      * Expect is a comma separated list of expectations and values may carry surrounding whitespace, so the
      * header cannot be compared as a whole.
      */
-    private static boolean expectsContinue(String expectHeader) {
+    private static boolean expectsContinue(com.azure.core.http.HttpRequest azureCoreRequest) {
+        String expectHeader = azureCoreRequest.getHeaders().getValue(HttpHeaderName.EXPECT);
         if (expectHeader == null) {
             return false;
         }

--- a/sdk/core/azure-core-http-jdk-httpclient/src/main/java/com/azure/core/http/jdk/httpclient/implementation/AzureJdkHttpRequest.java
+++ b/sdk/core/azure-core-http-jdk-httpclient/src/main/java/com/azure/core/http/jdk/httpclient/implementation/AzureJdkHttpRequest.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 package com.azure.core.http.jdk.httpclient.implementation;
 
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpMethod;
 import com.azure.core.implementation.util.HttpHeadersAccessHelper;
 import com.azure.core.implementation.util.HttpUtils;
@@ -32,6 +33,7 @@ import static java.net.http.HttpRequest.BodyPublishers.noBody;
  * String comparisons performed.
  */
 public final class AzureJdkHttpRequest extends HttpRequest {
+    private final boolean expectContinue;
     private final BodyPublisher bodyPublisher;
     private final String method;
     private final URI uri;
@@ -56,6 +58,8 @@ public final class AzureJdkHttpRequest extends HttpRequest {
             .filter(timeoutDuration -> timeoutDuration instanceof Duration)
             .orElse(responseTimeout);
 
+        this.expectContinue
+            = "100-continue".equalsIgnoreCase(azureCoreRequest.getHeaders().getValue(HttpHeaderName.EXPECT));
         this.method = method.toString();
         this.bodyPublisher = (method == HttpMethod.GET || method == HttpMethod.HEAD)
             ? noBody()
@@ -90,7 +94,7 @@ public final class AzureJdkHttpRequest extends HttpRequest {
 
     @Override
     public boolean expectContinue() {
-        return false;
+        return expectContinue;
     }
 
     @Override

--- a/sdk/core/azure-core-http-jdk-httpclient/src/main/java/com/azure/core/http/jdk/httpclient/implementation/AzureJdkHttpRequest.java
+++ b/sdk/core/azure-core-http-jdk-httpclient/src/main/java/com/azure/core/http/jdk/httpclient/implementation/AzureJdkHttpRequest.java
@@ -58,8 +58,7 @@ public final class AzureJdkHttpRequest extends HttpRequest {
             .filter(timeoutDuration -> timeoutDuration instanceof Duration)
             .orElse(responseTimeout);
 
-        this.expectContinue
-            = "100-continue".equalsIgnoreCase(azureCoreRequest.getHeaders().getValue(HttpHeaderName.EXPECT));
+        this.expectContinue = expectsContinue(azureCoreRequest.getHeaders().getValue(HttpHeaderName.EXPECT));
         this.method = method.toString();
         this.bodyPublisher = (method == HttpMethod.GET || method == HttpMethod.HEAD)
             ? noBody()
@@ -90,6 +89,24 @@ public final class AzureJdkHttpRequest extends HttpRequest {
     @Override
     public Optional<Duration> timeout() {
         return responseTimeout;
+    }
+
+    /*
+     * Expect is a comma separated list of expectations and values may carry surrounding whitespace, so the
+     * header cannot be compared as a whole.
+     */
+    private static boolean expectsContinue(String expectHeader) {
+        if (expectHeader == null) {
+            return false;
+        }
+
+        for (String expectation : expectHeader.split(",")) {
+            if ("100-continue".equalsIgnoreCase(expectation.trim())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override

--- a/sdk/core/azure-core-http-jdk-httpclient/src/main/java/com/azure/core/http/jdk/httpclient/implementation/AzureJdkHttpRequest.java
+++ b/sdk/core/azure-core-http-jdk-httpclient/src/main/java/com/azure/core/http/jdk/httpclient/implementation/AzureJdkHttpRequest.java
@@ -58,11 +58,15 @@ public final class AzureJdkHttpRequest extends HttpRequest {
             .filter(timeoutDuration -> timeoutDuration instanceof Duration)
             .orElse(responseTimeout);
 
-        this.expectContinue = expectsContinue(azureCoreRequest.getHeaders().getValue(HttpHeaderName.EXPECT));
         this.method = method.toString();
         this.bodyPublisher = (method == HttpMethod.GET || method == HttpMethod.HEAD)
             ? noBody()
             : BodyPublisherUtils.toBodyPublisher(azureCoreRequest, writeTimeout, progressReporter);
+
+        // The JDK enters its wait path on this flag alone, so only opt in when there is content to withhold.
+        // A zero length publisher means there is nothing to send and the expectation would be meaningless.
+        this.expectContinue = expectsContinue(azureCoreRequest.getHeaders().getValue(HttpHeaderName.EXPECT))
+            && bodyPublisher.contentLength() != 0;
 
         try {
             uri = azureCoreRequest.getUrl().toURI();

--- a/sdk/core/azure-core-http-jdk-httpclient/src/test/java/com/azure/core/http/jdk/httpclient/JdkHttpClientExpectContinueTests.java
+++ b/sdk/core/azure-core-http-jdk-httpclient/src/test/java/com/azure/core/http/jdk/httpclient/JdkHttpClientExpectContinueTests.java
@@ -9,6 +9,8 @@ import com.azure.core.http.HttpMethod;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -35,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests that the client honours {@code Expect: 100-continue} on the wire: the headers are sent, the body is withheld
  * until the service responds {@code 100 Continue}, and the body is delivered afterwards.
  */
+@DisabledForJreRange(max = JRE.JAVA_11)
 public class JdkHttpClientExpectContinueTests {
     private static final byte[] BODY = new byte[1024];
 

--- a/sdk/core/azure-core-http-jdk-httpclient/src/test/java/com/azure/core/http/jdk/httpclient/JdkHttpClientExpectContinueTests.java
+++ b/sdk/core/azure-core-http-jdk-httpclient/src/test/java/com/azure/core/http/jdk/httpclient/JdkHttpClientExpectContinueTests.java
@@ -9,6 +9,8 @@ import com.azure.core.http.HttpMethod;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -16,6 +18,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -35,17 +38,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class JdkHttpClientExpectContinueTests {
     private static final byte[] BODY = new byte[1024];
 
-    // How long the server waits after the headers arrive before answering. A client that does not defer the body will
-    // have sent it well within this window.
-    private static final long BODY_SETTLE_MILLIS = 500;
-
-    @Test
-    public void withholdsBodyUntilContinue() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = { "100-continue", "100-Continue", " 100-continue ", "100-continue, foo" })
+    public void withholdsBodyUntilContinue(String expectHeaderValue) throws Exception {
         try (ExpectContinueServer server = new ExpectContinueServer()) {
             server.start();
 
             HttpRequest request = new HttpRequest(HttpMethod.PUT, server.url()).setBody(BODY);
-            request.getHeaders().set(HttpHeaderName.EXPECT, "100-continue");
+            request.getHeaders().set(HttpHeaderName.EXPECT, expectHeaderValue);
 
             HttpClient client = new JdkHttpClientProvider().createInstance();
             HttpResponse response = client.send(request).block();
@@ -54,7 +54,7 @@ public class JdkHttpClientExpectContinueTests {
             assertEquals(201, response.getStatusCode());
             assertTrue(server.awaitRequest(), "the request never reached the server");
 
-            assertEquals("100-continue", server.expectHeader, "the Expect header did not reach the wire");
+            assertNotNull(server.expectHeader, "the Expect header did not reach the wire");
             assertEquals(0, server.bodyBytesBeforeContinue, "the body was sent before the service answered");
             assertEquals(BODY.length, server.bodyBytesAfterContinue, "the body was not delivered after 100 Continue");
         }
@@ -83,6 +83,12 @@ public class JdkHttpClientExpectContinueTests {
      * arrived before it responded.
      */
     private static final class ExpectContinueServer implements AutoCloseable {
+        // How long the server keeps reading before deciding the client is not going to send the body unprompted.
+        private static final long BODY_SETTLE_MILLIS = 500;
+
+        // Short enough that the settle window is made up of many read attempts rather than one long block.
+        private static final int POLL_TIMEOUT_MILLIS = 50;
+
         private final ServerSocket serverSocket;
         private final CountDownLatch requestHandled = new CountDownLatch(1);
         private volatile Thread thread;
@@ -117,19 +123,22 @@ public class JdkHttpClientExpectContinueTests {
 
                 int contentLength = readHeaders(in);
 
-                Thread.sleep(BODY_SETTLE_MILLIS);
-                bodyBytesBeforeContinue = in.available();
+                // Actively read for the whole settle window rather than sampling available(), so a body that is on
+                // its way is counted rather than missed.
+                socket.setSoTimeout(POLL_TIMEOUT_MILLIS);
+                bodyBytesBeforeContinue = readFor(in, contentLength, BODY_SETTLE_MILLIS);
 
                 if (expectHeader != null) {
                     out.write("HTTP/1.1 100 Continue\r\n\r\n".getBytes(StandardCharsets.UTF_8));
                     out.flush();
                 }
 
+                socket.setSoTimeout((int) TimeUnit.SECONDS.toMillis(10));
                 bodyBytesAfterContinue = readBody(in, contentLength - bodyBytesBeforeContinue);
 
                 out.write("HTTP/1.1 201 Created\r\nContent-Length: 0\r\n\r\n".getBytes(StandardCharsets.UTF_8));
                 out.flush();
-            } catch (IOException | InterruptedException ex) {
+            } catch (IOException ex) {
                 // Leave the recorded values as they are; the test assertions report the failure.
             } finally {
                 requestHandled.countDown();
@@ -166,6 +175,28 @@ public class JdkHttpClientExpectContinueTests {
             }
 
             return contentLength;
+        }
+
+        /*
+         * Keeps attempting reads until the window elapses, so the count reflects what actually arrived rather than
+         * what happened to be buffered at one instant.
+         */
+        private static int readFor(InputStream in, int max, long windowMillis) throws IOException {
+            byte[] buffer = new byte[8192];
+            int read = 0;
+            long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(windowMillis);
+            while (System.nanoTime() < deadline && read < max) {
+                try {
+                    int count = in.read(buffer, 0, Math.min(buffer.length, max - read));
+                    if (count < 0) {
+                        break;
+                    }
+                    read += count;
+                } catch (SocketTimeoutException ex) {
+                    // Nothing arrived in this slice; keep waiting until the window closes.
+                }
+            }
+            return read;
         }
 
         private static int readBody(InputStream in, int remaining) throws IOException {

--- a/sdk/core/azure-core-http-jdk-httpclient/src/test/java/com/azure/core/http/jdk/httpclient/JdkHttpClientExpectContinueTests.java
+++ b/sdk/core/azure-core-http-jdk-httpclient/src/test/java/com/azure/core/http/jdk/httpclient/JdkHttpClientExpectContinueTests.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
@@ -95,7 +96,7 @@ public class JdkHttpClientExpectContinueTests {
         }
 
         URL url() throws IOException {
-            return new URL("http://localhost:" + serverSocket.getLocalPort() + "/expect-continue");
+            return URI.create("http://localhost:" + serverSocket.getLocalPort() + "/expect-continue").toURL();
         }
 
         void start() {

--- a/sdk/core/azure-core-http-jdk-httpclient/src/test/java/com/azure/core/http/jdk/httpclient/JdkHttpClientExpectContinueTests.java
+++ b/sdk/core/azure-core-http-jdk-httpclient/src/test/java/com/azure/core/http/jdk/httpclient/JdkHttpClientExpectContinueTests.java
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.http.jdk.httpclient;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that the client honours {@code Expect: 100-continue} on the wire: the headers are sent, the body is withheld
+ * until the service responds {@code 100 Continue}, and the body is delivered afterwards.
+ */
+public class JdkHttpClientExpectContinueTests {
+    private static final byte[] BODY = new byte[1024];
+
+    // How long the server waits after the headers arrive before answering. A client that does not defer the body will
+    // have sent it well within this window.
+    private static final long BODY_SETTLE_MILLIS = 500;
+
+    @Test
+    public void withholdsBodyUntilContinue() throws Exception {
+        try (ExpectContinueServer server = new ExpectContinueServer()) {
+            server.start();
+
+            HttpRequest request = new HttpRequest(HttpMethod.PUT, server.url()).setBody(BODY);
+            request.getHeaders().set(HttpHeaderName.EXPECT, "100-continue");
+
+            HttpClient client = new JdkHttpClientProvider().createInstance();
+            HttpResponse response = client.send(request).block();
+
+            assertNotNull(response);
+            assertEquals(201, response.getStatusCode());
+            assertTrue(server.awaitRequest(), "the request never reached the server");
+
+            assertEquals("100-continue", server.expectHeader, "the Expect header did not reach the wire");
+            assertEquals(0, server.bodyBytesBeforeContinue, "the body was sent before the service answered");
+            assertEquals(BODY.length, server.bodyBytesAfterContinue, "the body was not delivered after 100 Continue");
+        }
+    }
+
+    @Test
+    public void sendsBodyImmediatelyWithoutTheHeader() throws Exception {
+        try (ExpectContinueServer server = new ExpectContinueServer()) {
+            server.start();
+
+            HttpClient client = new JdkHttpClientProvider().createInstance();
+            HttpResponse response = client.send(new HttpRequest(HttpMethod.PUT, server.url()).setBody(BODY)).block();
+
+            assertNotNull(response);
+            assertEquals(201, response.getStatusCode());
+            assertTrue(server.awaitRequest(), "the request never reached the server");
+
+            assertNull(server.expectHeader, "the Expect header should not have been set");
+            assertEquals(BODY.length, server.bodyBytesBeforeContinue,
+                "without the header the body should be sent immediately");
+        }
+    }
+
+    /**
+     * A minimal HTTP/1.1 server that answers the 100-continue handshake by hand, recording how many body bytes had
+     * arrived before it responded.
+     */
+    private static final class ExpectContinueServer implements AutoCloseable {
+        private final ServerSocket serverSocket;
+        private final CountDownLatch requestHandled = new CountDownLatch(1);
+        private volatile Thread thread;
+
+        private volatile String expectHeader;
+        private volatile int bodyBytesBeforeContinue = -1;
+        private volatile int bodyBytesAfterContinue = -1;
+
+        ExpectContinueServer() throws IOException {
+            this.serverSocket = new ServerSocket(0);
+        }
+
+        URL url() throws IOException {
+            return new URL("http://localhost:" + serverSocket.getLocalPort() + "/expect-continue");
+        }
+
+        void start() {
+            thread = new Thread(this::serve, "expect-continue-server");
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        boolean awaitRequest() throws InterruptedException {
+            return requestHandled.await(30, TimeUnit.SECONDS);
+        }
+
+        private void serve() {
+            try (Socket socket = serverSocket.accept()) {
+                socket.setTcpNoDelay(true);
+                InputStream in = socket.getInputStream();
+                OutputStream out = socket.getOutputStream();
+
+                int contentLength = readHeaders(in);
+
+                Thread.sleep(BODY_SETTLE_MILLIS);
+                bodyBytesBeforeContinue = in.available();
+
+                if (expectHeader != null) {
+                    out.write("HTTP/1.1 100 Continue\r\n\r\n".getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+                }
+
+                bodyBytesAfterContinue = readBody(in, contentLength - bodyBytesBeforeContinue);
+
+                out.write("HTTP/1.1 201 Created\r\nContent-Length: 0\r\n\r\n".getBytes(StandardCharsets.UTF_8));
+                out.flush();
+            } catch (IOException | InterruptedException ex) {
+                // Leave the recorded values as they are; the test assertions report the failure.
+            } finally {
+                requestHandled.countDown();
+            }
+        }
+
+        // Reads one byte at a time up to the end of the headers, so that no part of the body is consumed.
+        private int readHeaders(InputStream in) throws IOException {
+            ByteArrayOutputStream headerBytes = new ByteArrayOutputStream();
+            int consecutiveNewlines = 0;
+            int b;
+            while (consecutiveNewlines < 2 && (b = in.read()) != -1) {
+                headerBytes.write(b);
+                if (b == '\n') {
+                    consecutiveNewlines++;
+                } else if (b != '\r') {
+                    consecutiveNewlines = 0;
+                }
+            }
+
+            int contentLength = 0;
+            for (String line : new String(headerBytes.toByteArray(), StandardCharsets.UTF_8).split("\r\n")) {
+                int colon = line.indexOf(':');
+                if (colon < 0) {
+                    continue;
+                }
+                String name = line.substring(0, colon).trim().toLowerCase(Locale.ROOT);
+                String value = line.substring(colon + 1).trim();
+                if ("expect".equals(name)) {
+                    expectHeader = value.toLowerCase(Locale.ROOT);
+                } else if ("content-length".equals(name)) {
+                    contentLength = Integer.parseInt(value);
+                }
+            }
+
+            return contentLength;
+        }
+
+        private static int readBody(InputStream in, int remaining) throws IOException {
+            if (remaining <= 0) {
+                return 0;
+            }
+
+            int read = 0;
+            byte[] buffer = new byte[remaining];
+            while (read < remaining) {
+                int count = in.read(buffer, read, remaining - read);
+                if (count < 0) {
+                    break;
+                }
+                read += count;
+            }
+            return read;
+        }
+
+        @Override
+        public void close() throws IOException {
+            serverSocket.close();
+            if (thread != null) {
+                thread.interrupt();
+            }
+        }
+    }
+}

--- a/sdk/core/azure-core-http-jdk-httpclient/src/test/java/com/azure/core/http/jdk/httpclient/JdkHttpClientExpectContinueTests.java
+++ b/sdk/core/azure-core-http-jdk-httpclient/src/test/java/com/azure/core/http/jdk/httpclient/JdkHttpClientExpectContinueTests.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayOutputStream;
@@ -60,6 +61,27 @@ public class JdkHttpClientExpectContinueTests {
             assertNotNull(server.expectHeader, "the Expect header did not reach the wire");
             assertEquals(0, server.bodyBytesBeforeContinue, "the body was sent before the service answered");
             assertEquals(BODY.length, server.bodyBytesAfterContinue, "the body was not delivered after 100 Continue");
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = HttpMethod.class, names = { "GET", "HEAD" })
+    public void bodylessRequestDoesNotExpectContinue(HttpMethod method) throws Exception {
+        // The wrapper replaces the body with noBody() for these methods, so opting in would make the client wait
+        // for a handshake it has nothing to complete.
+        try (ExpectContinueServer server = new ExpectContinueServer()) {
+            server.start();
+
+            HttpRequest request = new HttpRequest(method, server.url());
+            request.getHeaders().set(HttpHeaderName.EXPECT, "100-continue");
+
+            HttpClient client = new JdkHttpClientProvider().createInstance();
+            HttpResponse response = client.send(request).block();
+
+            assertNotNull(response, "the request did not complete");
+            assertEquals(201, response.getStatusCode());
+            assertTrue(server.awaitRequest(), "the request never reached the server");
+            assertNull(server.expectHeader, "a request with no body should not carry the expectation");
         }
     }
 


### PR DESCRIPTION
`AzureJdkHttpRequest.expectContinue()` returned a hardcoded `false`, so `java.net.http` never performed the `Expect: 100-continue` handshake. The header was also dropped by the restricted header filter, so it never reached the wire either. The result was that a request carrying the expectation behaved exactly like one without it: the body was sent immediately and the service had no opportunity to reject it first.

The JDK implements the handshake itself once the request opts in, so the fix is to return `true` when the request carries the header. The JDK then adds the header and withholds the body until the service responds `100 Continue`. The restricted header filter stripping our copy is harmless for the same reason.

### Verification

`JdkHttpClientExpectContinueTests` drives the client against a raw socket that deliberately delays its `100 Continue`, and asserts on what reached the wire and when:

| | Before | After |
|---|---|---|
| `Expect` header on the wire | absent | present |
| Body bytes before `100 Continue` | 1024 (sent immediately) | 0 |
| Body delivered after `100 Continue` | n/a | 1024 |

A second test asserts that a request without the header still sends its body immediately, so the behaviour is scoped to requests that opt in.

The 48 pre-existing errors in this module's suite are unrelated - they reproduce identically on `main` without this change (52 tests / 48 errors on `main`, 54 tests / 48 errors here, the two extra being the new passing tests).

### Context

This came out of adding `Expect: 100-continue` support to the Storage blob clients (Azure/azure-sdk-for-java#50094). Of the four transports, only `azure-core-http-okhttp` performs the handshake today; `azure-core-http-vertx` sends the body immediately despite the Vert.x client exposing `sendHead()` and `continueHandler()`, and `azure-core-http-netty` has no client side support in netty or reactor-netty. A companion change for vertx follows.
