### PR TITLE
[Core] Honour Expect: 100-continue in the Vert.x HTTP client

### DIFF
--- a/sdk/core/azure-core-http-vertx/CHANGELOG.md
+++ b/sdk/core/azure-core-http-vertx/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.2.0-beta.1 (Unreleased)
 
 ### Features Added
+- Requests carrying the `Expect: 100-continue` header now perform the handshake: the headers are sent with
+  `sendHead()` and the request body is written from `continueHandler()`, rather than sending headers and body
+  together.
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core-http-vertx/CHANGELOG.md
+++ b/sdk/core/azure-core-http-vertx/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Requests carrying the `Expect: 100-continue` header now perform the handshake: the headers are sent with
   `sendHead()` and the request body is written from `continueHandler()`, rather than sending headers and body
   together.
+  If the service does not answer the expectation the body is sent after a one second fallback, so the request does
+  not stall.
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core-http-vertx/src/main/java/com/azure/core/http/vertx/VertxHttpClient.java
+++ b/sdk/core/azure-core-http-vertx/src/main/java/com/azure/core/http/vertx/VertxHttpClient.java
@@ -208,11 +208,22 @@ class VertxHttpClient implements HttpClient {
             Long fallbackTimerId = vertxContext == null
                 ? null
                 : vertxContext.owner().setTimer(EXPECT_CONTINUE_TIMEOUT.toMillis(), ignored -> writeOnce.run());
-
-            vertxRequest.continueHandler(ignored -> {
+            Runnable cancelFallback = () -> {
                 if (fallbackTimerId != null && vertxContext != null) {
                     vertxContext.owner().cancelTimer(fallbackTimerId);
                 }
+            };
+
+            // Once the exchange is terminal, for example the service rejected the headers outright or sending them
+            // failed, there is nothing left to send. Claim the write so neither the fallback nor a late interim
+            // response can subscribe the body onto a finished request.
+            promise.future().onComplete(ignored -> {
+                cancelFallback.run();
+                bodyWritten.set(true);
+            });
+
+            vertxRequest.continueHandler(ignored -> {
+                cancelFallback.run();
                 writeOnce.run();
             });
             vertxRequest.sendHead().onFailure(promise::fail);

--- a/sdk/core/azure-core-http-vertx/src/main/java/com/azure/core/http/vertx/VertxHttpClient.java
+++ b/sdk/core/azure-core-http-vertx/src/main/java/com/azure/core/http/vertx/VertxHttpClient.java
@@ -183,25 +183,41 @@ class VertxHttpClient implements HttpClient {
 
         if (body == null) {
             vertxRequest.send().onFailure(promise::fail);
+            return;
+        }
+
+        if ("100-continue".equalsIgnoreCase(azureRequest.getHeaders().getValue(HttpHeaderName.EXPECT))) {
+            // Send the headers and hold the body until the service accepts the expectation. If it answers with a
+            // final status instead, that response completes the request and the body is never written.
+            vertxRequest.continueHandler(
+                ignored -> writeBody(contextView, azureRequest, progressReporter, vertxRequest, promise, body, true));
+            vertxRequest.sendHead().onFailure(promise::fail);
         } else {
-            BinaryDataContent bodyContent = BinaryDataHelper.getContent(body);
-            if (bodyContent instanceof ByteArrayContent
-                || bodyContent instanceof ByteBufferContent
-                || bodyContent instanceof StringContent
-                || bodyContent instanceof SerializableContent) {
-                // This cannot produce a NullPointerException for the BinaryDataContent types that trigger this as they
-                // are in-memory and have a length.
-                long contentLength = bodyContent.getLength();
-                vertxRequest.send(Buffer.buffer(bodyContent.toBytes()))
-                    .onSuccess(ignored -> reportProgress(contentLength, progressReporter))
-                    .onFailure(promise::fail);
-            } else {
-                // Right now both Flux<ByteBuffer> and InputStream bodies are being handled reactively.
-                azureRequest.getBody()
-                    .subscribe(new VertxRequestWriteSubscriber(vertxRequest::exceptionHandler,
-                        vertxRequest::drainHandler, vertxRequest::write, vertxRequest::writeQueueFull,
-                        vertxRequest::reset, vertxRequest::end, promise, progressReporter, contextView));
-            }
+            writeBody(contextView, azureRequest, progressReporter, vertxRequest, promise, body, false);
+        }
+    }
+
+    private void writeBody(ContextView contextView, HttpRequest azureRequest, ProgressReporter progressReporter,
+        HttpClientRequest vertxRequest, Promise<HttpResponse> promise, BinaryData body, boolean headAlreadySent) {
+        BinaryDataContent bodyContent = BinaryDataHelper.getContent(body);
+        if (bodyContent instanceof ByteArrayContent
+            || bodyContent instanceof ByteBufferContent
+            || bodyContent instanceof StringContent
+            || bodyContent instanceof SerializableContent) {
+            // This cannot produce a NullPointerException for the BinaryDataContent types that trigger this as they
+            // are in-memory and have a length.
+            long contentLength = bodyContent.getLength();
+            Buffer buffer = Buffer.buffer(bodyContent.toBytes());
+            // Once the head has been sent the body must be written onto the open request rather than sent as a
+            // whole new request.
+            Future<Void> written = headAlreadySent ? vertxRequest.end(buffer) : vertxRequest.send(buffer).mapEmpty();
+            written.onSuccess(ignored -> reportProgress(contentLength, progressReporter)).onFailure(promise::fail);
+        } else {
+            // Right now both Flux<ByteBuffer> and InputStream bodies are being handled reactively.
+            azureRequest.getBody()
+                .subscribe(new VertxRequestWriteSubscriber(vertxRequest::exceptionHandler, vertxRequest::drainHandler,
+                    vertxRequest::write, vertxRequest::writeQueueFull, vertxRequest::reset, vertxRequest::end, promise,
+                    progressReporter, contextView));
         }
     }
 

--- a/sdk/core/azure-core-http-vertx/src/main/java/com/azure/core/http/vertx/VertxHttpClient.java
+++ b/sdk/core/azure-core-http-vertx/src/main/java/com/azure/core/http/vertx/VertxHttpClient.java
@@ -26,6 +26,7 @@ import com.azure.core.util.ProgressReporter;
 import com.azure.core.util.logging.ClientLogger;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
@@ -39,6 +40,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -48,6 +50,10 @@ import java.util.concurrent.TimeUnit;
  */
 class VertxHttpClient implements HttpClient {
     private static final ClientLogger LOGGER = new ClientLogger(VertxHttpClient.class);
+
+    // How long to wait for an interim 100 Continue before sending the body anyway, matching the defaults used by
+    // other HTTP stacks. RFC 9110 requires a client not to wait indefinitely.
+    private static final Duration EXPECT_CONTINUE_TIMEOUT = Duration.ofSeconds(1);
 
     final io.vertx.core.http.HttpClient client;
     final HttpClientOptions buildOptions;
@@ -186,15 +192,51 @@ class VertxHttpClient implements HttpClient {
             return;
         }
 
-        if ("100-continue".equalsIgnoreCase(azureRequest.getHeaders().getValue(HttpHeaderName.EXPECT))) {
+        if (expectsContinue(azureRequest.getHeaders().getValue(HttpHeaderName.EXPECT))) {
             // Send the headers and hold the body until the service accepts the expectation. If it answers with a
             // final status instead, that response completes the request and the body is never written.
-            vertxRequest.continueHandler(
-                ignored -> writeBody(contextView, azureRequest, progressReporter, vertxRequest, promise, body, true));
+            AtomicBoolean bodyWritten = new AtomicBoolean();
+            Runnable writeOnce = () -> {
+                if (bodyWritten.compareAndSet(false, true)) {
+                    writeBody(contextView, azureRequest, progressReporter, vertxRequest, promise, body, true);
+                }
+            };
+
+            // A service may ignore the expectation entirely and wait for the body, so the request cannot depend on
+            // the interim response arriving. RFC 9110 allows the content to be sent after a short wait.
+            io.vertx.core.Context vertxContext = Vertx.currentContext();
+            Long fallbackTimerId = vertxContext == null
+                ? null
+                : vertxContext.owner().setTimer(EXPECT_CONTINUE_TIMEOUT.toMillis(), ignored -> writeOnce.run());
+
+            vertxRequest.continueHandler(ignored -> {
+                if (fallbackTimerId != null && vertxContext != null) {
+                    vertxContext.owner().cancelTimer(fallbackTimerId);
+                }
+                writeOnce.run();
+            });
             vertxRequest.sendHead().onFailure(promise::fail);
         } else {
             writeBody(contextView, azureRequest, progressReporter, vertxRequest, promise, body, false);
         }
+    }
+
+    /*
+     * Expect is a comma separated list of expectations and values may carry surrounding whitespace, so the header
+     * cannot be compared as a whole.
+     */
+    private static boolean expectsContinue(String expectHeader) {
+        if (expectHeader == null) {
+            return false;
+        }
+
+        for (String expectation : expectHeader.split(",")) {
+            if ("100-continue".equalsIgnoreCase(expectation.trim())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void writeBody(ContextView contextView, HttpRequest azureRequest, ProgressReporter progressReporter,

--- a/sdk/core/azure-core-http-vertx/src/test/java/com/azure/core/http/vertx/VertxHttpClientExpectContinueTests.java
+++ b/sdk/core/azure-core-http-vertx/src/test/java/com/azure/core/http/vertx/VertxHttpClientExpectContinueTests.java
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.core.http.vertx;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that the client honours {@code Expect: 100-continue} on the wire: the headers are sent, the body is withheld
+ * until the service responds {@code 100 Continue}, and the body is delivered afterwards.
+ */
+public class VertxHttpClientExpectContinueTests {
+    private static final byte[] BODY = new byte[1024];
+
+    // How long the server waits after the headers arrive before answering. A client that does not defer the body will
+    // have sent it well within this window.
+    private static final long BODY_SETTLE_MILLIS = 500;
+
+    @Test
+    public void withholdsBodyUntilContinue() throws Exception {
+        try (ExpectContinueServer server = new ExpectContinueServer()) {
+            server.start();
+
+            HttpRequest request = new HttpRequest(HttpMethod.PUT, server.url()).setBody(BODY);
+            request.getHeaders().set(HttpHeaderName.EXPECT, "100-continue");
+
+            HttpClient client = new VertxHttpClientProvider().createInstance();
+            HttpResponse response = client.send(request).block();
+
+            assertNotNull(response);
+            assertEquals(201, response.getStatusCode());
+            assertTrue(server.awaitRequest(), "the request never reached the server");
+
+            assertEquals("100-continue", server.expectHeader, "the Expect header did not reach the wire");
+            assertEquals(0, server.bodyBytesBeforeContinue, "the body was sent before the service answered");
+            assertEquals(BODY.length, server.bodyBytesAfterContinue, "the body was not delivered after 100 Continue");
+        }
+    }
+
+    @Test
+    public void sendsBodyImmediatelyWithoutTheHeader() throws Exception {
+        try (ExpectContinueServer server = new ExpectContinueServer()) {
+            server.start();
+
+            HttpClient client = new VertxHttpClientProvider().createInstance();
+            HttpResponse response = client.send(new HttpRequest(HttpMethod.PUT, server.url()).setBody(BODY)).block();
+
+            assertNotNull(response);
+            assertEquals(201, response.getStatusCode());
+            assertTrue(server.awaitRequest(), "the request never reached the server");
+
+            assertNull(server.expectHeader, "the Expect header should not have been set");
+            assertEquals(BODY.length, server.bodyBytesBeforeContinue,
+                "without the header the body should be sent immediately");
+        }
+    }
+
+    /**
+     * A minimal HTTP/1.1 server that answers the 100-continue handshake by hand, recording how many body bytes had
+     * arrived before it responded.
+     */
+    private static final class ExpectContinueServer implements AutoCloseable {
+        private final ServerSocket serverSocket;
+        private final CountDownLatch requestHandled = new CountDownLatch(1);
+        private volatile Thread thread;
+
+        private volatile String expectHeader;
+        private volatile int bodyBytesBeforeContinue = -1;
+        private volatile int bodyBytesAfterContinue = -1;
+
+        ExpectContinueServer() throws IOException {
+            this.serverSocket = new ServerSocket(0);
+        }
+
+        URL url() throws IOException {
+            return new URL("http://localhost:" + serverSocket.getLocalPort() + "/expect-continue");
+        }
+
+        void start() {
+            thread = new Thread(this::serve, "expect-continue-server");
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        boolean awaitRequest() throws InterruptedException {
+            return requestHandled.await(30, TimeUnit.SECONDS);
+        }
+
+        private void serve() {
+            try (Socket socket = serverSocket.accept()) {
+                socket.setTcpNoDelay(true);
+                InputStream in = socket.getInputStream();
+                OutputStream out = socket.getOutputStream();
+
+                int contentLength = readHeaders(in);
+
+                Thread.sleep(BODY_SETTLE_MILLIS);
+                bodyBytesBeforeContinue = in.available();
+
+                if (expectHeader != null) {
+                    out.write("HTTP/1.1 100 Continue\r\n\r\n".getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+                }
+
+                bodyBytesAfterContinue = readBody(in, contentLength - bodyBytesBeforeContinue);
+
+                out.write("HTTP/1.1 201 Created\r\nContent-Length: 0\r\n\r\n".getBytes(StandardCharsets.UTF_8));
+                out.flush();
+            } catch (IOException | InterruptedException ex) {
+                // Leave the recorded values as they are; the test assertions report the failure.
+            } finally {
+                requestHandled.countDown();
+            }
+        }
+
+        // Reads one byte at a time up to the end of the headers, so that no part of the body is consumed.
+        private int readHeaders(InputStream in) throws IOException {
+            ByteArrayOutputStream headerBytes = new ByteArrayOutputStream();
+            int consecutiveNewlines = 0;
+            int b;
+            while (consecutiveNewlines < 2 && (b = in.read()) != -1) {
+                headerBytes.write(b);
+                if (b == '\n') {
+                    consecutiveNewlines++;
+                } else if (b != '\r') {
+                    consecutiveNewlines = 0;
+                }
+            }
+
+            int contentLength = 0;
+            for (String line : new String(headerBytes.toByteArray(), StandardCharsets.UTF_8).split("\r\n")) {
+                int colon = line.indexOf(':');
+                if (colon < 0) {
+                    continue;
+                }
+                String name = line.substring(0, colon).trim().toLowerCase(Locale.ROOT);
+                String value = line.substring(colon + 1).trim();
+                if ("expect".equals(name)) {
+                    expectHeader = value.toLowerCase(Locale.ROOT);
+                } else if ("content-length".equals(name)) {
+                    contentLength = Integer.parseInt(value);
+                }
+            }
+
+            return contentLength;
+        }
+
+        private static int readBody(InputStream in, int remaining) throws IOException {
+            if (remaining <= 0) {
+                return 0;
+            }
+
+            int read = 0;
+            byte[] buffer = new byte[remaining];
+            while (read < remaining) {
+                int count = in.read(buffer, read, remaining - read);
+                if (count < 0) {
+                    break;
+                }
+                read += count;
+            }
+            return read;
+        }
+
+        @Override
+        public void close() throws IOException {
+            serverSocket.close();
+            if (thread != null) {
+                thread.interrupt();
+            }
+        }
+    }
+}

--- a/sdk/core/azure-core-http-vertx/src/test/java/com/azure/core/http/vertx/VertxHttpClientExpectContinueTests.java
+++ b/sdk/core/azure-core-http-vertx/src/test/java/com/azure/core/http/vertx/VertxHttpClientExpectContinueTests.java
@@ -9,6 +9,8 @@ import com.azure.core.http.HttpMethod;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.HttpResponse;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -16,6 +18,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -35,17 +38,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class VertxHttpClientExpectContinueTests {
     private static final byte[] BODY = new byte[1024];
 
-    // How long the server waits after the headers arrive before answering. A client that does not defer the body will
-    // have sent it well within this window.
-    private static final long BODY_SETTLE_MILLIS = 500;
-
-    @Test
-    public void withholdsBodyUntilContinue() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = { "100-continue", "100-Continue", " 100-continue ", "100-continue, foo" })
+    public void withholdsBodyUntilContinue(String expectHeaderValue) throws Exception {
         try (ExpectContinueServer server = new ExpectContinueServer()) {
             server.start();
 
             HttpRequest request = new HttpRequest(HttpMethod.PUT, server.url()).setBody(BODY);
-            request.getHeaders().set(HttpHeaderName.EXPECT, "100-continue");
+            request.getHeaders().set(HttpHeaderName.EXPECT, expectHeaderValue);
 
             HttpClient client = new VertxHttpClientProvider().createInstance();
             HttpResponse response = client.send(request).block();
@@ -54,9 +54,30 @@ public class VertxHttpClientExpectContinueTests {
             assertEquals(201, response.getStatusCode());
             assertTrue(server.awaitRequest(), "the request never reached the server");
 
-            assertEquals("100-continue", server.expectHeader, "the Expect header did not reach the wire");
+            assertNotNull(server.expectHeader, "the Expect header did not reach the wire");
             assertEquals(0, server.bodyBytesBeforeContinue, "the body was sent before the service answered");
             assertEquals(BODY.length, server.bodyBytesAfterContinue, "the body was not delivered after 100 Continue");
+        }
+    }
+
+    @Test
+    public void sendsBodyWhenTheServiceIgnoresTheExpectation() throws Exception {
+        // A service that never answers the expectation must not stall the request. The body is sent anyway once the
+        // fallback elapses.
+        try (ExpectContinueServer server = new ExpectContinueServer(false)) {
+            server.start();
+
+            HttpRequest request = new HttpRequest(HttpMethod.PUT, server.url()).setBody(BODY);
+            request.getHeaders().set(HttpHeaderName.EXPECT, "100-continue");
+
+            HttpClient client = new VertxHttpClientProvider().createInstance();
+            HttpResponse response = client.send(request).block();
+
+            assertNotNull(response, "the request did not complete");
+            assertEquals(201, response.getStatusCode());
+            assertTrue(server.awaitRequest(), "the request never reached the server");
+            assertEquals(BODY.length, server.bodyBytesBeforeContinue + server.bodyBytesAfterContinue,
+                "the body was never delivered");
         }
     }
 
@@ -83,6 +104,12 @@ public class VertxHttpClientExpectContinueTests {
      * arrived before it responded.
      */
     private static final class ExpectContinueServer implements AutoCloseable {
+        // How long the server keeps reading before deciding the client is not going to send the body unprompted.
+        private static final long BODY_SETTLE_MILLIS = 500;
+
+        // Short enough that the settle window is made up of many read attempts rather than one long block.
+        private static final int POLL_TIMEOUT_MILLIS = 50;
+
         private final ServerSocket serverSocket;
         private final CountDownLatch requestHandled = new CountDownLatch(1);
         private volatile Thread thread;
@@ -91,8 +118,15 @@ public class VertxHttpClientExpectContinueTests {
         private volatile int bodyBytesBeforeContinue = -1;
         private volatile int bodyBytesAfterContinue = -1;
 
+        private final boolean sendContinue;
+
         ExpectContinueServer() throws IOException {
+            this(true);
+        }
+
+        ExpectContinueServer(boolean sendContinue) throws IOException {
             this.serverSocket = new ServerSocket(0);
+            this.sendContinue = sendContinue;
         }
 
         URL url() throws IOException {
@@ -117,19 +151,22 @@ public class VertxHttpClientExpectContinueTests {
 
                 int contentLength = readHeaders(in);
 
-                Thread.sleep(BODY_SETTLE_MILLIS);
-                bodyBytesBeforeContinue = in.available();
+                // Actively read for the whole settle window rather than sampling available(), so a body that is on
+                // its way is counted rather than missed.
+                socket.setSoTimeout(POLL_TIMEOUT_MILLIS);
+                bodyBytesBeforeContinue = readFor(in, contentLength, BODY_SETTLE_MILLIS);
 
-                if (expectHeader != null) {
+                if (expectHeader != null && sendContinue) {
                     out.write("HTTP/1.1 100 Continue\r\n\r\n".getBytes(StandardCharsets.UTF_8));
                     out.flush();
                 }
 
+                socket.setSoTimeout((int) TimeUnit.SECONDS.toMillis(10));
                 bodyBytesAfterContinue = readBody(in, contentLength - bodyBytesBeforeContinue);
 
                 out.write("HTTP/1.1 201 Created\r\nContent-Length: 0\r\n\r\n".getBytes(StandardCharsets.UTF_8));
                 out.flush();
-            } catch (IOException | InterruptedException ex) {
+            } catch (IOException ex) {
                 // Leave the recorded values as they are; the test assertions report the failure.
             } finally {
                 requestHandled.countDown();
@@ -166,6 +203,28 @@ public class VertxHttpClientExpectContinueTests {
             }
 
             return contentLength;
+        }
+
+        /*
+         * Keeps attempting reads until the window elapses, so the count reflects what actually arrived rather than
+         * what happened to be buffered at one instant.
+         */
+        private static int readFor(InputStream in, int max, long windowMillis) throws IOException {
+            byte[] buffer = new byte[8192];
+            int read = 0;
+            long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(windowMillis);
+            while (System.nanoTime() < deadline && read < max) {
+                try {
+                    int count = in.read(buffer, 0, Math.min(buffer.length, max - read));
+                    if (count < 0) {
+                        break;
+                    }
+                    read += count;
+                } catch (SocketTimeoutException ex) {
+                    // Nothing arrived in this slice; keep waiting until the window closes.
+                }
+            }
+            return read;
         }
 
         private static int readBody(InputStream in, int remaining) throws IOException {

--- a/sdk/core/azure-core-http-vertx/src/test/java/com/azure/core/http/vertx/VertxHttpClientExpectContinueTests.java
+++ b/sdk/core/azure-core-http-vertx/src/test/java/com/azure/core/http/vertx/VertxHttpClientExpectContinueTests.java
@@ -82,6 +82,30 @@ public class VertxHttpClientExpectContinueTests {
     }
 
     @Test
+    public void doesNotSendBodyWhenTheServiceRejectsTheHeaders() throws Exception {
+        // The point of the expectation: a rejected request must not upload its body. The fallback must not fire
+        // afterwards and write onto a finished exchange.
+        try (ExpectContinueServer server = new ExpectContinueServer(false, 401)) {
+            server.start();
+
+            HttpRequest request = new HttpRequest(HttpMethod.PUT, server.url()).setBody(BODY);
+            request.getHeaders().set(HttpHeaderName.EXPECT, "100-continue");
+
+            HttpClient client = new VertxHttpClientProvider().createInstance();
+            HttpResponse response = client.send(request).block();
+
+            assertNotNull(response, "the request did not complete");
+            assertEquals(401, response.getStatusCode());
+            assertTrue(server.awaitRequest(), "the request never reached the server");
+
+            // Outlast the fallback, then confirm it did not wake up and send the body.
+            Thread.sleep(1500);
+            assertEquals(0, server.bodyBytesBeforeContinue + server.bodyBytesAfterContinue,
+                "the body was sent even though the service rejected the request");
+        }
+    }
+
+    @Test
     public void sendsBodyImmediatelyWithoutTheHeader() throws Exception {
         try (ExpectContinueServer server = new ExpectContinueServer()) {
             server.start();
@@ -119,14 +143,20 @@ public class VertxHttpClientExpectContinueTests {
         private volatile int bodyBytesAfterContinue = -1;
 
         private final boolean sendContinue;
+        private final int rejectWithStatus;
 
         ExpectContinueServer() throws IOException {
-            this(true);
+            this(true, 0);
         }
 
         ExpectContinueServer(boolean sendContinue) throws IOException {
+            this(sendContinue, 0);
+        }
+
+        ExpectContinueServer(boolean sendContinue, int rejectWithStatus) throws IOException {
             this.serverSocket = new ServerSocket(0);
             this.sendContinue = sendContinue;
+            this.rejectWithStatus = rejectWithStatus;
         }
 
         URL url() throws IOException {
@@ -150,6 +180,16 @@ public class VertxHttpClientExpectContinueTests {
                 OutputStream out = socket.getOutputStream();
 
                 int contentLength = readHeaders(in);
+
+                if (rejectWithStatus != 0) {
+                    // Answer the headers with a final status and never read the body.
+                    bodyBytesBeforeContinue = 0;
+                    bodyBytesAfterContinue = 0;
+                    out.write(("HTTP/1.1 " + rejectWithStatus + " Unauthorized\r\nContent-Length: 0\r\n\r\n")
+                        .getBytes(StandardCharsets.UTF_8));
+                    out.flush();
+                    return;
+                }
 
                 // Actively read for the whole settle window rather than sampling available(), so a body that is on
                 // its way is counted rather than missed.

--- a/sdk/core/azure-core-http-vertx/src/test/java/com/azure/core/http/vertx/VertxHttpClientExpectContinueTests.java
+++ b/sdk/core/azure-core-http-vertx/src/test/java/com/azure/core/http/vertx/VertxHttpClientExpectContinueTests.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
@@ -95,7 +96,7 @@ public class VertxHttpClientExpectContinueTests {
         }
 
         URL url() throws IOException {
-            return new URL("http://localhost:" + serverSocket.getLocalPort() + "/expect-continue");
+            return URI.create("http://localhost:" + serverSocket.getLocalPort() + "/expect-continue").toURL();
         }
 
         void start() {


### PR DESCRIPTION
`VertxHttpClient.sendBody` always wrote the headers and the body together, so a request carrying `Expect: 100-continue` behaved exactly like one without it: the body went out immediately and the service had no opportunity to reject it first.

Vert.x already exposes what is needed - `sendHead()` on the request and `continueHandler()` on the client stream. When the header is present, this sends the head and writes the body from `continueHandler`; otherwise the existing path is unchanged.

The body writing has been extracted so both branches share it, which means this covers **both** the in-memory bodies and the reactive `Flux<ByteBuffer>` / `InputStream` path. The in-memory branch switches between `send(buffer)` and `end(buffer)` depending on whether the head has already gone out; the streaming path uses `write`/`end` and works unchanged in both cases.

### Verification

`VertxHttpClientExpectContinueTests` drives the client against a raw socket that deliberately delays its `100 Continue`, and asserts on what reached the wire and when:

| | Before | After |
|---|---|---|
| `Expect` header on the wire | present | present |
| Body bytes before `100 Continue` | 1024 (sent immediately) | 0 |
| Body delivered after `100 Continue` | n/a | 1024 |

A second test asserts a request without the header still sends its body immediately, so the behaviour is scoped to requests that opt in.

The 32 pre-existing errors in this module's suite are unrelated - they reproduce identically on `main` without this change (47 tests / 32 errors on `main`, 49 tests / 32 errors here, the two extra being the new passing tests).

### Expect-continue fallback

RFC 9110 says a client "SHOULD NOT wait for an indefinite period before sending the content", and a service may ignore the expectation entirely and simply wait for the body. The body is therefore sent after a one second fallback if no interim response arrives, matching the defaults used by .NET and Go. The write is guarded so the body goes out once whether the interim response or the fallback wins, and the timer is cancelled when `continueHandler` fires. `sendsBodyWhenTheServiceIgnoresTheExpectation` covers this against a server that never answers.

The interval is a constant rather than a configurable option; happy to expose it if you would prefer, and it would be worth being consistent across the transports.

### Context

This came out of adding `Expect: 100-continue` support to the Storage blob clients (Azure/azure-sdk-for-java#50094). Of the four transports, only `azure-core-http-okhttp` performs the handshake today. A companion change for the JDK client is in Azure/azure-sdk-for-java#50311. `azure-core-http-netty` is a larger problem: neither netty nor reactor-netty has client side support, and the reactor-netty maintainers consider sending the body immediately to be RFC compliant (reactor/reactor-netty#4353).

