### PR TITLE
App Config Spring - Bug fix multiple stores refresh failure

### DIFF
--- a/sdk/spring/spring-cloud-azure-appconfiguration-config/CHANGELOG.md
+++ b/sdk/spring/spring-cloud-azure-appconfiguration-config/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where a refresh, when using multiple stores, could result in a partially loaded store failed to load across retries and all available replicas.
+
 ### Other Changes
 
 ## 7.4.0 (2026-07-24)

--- a/sdk/spring/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/appconfiguration/config/implementation/AzureAppConfigDataLoader.java
+++ b/sdk/spring/spring-cloud-azure-appconfiguration-config/src/main/java/com/azure/spring/cloud/appconfiguration/config/implementation/AzureAppConfigDataLoader.java
@@ -136,13 +136,12 @@ public class AzureAppConfigDataLoader implements ConfigDataLoader<AzureAppConfig
             Exception loadException = loadConfiguration(sourceList);
             if (loadException != null) {
                 if (resource.isRefresh()) {
-                    logger.warn("Azure App Configuration failed during refresh for store: "
-                        + resource.getEndpoint() + ". Continuing with existing configuration.");
-                } else {
-                    logger.error("Azure App Configuration failed to load configuration during startup for store: "
-                        + resource.getEndpoint() + ". Application cannot start without required configuration.");
-                    failedToGeneratePropertySource(loadException);
+                    throw new RuntimeException(
+                        "Failed to refresh property sources for " + resource.getEndpoint(), loadException);
                 }
+                logger.error("Azure App Configuration failed to load configuration during startup for store: "
+                    + resource.getEndpoint() + ". Application cannot start without required configuration.");
+                failedToGeneratePropertySource(loadException);
             }
         }
 

--- a/sdk/spring/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/appconfiguration/config/implementation/AzureAppConfigDataLoaderTest.java
+++ b/sdk/spring/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/appconfiguration/config/implementation/AzureAppConfigDataLoaderTest.java
@@ -291,7 +291,7 @@ public class AzureAppConfigDataLoaderTest {
         RuntimeException exception = assertThrows(RuntimeException.class,
             () -> loader.load(configDataLoaderContextMock, refreshResource));
 
-        // Verify - refresh fails and only attempts once (no retry loop for refresh)
+        // Verify - refresh fails and does not enter the startup retry/backoff loop
         assertTrue(exception.getMessage().contains("Failed to refresh property sources"));
         verify(replicaClientFactoryMock, times(1)).findActiveClients(ENDPOINT);
     }

--- a/sdk/spring/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/appconfiguration/config/implementation/AzureAppConfigDataLoaderTest.java
+++ b/sdk/spring/spring-cloud-azure-appconfiguration-config/src/test/java/com/azure/spring/cloud/appconfiguration/config/implementation/AzureAppConfigDataLoaderTest.java
@@ -273,7 +273,7 @@ public class AzureAppConfigDataLoaderTest {
     }
 
     @Test
-    public void refreshOnlyAttemptsOnceOnFailureTest() throws IOException {
+    public void refreshOnlyAttemptsOnceAndThrowsOnFailureTest() {
         // Setup selector
         AppConfigurationKeyValueSelector selector = new AppConfigurationKeyValueSelector();
         selector.setKeyFilter(KEY_FILTER);
@@ -286,12 +286,13 @@ public class AzureAppConfigDataLoaderTest {
         lenient().when(clientMock.getEndpoint()).thenReturn(ENDPOINT);
         lenient().when(clientMock.listSettings(any(), any())).thenThrow(new RuntimeException("Simulated failure"));
 
-        // Test with refresh resource (isRefresh = true) - should NOT throw, just warn
+        // Test with refresh resource (isRefresh = true)
         AzureAppConfigDataLoader loader = new AzureAppConfigDataLoader(logFactoryMock);
-        ConfigData result = loader.load(configDataLoaderContextMock, refreshResource);
+        RuntimeException exception = assertThrows(RuntimeException.class,
+            () -> loader.load(configDataLoaderContextMock, refreshResource));
 
-        // Verify - only one findActiveClients call (no retry loop for refresh)
-        assertNotNull(result);
+        // Verify - refresh fails and only attempts once (no retry loop for refresh)
+        assertTrue(exception.getMessage().contains("Failed to refresh property sources"));
         verify(replicaClientFactoryMock, times(1)).findActiveClients(ENDPOINT);
     }
 
@@ -317,7 +318,7 @@ public class AzureAppConfigDataLoaderTest {
     }
 
     @Test
-    public void startupDoesNotRetryDuringRefreshTest() throws IOException {
+    public void refreshFailureDoesNotUseStartupRetryTest() {
         // Setup selector
         AppConfigurationKeyValueSelector selector = new AppConfigurationKeyValueSelector();
         selector.setKeyFilter(KEY_FILTER);
@@ -330,13 +331,13 @@ public class AzureAppConfigDataLoaderTest {
         when(clientMock.getEndpoint()).thenReturn(ENDPOINT);
         when(clientMock.listSettings(any(), any())).thenThrow(new RuntimeException("Test failure"));
 
-        // Test with refresh resource - should NOT throw, just warn and continue
+        // Test with refresh resource
         AzureAppConfigDataLoader loader = new AzureAppConfigDataLoader(logFactoryMock);
-        ConfigData result = loader.load(configDataLoaderContextMock, refreshResource);
+        RuntimeException exception = assertThrows(RuntimeException.class,
+            () -> loader.load(configDataLoaderContextMock, refreshResource));
 
-        // Verify - failure on first attempt, no retry
-        assertNotNull(result);
-        // Only one findActiveClients call (would be multiple in startup retry loop)
+        // Verify - refresh fails on the first attempt without entering the startup retry loop
+        assertTrue(exception.getMessage().contains("Failed to refresh property sources"));
         verify(replicaClientFactoryMock, times(1)).findActiveClients(ENDPOINT);
     }
 }


### PR DESCRIPTION
# Description

This change fixes a bug where a partial refresh load could occur in the following conditions:
- The provider is loading from multiple stores
- A refresh attempt happens where we detect changes in a store.
- The given store becomes inaccessible between the detection and the attempt to reload configurations.
- Retry and replicas also fail to load the configuration.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.
