### PR TITLE
Add Voice Live SDK identification

### DIFF
--- a/sdk/voicelive/azure-ai-voicelive/CHANGELOG.md
+++ b/sdk/voicelive/azure-ai-voicelive/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Added the Azure SDK identifier to the WebSocket `User-Agent` header and `x-ms-client-sdk` query parameter.
+
 ### Other Changes
 
 ## 1.1.0 (2026-08-03)

--- a/sdk/voicelive/azure-ai-voicelive/src/main/java/com/azure/ai/voicelive/VoiceLiveAsyncClient.java
+++ b/sdk/voicelive/azure-ai-voicelive/src/main/java/com/azure/ai/voicelive/VoiceLiveAsyncClient.java
@@ -3,8 +3,12 @@
 
 package com.azure.ai.voicelive;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -34,22 +38,26 @@ public final class VoiceLiveAsyncClient {
     private final KeyCredential keyCredential;
     private final TokenCredential tokenCredential;
     private final String apiVersion;
+    private final String userAgent;
     private final HttpHeaders additionalHeaders;
 
-    VoiceLiveAsyncClient(URI endpoint, KeyCredential keyCredential, String apiVersion, HttpHeaders additionalHeaders) {
+    VoiceLiveAsyncClient(URI endpoint, KeyCredential keyCredential, String apiVersion, String userAgent,
+        HttpHeaders additionalHeaders) {
         this.endpoint = Objects.requireNonNull(endpoint, "'endpoint' cannot be null");
         this.keyCredential = Objects.requireNonNull(keyCredential, "'keyCredential' cannot be null");
         this.tokenCredential = null;
         this.apiVersion = Objects.requireNonNull(apiVersion, "'apiVersion' cannot be null");
+        this.userAgent = Objects.requireNonNull(userAgent, "'userAgent' cannot be null");
         this.additionalHeaders = additionalHeaders != null ? additionalHeaders : new HttpHeaders();
     }
 
-    VoiceLiveAsyncClient(URI endpoint, TokenCredential tokenCredential, String apiVersion,
+    VoiceLiveAsyncClient(URI endpoint, TokenCredential tokenCredential, String apiVersion, String userAgent,
         HttpHeaders additionalHeaders) {
         this.endpoint = Objects.requireNonNull(endpoint, "'endpoint' cannot be null");
         this.keyCredential = null;
         this.tokenCredential = Objects.requireNonNull(tokenCredential, "'tokenCredential' cannot be null");
         this.apiVersion = Objects.requireNonNull(apiVersion, "'apiVersion' cannot be null");
+        this.userAgent = Objects.requireNonNull(userAgent, "'userAgent' cannot be null");
         this.additionalHeaders = additionalHeaders != null ? additionalHeaders : new HttpHeaders();
     }
 
@@ -229,17 +237,20 @@ public final class VoiceLiveAsyncClient {
             Map<String, String> queryParams = new LinkedHashMap<>();
 
             // Start with existing query parameters from the endpoint URL
-            if (httpEndpoint.getQuery() != null && !httpEndpoint.getQuery().isEmpty()) {
-                String[] pairs = httpEndpoint.getQuery().split("&");
+            if (httpEndpoint.getRawQuery() != null && !httpEndpoint.getRawQuery().isEmpty()) {
+                String[] pairs = httpEndpoint.getRawQuery().split("&");
                 for (String pair : pairs) {
                     int idx = pair.indexOf("=");
                     if (idx > 0) {
-                        String key = pair.substring(0, idx);
-                        String value = pair.substring(idx + 1);
+                        String key = decodeQueryParameter(pair.substring(0, idx));
+                        String value = decodeQueryParameter(pair.substring(idx + 1));
                         queryParams.put(key, value);
                     }
                 }
             }
+
+            // Identify the SDK when headers aren't available to the service. Request options may override this value.
+            queryParams.put("x-ms-client-sdk", userAgent);
 
             // Add/override with custom query parameters from request options
             if (additionalQueryParams != null && !additionalQueryParams.isEmpty()) {
@@ -260,14 +271,41 @@ public final class VoiceLiveAsyncClient {
                 if (queryBuilder.length() > 0) {
                     queryBuilder.append("&");
                 }
-                queryBuilder.append(entry.getKey()).append("=").append(entry.getValue());
+                queryBuilder.append(encodeQueryParameter(entry.getKey()))
+                    .append("=")
+                    .append(encodeQueryParameter(entry.getValue()));
             }
 
-            return new URI(scheme, httpEndpoint.getUserInfo(), httpEndpoint.getHost(), httpEndpoint.getPort(), path,
-                queryBuilder.length() > 0 ? queryBuilder.toString() : null, httpEndpoint.getFragment());
+            URI uriWithoutQuery = new URI(scheme, httpEndpoint.getUserInfo(), httpEndpoint.getHost(),
+                httpEndpoint.getPort(), path, null, httpEndpoint.getFragment());
+            if (queryBuilder.length() == 0) {
+                return uriWithoutQuery;
+            }
+
+            String uri = uriWithoutQuery.toASCIIString();
+            int fragmentIndex = uri.indexOf('#');
+            return URI.create(fragmentIndex < 0
+                ? uri + "?" + queryBuilder
+                : uri.substring(0, fragmentIndex) + "?" + queryBuilder + uri.substring(fragmentIndex));
         } catch (URISyntaxException e) {
             throw LOGGER
                 .logExceptionAsError(new IllegalArgumentException("Failed to convert endpoint to WebSocket URI", e));
+        }
+    }
+
+    private static String encodeQueryParameter(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name()).replace("+", "%20");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("UTF-8 encoding is not supported", e);
+        }
+    }
+
+    private static String decodeQueryParameter(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("UTF-8 encoding is not supported", e);
         }
     }
 }

--- a/sdk/voicelive/azure-ai-voicelive/src/main/java/com/azure/ai/voicelive/VoiceLiveClientBuilder.java
+++ b/sdk/voicelive/azure-ai-voicelive/src/main/java/com/azure/ai/voicelive/VoiceLiveClientBuilder.java
@@ -14,10 +14,12 @@ import com.azure.core.client.traits.KeyCredentialTrait;
 import com.azure.core.client.traits.TokenCredentialTrait;
 import com.azure.core.credential.KeyCredential;
 import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.HttpHeader;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpHeaders;
 import com.azure.core.util.ClientOptions;
 import com.azure.core.util.CoreUtils;
-
+import com.azure.core.util.UserAgentUtil;
 import com.azure.core.util.logging.ClientLogger;
 
 /**
@@ -128,12 +130,22 @@ public final class VoiceLiveClientBuilder implements TokenCredentialTrait<VoiceL
         }
 
         VoiceLiveServiceVersion version = serviceVersion != null ? serviceVersion : VoiceLiveServiceVersion.getLatest();
-        HttpHeaders additionalHeaders = CoreUtils.createHttpHeadersFromClientOptions(clientOptions);
+        String applicationId = CoreUtils.getApplicationId(clientOptions, null);
+        String userAgent = UserAgentUtil.toUserAgentString(applicationId, SDK_NAME, SDK_VERSION, null);
+        HttpHeaders additionalHeaders = new HttpHeaders().set(HttpHeaderName.USER_AGENT, userAgent);
+        HttpHeaders clientOptionHeaders = CoreUtils.createHttpHeadersFromClientOptions(clientOptions);
+        if (clientOptionHeaders != null) {
+            for (HttpHeader header : clientOptionHeaders) {
+                additionalHeaders.set(HttpHeaderName.fromString(header.getName()), header.getValue());
+            }
+        }
 
         if (keyCredential != null) {
-            return new VoiceLiveAsyncClient(endpoint, keyCredential, version.getVersion(), additionalHeaders);
+            return new VoiceLiveAsyncClient(endpoint, keyCredential, version.getVersion(), userAgent,
+                additionalHeaders);
         } else {
-            return new VoiceLiveAsyncClient(endpoint, tokenCredential, version.getVersion(), additionalHeaders);
+            return new VoiceLiveAsyncClient(endpoint, tokenCredential, version.getVersion(), userAgent,
+                additionalHeaders);
         }
     }
 }

--- a/sdk/voicelive/azure-ai-voicelive/src/test/java/com/azure/ai/voicelive/unit/VoiceLiveAsyncClientTest.java
+++ b/sdk/voicelive/azure-ai-voicelive/src/test/java/com/azure/ai/voicelive/unit/VoiceLiveAsyncClientTest.java
@@ -42,14 +42,15 @@ class VoiceLiveAsyncClientTest {
     void setUp() throws Exception {
         testEndpoint = new URI("https://test.cognitiveservices.azure.com");
         keyCredentialConstructor = VoiceLiveAsyncClient.class.getDeclaredConstructor(URI.class, KeyCredential.class,
-            String.class, HttpHeaders.class);
+            String.class, String.class, HttpHeaders.class);
         keyCredentialConstructor.setAccessible(true);
         toQueryParameters = VoiceLiveAsyncClient.class.getDeclaredMethod("toQueryParameters", AgentSessionConfig.class);
         toQueryParameters.setAccessible(true);
     }
 
     private VoiceLiveAsyncClient newClient(URI endpoint, KeyCredential credential) throws Exception {
-        return keyCredentialConstructor.newInstance(endpoint, credential, "2024-10-01-preview", mockHeaders);
+        return keyCredentialConstructor.newInstance(endpoint, credential, "2024-10-01-preview", "test-user-agent",
+            mockHeaders);
     }
 
     @SuppressWarnings("unchecked")

--- a/sdk/voicelive/azure-ai-voicelive/src/test/java/com/azure/ai/voicelive/unit/VoiceLiveClientBuilderTest.java
+++ b/sdk/voicelive/azure-ai-voicelive/src/test/java/com/azure/ai/voicelive/unit/VoiceLiveClientBuilderTest.java
@@ -8,13 +8,22 @@ import com.azure.ai.voicelive.VoiceLiveClientBuilder;
 import com.azure.ai.voicelive.VoiceLiveServiceVersion;
 import com.azure.core.credential.KeyCredential;
 import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpHeaders;
 import com.azure.core.test.utils.MockTokenCredential;
+import com.azure.core.util.ClientOptions;
+import com.azure.core.util.Header;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -208,14 +217,35 @@ class VoiceLiveClientBuilderTest {
     }
 
     @Test
-    void testBuilderWithDefaultTelemetry() {
-        String endpoint = "https://test.cognitiveservices.azure.com";
+    void testBuilderWithDefaultTelemetry() throws Exception {
+        VoiceLiveAsyncClient client = clientBuilder.endpoint("https://test.cognitiveservices.azure.com")
+            .credential(mockKeyCredential)
+            .clientOptions(new ClientOptions().setApplicationId("test-application"))
+            .buildAsyncClient();
 
-        assertDoesNotThrow(() -> {
-            VoiceLiveAsyncClient client
-                = clientBuilder.endpoint(endpoint).credential(mockKeyCredential).buildAsyncClient();
+        String userAgent = getField(client, "userAgent", String.class);
+        HttpHeaders headers = getField(client, "additionalHeaders", HttpHeaders.class);
+        assertTrue(userAgent.startsWith("test-application azsdk-java-azure-ai-voicelive/"));
+        assertEquals(userAgent, headers.getValue(HttpHeaderName.USER_AGENT));
+    }
 
-            assertNotNull(client);
-        });
+    @Test
+    void testBuilderCustomUserAgentOverridesDefaultHeader() throws Exception {
+        VoiceLiveAsyncClient client = clientBuilder.endpoint("https://test.cognitiveservices.azure.com")
+            .credential(mockKeyCredential)
+            .clientOptions(new ClientOptions()
+                .setHeaders(Collections.singletonList(new Header("User-Agent", "custom-user-agent"))))
+            .buildAsyncClient();
+
+        String userAgent = getField(client, "userAgent", String.class);
+        HttpHeaders headers = getField(client, "additionalHeaders", HttpHeaders.class);
+        assertTrue(userAgent.startsWith("azsdk-java-azure-ai-voicelive/"));
+        assertEquals("custom-user-agent", headers.getValue(HttpHeaderName.USER_AGENT));
+    }
+
+    private static <T> T getField(VoiceLiveAsyncClient client, String fieldName, Class<T> type) throws Exception {
+        Field field = VoiceLiveAsyncClient.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return type.cast(field.get(client));
     }
 }

--- a/sdk/voicelive/azure-ai-voicelive/src/test/java/com/azure/ai/voicelive/unit/VoiceLiveRequestOptionsClientTest.java
+++ b/sdk/voicelive/azure-ai-voicelive/src/test/java/com/azure/ai/voicelive/unit/VoiceLiveRequestOptionsClientTest.java
@@ -6,6 +6,7 @@ package com.azure.ai.voicelive.unit;
 import com.azure.ai.voicelive.VoiceLiveAsyncClient;
 import com.azure.ai.voicelive.models.VoiceLiveRequestOptions;
 import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.HttpHeaderName;
 import com.azure.core.http.HttpHeaders;
 import com.azure.core.test.utils.MockTokenCredential;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,38 +23,59 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * White-box tests for how {@link VoiceLiveAsyncClient} applies {@link VoiceLiveRequestOptions} when building the
- * WebSocket endpoint.
+ * WebSocket endpoint and connection headers.
  * <p>
- * The client's constructor and {@code convertToWebSocketEndpoint} method are intentionally non-public (internal API
- * surface), so this test reaches them via reflection rather than living in the {@code com.azure.ai.voicelive} package.
- * Model-only tests live in {@link VoiceLiveRequestOptionsTest}.
+ * The client's constructor and helper methods are intentionally non-public (internal API surface), so this test
+ * reaches them via reflection rather than living in the {@code com.azure.ai.voicelive} package. Model-only tests live
+ * in {@link VoiceLiveRequestOptionsTest}.
  */
 class VoiceLiveRequestOptionsClientTest {
+    private static final String USER_AGENT = "azsdk-java-azure-ai-voicelive/test-version (17; Windows 11; 10.0)";
+
     private URI testEndpoint;
     private String apiVersion;
     private Constructor<VoiceLiveAsyncClient> tokenCredentialConstructor;
     private Method convertToWebSocketEndpoint;
+    private Method mergeHeaders;
 
     @BeforeEach
     void setUp() throws Exception {
         testEndpoint = new URI("https://test.cognitiveservices.azure.com");
         apiVersion = "2024-10-01-preview";
         tokenCredentialConstructor = VoiceLiveAsyncClient.class.getDeclaredConstructor(URI.class, TokenCredential.class,
-            String.class, HttpHeaders.class);
+            String.class, String.class, HttpHeaders.class);
         tokenCredentialConstructor.setAccessible(true);
         convertToWebSocketEndpoint = VoiceLiveAsyncClient.class.getDeclaredMethod("convertToWebSocketEndpoint",
             URI.class, String.class, Map.class);
         convertToWebSocketEndpoint.setAccessible(true);
+        mergeHeaders
+            = VoiceLiveAsyncClient.class.getDeclaredMethod("mergeHeaders", HttpHeaders.class, HttpHeaders.class);
+        mergeHeaders.setAccessible(true);
     }
 
     private VoiceLiveAsyncClient newClient(URI endpoint) throws Exception {
-        return tokenCredentialConstructor.newInstance(endpoint, new MockTokenCredential(), apiVersion,
+        return tokenCredentialConstructor.newInstance(endpoint, new MockTokenCredential(), apiVersion, USER_AGENT,
             new HttpHeaders());
     }
 
     private URI convert(VoiceLiveAsyncClient client, URI endpoint, String model, Map<String, String> queryParams)
         throws Exception {
         return (URI) convertToWebSocketEndpoint.invoke(client, endpoint, model, queryParams);
+    }
+
+    private HttpHeaders merge(VoiceLiveAsyncClient client, HttpHeaders baseHeaders, HttpHeaders customHeaders)
+        throws Exception {
+        return (HttpHeaders) mergeHeaders.invoke(client, baseHeaders, customHeaders);
+    }
+
+    private static String getQueryParameter(URI uri, String name) {
+        for (String pair : uri.getQuery().split("&")) {
+            int separator = pair.indexOf('=');
+            if (separator >= 0 && name.equals(pair.substring(0, separator))) {
+                return pair.substring(separator + 1);
+            }
+        }
+        return null;
     }
 
     @Test
@@ -116,5 +138,41 @@ class VoiceLiveRequestOptionsClientTest {
         assertNotNull(result);
         assertTrue(result.getQuery().contains("api-version=" + apiVersion));
         assertTrue(result.getQuery().contains("deployment-id=test-deployment"));
+    }
+
+    @Test
+    void testSdkIdentificationAndExistingQueryParameter() throws Exception {
+        URI endpointWithQuery = new URI("https://test.cognitiveservices.azure.com?trafficType=customer-tag");
+        VoiceLiveAsyncClient client = newClient(endpointWithQuery);
+
+        URI result = convert(client, endpointWithQuery, "gpt-realtime", null);
+
+        assertEquals(USER_AGENT, getQueryParameter(result, "x-ms-client-sdk"));
+        assertEquals("customer-tag", getQueryParameter(result, "trafficType"));
+        assertTrue(result.getRawQuery().contains("x-ms-client-sdk="));
+        assertTrue(result.getRawQuery().contains("%20"));
+    }
+
+    @Test
+    void testRequestOptionsCanOverrideSdkIdentificationQueryParameter() throws Exception {
+        VoiceLiveRequestOptions requestOptions
+            = new VoiceLiveRequestOptions().addCustomQueryParameter("x-ms-client-sdk", "custom-sdk-id");
+        VoiceLiveAsyncClient client = newClient(testEndpoint);
+
+        URI result = convert(client, testEndpoint, "gpt-realtime", requestOptions.getCustomQueryParameters());
+
+        assertEquals("custom-sdk-id", getQueryParameter(result, "x-ms-client-sdk"));
+    }
+
+    @Test
+    void testRequestHeadersOverrideDefaultUserAgent() throws Exception {
+        HttpHeaders defaultHeaders = new HttpHeaders().set(HttpHeaderName.USER_AGENT, USER_AGENT);
+        VoiceLiveRequestOptions requestOptions = new VoiceLiveRequestOptions()
+            .addCustomHeader(HttpHeaderName.USER_AGENT.getCaseInsensitiveName(), "custom-user-agent");
+        VoiceLiveAsyncClient client = newClient(testEndpoint);
+
+        HttpHeaders result = merge(client, defaultHeaders, requestOptions.getCustomHeaders());
+
+        assertEquals("custom-user-agent", result.getValue(HttpHeaderName.USER_AGENT));
     }
 }


### PR DESCRIPTION
## Description

Add the standard Azure SDK identifier to Voice Live WebSocket connections through the `User-Agent` header and the `x-ms-client-sdk` query parameter. Preserve client and request-level overrides and existing endpoint query parameters.

Ports Azure/azure-sdk-for-python#48848 to the Java SDK.

## Testing

- `mvn -f sdk/voicelive/azure-ai-voicelive/pom.xml -Dtest="com.azure.ai.voicelive.unit.**" test` (346 tests passed)
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)