### PR TITLE
Fix TypeSpec Java sync method names

### DIFF
--- a/sdk/openai/azure-ai-openai-assistants/src/main/java/com/azure/ai/openai/assistants/AssistantsAsyncClient.java
+++ b/sdk/openai/azure-ai-openai-assistants/src/main/java/com/azure/ai/openai/assistants/AssistantsAsyncClient.java
@@ -2292,11 +2292,11 @@ public final class AssistantsAsyncClient {
      * completion of {@link Mono}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Mono<Response<BinaryData>> uploadFileWithResponse(BinaryData request, RequestOptions requestOptions) {
+    Mono<Response<BinaryData>> uploadFileWithResponseInternal(BinaryData request, RequestOptions requestOptions) {
         // Protocol API requires serialization of parts with content-disposition and data, as operation 'uploadFile' is
         // 'multipart/form-data'
         addAzureVersionToRequestOptions(serviceClient.getEndpoint(), requestOptions, serviceClient.getServiceVersion());
-        return this.serviceClient.uploadFileWithResponseAsync(request, requestOptions);
+        return this.serviceClient.uploadFileWithResponseInternalAsync(request, requestOptions);
     }
 
     /**
@@ -2660,7 +2660,7 @@ public final class AssistantsAsyncClient {
             .serializeTextField("filename", requestObj.getFilename())
             .end()
             .getRequestBody();
-        return uploadFileWithResponse(request, requestOptions).flatMap(FluxUtil::toMono)
+        return uploadFileWithResponseInternal(request, requestOptions).flatMap(FluxUtil::toMono)
             .map(protocolMethodData -> protocolMethodData.toObject(OpenAIFile.class));
     }
 
@@ -2689,7 +2689,7 @@ public final class AssistantsAsyncClient {
             .serializeTextField("filename", requestObj.getFilename())
             .end()
             .getRequestBody();
-        return uploadFileWithResponse(request, requestOptions).flatMap(FluxUtil::toMono)
+        return uploadFileWithResponseInternal(request, requestOptions).flatMap(FluxUtil::toMono)
             .map(protocolMethodData -> protocolMethodData.toObject(OpenAIFile.class));
     }
 
@@ -4035,40 +4035,4 @@ public final class AssistantsAsyncClient {
             .map(protocolMethodData -> protocolMethodData.toObject(RunStep.class));
     }
 
-    /**
-     * Uploads a file for use by other operations.
-     * <p><strong>Response Body Schema</strong></p>
-     * 
-     * <pre>
-     * {@code
-     * {
-     *     object: String (Required)
-     *     id: String (Required)
-     *     bytes: int (Required)
-     *     filename: String (Required)
-     *     created_at: long (Required)
-     *     purpose: String(fine-tune/fine-tune-results/assistants/assistants_output/batch/batch_output/vision) (Required)
-     *     status: String(uploaded/pending/running/processed/error/deleting/deleted) (Optional)
-     *     status_details: String (Optional)
-     * }
-     * }
-     * </pre>
-     *
-     * @param uploadFileRequest The file data to upload and its purpose.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return represents an assistant that can call the model and use tools along with {@link Response} on successful
-     * completion of {@link Mono}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    Mono<Response<BinaryData>> uploadFileWithResponseInternal(BinaryData uploadFileRequest,
-        RequestOptions requestOptions) {
-        // Operation 'uploadFile' is of content-type 'multipart/form-data'. Protocol API is not usable and hence not
-        // generated.
-        return this.serviceClient.uploadFileWithResponseInternalAsync(uploadFileRequest, requestOptions);
-    }
 }

--- a/sdk/openai/azure-ai-openai-assistants/src/main/java/com/azure/ai/openai/assistants/AssistantsClient.java
+++ b/sdk/openai/azure-ai-openai-assistants/src/main/java/com/azure/ai/openai/assistants/AssistantsClient.java
@@ -2307,11 +2307,11 @@ public final class AssistantsClient {
      * @return represents an assistant that can call the model and use tools along with {@link Response}.
      */
     @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<BinaryData> uploadFileWithResponse(BinaryData request, RequestOptions requestOptions) {
+    Response<BinaryData> uploadFileWithResponseInternal(BinaryData request, RequestOptions requestOptions) {
         // Protocol API requires serialization of parts with content-disposition and data, as operation 'uploadFile' is
         // 'multipart/form-data'
         addAzureVersionToRequestOptions(serviceClient.getEndpoint(), requestOptions, serviceClient.getServiceVersion());
-        return this.serviceClient.uploadFileWithResponse(request, requestOptions);
+        return this.serviceClient.uploadFileWithResponseInternal(request, requestOptions);
     }
 
     /**
@@ -2662,7 +2662,7 @@ public final class AssistantsClient {
             .serializeTextField("filename", requestObj.getFilename())
             .end()
             .getRequestBody();
-        return uploadFileWithResponse(request, requestOptions).getValue().toObject(OpenAIFile.class);
+        return uploadFileWithResponseInternal(request, requestOptions).getValue().toObject(OpenAIFile.class);
     }
 
     /**
@@ -2690,7 +2690,7 @@ public final class AssistantsClient {
             .serializeTextField("filename", requestObj.getFilename())
             .end()
             .getRequestBody();
-        return uploadFileWithResponse(request, requestOptions).getValue().toObject(OpenAIFile.class);
+        return uploadFileWithResponseInternal(request, requestOptions).getValue().toObject(OpenAIFile.class);
     }
 
     /**
@@ -4043,38 +4043,4 @@ public final class AssistantsClient {
         return getRunStepWithResponse(threadId, runId, stepId, requestOptions).getValue().toObject(RunStep.class);
     }
 
-    /**
-     * Uploads a file for use by other operations.
-     * <p><strong>Response Body Schema</strong></p>
-     * 
-     * <pre>
-     * {@code
-     * {
-     *     object: String (Required)
-     *     id: String (Required)
-     *     bytes: int (Required)
-     *     filename: String (Required)
-     *     created_at: long (Required)
-     *     purpose: String(fine-tune/fine-tune-results/assistants/assistants_output/batch/batch_output/vision) (Required)
-     *     status: String(uploaded/pending/running/processed/error/deleting/deleted) (Optional)
-     *     status_details: String (Optional)
-     * }
-     * }
-     * </pre>
-     *
-     * @param uploadFileRequest The file data to upload and its purpose.
-     * @param requestOptions The options to configure the HTTP request before HTTP client sends it.
-     * @throws HttpResponseException thrown if the request is rejected by server.
-     * @throws ClientAuthenticationException thrown if the request is rejected by server on status code 401.
-     * @throws ResourceNotFoundException thrown if the request is rejected by server on status code 404.
-     * @throws ResourceModifiedException thrown if the request is rejected by server on status code 409.
-     * @return represents an assistant that can call the model and use tools along with {@link Response}.
-     */
-    @Generated
-    @ServiceMethod(returns = ReturnType.SINGLE)
-    Response<BinaryData> uploadFileWithResponseInternal(BinaryData uploadFileRequest, RequestOptions requestOptions) {
-        // Operation 'uploadFile' is of content-type 'multipart/form-data'. Protocol API is not usable and hence not
-        // generated.
-        return this.serviceClient.uploadFileWithResponseInternal(uploadFileRequest, requestOptions);
-    }
 }

--- a/sdk/openai/azure-ai-openai/src/main/java/com/azure/ai/openai/OpenAIAsyncClient.java
+++ b/sdk/openai/azure-ai-openai/src/main/java/com/azure/ai/openai/OpenAIAsyncClient.java
@@ -996,7 +996,7 @@ public final class OpenAIAsyncClient {
         Mono<Response<BinaryData>> response = openAIServiceClient != null
             ? this.openAIServiceClient.getAudioTranscriptionAsResponseObjectWithResponseAsync(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions)
-            : this.serviceClient.getAudioTranscriptionAsResponseObjectWithResponseAsync(deploymentOrModelName,
+            : this.serviceClient.getAudioTranscriptionAsResponseObjectWithResponseInternalAsync(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions);
         return response.map(responseBinaryData -> new SimpleResponse<>(responseBinaryData,
             responseBinaryData.getValue().toObject(AudioTranscription.class)));
@@ -1079,7 +1079,7 @@ public final class OpenAIAsyncClient {
         Mono<Response<BinaryData>> response = openAIServiceClient != null
             ? this.openAIServiceClient.getAudioTranscriptionAsPlainTextWithResponseAsync(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions)
-            : this.serviceClient.getAudioTranscriptionAsPlainTextWithResponseAsync(deploymentOrModelName,
+            : this.serviceClient.getAudioTranscriptionAsPlainTextWithResponseInternalAsync(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions);
         return response.map(dataResponse -> new SimpleResponse<>(dataResponse, dataResponse.getValue().toString()));
     }
@@ -1158,7 +1158,7 @@ public final class OpenAIAsyncClient {
         Mono<Response<BinaryData>> response = openAIServiceClient != null
             ? this.openAIServiceClient.getAudioTranslationAsResponseObjectWithResponseAsync(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions)
-            : this.serviceClient.getAudioTranslationAsResponseObjectWithResponseAsync(deploymentOrModelName,
+            : this.serviceClient.getAudioTranslationAsResponseObjectWithResponseInternalAsync(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions);
         return response.map(responseBinaryData -> new SimpleResponse<>(responseBinaryData,
             responseBinaryData.getValue().toObject(AudioTranslation.class)));
@@ -1238,7 +1238,7 @@ public final class OpenAIAsyncClient {
         Mono<Response<BinaryData>> response = openAIServiceClient != null
             ? this.openAIServiceClient.getAudioTranslationAsPlainTextWithResponseAsync(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions)
-            : this.serviceClient.getAudioTranslationAsPlainTextWithResponseAsync(deploymentOrModelName,
+            : this.serviceClient.getAudioTranslationAsPlainTextWithResponseInternalAsync(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions);
         return response.map(
             responseBinaryData -> new SimpleResponse<>(responseBinaryData, responseBinaryData.getValue().toString()));
@@ -1264,7 +1264,7 @@ public final class OpenAIAsyncClient {
     public Mono<String> getAudioTranscriptionAsPlainText(String deploymentOrModelName,
         AudioTranscriptionOptions audioTranscriptionOptions) {
         RequestOptions requestOptions = new RequestOptions();
-        return getAudioTranscriptionAsPlainTextWithResponse(deploymentOrModelName,
+        return getAudioTranscriptionAsPlainTextWithResponseInternal(deploymentOrModelName,
             BinaryData.fromObject(audioTranscriptionOptions), requestOptions).flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
@@ -1288,7 +1288,7 @@ public final class OpenAIAsyncClient {
     public Mono<String> getAudioTranslationAsPlainText(String deploymentOrModelName,
         AudioTranslationOptions audioTranslationOptions) {
         RequestOptions requestOptions = new RequestOptions();
-        return getAudioTranslationAsPlainTextWithResponse(deploymentOrModelName,
+        return getAudioTranslationAsPlainTextWithResponseInternal(deploymentOrModelName,
             BinaryData.fromObject(audioTranslationOptions), requestOptions).flatMap(FluxUtil::toMono)
                 .map(protocolMethodData -> protocolMethodData.toObject(String.class));
     }
@@ -1656,18 +1656,19 @@ public final class OpenAIAsyncClient {
         } else {
             addAzureVersionToRequestOptions(serviceClient.getEndpoint(), requestOptions,
                 serviceClient.getServiceVersion());
-            uploadedFileWithResponse = this.serviceClient.uploadFileWithResponseAsync(uploadFileRequest, requestOptions)
-                .onErrorResume(HttpResponseException.class,
-                    (Function<Throwable, Mono<ResponseBase<HttpHeaders, BinaryData>>>) throwable -> {
-                        HttpResponseException ex = (HttpResponseException) throwable;
-                        HttpResponse httpResponse = ex.getResponse();
-                        if (httpResponse.getStatusCode() == 201) {
-                            return Mono.just(new ResponseBase<HttpHeaders, BinaryData>(httpResponse.getRequest(),
-                                httpResponse.getStatusCode(), httpResponse.getHeaders(),
-                                BinaryData.fromObject(ex.getValue()), null));
-                        }
-                        return Mono.error(throwable);
-                    });
+            uploadedFileWithResponse
+                = this.serviceClient.uploadFileWithResponseInternalAsync(uploadFileRequest, requestOptions)
+                    .onErrorResume(HttpResponseException.class,
+                        (Function<Throwable, Mono<ResponseBase<HttpHeaders, BinaryData>>>) throwable -> {
+                            HttpResponseException ex = (HttpResponseException) throwable;
+                            HttpResponse httpResponse = ex.getResponse();
+                            if (httpResponse.getStatusCode() == 201) {
+                                return Mono.just(new ResponseBase<HttpHeaders, BinaryData>(httpResponse.getRequest(),
+                                    httpResponse.getStatusCode(), httpResponse.getHeaders(),
+                                    BinaryData.fromObject(ex.getValue()), null));
+                            }
+                            return Mono.error(throwable);
+                        });
         }
         return uploadedFileWithResponse
             .map(response -> new SimpleResponse<>(response, response.getValue().toObject(OpenAIFile.class)));
@@ -2455,7 +2456,7 @@ public final class OpenAIAsyncClient {
             addAzureVersionToRequestOptions(serviceClient.getEndpoint(), requestOptions,
                 serviceClient.getServiceVersion());
             addUploadPartWithResponse
-                = this.serviceClient.addUploadPartWithResponseAsync(uploadId, requestBody, requestOptions);
+                = this.serviceClient.addUploadPartWithResponseInternalAsync(uploadId, requestBody, requestOptions);
         }
         return addUploadPartWithResponse
             .map(response -> new SimpleResponse<>(response, response.getValue().toObject(UploadPart.class)));

--- a/sdk/openai/azure-ai-openai/src/main/java/com/azure/ai/openai/OpenAIClient.java
+++ b/sdk/openai/azure-ai-openai/src/main/java/com/azure/ai/openai/OpenAIClient.java
@@ -981,8 +981,8 @@ public final class OpenAIClient {
         Response<BinaryData> response = openAIServiceClient != null
             ? this.openAIServiceClient.getAudioTranscriptionAsPlainTextWithResponse(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions)
-            : this.serviceClient.getAudioTranscriptionAsPlainTextWithResponse(deploymentOrModelName, uploadFileRequest,
-                multipartRequestOptions);
+            : this.serviceClient.getAudioTranscriptionAsPlainTextWithResponseInternal(deploymentOrModelName,
+                uploadFileRequest, multipartRequestOptions);
         return new SimpleResponse<>(response, response.getValue().toObject(AudioTranscription.class));
     }
 
@@ -1057,8 +1057,8 @@ public final class OpenAIClient {
         Response<BinaryData> response = openAIServiceClient != null
             ? this.openAIServiceClient.getAudioTranscriptionAsPlainTextWithResponse(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions)
-            : this.serviceClient.getAudioTranscriptionAsPlainTextWithResponse(deploymentOrModelName, uploadFileRequest,
-                multipartRequestOptions);
+            : this.serviceClient.getAudioTranscriptionAsPlainTextWithResponseInternal(deploymentOrModelName,
+                uploadFileRequest, multipartRequestOptions);
         return new SimpleResponse<>(response, response.getValue().toString());
     }
 
@@ -1132,8 +1132,8 @@ public final class OpenAIClient {
         Response<BinaryData> response = openAIServiceClient != null
             ? this.openAIServiceClient.getAudioTranslationAsPlainTextWithResponse(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions)
-            : this.serviceClient.getAudioTranslationAsPlainTextWithResponse(deploymentOrModelName, uploadFileRequest,
-                multipartRequestOptions);
+            : this.serviceClient.getAudioTranslationAsPlainTextWithResponseInternal(deploymentOrModelName,
+                uploadFileRequest, multipartRequestOptions);
         return new SimpleResponse<>(response, response.getValue().toObject(AudioTranslation.class));
     }
 
@@ -1206,8 +1206,8 @@ public final class OpenAIClient {
         Response<BinaryData> response = openAIServiceClient != null
             ? this.openAIServiceClient.getAudioTranslationAsPlainTextWithResponse(deploymentOrModelName,
                 uploadFileRequest, multipartRequestOptions)
-            : this.serviceClient.getAudioTranslationAsPlainTextWithResponse(deploymentOrModelName, uploadFileRequest,
-                multipartRequestOptions);
+            : this.serviceClient.getAudioTranslationAsPlainTextWithResponseInternal(deploymentOrModelName,
+                uploadFileRequest, multipartRequestOptions);
         return new SimpleResponse<>(response, response.getValue().toString());
     }
 
@@ -1230,7 +1230,7 @@ public final class OpenAIClient {
     public String getAudioTranscriptionAsPlainText(String deploymentOrModelName,
         AudioTranscriptionOptions audioTranscriptionOptions) {
         RequestOptions requestOptions = new RequestOptions();
-        return getAudioTranscriptionAsPlainTextWithResponse(deploymentOrModelName,
+        return getAudioTranscriptionAsPlainTextWithResponseInternal(deploymentOrModelName,
             BinaryData.fromObject(audioTranscriptionOptions), requestOptions).getValue().toObject(String.class);
     }
 
@@ -1252,7 +1252,7 @@ public final class OpenAIClient {
     public String getAudioTranslationAsPlainText(String deploymentOrModelName,
         AudioTranslationOptions audioTranslationOptions) {
         RequestOptions requestOptions = new RequestOptions();
-        return getAudioTranslationAsPlainTextWithResponse(deploymentOrModelName,
+        return getAudioTranslationAsPlainTextWithResponseInternal(deploymentOrModelName,
             BinaryData.fromObject(audioTranslationOptions), requestOptions).getValue().toObject(String.class);
     }
 
@@ -1613,7 +1613,8 @@ public final class OpenAIClient {
             addAzureVersionToRequestOptions(serviceClient.getEndpoint(), requestOptions,
                 serviceClient.getServiceVersion());
             try {
-                uploadedFileWithResponse = this.serviceClient.uploadFileWithResponse(uploadFileRequest, requestOptions);
+                uploadedFileWithResponse
+                    = this.serviceClient.uploadFileWithResponseInternal(uploadFileRequest, requestOptions);
             } catch (HttpResponseException ex) {
                 final HttpResponse httpResponse = ex.getResponse();
                 if (httpResponse.getStatusCode() == 201) {
@@ -2397,7 +2398,7 @@ public final class OpenAIClient {
             addAzureVersionToRequestOptions(serviceClient.getEndpoint(), requestOptions,
                 serviceClient.getServiceVersion());
             addUploadPartWithResponse
-                = this.serviceClient.addUploadPartWithResponse(uploadId, requestBody, requestOptions);
+                = this.serviceClient.addUploadPartWithResponseInternal(uploadId, requestBody, requestOptions);
         }
         return new SimpleResponse<>(addUploadPartWithResponse,
             addUploadPartWithResponse.getValue().toObject(UploadPart.class));

--- a/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/TranscriptionAsyncClient.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/TranscriptionAsyncClient.java
@@ -101,7 +101,7 @@ public final class TranscriptionAsyncClient {
         RequestOptions requestOptions) {
         AudioFileDetails audio = options.getFileDetails();
         RequestOptions effectiveRequestOptions = requestOptions == null ? new RequestOptions() : requestOptions;
-        return transcribeWithResponse(
+        return transcribeWithResponseInternal(
             new MultipartFormDataHelper(effectiveRequestOptions).serializeJsonField("definition", options)
                 .serializeFileField("audio", audio == null ? null : audio.getContent(),
                     audio == null ? null : audio.getContentType(), audio == null ? null : audio.getFilename())

--- a/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/TranscriptionClient.java
+++ b/sdk/transcription/azure-ai-speech-transcription/src/main/java/com/azure/ai/speech/transcription/TranscriptionClient.java
@@ -101,7 +101,7 @@ public final class TranscriptionClient {
         RequestOptions requestOptions) {
         AudioFileDetails audio = options.getFileDetails();
         RequestOptions effectiveRequestOptions = requestOptions == null ? new RequestOptions() : requestOptions;
-        Response<BinaryData> response = transcribeWithResponse(
+        Response<BinaryData> response = transcribeWithResponseInternal(
             new MultipartFormDataHelper(effectiveRequestOptions).serializeJsonField("definition", options)
                 .serializeFileField("audio", audio == null ? null : audio.getContent(),
                     audio == null ? null : audio.getContentType(), audio == null ? null : audio.getFilename())

--- a/sdk/translation/azure-ai-translation-document/src/main/java/com/azure/ai/translation/document/SingleDocumentTranslationAsyncClient.java
+++ b/sdk/translation/azure-ai-translation-document/src/main/java/com/azure/ai/translation/document/SingleDocumentTranslationAsyncClient.java
@@ -212,7 +212,7 @@ public final class SingleDocumentTranslationAsyncClient {
             requestOptions.addQueryParam("translateTextWithinImage",
                 String.valueOf(translateOptions.isTranslateTextWithinImage()), false);
         }
-        return translateWithResponse(targetLanguage,
+        return translateWithResponseInternal(targetLanguage,
             new MultipartFormDataHelper(requestOptions)
                 .serializeFileField("document", documentTranslateContent.getDocument().getContent(),
                     documentTranslateContent.getDocument().getContentType(),

--- a/sdk/translation/azure-ai-translation-document/src/main/java/com/azure/ai/translation/document/SingleDocumentTranslationClient.java
+++ b/sdk/translation/azure-ai-translation-document/src/main/java/com/azure/ai/translation/document/SingleDocumentTranslationClient.java
@@ -210,7 +210,7 @@ public final class SingleDocumentTranslationClient {
             requestOptions.addQueryParam("translateTextWithinImage",
                 String.valueOf(translateOptions.isTranslateTextWithinImage()), false);
         }
-        return translateWithResponse(targetLanguage,
+        return translateWithResponseInternal(targetLanguage,
             new MultipartFormDataHelper(requestOptions)
                 .serializeFileField("document", documentTranslateContent.getDocument().getContent(),
                     documentTranslateContent.getDocument().getContentType(),


### PR DESCRIPTION
Fixes method-name fallout from the TypeSpec Java regeneration.

- Preserve the customized Assistants multipart implementation as `uploadFileWithResponseInternal`.
- Remove the duplicate generated Assistants bridge.
- Update stale internal calls in OpenAI, Transcription, and Document Translation.

All SDK modules changed by the sync PR compile successfully.
