### PR TITLE
Suppress Transcription helper lint

### DIFF
--- a/sdk/transcription/azure-ai-speech-transcription/checkstyle-suppressions.xml
+++ b/sdk/transcription/azure-ai-speech-transcription/checkstyle-suppressions.xml
@@ -5,4 +5,5 @@
 <suppressions>
   <suppress files="com.azure.ai.speech.transcription.TranscriptionAsyncClient.java" checks="io.clientcore.linting.extensions.checkstyle.checks.ServiceClientCheck" />
   <suppress files="com.azure.ai.speech.transcription.TranscriptionClient.java" checks="io.clientcore.linting.extensions.checkstyle.checks.ServiceClientCheck" />
+  <suppress files="com.azure.ai.speech.transcription.implementation.MultipartFormDataHelper.java" checks="io.clientcore.linting.extensions.checkstyle.checks.EnforceFinalFieldsCheck" />
 </suppressions>


### PR DESCRIPTION
Preserve the existing `MultipartFormDataHelper` final-field suppression after introducing a local Transcription suppression file.

Transcription now reports zero Checkstyle violations.
