### PR TITLE
Preserve implementation lint suppression

### DIFF
--- a/sdk/transcription/azure-ai-speech-transcription/checkstyle-suppressions.xml
+++ b/sdk/transcription/azure-ai-speech-transcription/checkstyle-suppressions.xml
@@ -5,5 +5,5 @@
 <suppressions>
   <suppress files="com.azure.ai.speech.transcription.TranscriptionAsyncClient.java" checks="io.clientcore.linting.extensions.checkstyle.checks.ServiceClientCheck" />
   <suppress files="com.azure.ai.speech.transcription.TranscriptionClient.java" checks="io.clientcore.linting.extensions.checkstyle.checks.ServiceClientCheck" />
-  <suppress files="com.azure.ai.speech.transcription.implementation.MultipartFormDataHelper.java" checks="io.clientcore.linting.extensions.checkstyle.checks.EnforceFinalFieldsCheck" />
+  <suppress files=".*[/\\]implementation[/\\].*\.java" checks="io\.clientcore\.linting\.extensions\.checkstyle\.checks\..*" />
 </suppressions>


### PR DESCRIPTION
Preserve the global behavior that suppresses lint-extension checks for generated implementation classes when using a module-local suppression file.

Transcription reports zero Checkstyle violations.
