### PR TITLE
Add lightweight pull request spelling validation

### DIFF
--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -1,0 +1,41 @@
+name: Check Spelling
+
+on:
+  pull_request:
+    # Keep this list aligned with eng/pipelines/pullrequest.yml.
+    branches:
+      - main
+      - feature/*
+      - hotfix/*
+      - release/*
+      - restapi*
+      - pipelinev3*
+
+permissions:
+  contents: read
+
+jobs:
+  check-spelling:
+    name: Check Spelling
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 2
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: eng/common/spelling/package-lock.json
+
+      - name: Check spelling
+        shell: pwsh
+        run: >
+          ./eng/common/scripts/check-spelling-in-changed-files.ps1
+          -CspellConfigPath .vscode/cspell.json
+          -ExitWithError
+          -SourceCommittish HEAD
+          -TargetCommittish HEAD^

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -54,6 +54,7 @@
     "*.crt",
     "*.yml",
     ".github/skills/agentic-workflows/**",
+    ".github/skills/azsdk-common-*/**",
     ".github/workflows/issue-triage.md",
     ".vscode/cspell.json",
     ".vscode/eclipse-format-azure-sdk-for-java.xml",

--- a/eng/scripts/tests/Cspell-Configuration.tests.ps1
+++ b/eng/scripts/tests/Cspell-Configuration.tests.ps1
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+BeforeAll {
+    $script:RepositoryRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..')
+    $script:SdkRoot = Join-Path $script:RepositoryRoot 'sdk'
+
+    function Get-RelativeRepositoryPath {
+        param([Parameter(Mandatory = $true)][string]$Path)
+
+        return [System.IO.Path]::GetRelativePath($script:RepositoryRoot, $Path).Replace('\', '/')
+    }
+
+    function Get-CspellConfigs {
+        return @(
+            Get-ChildItem -LiteralPath $script:SdkRoot -File -Recurse |
+                Where-Object { $_.Name -in @('cspell.json', 'cspell.yml', 'cspell.yaml') }
+        )
+    }
+}
+
+Describe 'SDK CSpell configuration' -Tag 'UnitTest' {
+    It 'imports the root config from every SDK area config' {
+        $areaConfigs = @(
+            Get-CspellConfigs |
+                Where-Object { ((Get-RelativeRepositoryPath $_.FullName) -split '/').Count -eq 3 }
+        )
+
+        $areaConfigs.Count | Should -BeGreaterThan 0
+        foreach ($config in $areaConfigs) {
+            Get-Content -LiteralPath $config.FullName -Raw |
+                Should -Match ([regex]::Escape('../../.vscode/cspell.json')) `
+                -Because "$(Get-RelativeRepositoryPath $config.FullName) must inherit the root settings"
+        }
+    }
+
+    It 'imports every nested SDK config from its area config' {
+        $nestedConfigs = @(
+            Get-CspellConfigs |
+                Where-Object { ((Get-RelativeRepositoryPath $_.FullName) -split '/').Count -gt 3 }
+        )
+
+        $nestedConfigs.Count | Should -BeGreaterThan 0
+        foreach ($nestedConfig in $nestedConfigs) {
+            $relativePath = Get-RelativeRepositoryPath $nestedConfig.FullName
+            $segments = $relativePath -split '/'
+            $areaDirectory = Join-Path $script:SdkRoot $segments[1]
+            $areaConfigs = @(
+                Get-ChildItem -LiteralPath $areaDirectory -File |
+                    Where-Object { $_.Name -in @('cspell.json', 'cspell.yml', 'cspell.yaml') }
+            )
+
+            $areaConfigs.Count | Should -Be 1 `
+                -Because "$relativePath requires one unambiguous area config"
+
+            $expectedImport = './' + ($segments[2..($segments.Count - 1)] -join '/')
+            Get-Content -LiteralPath $areaConfigs[0].FullName -Raw |
+                Should -Match ([regex]::Escape($expectedImport)) `
+                -Because "$relativePath must be reachable from its area config"
+        }
+    }
+}

--- a/eng/scripts/tests/Cspell-Configuration.tests.ps1
+++ b/eng/scripts/tests/Cspell-Configuration.tests.ps1
@@ -34,15 +34,15 @@ Describe 'SDK CSpell configuration' -Tag 'UnitTest' {
         }
     }
 
-    It 'imports every nested SDK config from its area config' {
-        $nestedConfigs = @(
+    It 'imports every package-level SDK config from its area config' {
+        $packageConfigs = @(
             Get-CspellConfigs |
-                Where-Object { ((Get-RelativeRepositoryPath $_.FullName) -split '/').Count -gt 3 }
+                Where-Object { ((Get-RelativeRepositoryPath $_.FullName) -split '/').Count -eq 4 }
         )
 
-        $nestedConfigs.Count | Should -BeGreaterThan 0
-        foreach ($nestedConfig in $nestedConfigs) {
-            $relativePath = Get-RelativeRepositoryPath $nestedConfig.FullName
+        $packageConfigs.Count | Should -BeGreaterThan 0
+        foreach ($packageConfig in $packageConfigs) {
+            $relativePath = Get-RelativeRepositoryPath $packageConfig.FullName
             $segments = $relativePath -split '/'
             $areaDirectory = Join-Path $script:SdkRoot $segments[1]
             $areaConfigs = @(

--- a/sdk/contentunderstanding/cspell.yml
+++ b/sdk/contentunderstanding/cspell.yml
@@ -6,4 +6,5 @@
 version: "0.2"
 import:
   - ../../.vscode/cspell.json
+  - ./azure-ai-contentunderstanding/cspell.json
 words:

--- a/sdk/cosmos/cspell.yml
+++ b/sdk/cosmos/cspell.yml
@@ -1,5 +1,6 @@
 import:
   - ../../.vscode/cspell.json
+  - ./pipeline/cspell.json
 words:
   - "aarch"
   - "accums"

--- a/sdk/transcription/cspell.yml
+++ b/sdk/transcription/cspell.yml
@@ -6,4 +6,5 @@
 version: "0.2"
 import:
   - ../../.vscode/cspell.json
+  - ./azure-ai-speech-transcription/cspell.json
 words:

--- a/sdk/voicelive/cspell.yml
+++ b/sdk/voicelive/cspell.yml
@@ -6,5 +6,6 @@
 version: "0.2"
 import:
   - ../../.vscode/cspell.json
+  - ./azure-ai-voicelive/cspell.json
 words:
   - "probs"


### PR DESCRIPTION
## Description

- Adds a lightweight `Check Spelling` GitHub Actions workflow for the same target branches as `java - pullrequest`.
- Reuses the existing changed-file CSpell runner and pinned dependency.
- Connects four package-level CSpell configs to their SDK-area configs.
- Adds an inventory test to prevent orphaned SDK CSpell configs.
- Excludes synchronized `azsdk-common-*` skills, matching the existing Azure pipeline exclusion.

## Motivation

CSpell currently runs in the Azure Analyze job. Moving it to an independent check is a prerequisite for letting safe documentation changes avoid the Java pipeline without losing spelling validation.

Four package-level dictionaries were not reachable through their area configs. This change connects them before moving enforcement.

## Validation

- Pester 5.7.1: 2 tests passed.
- actionlint 1.7.12 passed.
- The changed-file spelling command passed.
- Area-level and package-level dictionary probes passed.

## Scope

This PR intentionally keeps CSpell in Analyze and does not add Azure path exclusions yet. `Check Spelling` must become a required status check before removing the existing Analyze step or excluding documentation paths from `java - pullrequest`.

*Written with the help of vcolin7-copilot.*