### PR TITLE
Add Communication Identity service version 2026-09-23

### DIFF
--- a/sdk/communication/azure-communication-identity/CHANGELOG.md
+++ b/sdk/communication/azure-communication-identity/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for service version `2026-09-23`, which is now the default.
+
 ### Breaking Changes
 
 ### Bugs Fixed
@@ -514,4 +516,3 @@ Updated `azure-communication-identity` version
 - Added CommunicationIdentityClient and CommunicationIdentityAsyncClient (originally was part of the azure-communication-aministration package).
 - Added support for Azure Active Directory Authentication.
 - Added ability to create a user and issue token for it at the same time.
-

--- a/sdk/communication/azure-communication-identity/src/main/java/com/azure/communication/identity/CommunicationIdentityServiceVersion.java
+++ b/sdk/communication/azure-communication-identity/src/main/java/com/azure/communication/identity/CommunicationIdentityServiceVersion.java
@@ -27,7 +27,12 @@ public enum CommunicationIdentityServiceVersion implements ServiceVersion {
     /**
      * Service version {@code 2023-10-01}.
      */
-    V2023_10_01("2023-10-01");
+    V2023_10_01("2023-10-01"),
+
+    /**
+     * Service version {@code 2026-09-23}.
+     */
+    V2026_09_23("2026-09-23");
 
     private final String version;
 
@@ -50,6 +55,6 @@ public enum CommunicationIdentityServiceVersion implements ServiceVersion {
      * @return the latest {@link CommunicationIdentityServiceVersion}
      */
     public static CommunicationIdentityServiceVersion getLatest() {
-        return V2023_10_01;
+        return V2026_09_23;
     }
 }

--- a/sdk/communication/azure-communication-identity/src/test/java/com/azure/communication/identity/CommunicationIdentityBuilderUnitTests.java
+++ b/sdk/communication/azure-communication-identity/src/test/java/com/azure/communication/identity/CommunicationIdentityBuilderUnitTests.java
@@ -19,7 +19,9 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -63,6 +65,38 @@ public class CommunicationIdentityBuilderUnitTests {
         });
         CommunicationIdentityClient syncClient = builder.buildClient();
         assertNotNull(syncClient);
+    }
+
+    @Test
+    public void syncClientUsesLatestServiceVersionByDefault() {
+        AtomicReference<String> requestQuery = new AtomicReference<>();
+        CommunicationIdentityClient client
+            = builder.connectionString(MOCK_CONNECTION_STRING).httpClient(new NoOpHttpClient() {
+                @Override
+                public Mono<HttpResponse> send(HttpRequest request) {
+                    requestQuery.set(request.getUrl().getQuery());
+                    return Mono.just(CommunicationIdentityResponseMocker.createUserResult(request));
+                }
+            }).buildClient();
+
+        assertThrows(RuntimeException.class, client::createUser);
+        assertApiVersion(requestQuery.get(), "2026-09-23");
+    }
+
+    @Test
+    public void asyncClientUsesLatestServiceVersionByDefault() {
+        AtomicReference<String> requestQuery = new AtomicReference<>();
+        CommunicationIdentityAsyncClient client
+            = builder.connectionString(MOCK_CONNECTION_STRING).httpClient(new NoOpHttpClient() {
+                @Override
+                public Mono<HttpResponse> send(HttpRequest request) {
+                    requestQuery.set(request.getUrl().getQuery());
+                    return Mono.just(CommunicationIdentityResponseMocker.createUserResult(request));
+                }
+            }).buildAsyncClient();
+
+        assertThrows(RuntimeException.class, () -> client.createUser().block());
+        assertApiVersion(requestQuery.get(), "2026-09-23");
     }
 
     @Test
@@ -231,5 +265,9 @@ public class CommunicationIdentityBuilderUnitTests {
     private void assertHMACHeadersExist(HttpHeaders headers) {
         assertNotNull(headers.get(HttpHeaderName.AUTHORIZATION));
         assertNotNull(headers.get("x-ms-content-sha256"));
+    }
+
+    private void assertApiVersion(String requestQuery, String expectedVersion) {
+        assertEquals("api-version=" + expectedVersion, requestQuery);
     }
 }


### PR DESCRIPTION
# Description

Adds Communication Identity service version `2026-09-23` so clients use the new API version by default while retaining explicit access to prior supported versions.

The change extends `CommunicationIdentityServiceVersion`, updates `getLatest()`, and adds sync and async transport-level tests that verify the default `api-version=2026-09-23` query parameter.

The targeted builder test suite passes with 19 tests. The full playback suite is currently blocked by the local test proxy using an invalid recording path and refusing connections on port 5000.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md).**

## [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#developer-guide)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md#building-and-unit-testing)
- [x] Pull request includes test coverage for the included changes.